### PR TITLE
feat(particles): add a mesh render mode, unify out-of-range textureIndex

### DIFF
--- a/packages/exojs-particles/src/ParticleSystem.ts
+++ b/packages/exojs-particles/src/ParticleSystem.ts
@@ -193,6 +193,21 @@ export class ParticleSystem extends Drawable {
   public readonly color: Uint32Array; // packed 0xAABBGGRR
   public readonly elapsed: Float32Array; // seconds since spawn
   public readonly lifetime: Float32Array; // total seconds before expiry; -1 sentinel for dead in GPU mode
+
+  /**
+   * Per-slot atlas frame selector: an index into {@link frames}.
+   *
+   * **Anything that is not a valid explicit index shows frame 0.** The array is
+   * zero-initialised, so a particle whose index was never set already shows
+   * frame 0, and an index at or past the declared frame count falls back to the
+   * same frame rather than to the last one — one rule instead of two different
+   * behaviours depending on how the index went wrong. It holds identically on
+   * the CPU packer and in the compute pipeline, so a system looks the same on
+   * either backend.
+   *
+   * Ignored entirely when the system declares no frames: the whole texture is
+   * then the single frame.
+   */
   public readonly textureIndex: Uint16Array;
 
   /**
@@ -355,8 +370,8 @@ export class ParticleSystem extends Drawable {
 
   /**
    * Atlas frames declared on this system, or empty when the texture is
-   * used as a single frame. Each particle's `textureIndex[i]` selects
-   * an entry from this list; out-of-range indices are clamped to 0.
+   * used as a single frame. Each particle's {@link textureIndex} selects
+   * an entry from this list; anything out of range shows frame 0.
    */
   public get frames(): readonly Rectangle[] {
     return this._frames;

--- a/packages/exojs-particles/src/gpu/ParticleGpuState.ts
+++ b/packages/exojs-particles/src/gpu/ParticleGpuState.ts
@@ -534,8 +534,13 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     // Module bodies (in registration order).
 ${moduleBodies}
 
-    // Resolve frame UVs.
-    let frameIndex = min(textureIndex[idx], ${frameCountConst}u - 1u);
+    // Resolve frame UVs. Anything that is not a valid explicit index shows
+    // frame 0, which is what the CPU packer does and what a slot whose index
+    // was never set already shows — \`textureIndex\` is zero-initialised.
+    // Clamping to the last frame instead would be animation-hold semantics,
+    // and this is a frame selector rather than an animation cursor.
+    let rawFrameIndex = textureIndex[idx];
+    let frameIndex = select(0u, rawFrameIndex, rawFrameIndex < ${frameCountConst}u);
     let frameUvBounds = frameUv.frames[frameIndex];
 
     // Pack interleaved instance data (10 u32s per particle):

--- a/packages/exojs-particles/src/public.ts
+++ b/packages/exojs-particles/src/public.ts
@@ -9,6 +9,8 @@ export type { ParticlesExtensionOptions } from './particlesExtension';
 export { createParticlesExtension, particlesExtension } from './particlesExtension';
 export type { ParticleSystemOptions } from './ParticleSystem';
 export { ParticleSystem } from './ParticleSystem';
+export type { MeshParticlesOptions } from './renderModes/MeshParticles';
+export { MeshParticles } from './renderModes/MeshParticles';
 export { ParticleMaterial } from './renderModes/ParticleMaterial';
 export { ParticleRenderMode } from './renderModes/ParticleRenderMode';
 export { QuadParticles } from './renderModes/QuadParticles';

--- a/packages/exojs-particles/src/renderModes/MeshParticles.ts
+++ b/packages/exojs-particles/src/renderModes/MeshParticles.ts
@@ -1,0 +1,420 @@
+import type { AttributeType, GeometryAttribute, Material } from '@codexo/exojs';
+import { Geometry, ShaderSource } from '@codexo/exojs';
+
+import type { ParticleSystem } from '#ParticleSystem';
+
+import fragmentSource from '../renderers/glsl/particle.frag';
+import { instanceAttributes, instanceStrideBytes, ParticleInstanceWriter } from './ParticleInstanceWriter';
+import { ParticleMaterial } from './ParticleMaterial';
+import { ParticleRenderMode } from './ParticleRenderMode';
+
+/** Floats one entry of the baked mesh vertex table occupies: x, y, u, v. */
+const floatsPerMeshVertex = 4;
+
+const componentByteSizes: Record<AttributeType, number> = {
+  f32: 4,
+  u8: 1,
+  u16: 2,
+  u32: 4,
+  i32: 4,
+};
+
+const positionAttributeNames = new Set<string>(['a_position', 'position']);
+const texcoordAttributeNames = new Set<string>(['a_texcoord', 'texcoord', 'a_uv', 'uv']);
+
+/** Construction options for {@link MeshParticles}. */
+export interface MeshParticlesOptions {
+  /**
+   * The shape one particle draws, in system-local units before the
+   * per-particle scale and rotation are applied. Read once, at construction:
+   * mutating it afterwards does not re-bake the shader.
+   *
+   * Its position attribute (`a_position`/`position`) supplies the vertex
+   * positions and its texcoord attribute (`a_texcoord`/`texcoord`/`a_uv`/`uv`)
+   * the UVs. See {@link MeshParticles} for what a geometry without the latter
+   * renders as.
+   */
+  readonly geometry: Geometry;
+}
+
+/** Read one component of `attribute`, applying its normalisation. */
+const readComponent = (view: DataView, attribute: GeometryAttribute, byteOffset: number): number => {
+  switch (attribute.type) {
+    case 'f32':
+      return view.getFloat32(byteOffset, true);
+    case 'u8': {
+      const value = view.getUint8(byteOffset);
+
+      return attribute.normalized ? value / 255 : value;
+    }
+    case 'u16': {
+      const value = view.getUint16(byteOffset, true);
+
+      return attribute.normalized ? value / 65535 : value;
+    }
+    case 'u32': {
+      const value = view.getUint32(byteOffset, true);
+
+      return attribute.normalized ? value / 4294967295 : value;
+    }
+    case 'i32': {
+      const value = view.getInt32(byteOffset, true);
+
+      return attribute.normalized ? Math.max(value / 2147483647, -1) : value;
+    }
+  }
+};
+
+/**
+ * Reads a mesh geometry's (x, y, u, v) per vertex into one flat table.
+ *
+ * `Geometry` guarantees a position attribute exists — it resolves one in its
+ * own constructor and throws otherwise — so the same resolution order is
+ * mirrored here rather than re-validated. A geometry without a texcoord
+ * attribute leaves the UV columns at zero.
+ */
+const readMeshTable = (mesh: Geometry): Float32Array => {
+  const { attributes, stride, vertexData } = mesh;
+  const vertexCount = mesh.vertexCount;
+  const table = new Float32Array(vertexCount * floatsPerMeshVertex);
+  const view =
+    vertexData instanceof Float32Array ? new DataView(vertexData.buffer, vertexData.byteOffset, vertexData.byteLength) : new DataView(vertexData);
+
+  const position =
+    attributes.find(attribute => positionAttributeNames.has(attribute.name)) ??
+    attributes.find(attribute => attribute.name.toLowerCase().includes('position'))!;
+  const texcoord = attributes.find(attribute => texcoordAttributeNames.has(attribute.name)) ?? null;
+
+  for (let i = 0; i < vertexCount; i++) {
+    const vertexStart = i * stride;
+    const out = i * floatsPerMeshVertex;
+
+    table[out + 0] = readComponent(view, position, vertexStart + position.offset);
+    table[out + 1] = readComponent(view, position, vertexStart + position.offset + componentByteSizes[position.type]);
+
+    if (texcoord !== null) {
+      table[out + 2] = readComponent(view, texcoord, vertexStart + texcoord.offset);
+      table[out + 3] = readComponent(view, texcoord, vertexStart + texcoord.offset + componentByteSizes[texcoord.type]);
+    }
+  }
+
+  return table;
+};
+
+/**
+ * Render a number as a shader float literal. Both GLSL ES 3.00 and WGSL accept
+ * exponent forms as written, but an integral value needs the decimal point to
+ * read as a float rather than an int.
+ */
+const formatFloat = (value: number): string => {
+  const text = String(value);
+
+  return /[.eE]/.test(text) ? text : `${text}.0`;
+};
+
+const glslMeshTable = (table: Float32Array): string => {
+  const count = table.length / floatsPerMeshVertex;
+  const entries: string[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const o = i * floatsPerMeshVertex;
+
+    entries.push(`    vec4(${formatFloat(table[o]!)}, ${formatFloat(table[o + 1]!)}, ${formatFloat(table[o + 2]!)}, ${formatFloat(table[o + 3]!)})`);
+  }
+
+  return `const vec4 c_meshVertices[${count}] = vec4[${count}](\n${entries.join(',\n')}\n);`;
+};
+
+const wgslMeshTable = (table: Float32Array): string => {
+  const count = table.length / floatsPerMeshVertex;
+  const entries: string[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const o = i * floatsPerMeshVertex;
+
+    entries.push(
+      `    vec4<f32>(${formatFloat(table[o]!)}, ${formatFloat(table[o + 1]!)}, ${formatFloat(table[o + 2]!)}, ${formatFloat(table[o + 3]!)})`,
+    );
+  }
+
+  return `var<private> meshVertices: array<vec4<f32>, ${count}> = array<vec4<f32>, ${count}>(\n${entries.join(',\n')}\n);`;
+};
+
+/**
+ * GLSL vertex stage for {@link MeshParticles}, baked around one mesh's vertex
+ * table. Line for line the quad's `glsl/particle.vert` with two substitutions:
+ * the corner derived from `gl_VertexID` becomes a lookup into the table at
+ * `gl_VertexID`, and the corner-selected UV becomes a mix across the whole
+ * mesh UV.
+ *
+ * Generated rather than shipped as a `.vert` file because the table is
+ * per-mesh: the executors bind exactly one vertex buffer, which the
+ * per-instance data already occupies, and neither backend lets a mode
+ * contribute a uniform of its own. Baking the mesh into the source is what
+ * keeps this mode inside the seam. The fragment stage needs no baking, so it
+ * is the shipped quad fragment shader unchanged.
+ */
+export const meshParticleVertexGlsl = (table: Float32Array): string => `#version 300 es
+precision highp float;
+precision highp int;
+
+// Per-instance attributes (one entry per particle, 40 bytes total).
+layout(location = 0) in vec2 a_position;         // particle position in system-local space
+layout(location = 1) in vec2 a_scale;            // particle scale
+layout(location = 2) in float a_rotation;        // particle rotation in degrees
+layout(location = 3) in vec4 a_color;            // RGBA tint
+layout(location = 4) in vec2 a_uvMin;            // top-left UV (u, v) — pre-resolved per instance
+layout(location = 5) in vec2 a_uvMax;            // bottom-right UV (u, v) — pre-resolved per instance
+
+uniform mat3 u_projection;
+uniform mat3 u_systemTransform;
+
+// The mesh's own vertices as (x, y, u, v), addressed by the value the index
+// buffer supplies — the same role gl_VertexID plays for the quad's corners.
+${glslMeshTable(table)}
+
+out vec2 v_texcoord;
+out vec4 v_color;
+
+void main(void) {
+    vec4 meshVertex = c_meshVertices[gl_VertexID];
+    vec2 local = meshVertex.xy;
+
+    // Per-particle scale + rotation, identical to the quad's.
+    vec2 rotation = vec2(sin(radians(a_rotation)), cos(radians(a_rotation)));
+    vec2 transformed = vec2(
+        (local.x * (a_scale.x * rotation.y)) + (local.y * (a_scale.y * rotation.x)),
+        (local.x * (a_scale.x * -rotation.x)) + (local.y * (a_scale.y * rotation.y))
+    );
+
+    vec3 worldPos = vec3(transformed + a_position, 1.0);
+
+    gl_Position = vec4((u_projection * u_systemTransform * worldPos).xy, 0.0, 1.0);
+
+    // The mesh's own UVs address the particle's frame rather than the whole
+    // texture, so a mesh particle still selects an atlas frame.
+    v_texcoord = mix(a_uvMin, a_uvMax, meshVertex.zw);
+
+    v_color = vec4(a_color.rgb * a_color.a, a_color.a);
+}
+`;
+
+/**
+ * WGSL counterpart of {@link meshParticleVertexGlsl} plus the quad's fragment
+ * stage. Vertex and fragment entry points share one source per WGSL
+ * convention, and the per-instance attributes bind by `@location`, matching
+ * the declaration order and byte offsets of `instanceAttributes`.
+ *
+ * The uniform struct is the one the WebGPU particle renderer writes for every
+ * mode, so `localBounds` and `uvBounds` are declared but unused here: a mesh
+ * carries its own local footprint rather than taking it from the texture frame.
+ */
+export const meshParticleWgsl = (table: Float32Array): string => `
+struct ProjectionUniforms {
+    projection: mat4x4<f32>,
+    translation: mat4x4<f32>,
+    flags: vec4<f32>,
+    localBounds: vec4<f32>,    // quadMin.xy, quadSize.xy — unused by this mode
+    uvBounds: vec4<f32>,       // uvMin.xy, uvMax.xy — unused by this mode
+};
+
+@group(0) @binding(0)
+var<uniform> uniforms: ProjectionUniforms;
+
+@group(1) @binding(0)
+var particleTexture: texture_2d<f32>;
+
+@group(1) @binding(1)
+var particleSampler: sampler;
+
+// The mesh's own vertices as (x, y, u, v), addressed by the value the index
+// buffer supplies — the same role vertex_index plays for the quad's corners.
+${wgslMeshTable(table)}
+
+// Per-instance attributes (one entry per particle, 40 bytes total).
+struct VertexInput {
+    @builtin(vertex_index) vertexIndex: u32,
+    @location(0) translation: vec2<f32>,
+    @location(1) scale: vec2<f32>,
+    @location(2) rotation: f32,
+    @location(3) color: vec4<f32>,
+    @location(4) uvMin: vec2<f32>,            // pre-resolved frame UV (top-left)
+    @location(5) uvMax: vec2<f32>,            // pre-resolved frame UV (bottom-right)
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) texcoord: vec2<f32>,
+    @location(1) color: vec4<f32>,
+};
+
+@vertex
+fn vertexMain(input: VertexInput) -> VertexOutput {
+    let meshVertex = meshVertices[input.vertexIndex];
+    let localPosition = meshVertex.xy;
+
+    let radians = radians(input.rotation);
+    let sinValue = sin(radians);
+    let cosValue = cos(radians);
+    let rotated = vec2<f32>(
+        (localPosition.x * (input.scale.x * cosValue)) + (localPosition.y * (input.scale.y * sinValue)) + input.translation.x,
+        (localPosition.x * (input.scale.x * -sinValue)) + (localPosition.y * (input.scale.y * cosValue)) + input.translation.y
+    );
+
+    var output: VertexOutput;
+
+    output.position = uniforms.projection * uniforms.translation * vec4<f32>(rotated, 0.0, 1.0);
+    // The mesh's own UVs address the particle's frame rather than the whole
+    // texture, so a mesh particle still selects an atlas frame.
+    output.texcoord = mix(input.uvMin, input.uvMax, meshVertex.zw);
+    output.color = vec4(input.color.rgb * input.color.a, input.color.a);
+
+    return output;
+}
+
+@fragment
+fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+    let sampled = textureSample(particleTexture, particleSampler, input.texcoord);
+    let premultipliedSample = select(sampled, vec4(sampled.rgb * sampled.a, sampled.a), uniforms.flags.x > 0.5);
+
+    return premultipliedSample * input.color;
+}
+`;
+
+/**
+ * One caller-supplied mesh per particle, drawn as a single instanced draw.
+ *
+ * The cheap counterpart to `RibbonParticles`: the relationship stays one
+ * particle, one instance, and the per-instance data is byte-identical to
+ * `QuadParticles`'s — {@link instanceAttributes}, filled by the same
+ * writer. Only the shape changes. That is what makes this mode **GPU-eligible**
+ * without touching the compute pipeline: the pipeline emits precisely that
+ * layout, so a system on the GPU path binds its instance buffer directly and
+ * never calls {@link build}.
+ *
+ * **The mesh is baked into the shader**, read once at construction. Its
+ * vertices become a constant `(x, y, u, v)` table addressed by the vertex
+ * index, which is the same thing the quad does with its four corners — from the
+ * shader's side a mesh is just a quad with more vertices. Consequences worth
+ * knowing:
+ *
+ * - One `MeshParticles` instance means one compiled program per backend, so
+ *   share a single instance across the systems that draw the same shape rather
+ *   than constructing one per system.
+ * - Mutating the geometry after construction changes nothing. Construct a new
+ *   mode instead.
+ * - The table is shader source, so a mesh of a few hundred vertices is the
+ *   sensible ceiling; this mode is for sparks, shards, leaves and petals, not
+ *   for detailed models.
+ *
+ * **Atlas frames still work.** The mesh's own UVs are treated exactly like the
+ * quad's 0..1 corners: the shader mixes them across the particle's resolved
+ * frame (`uv = mix(uvMin, uvMax, meshUV)`), so `system.frames` plus a
+ * per-particle `textureIndex` selects a frame the same way. A geometry with
+ * **no texcoord attribute** therefore carries UV `(0, 0)` on every vertex and
+ * the mix degenerates to `uvMin` — the whole mesh samples the single texel at
+ * the frame's top-left corner, which on the default 1×1 white texture is
+ * exactly "untextured, tinted by the particle's `color`".
+ *
+ * **Sizing is the mesh's own.** Unlike the quad, which derives its footprint
+ * from the texture frame, a mesh particle's footprint is whatever its vertex
+ * positions say, in system-local units, multiplied by the per-particle
+ * `scaleX`/`scaleY`. The texture only supplies colour.
+ *
+ * @example
+ * const shard = new Geometry({
+ *     attributes: [
+ *         { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+ *         { name: 'a_uv', size: 2, type: 'f32', normalized: false, offset: 8 },
+ *     ],
+ *     vertexData: new Float32Array([0, -8, 0.5, 0, 6, 6, 1, 1, -6, 6, 0, 1]),
+ *     stride: 16,
+ * });
+ *
+ * const debris = new ParticleSystem(rockTexture, {
+ *     capacity: 512,
+ *     render: new MeshParticles({ geometry: shard }),
+ * });
+ *
+ * debris.addUpdateModule(new RotateOverLifetime(180)); // each shard tumbles
+ */
+export class MeshParticles extends ParticleRenderMode {
+  public override readonly gpuEligible = true;
+  public readonly instanced = true;
+
+  /**
+   * The geometry this mode was constructed with — the shape one particle
+   * draws. Owned by the caller: {@link destroy} leaves it alone, so one mesh
+   * can back several modes.
+   */
+  public readonly mesh: Geometry;
+
+  /**
+   * The base geometry the executors draw with. It carries the mesh's topology
+   * and index buffer — that is what turns the mesh's vertices into triangles —
+   * while its attributes describe the per-instance buffer {@link build} fills,
+   * because that buffer is the only one bound. The placeholder `vertexData` is
+   * sized to the mesh's vertex count so a mesh without indices still draws all
+   * of its vertices per instance.
+   */
+  public readonly geometry: Geometry;
+
+  private readonly _meshTable: Float32Array;
+  private readonly _writer = new ParticleInstanceWriter();
+
+  private _material: ParticleMaterial | null = null;
+  private _float32 = new Float32Array(this.data);
+  private _uint32 = new Uint32Array(this.data);
+
+  public constructor(options: MeshParticlesOptions) {
+    super();
+
+    const mesh = options.geometry;
+
+    this.mesh = mesh;
+    this._meshTable = readMeshTable(mesh);
+    this.geometry = new Geometry({
+      attributes: instanceAttributes,
+      vertexData: new ArrayBuffer(mesh.vertexCount * instanceStrideBytes),
+      stride: instanceStrideBytes,
+      indices: mesh.indices,
+      topology: mesh.topology,
+      usage: 'stream',
+    });
+  }
+
+  /**
+   * Built on first read rather than in the constructor: a system may be
+   * simulated without ever being drawn, and the shader pair is only needed
+   * once a backend actually compiles it.
+   */
+  public get material(): Material {
+    this._material ??= new ParticleMaterial({
+      shader: new ShaderSource({
+        glsl: { vertex: meshParticleVertexGlsl(this._meshTable), fragment: fragmentSource },
+        wgsl: meshParticleWgsl(this._meshTable),
+      }),
+    });
+
+    return this._material;
+  }
+
+  public build(system: ParticleSystem): void {
+    // Must precede the view reads below: growing swaps in fresh typed-array
+    // views over a new backing buffer.
+    this._ensureCapacity(system.liveCount * instanceStrideBytes);
+
+    this._setCount(this._writer.write(system, this._float32, this._uint32));
+  }
+
+  public override destroy(): void {
+    this._material?.destroy();
+    this._material = null;
+    this.geometry.destroy();
+  }
+
+  protected override _onBufferGrown(data: ArrayBuffer): void {
+    this._float32 = new Float32Array(data);
+    this._uint32 = new Uint32Array(data);
+  }
+}

--- a/packages/exojs-particles/src/renderModes/ParticleInstanceWriter.ts
+++ b/packages/exojs-particles/src/renderModes/ParticleInstanceWriter.ts
@@ -66,6 +66,9 @@ export class ParticleInstanceWriter {
     // to the system.textureFrame when no atlas is declared.
     const { uvMins, uvMaxs } = this._computeFrameUvs(system);
     const frameCount = uvMins.length / 2;
+    // Anything that is not a valid explicit index shows frame 0, matching both
+    // the zero-initialised default and the compute pipeline. See
+    // `ParticleSystem.textureIndex`.
     const fallbackFrame = 0;
 
     let writeIndex = 0;

--- a/packages/exojs-particles/src/renderModes/ParticleInstanceWriter.ts
+++ b/packages/exojs-particles/src/renderModes/ParticleInstanceWriter.ts
@@ -1,0 +1,156 @@
+import type { GeometryAttribute } from '@codexo/exojs';
+
+import type { ParticleSystem } from '#ParticleSystem';
+
+/** Bytes one particle occupies in the interleaved per-instance buffer. */
+export const instanceStrideBytes = 40;
+
+/** 32-bit words one particle occupies in that buffer. */
+export const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT;
+
+/**
+ * The per-instance attribute layout every instanced render mode declares, and
+ * the layout the GPU compute pipeline emits into its instance buffer:
+ *
+ * ```
+ *   a_position   f32x2  (offset  0,  8 bytes)  particle position (system-local)
+ *   a_scale      f32x2  (offset  8,  8 bytes)
+ *   a_rotation   f32    (offset 16,  4 bytes)  degrees
+ *   a_color      u8x4   (offset 20,  4 bytes)  RGBA tint, normalised
+ *   a_uvMin      f32x2  (offset 24,  8 bytes)  pre-resolved frame uvMin
+ *   a_uvMax      f32x2  (offset 32,  8 bytes)  pre-resolved frame uvMax
+ * ```
+ *
+ * Shared rather than copied per mode so a mode using it cannot drift out of
+ * step with the compute shader and quietly lose its GPU eligibility. `Geometry`
+ * copies the attribute objects it is handed, so one frozen list serves every
+ * mode.
+ */
+export const instanceAttributes: readonly GeometryAttribute[] = [
+  { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+  { name: 'a_scale', size: 2, type: 'f32', normalized: false, offset: 8 },
+  { name: 'a_rotation', size: 1, type: 'f32', normalized: false, offset: 16 },
+  { name: 'a_color', size: 4, type: 'u8', normalized: true, offset: 20 },
+  { name: 'a_uvMin', size: 2, type: 'f32', normalized: false, offset: 24 },
+  { name: 'a_uvMax', size: 2, type: 'f32', normalized: false, offset: 32 },
+];
+
+/**
+ * Fills the interleaved per-instance buffer shared by the instanced render
+ * modes — one 40-byte record per live particle, in {@link instanceAttributes}
+ * order.
+ *
+ * A class rather than a free function because the frame-UV table it resolves
+ * per frame is scratch state that must survive between calls: the arithmetic
+ * runs once per declared frame, not once per particle.
+ *
+ * This is the CPU counterpart of the compute pipeline's pack-instances step;
+ * the two must agree byte for byte, since a GPU-eligible mode's system swaps
+ * between them silently depending on the backend.
+ */
+export class ParticleInstanceWriter {
+  private _uvMinsScratch = new Float32Array(2);
+  private _uvMaxsScratch = new Float32Array(2);
+
+  /**
+   * Pack `system`'s live particles into the two views over one buffer, which
+   * must already hold `system.liveCount * instanceStrideBytes` bytes. Returns
+   * the number of instances written — dead slots in a GPU-mode system's live
+   * range are skipped, so that can be below `liveCount`.
+   */
+  public write(system: ParticleSystem, f32: Float32Array, u32: Uint32Array): number {
+    const limit = system.liveCount;
+    const { posX, posY, scaleX, scaleY, rotations, color, textureIndex, alive } = system;
+
+    // Pre-compute frame UVs from system.frames + texture; falls back
+    // to the system.textureFrame when no atlas is declared.
+    const { uvMins, uvMaxs } = this._computeFrameUvs(system);
+    const frameCount = uvMins.length / 2;
+    const fallbackFrame = 0;
+
+    let writeIndex = 0;
+
+    for (let i = 0; i < limit; i++) {
+      // Skip dead slots in GPU-mode systems where the live range can
+      // contain holes.
+      if (alive[i] === 0) {
+        continue;
+      }
+
+      const offset = writeIndex * wordsPerInstance;
+      const frame = textureIndex[i]! < frameCount ? textureIndex[i]! : fallbackFrame;
+      const uvBase = frame * 2;
+
+      f32[offset + 0] = posX[i]!;
+      f32[offset + 1] = posY[i]!;
+      f32[offset + 2] = scaleX[i]!;
+      f32[offset + 3] = scaleY[i]!;
+      f32[offset + 4] = rotations[i]!;
+      u32[offset + 5] = color[i]!;
+      f32[offset + 6] = uvMins[uvBase + 0]!;
+      f32[offset + 7] = uvMins[uvBase + 1]!;
+      f32[offset + 8] = uvMaxs[uvBase + 0]!;
+      f32[offset + 9] = uvMaxs[uvBase + 1]!;
+
+      writeIndex++;
+    }
+
+    return writeIndex;
+  }
+
+  /**
+   * Compute (uvMin, uvMax) pairs for every declared frame on the system.
+   * Pulled out of the hot pack loop so the arithmetic runs once per frame
+   * rather than once per particle. Falls back to a single entry from
+   * `system.textureFrame` when no atlas is declared.
+   */
+  private _computeFrameUvs(system: ParticleSystem): { uvMins: Float32Array; uvMaxs: Float32Array } {
+    const frames = system.frames;
+    const tex = system.texture;
+    const texW = tex.width;
+    const texH = tex.height;
+    const flipY = tex.flipY;
+
+    const count = frames.length === 0 ? 1 : frames.length;
+
+    // Re-allocate scratch when capacity grows.
+    if (this._uvMinsScratch.length < count * 2) {
+      this._uvMinsScratch = new Float32Array(count * 2);
+      this._uvMaxsScratch = new Float32Array(count * 2);
+    }
+
+    const mins = this._uvMinsScratch;
+    const maxs = this._uvMaxsScratch;
+
+    if (frames.length === 0) {
+      const f = system.textureFrame;
+      const minU = f.left / texW;
+      const maxU = f.right / texW;
+      const topV = f.top / texH;
+      const bottomV = f.bottom / texH;
+
+      mins[0] = minU;
+      mins[1] = flipY ? bottomV : topV;
+      maxs[0] = maxU;
+      maxs[1] = flipY ? topV : bottomV;
+
+      return { uvMins: mins, uvMaxs: maxs };
+    }
+
+    for (let i = 0; i < frames.length; i++) {
+      const f = frames[i]!;
+      const o = i * 2;
+      const minU = f.left / texW;
+      const maxU = f.right / texW;
+      const topV = f.top / texH;
+      const bottomV = f.bottom / texH;
+
+      mins[o + 0] = minU;
+      mins[o + 1] = flipY ? bottomV : topV;
+      maxs[o + 0] = maxU;
+      maxs[o + 1] = flipY ? topV : bottomV;
+    }
+
+    return { uvMins: mins, uvMaxs: maxs };
+  }
+}

--- a/packages/exojs-particles/src/renderModes/ParticleRenderMode.ts
+++ b/packages/exojs-particles/src/renderModes/ParticleRenderMode.ts
@@ -50,8 +50,10 @@ export abstract class ParticleRenderMode {
    * onto the CPU path, silently and observably via `ParticleSystem.gpuMode`.
    *
    * A GPU-eligible mode's layout must match what the compute pipeline emits
-   * into `gpuState.instanceBuffer` — today that is `QuadParticles`'s layout,
-   * and it is the only GPU-eligible mode.
+   * into `gpuState.instanceBuffer` — the shared 40-byte per-instance layout
+   * (`instanceAttributes`). `QuadParticles` and `MeshParticles` both declare
+   * exactly that layout and differ only in the shape they expand it into,
+   * which is why both are eligible without the compute shader knowing either.
    */
   public readonly gpuEligible: boolean = false;
 

--- a/packages/exojs-particles/src/renderModes/QuadParticles.ts
+++ b/packages/exojs-particles/src/renderModes/QuadParticles.ts
@@ -5,11 +5,10 @@ import type { ParticleSystem } from '#ParticleSystem';
 
 import fragmentSource from '../renderers/glsl/particle.frag';
 import vertexSource from '../renderers/glsl/particle.vert';
+import { instanceAttributes, instanceStrideBytes, ParticleInstanceWriter } from './ParticleInstanceWriter';
 import { ParticleMaterial } from './ParticleMaterial';
 import { ParticleRenderMode } from './ParticleRenderMode';
 
-const instanceStrideBytes = 40;
-const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT;
 const quadVertexCount = 4;
 const quadIndices = new Uint16Array([0, 1, 2, 0, 2, 3]);
 
@@ -101,26 +100,15 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
  * The default render mode: one textured, rotated, tinted quad per particle,
  * drawn as a single instanced triangle-list.
  *
- * Layout of the per-instance buffer {@link build} fills (40 bytes, 6
- * attributes):
+ * {@link build} fills the shared 40-byte per-instance layout described by
+ * {@link instanceAttributes}. UVs are baked per-particle so the system can
+ * carry an atlas of frames — `system.frames` declares the rectangles and each
+ * particle's `textureIndex` selects one, resolved to UVs once per particle per
+ * frame; no per-instance shader-side indexing needed.
  *
- * ```
- *   a_position   f32x2  (offset  0,  8 bytes)  particle position (system-local)
- *   a_scale      f32x2  (offset  8,  8 bytes)
- *   a_rotation   f32    (offset 16,  4 bytes)  degrees
- *   a_color      u8x4   (offset 20,  4 bytes)  RGBA tint, normalised
- *   a_uvMin      f32x2  (offset 24,  8 bytes)  pre-resolved frame uvMin
- *   a_uvMax      f32x2  (offset 32,  8 bytes)  pre-resolved frame uvMax
- * ```
- *
- * UVs are baked per-particle so the system can carry an atlas of frames —
- * `system.frames` declares the rectangles and each particle's `textureIndex`
- * selects one. {@link build} resolves frame-rectangle to UVs once per particle
- * per frame; no per-instance shader-side indexing needed.
- *
- * This is the only GPU-eligible mode: the system's compute pipeline emits
- * exactly this layout into its instance buffer, so a system running on the GPU
- * path can bind that buffer directly and skip {@link build} entirely.
+ * GPU-eligible: the system's compute pipeline emits exactly that layout into
+ * its instance buffer, so a system running on the GPU path can bind that buffer
+ * directly and skip {@link build} entirely.
  */
 export class QuadParticles extends ParticleRenderMode {
   public override readonly gpuEligible = true;
@@ -134,14 +122,7 @@ export class QuadParticles extends ParticleRenderMode {
    * addresses.
    */
   public readonly geometry = new Geometry({
-    attributes: [
-      { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
-      { name: 'a_scale', size: 2, type: 'f32', normalized: false, offset: 8 },
-      { name: 'a_rotation', size: 1, type: 'f32', normalized: false, offset: 16 },
-      { name: 'a_color', size: 4, type: 'u8', normalized: true, offset: 20 },
-      { name: 'a_uvMin', size: 2, type: 'f32', normalized: false, offset: 24 },
-      { name: 'a_uvMax', size: 2, type: 'f32', normalized: false, offset: 32 },
-    ],
+    attributes: instanceAttributes,
     vertexData: new ArrayBuffer(quadVertexCount * instanceStrideBytes),
     stride: instanceStrideBytes,
     indices: quadIndices,
@@ -149,11 +130,11 @@ export class QuadParticles extends ParticleRenderMode {
     usage: 'stream',
   });
 
+  private readonly _writer = new ParticleInstanceWriter();
+
   private _material: ParticleMaterial | null = null;
   private _float32 = new Float32Array(this.data);
   private _uint32 = new Uint32Array(this.data);
-  private _uvMinsScratch = new Float32Array(2);
-  private _uvMaxsScratch = new Float32Array(2);
 
   /**
    * Built on first read rather than in the constructor: a system may be
@@ -172,50 +153,11 @@ export class QuadParticles extends ParticleRenderMode {
   }
 
   public build(system: ParticleSystem): void {
-    const limit = system.liveCount;
-
     // Must precede the view reads below: growing swaps in fresh typed-array
     // views over a new backing buffer.
-    this._ensureCapacity(limit * instanceStrideBytes);
+    this._ensureCapacity(system.liveCount * instanceStrideBytes);
 
-    const f32 = this._float32;
-    const u32 = this._uint32;
-    const { posX, posY, scaleX, scaleY, rotations, color, textureIndex, alive } = system;
-
-    // Pre-compute frame UVs from system.frames + texture; falls back
-    // to the system.textureFrame when no atlas is declared.
-    const { uvMins, uvMaxs } = this._computeFrameUvs(system);
-    const frameCount = uvMins.length / 2;
-    const fallbackFrame = 0;
-
-    let writeIndex = 0;
-
-    for (let i = 0; i < limit; i++) {
-      // Skip dead slots in GPU-mode systems where the live range can
-      // contain holes.
-      if (alive[i] === 0) {
-        continue;
-      }
-
-      const offset = writeIndex * wordsPerInstance;
-      const frame = textureIndex[i]! < frameCount ? textureIndex[i]! : fallbackFrame;
-      const uvBase = frame * 2;
-
-      f32[offset + 0] = posX[i]!;
-      f32[offset + 1] = posY[i]!;
-      f32[offset + 2] = scaleX[i]!;
-      f32[offset + 3] = scaleY[i]!;
-      f32[offset + 4] = rotations[i]!;
-      u32[offset + 5] = color[i]!;
-      f32[offset + 6] = uvMins[uvBase + 0]!;
-      f32[offset + 7] = uvMins[uvBase + 1]!;
-      f32[offset + 8] = uvMaxs[uvBase + 0]!;
-      f32[offset + 9] = uvMaxs[uvBase + 1]!;
-
-      writeIndex++;
-    }
-
-    this._setCount(writeIndex);
+    this._setCount(this._writer.write(system, this._float32, this._uint32));
   }
 
   public override destroy(): void {
@@ -227,61 +169,5 @@ export class QuadParticles extends ParticleRenderMode {
   protected override _onBufferGrown(data: ArrayBuffer): void {
     this._float32 = new Float32Array(data);
     this._uint32 = new Uint32Array(data);
-  }
-
-  /**
-   * Compute (uvMin, uvMax) pairs for every declared frame on the system.
-   * Pulled out of the hot pack loop so the arithmetic runs once per frame
-   * rather than once per particle. Falls back to a single entry from
-   * `system.textureFrame` when no atlas is declared.
-   */
-  private _computeFrameUvs(system: ParticleSystem): { uvMins: Float32Array; uvMaxs: Float32Array } {
-    const frames = system.frames;
-    const tex = system.texture;
-    const texW = tex.width;
-    const texH = tex.height;
-    const flipY = tex.flipY;
-
-    const count = frames.length === 0 ? 1 : frames.length;
-
-    // Re-allocate scratch when capacity grows.
-    if (this._uvMinsScratch.length < count * 2) {
-      this._uvMinsScratch = new Float32Array(count * 2);
-      this._uvMaxsScratch = new Float32Array(count * 2);
-    }
-
-    const mins = this._uvMinsScratch;
-    const maxs = this._uvMaxsScratch;
-
-    if (frames.length === 0) {
-      const f = system.textureFrame;
-      const minU = f.left / texW;
-      const maxU = f.right / texW;
-      const topV = f.top / texH;
-      const bottomV = f.bottom / texH;
-
-      mins[0] = minU;
-      mins[1] = flipY ? bottomV : topV;
-      maxs[0] = maxU;
-      maxs[1] = flipY ? topV : bottomV;
-
-      return { uvMins: mins, uvMaxs: maxs };
-    }
-
-    for (let i = 0; i < frames.length; i++) {
-      const f = frames[i]!;
-      const o = i * 2;
-      const minU = f.left / texW;
-      const maxU = f.right / texW;
-      const topV = f.top / texH;
-      const bottomV = f.bottom / texH;
-
-      mins[o + 0] = minU;
-      mins[o + 1] = flipY ? bottomV : topV;
-      maxs[o + 0] = maxU;
-      maxs[o + 1] = flipY ? topV : bottomV;
-    }
-
-    return { uvMins: mins, uvMaxs: maxs };
   }
 }

--- a/packages/exojs-particles/test/particle-gpu.test.ts
+++ b/packages/exojs-particles/test/particle-gpu.test.ts
@@ -19,6 +19,7 @@ import { SpawnOnDeath } from '../src/modules/SpawnOnDeath';
 import { Turbulence } from '../src/modules/Turbulence';
 import { UpdateModule } from '../src/modules/UpdateModule';
 import { ParticleSystem } from '../src/ParticleSystem';
+import { QuadParticles } from '../src/renderModes/QuadParticles';
 
 const makeTexture = (): Texture => {
   const canvas = document.createElement('canvas');
@@ -794,6 +795,65 @@ describe('ParticleGpuState frame-UV packing (_writeFrames)', () => {
     expect(view[1]).toBe(1);
     expect(view[2]).toBe(1);
     expect(view[3]).toBe(0);
+  });
+});
+
+describe('Out-of-range textureIndex', () => {
+  let restoreGlobals: () => void;
+
+  beforeEach(() => {
+    restoreGlobals = installGlobals();
+  });
+
+  afterEach(() => {
+    restoreGlobals();
+  });
+
+  test('shows frame 0 on the CPU packer and in the generated compute shader alike', () => {
+    const env = makeMockDevice();
+    const tex = makeTexture(); // 16x16
+    const frames = [new Rectangle(0, 0, 8, 8), new Rectangle(8, 0, 8, 8)];
+    const system = new ParticleSystem(tex, frames, { capacity: 4, device: env.device });
+
+    system.addUpdateModule(new ApplyForce(0, 0));
+
+    const inRange = system.spawn();
+    const outOfRange = system.spawn();
+    const neverSet = system.spawn();
+
+    for (const slot of [inRange, outOfRange, neverSet]) {
+      system.lifetime[slot] = 10;
+    }
+
+    system.textureIndex[inRange] = 1;
+    system.textureIndex[outOfRange] = 7;
+    // `neverSet` keeps the zero-initialised default.
+
+    system.update(tick(0.016));
+
+    expect(system.gpuMode).toBe(true);
+
+    // GPU side: the pack step selects frame 0 for an index past the declared
+    // count, rather than clamping it to the last frame.
+    const shaderSource = env.shaderSources[0]!;
+
+    expect(shaderSource).toContain('select(0u, rawFrameIndex, rawFrameIndex < 2u)');
+    expect(shaderSource).not.toContain('min(textureIndex[idx]');
+
+    // CPU side: the same three particles packed through the render mode.
+    const mode = new QuadParticles();
+
+    mode.build(system);
+
+    const floats = new Float32Array(mode.data);
+    const uvMinU = (instance: number): number => floats[instance * 10 + 6]!;
+
+    // Frame 1 spans u 0.5..1 on a 16x16 texture, frame 0 spans u 0..0.5.
+    expect(uvMinU(0)).toBeCloseTo(0.5);
+    expect(uvMinU(1)).toBeCloseTo(0);
+    // An index that was never set and one that is out of range are the same
+    // particle as far as the atlas is concerned.
+    expect(uvMinU(1)).toBe(uvMinU(2));
   });
 });
 

--- a/packages/exojs-particles/test/render-mode-mesh.test.ts
+++ b/packages/exojs-particles/test/render-mode-mesh.test.ts
@@ -1,0 +1,146 @@
+import { Geometry } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import { ParticleSystem } from '../src/ParticleSystem';
+import { MeshParticles } from '../src/renderModes/MeshParticles';
+import { QuadParticles } from '../src/renderModes/QuadParticles';
+
+/** A right triangle with the right angle top-left, UVs spanning its bounds. */
+const makeTriangle = (indexed = false): Geometry =>
+  new Geometry({
+    attributes: [
+      { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+      { name: 'a_uv', size: 2, type: 'f32', normalized: false, offset: 8 },
+    ],
+    // prettier-ignore
+    vertexData: new Float32Array([
+      -16, -16, 0, 0,
+       16, -16, 1, 0,
+      -16,  16, 0, 1,
+    ]),
+    stride: 16,
+    indices: indexed ? new Uint16Array([0, 1, 2]) : null,
+  });
+
+const makeUntexturedTriangle = (): Geometry =>
+  new Geometry({
+    attributes: [{ name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 }],
+    vertexData: new Float32Array([-4, -4, 4, -4, -4, 4]),
+    stride: 8,
+  });
+
+const spawnParticles = (system: ParticleSystem, count: number): void => {
+  for (let i = 0; i < count; i++) {
+    const slot = system.spawn();
+
+    system.posX[slot] = i * 10;
+    system.posY[slot] = i * 20;
+    system.scaleX[slot] = 1 + i;
+    system.scaleY[slot] = 2 + i;
+    system.rotations[slot] = i * 15;
+    system.color[slot] = 0xff00ff00 + i;
+    system.lifetime[slot] = 5;
+  }
+};
+
+describe('MeshParticles', () => {
+  it('declares an instanced, GPU-eligible mode carrying the mesh topology', () => {
+    const mode = new MeshParticles({ geometry: makeTriangle() });
+
+    expect(mode.instanced).toBe(true);
+    expect(mode.gpuEligible).toBe(true);
+    expect(mode.geometry.topology).toBe('triangle-list');
+  });
+
+  it('keeps the supplied geometry as its mesh and draws one instance of it', () => {
+    const mesh = makeTriangle();
+    const mode = new MeshParticles({ geometry: mesh });
+
+    expect(mode.mesh).toBe(mesh);
+    // Non-indexed: the draw covers the mesh's own vertices per instance.
+    expect(mode.geometry.indices).toBeNull();
+    expect(mode.geometry.indexCount).toBe(mesh.vertexCount);
+  });
+
+  it('adopts the mesh index buffer when it has one', () => {
+    const mesh = makeTriangle(true);
+    const mode = new MeshParticles({ geometry: mesh });
+
+    expect(mode.geometry.indices).toBe(mesh.indices);
+    expect(mode.geometry.indexCount).toBe(3);
+  });
+
+  it('declares the shared 40-byte per-instance layout rather than the mesh layout', () => {
+    const mode = new MeshParticles({ geometry: makeTriangle() });
+
+    expect(mode.geometry.stride).toBe(40);
+    expect(mode.geometry.attributes.map(attribute => attribute.name)).toEqual(['a_position', 'a_scale', 'a_rotation', 'a_color', 'a_uvMin', 'a_uvMax']);
+  });
+
+  it('builds one 40-byte instance per live particle', () => {
+    const system = new ParticleSystem({ capacity: 8 });
+    const mode = new MeshParticles({ geometry: makeTriangle() });
+
+    spawnParticles(system, 3);
+    mode.build(system);
+
+    expect(mode.count).toBe(3);
+    expect(mode.data.byteLength).toBeGreaterThanOrEqual(3 * 40);
+
+    const floats = new Float32Array(mode.data);
+
+    // Instance 1 starts at float index 10 (40 bytes / 4).
+    expect(floats[10]).toBe(10);
+    expect(floats[11]).toBe(20);
+  });
+
+  it('packs the same per-instance bytes the quad mode packs', () => {
+    const system = new ParticleSystem({ capacity: 8 });
+    const mesh = new MeshParticles({ geometry: makeTriangle() });
+    const quad = new QuadParticles();
+
+    spawnParticles(system, 4);
+    mesh.build(system);
+    quad.build(system);
+
+    expect(mesh.count).toBe(quad.count);
+    // Byte-for-byte equality is what keeps this mode GPU-eligible: the compute
+    // pipeline emits this layout and no other.
+    expect(new Uint8Array(mesh.data, 0, mesh.count * 40)).toEqual(new Uint8Array(quad.data, 0, quad.count * 40));
+  });
+
+  it('reports zero instances for an empty system', () => {
+    const mode = new MeshParticles({ geometry: makeTriangle() });
+
+    mode.build(new ParticleSystem({ capacity: 8 }));
+
+    expect(mode.count).toBe(0);
+  });
+
+  it('bakes the mesh vertices into both shader sources', () => {
+    const mode = new MeshParticles({ geometry: makeTriangle() });
+    const shader = mode.material.shader;
+
+    expect(shader.glsl?.vertex).toContain('const vec4 c_meshVertices[3]');
+    expect(shader.glsl?.vertex).toContain('vec4(16.0, -16.0, 1.0, 0.0)');
+    expect(shader.wgsl).toContain('array<vec4<f32>, 3>');
+    expect(shader.wgsl).toContain('vec4<f32>(16.0, -16.0, 1.0, 0.0)');
+  });
+
+  it('mixes the mesh UV across the particle frame rather than the whole texture', () => {
+    const mode = new MeshParticles({ geometry: makeTriangle() });
+    const shader = mode.material.shader;
+
+    expect(shader.glsl?.vertex).toContain('mix(a_uvMin, a_uvMax, meshVertex.zw)');
+    expect(shader.wgsl).toContain('mix(input.uvMin, input.uvMax, meshVertex.zw)');
+  });
+
+  it('bakes zero UVs for a mesh without a texcoord attribute', () => {
+    const mode = new MeshParticles({ geometry: makeUntexturedTriangle() });
+
+    // Every vertex carries UV (0, 0), so the mix collapses to uvMin and the
+    // mesh samples one texel of its frame.
+    expect(mode.material.shader.glsl?.vertex).toContain('vec4(-4.0, -4.0, 0.0, 0.0)');
+    expect(mode.material.shader.glsl?.vertex).toContain('vec4(4.0, -4.0, 0.0, 0.0)');
+  });
+});

--- a/site/src/content/api/mesh-particles-options.json
+++ b/site/src/content/api/mesh-particles-options.json
@@ -1,0 +1,71 @@
+{
+  "title": "MeshParticlesOptions",
+  "description": "Construction options for MeshParticles.",
+  "symbol": "MeshParticlesOptions",
+  "kind": "interface",
+  "subsystem": "particles",
+  "importPath": "@codexo/exojs-particles",
+  "tier": "stable",
+  "memberCount": 1,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 1,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Construction options for MeshParticles."
+      ],
+      "importLine": "import { MeshParticlesOptions } from '@codexo/exojs-particles'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "geometry",
+          "signature": "geometry: Geometry",
+          "signatureTokens": [
+            {
+              "text": "geometry",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "The shape one particle draws, in system-local units before the per-particle scale and rotation are applied. Read once, at construction: mutating it afterwards does not re-bake the shader. Its position attribute (a_position/position) supplies the vertex positions and its texcoord attribute (a_texcoord/texcoord/a_uv/uv) the UVs. See MeshParticles for what a geometry without the latter renders as."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-particles/src/renderModes/MeshParticles.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/MeshParticles.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-particles/src/renderModes/MeshParticles.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/MeshParticles.ts"
+}

--- a/site/src/content/api/mesh-particles.json
+++ b/site/src/content/api/mesh-particles.json
@@ -1,16 +1,16 @@
 {
-  "title": "ParticleRenderMode",
-  "description": "Turns a particle system's SoA storage into drawable vertex data. A mode owns the whole \"how\": the vertex layout, the shader pair, the draw model, and the loop that fills the buffer. The backend renderers only upload what it produces and issue the draw it declares, so a new primitive is a new mode rather than a renderer change. Implementations are fixed at system construction (see `ParticleSystemOptions.render`) and default to `QuadParticles`. **Limits of the seam.** The executors are deliberately thin, so a new mode has to stay inside what they can express: - The geometry's `stride` must be a multiple of 4. WebGPU's `queue.writeBuffer` validates its copy size against that alignment and rejects anything else, so a mode with, say, a 38-byte stride draws on WebGL2 and fails validation on WebGPU. - An **indexed, non-instanced** mode always draws the geometry's fixed `indexCount` and ignores count on both backends. That is right for a fixed-topology mode and wrong for one whose element count varies per frame; such a mode needs the executors taught to derive an index count from count first. No mode ships in that shape today. - The **instanced, non-indexed** path draws `geometry.indexCount` vertices per instance, which for a geometry without indices is the vertex count its placeholder `vertexData` implies. A mode on that path therefore has to size `vertexData` to its vertices-per-instance rather than leave it empty.",
-  "symbol": "ParticleRenderMode",
+  "title": "MeshParticles",
+  "description": "One caller-supplied mesh per particle, drawn as a single instanced draw. The cheap counterpart to `RibbonParticles`: the relationship stays one particle, one instance, and the per-instance data is byte-identical to `QuadParticles`'s — instanceAttributes, filled by the same writer. Only the shape changes. That is what makes this mode **GPU-eligible** without touching the compute pipeline: the pipeline emits precisely that layout, so a system on the GPU path binds its instance buffer directly and never calls build. **The mesh is baked into the shader**, read once at construction. Its vertices become a constant `(x, y, u, v)` table addressed by the vertex index, which is the same thing the quad does with its four corners — from the shader's side a mesh is just a quad with more vertices. Consequences worth knowing: - One `MeshParticles` instance means one compiled program per backend, so share a single instance across the systems that draw the same shape rather than constructing one per system. - Mutating the geometry after construction changes nothing. Construct a new mode instead. - The table is shader source, so a mesh of a few hundred vertices is the sensible ceiling; this mode is for sparks, shards, leaves and petals, not for detailed models. **Atlas frames still work.** The mesh's own UVs are treated exactly like the quad's 0..1 corners: the shader mixes them across the particle's resolved frame (`uv = mix(uvMin, uvMax, meshUV)`), so `system.frames` plus a per-particle `textureIndex` selects a frame the same way. A geometry with **no texcoord attribute** therefore carries UV `(0, 0)` on every vertex and the mix degenerates to `uvMin` — the whole mesh samples the single texel at the frame's top-left corner, which on the default 1×1 white texture is exactly \"untextured, tinted by the particle's `color`\". **Sizing is the mesh's own.** Unlike the quad, which derives its footprint from the texture frame, a mesh particle's footprint is whatever its vertex positions say, in system-local units, multiplied by the per-particle `scaleX`/`scaleY`. The texture only supplies colour.",
+  "symbol": "MeshParticles",
   "kind": "class",
   "subsystem": "particles",
   "importPath": "@codexo/exojs-particles",
   "tier": "stable",
-  "memberCount": 12,
+  "memberCount": 13,
   "counts": {
     "constructors": 1,
     "methods": 5,
-    "properties": 6,
+    "properties": 7,
     "events": 0
   },
   "sections": [
@@ -19,13 +19,14 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Turns a particle system's SoA storage into drawable vertex data.",
-        "A mode owns the whole \"how\": the vertex layout, the shader pair, the draw model, and the loop that fills the buffer. The backend renderers only upload what it produces and issue the draw it declares, so a new primitive is a new mode rather than a renderer change.",
-        "Implementations are fixed at system construction (see `ParticleSystemOptions.render`) and default to `QuadParticles`.",
-        "**Limits of the seam.** The executors are deliberately thin, so a new mode has to stay inside what they can express:",
-        "- The geometry's `stride` must be a multiple of 4. WebGPU's `queue.writeBuffer` validates its copy size against that alignment and rejects anything else, so a mode with, say, a 38-byte stride draws on WebGL2 and fails validation on WebGPU. - An **indexed, non-instanced** mode always draws the geometry's fixed `indexCount` and ignores count on both backends. That is right for a fixed-topology mode and wrong for one whose element count varies per frame; such a mode needs the executors taught to derive an index count from count first. No mode ships in that shape today. - The **instanced, non-indexed** path draws `geometry.indexCount` vertices per instance, which for a geometry without indices is the vertex count its placeholder `vertexData` implies. A mode on that path therefore has to size `vertexData` to its vertices-per-instance rather than leave it empty."
+        "One caller-supplied mesh per particle, drawn as a single instanced draw.",
+        "The cheap counterpart to `RibbonParticles`: the relationship stays one particle, one instance, and the per-instance data is byte-identical to `QuadParticles`'s — instanceAttributes, filled by the same writer. Only the shape changes. That is what makes this mode **GPU-eligible** without touching the compute pipeline: the pipeline emits precisely that layout, so a system on the GPU path binds its instance buffer directly and never calls build.",
+        "**The mesh is baked into the shader**, read once at construction. Its vertices become a constant `(x, y, u, v)` table addressed by the vertex index, which is the same thing the quad does with its four corners — from the shader's side a mesh is just a quad with more vertices. Consequences worth knowing:",
+        "- One `MeshParticles` instance means one compiled program per backend, so share a single instance across the systems that draw the same shape rather than constructing one per system. - Mutating the geometry after construction changes nothing. Construct a new mode instead. - The table is shader source, so a mesh of a few hundred vertices is the sensible ceiling; this mode is for sparks, shards, leaves and petals, not for detailed models.",
+        "**Atlas frames still work.** The mesh's own UVs are treated exactly like the quad's 0..1 corners: the shader mixes them across the particle's resolved frame (`uv = mix(uvMin, uvMax, meshUV)`), so `system.frames` plus a per-particle `textureIndex` selects a frame the same way. A geometry with **no texcoord attribute** therefore carries UV `(0, 0)` on every vertex and the mix degenerates to `uvMin` — the whole mesh samples the single texel at the frame's top-left corner, which on the default 1×1 white texture is exactly \"untextured, tinted by the particle's `color`\".",
+        "**Sizing is the mesh's own.** Unlike the quad, which derives its footprint from the texture frame, a mesh particle's footprint is whatever its vertex positions say, in system-local units, multiplied by the per-particle `scaleX`/`scaleY`. The texture only supplies colour."
       ],
-      "importLine": "import { ParticleRenderMode } from '@codexo/exojs-particles'",
+      "importLine": "import { MeshParticles } from '@codexo/exojs-particles'",
       "sourceLink": null
     },
     {
@@ -34,7 +35,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(): ParticleRenderMode",
+          "signature": "new(options: MeshParticlesOptions): MeshParticles",
           "signatureTokens": [
             {
               "text": "new",
@@ -45,6 +46,18 @@
               "kind": "punctuation"
             },
             {
+              "text": "options",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "MeshParticlesOptions",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -53,12 +66,18 @@
               "kind": "punctuation"
             },
             {
-              "text": "ParticleRenderMode",
+              "text": "MeshParticles",
               "kind": "type"
             }
           ],
-          "params": [],
-          "returnType": "ParticleRenderMode",
+          "params": [
+            {
+              "name": "options",
+              "type": "MeshParticlesOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "MeshParticles",
           "description": ""
         }
       ],
@@ -119,7 +138,7 @@
         },
         {
           "name": "_onBufferGrown",
-          "signature": "_onBufferGrown(_data: ArrayBuffer): void",
+          "signature": "_onBufferGrown(data: ArrayBuffer): void",
           "signatureTokens": [
             {
               "text": "_onBufferGrown",
@@ -130,7 +149,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "_data",
+              "text": "data",
               "kind": "param"
             },
             {
@@ -156,7 +175,7 @@
           ],
           "params": [
             {
-              "name": "_data",
+              "name": "data",
               "type": "ArrayBuffer",
               "optional": false
             }
@@ -315,11 +334,11 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Base geometry: topology, named attributes, buffer usage."
+          "description": "The base geometry the executors draw with. It carries the mesh's topology and index buffer — that is what turns the mesh's vertices into triangles — while its attributes describe the per-instance buffer build fills, because that buffer is the only one bound. The placeholder vertexData is sized to the mesh's vertex count so a mesh without indices still draws all of its vertices per instance."
         },
         {
           "name": "gpuEligible",
-          "signature": "gpuEligible: boolean",
+          "signature": "gpuEligible: true",
           "signatureTokens": [
             {
               "text": "gpuEligible",
@@ -330,7 +349,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "boolean",
+              "text": "true",
               "kind": "keyword"
             }
           ],
@@ -340,7 +359,7 @@
         },
         {
           "name": "instanced",
-          "signature": "instanced: boolean",
+          "signature": "instanced: true",
           "signatureTokens": [
             {
               "text": "instanced",
@@ -351,7 +370,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "boolean",
+              "text": "true",
               "kind": "keyword"
             }
           ],
@@ -360,11 +379,11 @@
           "description": "Draw model. true issues an instanced draw against geometry; false a plain draw over the built vertex buffer. Declared here because Geometry carries topology but has no instancing concept."
         },
         {
-          "name": "material",
-          "signature": "material: Material",
+          "name": "mesh",
+          "signature": "mesh: Geometry",
           "signatureTokens": [
             {
-              "text": "material",
+              "text": "mesh",
               "kind": "name"
             },
             {
@@ -372,13 +391,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Material",
+              "text": "Geometry",
               "kind": "type"
             }
           ],
           "params": [],
           "returnType": null,
-          "description": "Shader pair plus uniforms/textures for this mode."
+          "description": "The geometry this mode was constructed with — the shape one particle draws. Owned by the caller: destroy leaves it alone, so one mesh can back several modes."
         },
         {
           "name": "count",
@@ -421,6 +440,27 @@
           "params": [],
           "returnType": null,
           "description": "The buffer the renderer uploads. Valid until the next build."
+        },
+        {
+          "name": "material",
+          "signature": "material: Material",
+          "signatureTokens": [
+            {
+              "text": "material",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Material",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Shader pair plus uniforms/textures for this mode."
         }
       ],
       "paragraphs": [],
@@ -434,11 +474,11 @@
       "paragraphs": [],
       "importLine": null,
       "sourceLink": {
-        "label": "packages/exojs-particles/src/renderModes/ParticleRenderMode.ts",
-        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/ParticleRenderMode.ts"
+        "label": "packages/exojs-particles/src/renderModes/MeshParticles.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/MeshParticles.ts"
       }
     }
   ],
-  "sourcePath": "packages/exojs-particles/src/renderModes/ParticleRenderMode.ts",
-  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/ParticleRenderMode.ts"
+  "sourcePath": "packages/exojs-particles/src/renderModes/MeshParticles.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/MeshParticles.ts"
 }

--- a/site/src/content/api/particle-system.json
+++ b/site/src/content/api/particle-system.json
@@ -2865,7 +2865,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Per-slot atlas frame selector: an index into frames. **Anything that is not a valid explicit index shows frame 0.** The array is zero-initialised, so a particle whose index was never set already shows frame 0, and an index at or past the declared frame count falls back to the same frame rather than to the last one — one rule instead of two different behaviours depending on how the index went wrong. It holds identically on the CPU packer and in the compute pipeline, so a system looks the same on either backend. Ignored entirely when the system declares no frames: the whole texture is then the single frame."
         },
         {
           "name": "velX",
@@ -3219,7 +3219,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Atlas frames declared on this system, or empty when the texture is used as a single frame. Each particle's textureIndex[i] selects an entry from this list; out-of-range indices are clamped to 0."
+          "description": "Atlas frames declared on this system, or empty when the texture is used as a single frame. Each particle's textureIndex selects an entry from this list; anything out of range shows frame 0."
         },
         {
           "name": "gpuMode",

--- a/site/src/content/api/quad-particles.json
+++ b/site/src/content/api/quad-particles.json
@@ -1,6 +1,6 @@
 {
   "title": "QuadParticles",
-  "description": "The default render mode: one textured, rotated, tinted quad per particle, drawn as a single instanced triangle-list. Layout of the per-instance buffer build fills (40 bytes, 6 attributes): ``` a_position f32x2 (offset 0, 8 bytes) particle position (system-local) a_scale f32x2 (offset 8, 8 bytes) a_rotation f32 (offset 16, 4 bytes) degrees a_color u8x4 (offset 20, 4 bytes) RGBA tint, normalised a_uvMin f32x2 (offset 24, 8 bytes) pre-resolved frame uvMin a_uvMax f32x2 (offset 32, 8 bytes) pre-resolved frame uvMax ``` UVs are baked per-particle so the system can carry an atlas of frames — `system.frames` declares the rectangles and each particle's `textureIndex` selects one. build resolves frame-rectangle to UVs once per particle per frame; no per-instance shader-side indexing needed. This is the only GPU-eligible mode: the system's compute pipeline emits exactly this layout into its instance buffer, so a system running on the GPU path can bind that buffer directly and skip build entirely.",
+  "description": "The default render mode: one textured, rotated, tinted quad per particle, drawn as a single instanced triangle-list. build fills the shared 40-byte per-instance layout described by instanceAttributes. UVs are baked per-particle so the system can carry an atlas of frames — `system.frames` declares the rectangles and each particle's `textureIndex` selects one, resolved to UVs once per particle per frame; no per-instance shader-side indexing needed. GPU-eligible: the system's compute pipeline emits exactly that layout into its instance buffer, so a system running on the GPU path can bind that buffer directly and skip build entirely.",
   "symbol": "QuadParticles",
   "kind": "class",
   "subsystem": "particles",
@@ -20,10 +20,8 @@
       "members": [],
       "paragraphs": [
         "The default render mode: one textured, rotated, tinted quad per particle, drawn as a single instanced triangle-list.",
-        "Layout of the per-instance buffer build fills (40 bytes, 6 attributes):",
-        "``` a_position f32x2 (offset 0, 8 bytes) particle position (system-local) a_scale f32x2 (offset 8, 8 bytes) a_rotation f32 (offset 16, 4 bytes) degrees a_color u8x4 (offset 20, 4 bytes) RGBA tint, normalised a_uvMin f32x2 (offset 24, 8 bytes) pre-resolved frame uvMin a_uvMax f32x2 (offset 32, 8 bytes) pre-resolved frame uvMax ```",
-        "UVs are baked per-particle so the system can carry an atlas of frames — `system.frames` declares the rectangles and each particle's `textureIndex` selects one. build resolves frame-rectangle to UVs once per particle per frame; no per-instance shader-side indexing needed.",
-        "This is the only GPU-eligible mode: the system's compute pipeline emits exactly this layout into its instance buffer, so a system running on the GPU path can bind that buffer directly and skip build entirely."
+        "build fills the shared 40-byte per-instance layout described by instanceAttributes. UVs are baked per-particle so the system can carry an atlas of frames — `system.frames` declares the rectangles and each particle's `textureIndex` selects one, resolved to UVs once per particle per frame; no per-instance shader-side indexing needed.",
+        "GPU-eligible: the system's compute pipeline emits exactly that layout into its instance buffer, so a system running on the GPU path can bind that buffer directly and skip build entirely."
       ],
       "importLine": "import { QuadParticles } from '@codexo/exojs-particles'",
       "sourceLink": null
@@ -336,7 +334,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Whether this mode can run while the system is in GPU compute mode. Mirrors UpdateModule.wgsl(): a mode that cannot forces the whole system onto the CPU path, silently and observably via ParticleSystem.gpuMode. A GPU-eligible mode's layout must match what the compute pipeline emits into gpuState.instanceBuffer — today that is QuadParticles's layout, and it is the only GPU-eligible mode."
+          "description": "Whether this mode can run while the system is in GPU compute mode. Mirrors UpdateModule.wgsl(): a mode that cannot forces the whole system onto the CPU path, silently and observably via ParticleSystem.gpuMode. A GPU-eligible mode's layout must match what the compute pipeline emits into gpuState.instanceBuffer — the shared 40-byte per-instance layout (instanceAttributes). QuadParticles and MeshParticles both declare exactly that layout and differ only in the shape they expand it into, which is why both are eligible without the compute shader knowing either."
         },
         {
           "name": "instanced",

--- a/site/src/content/api/ribbon-particles.json
+++ b/site/src/content/api/ribbon-particles.json
@@ -376,7 +376,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Whether this mode can run while the system is in GPU compute mode. Mirrors UpdateModule.wgsl(): a mode that cannot forces the whole system onto the CPU path, silently and observably via ParticleSystem.gpuMode. A GPU-eligible mode's layout must match what the compute pipeline emits into gpuState.instanceBuffer — today that is QuadParticles's layout, and it is the only GPU-eligible mode."
+          "description": "Whether this mode can run while the system is in GPU compute mode. Mirrors UpdateModule.wgsl(): a mode that cannot forces the whole system onto the CPU path, silently and observably via ParticleSystem.gpuMode. A GPU-eligible mode's layout must match what the compute pipeline emits into gpuState.instanceBuffer — the shared 40-byte per-instance layout (instanceAttributes). QuadParticles and MeshParticles both declare exactly that layout and differ only in the shape they expand it into, which is why both are eligible without the compute shader knowing either."
         },
         {
           "name": "instanced",

--- a/test/rendering/browser/webgl2-particles.test.ts
+++ b/test/rendering/browser/webgl2-particles.test.ts
@@ -20,11 +20,12 @@ import type { Application } from '#core/Application';
 import { Color } from '#core/Color';
 import { materializeRendererBindings } from '#extensions/materialize';
 import { Container } from '#rendering/Container';
+import { Geometry } from '#rendering/geometry/Geometry';
 import type { RenderNode } from '#rendering/RenderNode';
 import { Texture } from '#rendering/texture/Texture';
 import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
 
-import { particlesExtension, ParticleSystem, RibbonParticles } from '../../../packages/exojs-particles/src/index';
+import { MeshParticles, particlesExtension, ParticleSystem, RibbonParticles } from '../../../packages/exojs-particles/src/index';
 import { readWebGl2Pixel } from './_backendSetup';
 import { wireCoreRenderers } from './_coreRenderers';
 import { expectPixelNear } from './_pixels';
@@ -101,6 +102,43 @@ const createSolidTexture = (color: string, width = 16, height = 16): Texture => 
 
   return new Texture(src);
 };
+
+/** A 16×16 texture, red in its left half and blue in its right half. */
+const createSplitTexture = (): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = 16;
+  src.height = 16;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = '#ff0000';
+  ctx.fillRect(0, 0, 8, 16);
+  ctx.fillStyle = '#0000ff';
+  ctx.fillRect(8, 0, 8, 16);
+
+  return new Texture(src);
+};
+
+/**
+ * A right triangle spanning ±16 system-local units with the right angle at its
+ * top-left corner, UVs running 0..1 across its bounding box. Non-indexed, so
+ * the instanced draw derives its vertex count from the mesh itself.
+ */
+const createTriangleMesh = (): Geometry =>
+  new Geometry({
+    attributes: [
+      { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+      { name: 'a_uv', size: 2, type: 'f32', normalized: false, offset: 8 },
+    ],
+    // prettier-ignore
+    vertexData: new Float32Array([
+      -16, -16, 0, 0,
+       16, -16, 1, 0,
+      -16,  16, 0, 1,
+    ]),
+    stride: 16,
+  });
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -317,6 +355,91 @@ describe('WebGL2 ParticleSystem — ribbon', () => {
       expectPixelNear(readWebGl2Pixel(backend, 47, 32), [0, 255, 0, 255]);
     } finally {
       root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+describe('WebGL2 ParticleSystem — mesh', () => {
+  test('a particle draws the supplied mesh, sampling its frame through the mesh UVs', async () => {
+    const backend = await createBackend();
+    const texture = createSplitTexture();
+    const mesh = createTriangleMesh();
+    const root = new Container();
+    // The mesh mode bakes its own shader pair around the geometry, which only a
+    // real backend ever compiles — a broken one draws nothing and fails the
+    // interior assertions below rather than passing silently in the node lanes.
+    const system = new ParticleSystem(texture, { capacity: 4, render: new MeshParticles({ geometry: mesh }) });
+
+    try {
+      const slot = system.spawn();
+
+      system.posX[slot] = 0;
+      system.posY[slot] = 0;
+      system.scaleX[slot] = 1;
+      system.scaleY[slot] = 1;
+      system.rotations[slot] = 0;
+      system.color[slot] = 0xffffffff; // opaque white — texture color passes through
+      system.lifetime[slot] = 1;
+
+      // At (32, 32) the triangle covers x 16..48, y 16..48 below the diagonal
+      // running from (48, 16) to (16, 48).
+      system.setPosition(32, 32);
+      root.addChild(system);
+
+      render(backend, root);
+
+      // Inside, left of the mesh's own UV midpoint: samples the texture's red half.
+      expectPixelNear(readWebGl2Pixel(backend, 24, 24), [255, 0, 0, 255]);
+      // Inside, right of it: samples the blue half. Both together prove the mesh
+      // UVs reach the sampler rather than the quad's corner UVs.
+      expectPixelNear(readWebGl2Pixel(backend, 38, 18), [0, 0, 255, 255]);
+      // Inside the mesh's bounding box but past its hypotenuse — the assertion a
+      // mesh drawn as a quad would fail.
+      expectPixelNear(readWebGl2Pixel(backend, 44, 44), [0, 0, 0, 255]);
+      // A safely mesh-free corner remains the clear color.
+      expectPixelNear(readWebGl2Pixel(backend, 4, 4), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      mesh.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('the per-particle scale and rotation drive the mesh', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ffffff', 16, 16);
+    const mesh = createTriangleMesh();
+    const root = new Container();
+    const system = new ParticleSystem(texture, { capacity: 4, render: new MeshParticles({ geometry: mesh }) });
+
+    try {
+      const slot = system.spawn();
+
+      system.posX[slot] = 0;
+      system.posY[slot] = 0;
+      system.scaleX[slot] = 0.5;
+      system.scaleY[slot] = 0.5;
+      // 180° puts the right angle at the bottom-right instead of the top-left.
+      system.rotations[slot] = 180;
+      system.color[slot] = new Color(0, 255, 0).toRgba();
+      system.lifetime[slot] = 1;
+
+      system.setPosition(32, 32);
+      root.addChild(system);
+
+      render(backend, root);
+
+      // Half scale: the mesh now spans ±8, so the far corner of the unscaled
+      // footprint is empty while the rotated interior is filled.
+      expectPixelNear(readWebGl2Pixel(backend, 38, 38), [0, 255, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 26, 26), [0, 0, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 20, 32), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      mesh.destroy();
       texture.destroy();
       backend.destroy();
     }

--- a/test/rendering/browser/webgpu-particles.test.ts
+++ b/test/rendering/browser/webgpu-particles.test.ts
@@ -28,13 +28,15 @@
 
 import type { Application } from '#core/Application';
 import { Color } from '#core/Color';
+import { Time } from '#core/Time';
 import { materializeRendererBindings } from '#extensions/materialize';
 import { Container } from '#rendering/Container';
+import { Geometry } from '#rendering/geometry/Geometry';
 import type { RenderNode } from '#rendering/RenderNode';
 import { Texture } from '#rendering/texture/Texture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
-import { particlesExtension, ParticleSystem, RibbonParticles } from '../../../packages/exojs-particles/src/index';
+import { ApplyForce, MeshParticles, particlesExtension, ParticleSystem, RibbonParticles } from '../../../packages/exojs-particles/src/index';
 import { readWebGpuPixels } from './_backendSetup';
 import { wireCoreRenderers } from './_coreRenderers';
 import { expectPixelNear } from './_pixels';
@@ -88,6 +90,43 @@ const createSolidTexture = (color: string, size = 16): Texture => {
 
   return new Texture(src);
 };
+
+/** A 16×16 texture, red in its left half and blue in its right half. */
+const createSplitTexture = (): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = 16;
+  src.height = 16;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = '#ff0000';
+  ctx.fillRect(0, 0, 8, 16);
+  ctx.fillStyle = '#0000ff';
+  ctx.fillRect(8, 0, 8, 16);
+
+  return new Texture(src);
+};
+
+/**
+ * A right triangle spanning ±16 system-local units with the right angle at its
+ * top-left corner, UVs running 0..1 across its bounding box. Non-indexed, so
+ * the instanced draw derives its vertex count from the mesh itself.
+ */
+const createTriangleMesh = (): Geometry =>
+  new Geometry({
+    attributes: [
+      { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+      { name: 'a_uv', size: 2, type: 'f32', normalized: false, offset: 8 },
+    ],
+    // prettier-ignore
+    vertexData: new Float32Array([
+      -16, -16, 0, 0,
+       16, -16, 1, 0,
+      -16,  16, 0, 1,
+    ]),
+    stride: 16,
+  });
 
 const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
 
@@ -253,6 +292,166 @@ describe('WebGPU ParticleSystem — ribbon', () => {
       expectPixelNear(readPixel(4, 4), [0, 0, 0, 255]);
     } finally {
       root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+describe('WebGPU ParticleSystem — mesh', () => {
+  test('a particle draws the supplied mesh, sampling its frame through the mesh UVs', async ctx => {
+    const backend = await setupBackend();
+
+    const texture = createSplitTexture();
+    const mesh = createTriangleMesh();
+    const root = new Container();
+    // The mesh mode bakes its own WGSL around the geometry, which only a real
+    // device ever compiles — a broken module draws nothing and fails the
+    // interior assertions below rather than passing silently in the node lanes.
+    const system = new ParticleSystem(texture, { capacity: 4, render: new MeshParticles({ geometry: mesh }) });
+
+    try {
+      const slot = system.spawn();
+
+      system.posX[slot] = 0;
+      system.posY[slot] = 0;
+      system.scaleX[slot] = 1;
+      system.scaleY[slot] = 1;
+      system.rotations[slot] = 0;
+      system.color[slot] = 0xffffffff; // opaque white — texture color passes through
+      system.lifetime[slot] = 1;
+
+      // At (32, 32) the triangle covers x 16..48, y 16..48 below the diagonal
+      // running from (48, 16) to (16, 48).
+      system.setPosition(32, 32);
+      root.addChild(system);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      const readPixel = readWebGpuPixels(backend, canvasSize);
+
+      // Inside, left of the mesh's own UV midpoint: samples the texture's red half.
+      expectPixelNear(readPixel(24, 24), [255, 0, 0, 255]);
+      // Inside, right of it: samples the blue half. Both together prove the mesh
+      // UVs reach the sampler rather than the quad's corner UVs.
+      expectPixelNear(readPixel(38, 18), [0, 0, 255, 255]);
+      // Inside the mesh's bounding box but past its hypotenuse — the assertion a
+      // mesh drawn as a quad would fail.
+      expectPixelNear(readPixel(44, 44), [0, 0, 0, 255]);
+      // A safely mesh-free corner remains the clear color.
+      expectPixelNear(readPixel(4, 4), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      mesh.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('the per-particle scale and rotation drive the mesh', async ctx => {
+    const backend = await setupBackend();
+
+    const texture = createSolidTexture('#ffffff');
+    const mesh = createTriangleMesh();
+    const root = new Container();
+    const system = new ParticleSystem(texture, { capacity: 4, render: new MeshParticles({ geometry: mesh }) });
+
+    try {
+      const slot = system.spawn();
+
+      system.posX[slot] = 0;
+      system.posY[slot] = 0;
+      system.scaleX[slot] = 0.5;
+      system.scaleY[slot] = 0.5;
+      // 180° puts the right angle at the bottom-right instead of the top-left.
+      system.rotations[slot] = 180;
+      system.color[slot] = new Color(0, 255, 0).toRgba();
+      system.lifetime[slot] = 1;
+
+      system.setPosition(32, 32);
+      root.addChild(system);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      const readPixel = readWebGpuPixels(backend, canvasSize);
+
+      // Half scale: the mesh now spans ±8, so the far corner of the unscaled
+      // footprint is empty while the rotated interior is filled.
+      expectPixelNear(readPixel(38, 38), [0, 255, 0, 255]);
+      expectPixelNear(readPixel(26, 26), [0, 0, 0, 255]);
+      expectPixelNear(readPixel(20, 32), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      mesh.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+describe('WebGPU ParticleSystem — mesh on the GPU compute path', () => {
+  test('a mesh system runs its simulation on the GPU and draws from the compute output', async ctx => {
+    const backend = await setupBackend();
+
+    const texture = createSolidTexture('#ffffff');
+    const mesh = createTriangleMesh();
+    const root = new Container();
+    // Handing the system the backend's own device puts it on the GPU path at
+    // the first update, so the compute pipeline compiles for real and writes
+    // the instance buffer this draw binds directly. The mesh mode declares the
+    // layout that pipeline emits; if it did not, nothing would land here.
+    const system = new ParticleSystem(texture, {
+      capacity: 4,
+      device: getBackendDevice(backend),
+      render: new MeshParticles({ geometry: mesh }),
+    });
+
+    try {
+      system.addUpdateModule(new ApplyForce(0, 0));
+
+      const slot = system.spawn();
+
+      system.posX[slot] = 0;
+      system.posY[slot] = 0;
+      system.scaleX[slot] = 1;
+      system.scaleY[slot] = 1;
+      system.rotations[slot] = 0;
+      system.color[slot] = new Color(0, 255, 0).toRgba();
+      system.lifetime[slot] = 10;
+
+      system.setPosition(32, 32);
+      root.addChild(system);
+
+      // The system tears its GPU state down the first time it sees a backend
+      // it has not been collected against, so the first frame is always the
+      // CPU path. Render once to bind the backend, then update again — that
+      // second update is the one that compiles the compute pipeline.
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      system.update(Time.zero.clone().set(16));
+
+      expect(system.gpuMode).toBe(true);
+
+      if (!(await renderScene(ctx, backend, root))) {
+        return;
+      }
+
+      const readPixel = readWebGpuPixels(backend, canvasSize);
+
+      // The same triangle the CPU path draws, this time expanded from an
+      // instance record the compute shader packed.
+      expectPixelNear(readPixel(24, 24), [0, 255, 0, 255]);
+      expectPixelNear(readPixel(44, 44), [0, 0, 0, 255]);
+      expectPixelNear(readPixel(4, 4), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      mesh.destroy();
       texture.destroy();
       backend.destroy();
     }


### PR DESCRIPTION
Two follow-ups to the render-mode seam (#488) and the ribbon (#489).

**`MeshParticles`** — each particle instances a caller-supplied `Geometry` instead of a quad. It keeps the same 40-byte per-instance layout `QuadParticles` uses, which has two deliberate consequences: it is **GPU-eligible without touching the compute shader** (verified: `ParticleGpuState._buildShader` writes only position/scale/rotation/colour/uvMin/uvMax, nothing quad-specific — no corner expansion, no vertex-count assumption), and atlas frames keep working because the mesh's own UVs are mixed into `uvMin..uvMax` exactly as the quad's 0..1 corners are. The layout is now literally shared between the two modes (`ParticleInstanceWriter`) rather than copied, so they cannot drift from the compute output.

**Out-of-range `textureIndex` unified on frame 0.** The compute shader clamped to the *last* frame while the CPU packer fell back to frame *0*, so the same system showed a different frame depending on backend and mode. Frame 0 wins because `textureIndex` is a zero-initialised `Uint16Array` — a never-set index already shows frame 0, so this gives one rule instead of two different wrong-index behaviours. Clamping to last would be animation-hold semantics, which do not apply to a frame selector.

**Known limitation, stated plainly.** Both executors bind exactly one vertex buffer with a single divisor (`buffers: [vertexLayout]` on WebGPU; one `divisor` for all attributes on WebGL2), so a mode cannot supply per-vertex data alongside per-instance data. `MeshParticles` therefore bakes the mesh into a constant table in generated shader source, addressed by vertex index — the direct generalisation of how the quad derives its four corners. It required no renderer change and is fully tested on real hardware, but it means one `MeshParticles` instance compiles one program, mutating the geometry afterwards is a no-op, and a few hundred vertices is the sensible ceiling. All documented in JSDoc. Teaching the seam to bind a second, per-vertex buffer would lift the ceiling without changing this public API, and is filed as a follow-up.

**Verification.** 189 package tests, 8996 node-gate tests, 270 WebGL2 and 297 WebGPU browser tests. New real-GL and real-WebGPU specs render an actual triangle and assert a point inside the mesh AABB but past its hypotenuse stays background — the assertion a mesh wrongly drawn as a quad would fail. A WebGPU spec additionally drives the system through the compute path and asserts the triangle came from `gpuState.instanceBuffer`; this is the first test anywhere that compiles the composite compute shader on a real device. Every new spec was confirmed to have teeth by breaking the shader, watching it fail, and reverting.