### PR TITLE
feat(particles): bind mesh geometry as a second vertex buffer

### DIFF
--- a/packages/exojs-particles/src/public.ts
+++ b/packages/exojs-particles/src/public.ts
@@ -11,6 +11,8 @@ export type { ParticleSystemOptions } from './ParticleSystem';
 export { ParticleSystem } from './ParticleSystem';
 export type { MeshParticlesOptions } from './renderModes/MeshParticles';
 export { MeshParticles } from './renderModes/MeshParticles';
+export type { ParticleBufferLayoutOptions } from './renderModes/ParticleBufferLayout';
+export { ParticleBufferLayout } from './renderModes/ParticleBufferLayout';
 export { ParticleMaterial } from './renderModes/ParticleMaterial';
 export { ParticleRenderMode } from './renderModes/ParticleRenderMode';
 export { QuadParticles } from './renderModes/QuadParticles';

--- a/packages/exojs-particles/src/renderModes/MeshParticles.ts
+++ b/packages/exojs-particles/src/renderModes/MeshParticles.ts
@@ -4,12 +4,25 @@ import { Geometry, ShaderSource } from '@codexo/exojs';
 import type { ParticleSystem } from '#ParticleSystem';
 
 import fragmentSource from '../renderers/glsl/particle.frag';
+import vertexSource from './glsl/mesh.vert';
+import { assertVertexGeometryCompatible, ParticleBufferLayout } from './ParticleBufferLayout';
 import { instanceAttributes, instanceStrideBytes, ParticleInstanceWriter } from './ParticleInstanceWriter';
 import { ParticleMaterial } from './ParticleMaterial';
 import { ParticleRenderMode } from './ParticleRenderMode';
 
-/** Floats one entry of the baked mesh vertex table occupies: x, y, u, v. */
+/** Floats one entry of the normalised mesh vertex table occupies: x, y, u, v. */
 const floatsPerMeshVertex = 4;
+
+const meshVertexStrideBytes = floatsPerMeshVertex * Float32Array.BYTES_PER_ELEMENT;
+
+/**
+ * Layout the normalised mesh table is read back with. Named apart from the
+ * per-instance attributes because both sets bind into the same shader.
+ */
+const meshVertexAttributes: readonly GeometryAttribute[] = [
+  { name: 'a_meshPosition', size: 2, type: 'f32', normalized: false, offset: 0 },
+  { name: 'a_meshTexcoord', size: 2, type: 'f32', normalized: false, offset: 8 },
+];
 
 const componentByteSizes: Record<AttributeType, number> = {
   f32: 4,
@@ -26,13 +39,12 @@ const texcoordAttributeNames = new Set<string>(['a_texcoord', 'texcoord', 'a_uv'
 export interface MeshParticlesOptions {
   /**
    * The shape one particle draws, in system-local units before the
-   * per-particle scale and rotation are applied. Read once, at construction:
-   * mutating it afterwards does not re-bake the shader.
+   * per-particle scale and rotation are applied.
    *
    * Its position attribute (`a_position`/`position`) supplies the vertex
    * positions and its texcoord attribute (`a_texcoord`/`texcoord`/`a_uv`/`uv`)
    * the UVs. See {@link MeshParticles} for what a geometry without the latter
-   * renders as.
+   * renders as, and for how to make a mutation take effect.
    */
   readonly geometry: Geometry;
 }
@@ -66,17 +78,24 @@ const readComponent = (view: DataView, attribute: GeometryAttribute, byteOffset:
 };
 
 /**
- * Reads a mesh geometry's (x, y, u, v) per vertex into one flat table.
+ * Read a mesh geometry's (x, y, u, v) per vertex into one flat table.
+ *
+ * The shader this mode ships is fixed, so it binds fixed attribute names and a
+ * fixed stride, while a caller's mesh may declare any names in any supported
+ * types. Normalising here is what lets one compiled program serve every mesh.
  *
  * `Geometry` guarantees a position attribute exists — it resolves one in its
  * own constructor and throws otherwise — so the same resolution order is
  * mirrored here rather than re-validated. A geometry without a texcoord
  * attribute leaves the UV columns at zero.
+ *
+ * @param out Table to fill; a new one is allocated when it is the wrong size,
+ *   so a re-read after an in-place mutation reuses the existing allocation.
  */
-const readMeshTable = (mesh: Geometry): Float32Array => {
+const readMeshTable = (mesh: Geometry, out: Float32Array | null = null): Float32Array => {
   const { attributes, stride, vertexData } = mesh;
   const vertexCount = mesh.vertexCount;
-  const table = new Float32Array(vertexCount * floatsPerMeshVertex);
+  const table = out !== null && out.length === vertexCount * floatsPerMeshVertex ? out : new Float32Array(vertexCount * floatsPerMeshVertex);
   const view =
     vertexData instanceof Float32Array ? new DataView(vertexData.buffer, vertexData.byteOffset, vertexData.byteLength) : new DataView(vertexData);
 
@@ -87,14 +106,17 @@ const readMeshTable = (mesh: Geometry): Float32Array => {
 
   for (let i = 0; i < vertexCount; i++) {
     const vertexStart = i * stride;
-    const out = i * floatsPerMeshVertex;
+    const target = i * floatsPerMeshVertex;
 
-    table[out + 0] = readComponent(view, position, vertexStart + position.offset);
-    table[out + 1] = readComponent(view, position, vertexStart + position.offset + componentByteSizes[position.type]);
+    table[target + 0] = readComponent(view, position, vertexStart + position.offset);
+    table[target + 1] = readComponent(view, position, vertexStart + position.offset + componentByteSizes[position.type]);
 
     if (texcoord !== null) {
-      table[out + 2] = readComponent(view, texcoord, vertexStart + texcoord.offset);
-      table[out + 3] = readComponent(view, texcoord, vertexStart + texcoord.offset + componentByteSizes[texcoord.type]);
+      table[target + 2] = readComponent(view, texcoord, vertexStart + texcoord.offset);
+      table[target + 3] = readComponent(view, texcoord, vertexStart + texcoord.offset + componentByteSizes[texcoord.type]);
+    } else {
+      table[target + 2] = 0;
+      table[target + 3] = 0;
     }
   }
 
@@ -102,114 +124,17 @@ const readMeshTable = (mesh: Geometry): Float32Array => {
 };
 
 /**
- * Render a number as a shader float literal. Both GLSL ES 3.00 and WGSL accept
- * exponent forms as written, but an integral value needs the decimal point to
- * read as a float rather than an int.
- */
-const formatFloat = (value: number): string => {
-  const text = String(value);
-
-  return /[.eE]/.test(text) ? text : `${text}.0`;
-};
-
-const glslMeshTable = (table: Float32Array): string => {
-  const count = table.length / floatsPerMeshVertex;
-  const entries: string[] = [];
-
-  for (let i = 0; i < count; i++) {
-    const o = i * floatsPerMeshVertex;
-
-    entries.push(`    vec4(${formatFloat(table[o]!)}, ${formatFloat(table[o + 1]!)}, ${formatFloat(table[o + 2]!)}, ${formatFloat(table[o + 3]!)})`);
-  }
-
-  return `const vec4 c_meshVertices[${count}] = vec4[${count}](\n${entries.join(',\n')}\n);`;
-};
-
-const wgslMeshTable = (table: Float32Array): string => {
-  const count = table.length / floatsPerMeshVertex;
-  const entries: string[] = [];
-
-  for (let i = 0; i < count; i++) {
-    const o = i * floatsPerMeshVertex;
-
-    entries.push(
-      `    vec4<f32>(${formatFloat(table[o]!)}, ${formatFloat(table[o + 1]!)}, ${formatFloat(table[o + 2]!)}, ${formatFloat(table[o + 3]!)})`,
-    );
-  }
-
-  return `var<private> meshVertices: array<vec4<f32>, ${count}> = array<vec4<f32>, ${count}>(\n${entries.join(',\n')}\n);`;
-};
-
-/**
- * GLSL vertex stage for {@link MeshParticles}, baked around one mesh's vertex
- * table. Line for line the quad's `glsl/particle.vert` with two substitutions:
- * the corner derived from `gl_VertexID` becomes a lookup into the table at
- * `gl_VertexID`, and the corner-selected UV becomes a mix across the whole
- * mesh UV.
- *
- * Generated rather than shipped as a `.vert` file because the table is
- * per-mesh: the executors bind exactly one vertex buffer, which the
- * per-instance data already occupies, and neither backend lets a mode
- * contribute a uniform of its own. Baking the mesh into the source is what
- * keeps this mode inside the seam. The fragment stage needs no baking, so it
- * is the shipped quad fragment shader unchanged.
- */
-export const meshParticleVertexGlsl = (table: Float32Array): string => `#version 300 es
-precision highp float;
-precision highp int;
-
-// Per-instance attributes (one entry per particle, 40 bytes total).
-layout(location = 0) in vec2 a_position;         // particle position in system-local space
-layout(location = 1) in vec2 a_scale;            // particle scale
-layout(location = 2) in float a_rotation;        // particle rotation in degrees
-layout(location = 3) in vec4 a_color;            // RGBA tint
-layout(location = 4) in vec2 a_uvMin;            // top-left UV (u, v) — pre-resolved per instance
-layout(location = 5) in vec2 a_uvMax;            // bottom-right UV (u, v) — pre-resolved per instance
-
-uniform mat3 u_projection;
-uniform mat3 u_systemTransform;
-
-// The mesh's own vertices as (x, y, u, v), addressed by the value the index
-// buffer supplies — the same role gl_VertexID plays for the quad's corners.
-${glslMeshTable(table)}
-
-out vec2 v_texcoord;
-out vec4 v_color;
-
-void main(void) {
-    vec4 meshVertex = c_meshVertices[gl_VertexID];
-    vec2 local = meshVertex.xy;
-
-    // Per-particle scale + rotation, identical to the quad's.
-    vec2 rotation = vec2(sin(radians(a_rotation)), cos(radians(a_rotation)));
-    vec2 transformed = vec2(
-        (local.x * (a_scale.x * rotation.y)) + (local.y * (a_scale.y * rotation.x)),
-        (local.x * (a_scale.x * -rotation.x)) + (local.y * (a_scale.y * rotation.y))
-    );
-
-    vec3 worldPos = vec3(transformed + a_position, 1.0);
-
-    gl_Position = vec4((u_projection * u_systemTransform * worldPos).xy, 0.0, 1.0);
-
-    // The mesh's own UVs address the particle's frame rather than the whole
-    // texture, so a mesh particle still selects an atlas frame.
-    v_texcoord = mix(a_uvMin, a_uvMax, meshVertex.zw);
-
-    v_color = vec4(a_color.rgb * a_color.a, a_color.a);
-}
-`;
-
-/**
- * WGSL counterpart of {@link meshParticleVertexGlsl} plus the quad's fragment
- * stage. Vertex and fragment entry points share one source per WGSL
- * convention, and the per-instance attributes bind by `@location`, matching
- * the declaration order and byte offsets of `instanceAttributes`.
+ * WGSL counterpart of `glsl/mesh.vert` plus the quad's fragment stage. Vertex
+ * and fragment entry points share one source per WGSL convention. The
+ * per-instance attributes bind at `@location(0..5)`, matching the declaration
+ * order and byte offsets of {@link instanceAttributes}, and the mesh's own
+ * vertices follow at `@location(6..7)` from the second vertex buffer.
  *
  * The uniform struct is the one the WebGPU particle renderer writes for every
  * mode, so `localBounds` and `uvBounds` are declared but unused here: a mesh
  * carries its own local footprint rather than taking it from the texture frame.
  */
-export const meshParticleWgsl = (table: Float32Array): string => `
+export const meshParticleWgsl = `
 struct ProjectionUniforms {
     projection: mat4x4<f32>,
     translation: mat4x4<f32>,
@@ -227,19 +152,17 @@ var particleTexture: texture_2d<f32>;
 @group(1) @binding(1)
 var particleSampler: sampler;
 
-// The mesh's own vertices as (x, y, u, v), addressed by the value the index
-// buffer supplies — the same role vertex_index plays for the quad's corners.
-${wgslMeshTable(table)}
-
-// Per-instance attributes (one entry per particle, 40 bytes total).
 struct VertexInput {
-    @builtin(vertex_index) vertexIndex: u32,
+    // Per-instance (one entry per particle, 40 bytes total).
     @location(0) translation: vec2<f32>,
     @location(1) scale: vec2<f32>,
     @location(2) rotation: f32,
     @location(3) color: vec4<f32>,
     @location(4) uvMin: vec2<f32>,            // pre-resolved frame UV (top-left)
     @location(5) uvMax: vec2<f32>,            // pre-resolved frame UV (bottom-right)
+    // Per-vertex, from the mode's mesh geometry.
+    @location(6) meshPosition: vec2<f32>,
+    @location(7) meshTexcoord: vec2<f32>,
 };
 
 struct VertexOutput {
@@ -250,8 +173,7 @@ struct VertexOutput {
 
 @vertex
 fn vertexMain(input: VertexInput) -> VertexOutput {
-    let meshVertex = meshVertices[input.vertexIndex];
-    let localPosition = meshVertex.xy;
+    let localPosition = input.meshPosition;
 
     let radians = radians(input.rotation);
     let sinValue = sin(radians);
@@ -266,7 +188,7 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     output.position = uniforms.projection * uniforms.translation * vec4<f32>(rotated, 0.0, 1.0);
     // The mesh's own UVs address the particle's frame rather than the whole
     // texture, so a mesh particle still selects an atlas frame.
-    output.texcoord = mix(input.uvMin, input.uvMax, meshVertex.zw);
+    output.texcoord = mix(input.uvMin, input.uvMax, input.meshTexcoord);
     output.color = vec4(input.color.rgb * input.color.a, input.color.a);
 
     return output;
@@ -292,20 +214,16 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
  * layout, so a system on the GPU path binds its instance buffer directly and
  * never calls {@link build}.
  *
- * **The mesh is baked into the shader**, read once at construction. Its
- * vertices become a constant `(x, y, u, v)` table addressed by the vertex
- * index, which is the same thing the quad does with its four corners — from the
- * shader's side a mesh is just a quad with more vertices. Consequences worth
- * knowing:
+ * **The mesh rides in its own vertex buffer**, alongside the per-instance one.
+ * The shader is fixed and shared, so any number of `MeshParticles` compile one
+ * program per backend regardless of how many distinct shapes they draw, and a
+ * mesh is limited only by what a vertex buffer holds.
  *
- * - One `MeshParticles` instance means one compiled program per backend, so
- *   share a single instance across the systems that draw the same shape rather
- *   than constructing one per system.
- * - Mutating the geometry after construction changes nothing. Construct a new
- *   mode instead.
- * - The table is shader source, so a mesh of a few hundred vertices is the
- *   sensible ceiling; this mode is for sparks, shards, leaves and petals, not
- *   for detailed models.
+ * **Mutating the mesh works.** Its vertices are read into a normalised
+ * `(x, y, u, v)` table — the shader binds fixed names, a caller's geometry may
+ * use any — and re-read whenever the geometry's `version` changes. Edit the
+ * geometry in place, call `invalidate()` on it, and the next draw picks it up.
+ * Changing the vertex *count* is equally fine.
  *
  * **Atlas frames still work.** The mesh's own UVs are treated exactly like the
  * quad's 0..1 corners: the shader mixes them across the particle's resolved
@@ -350,18 +268,23 @@ export class MeshParticles extends ParticleRenderMode {
   public readonly mesh: Geometry;
 
   /**
-   * The base geometry the executors draw with. It carries the mesh's topology
-   * and index buffer — that is what turns the mesh's vertices into triangles —
-   * while its attributes describe the per-instance buffer {@link build} fills,
-   * because that buffer is the only one bound. The placeholder `vertexData` is
-   * sized to the mesh's vertex count so a mesh without indices still draws all
-   * of its vertices per instance.
+   * The normalised mesh the executors bind as the per-vertex buffer: the
+   * caller's {@link mesh} reduced to `(x, y, u, v)` per vertex, keeping its
+   * topology and index list. Owned by this mode and disposed with it.
    */
-  public readonly geometry: Geometry;
+  public override readonly vertexGeometry: Geometry;
 
-  private readonly _meshTable: Float32Array;
+  /** Per-instance layout, byte-identical to the quad's and to the compute output. */
+  public readonly dataLayout = new ParticleBufferLayout({
+    attributes: instanceAttributes,
+    stride: instanceStrideBytes,
+    usage: 'stream',
+  });
+
   private readonly _writer = new ParticleInstanceWriter();
 
+  private _meshTable: Float32Array;
+  private _meshVersion: number;
   private _material: ParticleMaterial | null = null;
   private _float32 = new Float32Array(this.data);
   private _uint32 = new Uint32Array(this.data);
@@ -373,14 +296,17 @@ export class MeshParticles extends ParticleRenderMode {
 
     this.mesh = mesh;
     this._meshTable = readMeshTable(mesh);
-    this.geometry = new Geometry({
-      attributes: instanceAttributes,
-      vertexData: new ArrayBuffer(mesh.vertexCount * instanceStrideBytes),
-      stride: instanceStrideBytes,
+    this._meshVersion = mesh.version;
+    this.vertexGeometry = new Geometry({
+      attributes: meshVertexAttributes,
+      vertexData: this._meshTable,
+      stride: meshVertexStrideBytes,
       indices: mesh.indices,
       topology: mesh.topology,
-      usage: 'stream',
+      usage: mesh.usage,
     });
+
+    assertVertexGeometryCompatible(this.dataLayout, this.vertexGeometry, this.instanced, 'MeshParticles');
   }
 
   /**
@@ -391,8 +317,8 @@ export class MeshParticles extends ParticleRenderMode {
   public get material(): Material {
     this._material ??= new ParticleMaterial({
       shader: new ShaderSource({
-        glsl: { vertex: meshParticleVertexGlsl(this._meshTable), fragment: fragmentSource },
-        wgsl: meshParticleWgsl(this._meshTable),
+        glsl: { vertex: vertexSource, fragment: fragmentSource },
+        wgsl: meshParticleWgsl,
       }),
     });
 
@@ -400,6 +326,8 @@ export class MeshParticles extends ParticleRenderMode {
   }
 
   public build(system: ParticleSystem): void {
+    this._syncMesh();
+
     // Must precede the view reads below: growing swaps in fresh typed-array
     // views over a new backing buffer.
     this._ensureCapacity(system.liveCount * instanceStrideBytes);
@@ -410,11 +338,36 @@ export class MeshParticles extends ParticleRenderMode {
   public override destroy(): void {
     this._material?.destroy();
     this._material = null;
-    this.geometry.destroy();
+    this.vertexGeometry.destroy();
   }
 
   protected override _onBufferGrown(data: ArrayBuffer): void {
     this._float32 = new Float32Array(data);
     this._uint32 = new Uint32Array(data);
+  }
+
+  /**
+   * Re-read the caller's mesh when it has been mutated since the last look.
+   *
+   * Re-runs from {@link build} rather than from a draw so it also happens for a
+   * system whose backend has not compiled a pipeline yet. A vertex count change
+   * swaps the table, which is why the geometry's own `vertexData` is reassigned
+   * rather than written through — the executors notice via its `version`.
+   */
+  private _syncMesh(): void {
+    if (this._meshVersion === this.mesh.version) {
+      return;
+    }
+
+    this._meshVersion = this.mesh.version;
+
+    const table = readMeshTable(this.mesh, this._meshTable);
+
+    if (table !== this._meshTable) {
+      this._meshTable = table;
+      this.vertexGeometry.vertexData = table;
+    }
+
+    this.vertexGeometry.invalidate();
   }
 }

--- a/packages/exojs-particles/src/renderModes/ParticleBufferLayout.ts
+++ b/packages/exojs-particles/src/renderModes/ParticleBufferLayout.ts
@@ -1,0 +1,181 @@
+import type { AttributeType, Geometry, GeometryAttribute, GeometryUsage, Topology } from '@codexo/exojs';
+
+const attributeTypeByteSizes: Record<AttributeType, number> = {
+  f32: 4,
+  u8: 1,
+  u16: 2,
+  u32: 4,
+  i32: 4,
+};
+
+const validTopologies = new Set<Topology>(['triangle-list', 'triangle-strip']);
+const validUsages = new Set<GeometryUsage>(['static', 'dynamic', 'stream']);
+
+interface AttributeRange {
+  readonly name: string;
+  readonly start: number;
+  readonly end: number;
+}
+
+/**
+ * Check that an attribute set describes a bindable interleaved record: unique
+ * names, sane sizes and offsets, and ranges that neither overlap each other nor
+ * reach past the stride.
+ */
+const validateAttributes = (attributes: readonly GeometryAttribute[], stride: number): void => {
+  const ranges: AttributeRange[] = [];
+  const names = new Set<string>();
+
+  for (const attribute of attributes) {
+    if (typeof attribute.name !== 'string' || attribute.name.length === 0) {
+      throw new Error('ParticleBufferLayout attribute name must be a non-empty string.');
+    }
+
+    if (names.has(attribute.name)) {
+      throw new Error(`ParticleBufferLayout attribute "${attribute.name}" is declared more than once.`);
+    }
+
+    names.add(attribute.name);
+
+    if (!Number.isInteger(attribute.size) || attribute.size < 1 || attribute.size > 4) {
+      throw new Error(`ParticleBufferLayout attribute "${attribute.name}" size must be an integer in [1..4] (got ${attribute.size}).`);
+    }
+
+    if (!Number.isInteger(attribute.offset) || attribute.offset < 0) {
+      throw new Error(`ParticleBufferLayout attribute "${attribute.name}" offset must be a non-negative integer (got ${attribute.offset}).`);
+    }
+
+    const end = attribute.offset + attributeTypeByteSizes[attribute.type] * attribute.size;
+
+    if (end > stride) {
+      throw new Error(`ParticleBufferLayout attribute "${attribute.name}" range [${attribute.offset}, ${end}) exceeds stride ${stride}.`);
+    }
+
+    for (const range of ranges) {
+      if (attribute.offset < range.end && end > range.start) {
+        throw new Error(`ParticleBufferLayout attribute "${attribute.name}" overlaps attribute "${range.name}" in the interleaved layout.`);
+      }
+    }
+
+    ranges.push({ name: attribute.name, start: attribute.offset, end });
+  }
+};
+
+/** Construction options for {@link ParticleBufferLayout}. */
+export interface ParticleBufferLayoutOptions {
+  /** Interleaved attributes, in declaration order. Shader locations follow this order. */
+  readonly attributes: readonly GeometryAttribute[];
+
+  /** Bytes one record occupies. Must be a positive integer. */
+  readonly stride: number;
+
+  /** Upload hint for the buffer this layout describes. Defaults to `stream`. */
+  readonly usage?: GeometryUsage;
+
+  /**
+   * Topology of the draw, used only when the mode declares no per-vertex
+   * geometry to take it from. Defaults to `triangle-list`.
+   */
+  readonly topology?: Topology;
+
+  /**
+   * Index list for the draw, used only when the mode declares no per-vertex
+   * geometry to take it from. Defaults to none.
+   */
+  readonly indices?: Uint16Array | Uint32Array | null;
+}
+
+/**
+ * Describes the interleaved buffer a render mode's `build()` fills each frame.
+ *
+ * Deliberately not a `Geometry`. A `Geometry` requires a position attribute,
+ * requires that attribute to carry at least two components, and validates any
+ * index list against the vertex count implied by its `vertexData` — three rules
+ * that are meaningful for geometry and meaningless for a per-instance record.
+ * Satisfying them used to cost the instanced modes a zero-filled placeholder
+ * buffer that was never uploaded, sized purely to keep the index check quiet.
+ *
+ * What is checked here is the subset that protects a real GPU binding: a
+ * positive stride, at least one attribute, unique names, and ranges that
+ * neither overlap each other nor reach past the stride.
+ *
+ * A layout is a description rather than a resource: it owns no GPU handle and
+ * needs no disposal.
+ */
+export class ParticleBufferLayout {
+  public readonly attributes: readonly GeometryAttribute[];
+  public readonly stride: number;
+  public readonly usage: GeometryUsage;
+  public readonly topology: Topology;
+  public readonly indices: Uint16Array | Uint32Array | null;
+
+  public constructor(options: ParticleBufferLayoutOptions) {
+    const { attributes, stride, usage = 'stream', topology = 'triangle-list', indices = null } = options;
+
+    if (attributes.length === 0) {
+      throw new Error('ParticleBufferLayout attributes must be a non-empty array.');
+    }
+
+    if (!Number.isInteger(stride) || stride <= 0) {
+      throw new Error(`ParticleBufferLayout stride must be a positive integer (got ${stride}).`);
+    }
+
+    if (!validTopologies.has(topology)) {
+      throw new Error(`ParticleBufferLayout topology must be one of: triangle-list, triangle-strip (got ${String(topology)}).`);
+    }
+
+    if (!validUsages.has(usage)) {
+      throw new Error(`ParticleBufferLayout usage must be one of: static, dynamic, stream (got ${String(usage)}).`);
+    }
+
+    validateAttributes(attributes, stride);
+
+    this.attributes = attributes.map(attribute => ({ ...attribute }));
+    this.stride = stride;
+    this.usage = usage;
+    this.topology = topology;
+    this.indices = indices;
+  }
+
+  /** Elements one draw consumes from {@link indices}, or 0 when there are none. */
+  public get indexCount(): number {
+    return this.indices?.length ?? 0;
+  }
+}
+
+/**
+ * Guard the two seam combinations a mode must not declare.
+ *
+ * Called by a mode's own constructor, so the error names the mistake where it
+ * was made, and repeated by each executor when it first realises a mode, so a
+ * mode written outside this package cannot slip past. Both checks are cheap and
+ * run once per mode rather than per frame.
+ *
+ * @param modeName Class name of the mode, used to prefix the error.
+ */
+export const assertVertexGeometryCompatible = (
+  dataLayout: ParticleBufferLayout,
+  vertexGeometry: Geometry | null,
+  instanced: boolean,
+  modeName: string,
+): void => {
+  if (vertexGeometry === null) {
+    return;
+  }
+
+  if (!instanced) {
+    throw new Error(
+      `${modeName}: a per-vertex geometry requires an instanced mode. Without instancing both buffers would step per vertex, which no draw can express.`,
+    );
+  }
+
+  const declared = new Set(dataLayout.attributes.map(attribute => attribute.name));
+
+  for (const attribute of vertexGeometry.attributes) {
+    if (declared.has(attribute.name)) {
+      throw new Error(
+        `${modeName}: attribute "${attribute.name}" is declared by both the per-frame buffer and the per-vertex geometry. Every attribute name must be unique across the two buffers.`,
+      );
+    }
+  }
+};

--- a/packages/exojs-particles/src/renderModes/ParticleRenderMode.ts
+++ b/packages/exojs-particles/src/renderModes/ParticleRenderMode.ts
@@ -2,6 +2,8 @@ import type { Geometry, Material } from '@codexo/exojs';
 
 import type { ParticleSystem } from '#ParticleSystem';
 
+import type { ParticleBufferLayout } from './ParticleBufferLayout';
+
 /**
  * Turns a particle system's SoA storage into drawable vertex data.
  *
@@ -25,22 +27,49 @@ import type { ParticleSystem } from '#ParticleSystem';
  *   a fixed-topology mode and wrong for one whose element count varies per
  *   frame; such a mode needs the executors taught to derive an index count
  *   from {@link count} first. No mode ships in that shape today.
- * - The **instanced, non-indexed** path draws `geometry.indexCount` vertices
- *   per instance, which for a geometry without indices is the vertex count its
- *   placeholder `vertexData` implies. A mode on that path therefore has to
- *   size `vertexData` to its vertices-per-instance rather than leave it empty.
+ * - An **instanced** mode that declares no {@link vertexGeometry} has to derive
+ *   its vertices in the shader from the vertex index, and its
+ *   {@link dataLayout} must carry the indices that address them. Without either
+ *   there is nothing to tell the executors how many vertices one instance
+ *   spans.
  */
 export abstract class ParticleRenderMode {
-  /** Base geometry: topology, named attributes, buffer usage. */
-  public abstract readonly geometry: Geometry;
+  /**
+   * Layout of the buffer {@link build} fills each frame: attributes, stride,
+   * upload hint, and — when this mode declares no {@link vertexGeometry} — the
+   * topology and index list the draw uses.
+   *
+   * Named after {@link data}, the buffer it describes. It holds per-instance
+   * records for an instanced mode and per-vertex records otherwise, so a name
+   * fixed to either would be wrong for one of the two draw models.
+   */
+  public abstract readonly dataLayout: ParticleBufferLayout;
+
+  /**
+   * Fixed per-vertex geometry this mode instances, or `null` when it derives
+   * its vertices in the shader from the vertex index — which is what
+   * `QuadParticles` and `RibbonParticles` do.
+   *
+   * When set, it supplies the topology, index list and index count for the draw
+   * in place of {@link dataLayout}'s, and the executors bind its `vertexData`
+   * as a second vertex buffer stepping per vertex beside the per-instance one.
+   * Only meaningful on an instanced mode: without instancing both buffers would
+   * step per vertex and no draw is expressible.
+   *
+   * Attribute names must not collide with {@link dataLayout}'s, since both sets
+   * bind into the same shader. Mutating the geometry is picked up on the next
+   * draw through its `version`, so `invalidate()` after an in-place edit is
+   * enough to reach the GPU.
+   */
+  public readonly vertexGeometry: Geometry | null = null;
 
   /** Shader pair plus uniforms/textures for this mode. */
   public abstract readonly material: Material;
 
   /**
-   * Draw model. `true` issues an instanced draw against {@link geometry};
-   * `false` a plain draw over the built vertex buffer. Declared here because
-   * `Geometry` carries topology but has no instancing concept.
+   * Draw model. `true` issues an instanced draw, `false` a plain draw over the
+   * built vertex buffer. Declared here because a layout carries topology but
+   * has no instancing concept.
    */
   public abstract readonly instanced: boolean;
 

--- a/packages/exojs-particles/src/renderModes/QuadParticles.ts
+++ b/packages/exojs-particles/src/renderModes/QuadParticles.ts
@@ -1,22 +1,22 @@
 import type { Material } from '@codexo/exojs';
-import { Geometry, ShaderSource } from '@codexo/exojs';
+import { ShaderSource } from '@codexo/exojs';
 
 import type { ParticleSystem } from '#ParticleSystem';
 
 import fragmentSource from '../renderers/glsl/particle.frag';
 import vertexSource from '../renderers/glsl/particle.vert';
+import { ParticleBufferLayout } from './ParticleBufferLayout';
 import { instanceAttributes, instanceStrideBytes, ParticleInstanceWriter } from './ParticleInstanceWriter';
 import { ParticleMaterial } from './ParticleMaterial';
 import { ParticleRenderMode } from './ParticleRenderMode';
 
-const quadVertexCount = 4;
 const quadIndices = new Uint16Array([0, 1, 2, 0, 2, 3]);
 
 /**
  * WGSL counterpart of `glsl/particle.vert` + `glsl/particle.frag`. Vertex and
  * fragment entry points share one source per WGSL convention, and the
  * per-instance attributes bind by `@location`, matching the declaration order
- * and byte offsets of {@link QuadParticles.geometry}.
+ * and byte offsets of {@link QuadParticles.dataLayout}.
  *
  * The quad's corner is derived from `vertex_index` exactly as the GLSL derives
  * it from `gl_VertexID`, so both backends need nothing beyond this mode's own
@@ -116,14 +116,12 @@ export class QuadParticles extends ParticleRenderMode {
 
   /**
    * The quad's four corners are derived in the shader — from `gl_VertexID` on
-   * WebGL2 and from `vertex_index` on WebGPU — so this
-   * geometry describes the per-instance layout and carries a zero-filled
-   * placeholder large enough for the four corner slots the index buffer
-   * addresses.
+   * WebGL2 and from `vertex_index` on WebGPU — so this mode declares no
+   * per-vertex geometry and its layout carries the indices that address those
+   * four corner slots.
    */
-  public readonly geometry = new Geometry({
+  public readonly dataLayout = new ParticleBufferLayout({
     attributes: instanceAttributes,
-    vertexData: new ArrayBuffer(quadVertexCount * instanceStrideBytes),
     stride: instanceStrideBytes,
     indices: quadIndices,
     topology: 'triangle-list',
@@ -163,7 +161,6 @@ export class QuadParticles extends ParticleRenderMode {
   public override destroy(): void {
     this._material?.destroy();
     this._material = null;
-    this.geometry.destroy();
   }
 
   protected override _onBufferGrown(data: ArrayBuffer): void {

--- a/packages/exojs-particles/src/renderModes/RibbonParticles.ts
+++ b/packages/exojs-particles/src/renderModes/RibbonParticles.ts
@@ -1,10 +1,11 @@
 import type { Material } from '@codexo/exojs';
-import { Geometry, ShaderSource } from '@codexo/exojs';
+import { ShaderSource } from '@codexo/exojs';
 
 import type { ParticleSystem } from '#ParticleSystem';
 
 import fragmentSource from './glsl/ribbon.frag';
 import vertexSource from './glsl/ribbon.vert';
+import { ParticleBufferLayout } from './ParticleBufferLayout';
 import { ParticleMaterial } from './ParticleMaterial';
 import { ParticleRenderMode } from './ParticleRenderMode';
 
@@ -27,7 +28,7 @@ export interface RibbonParticlesOptions {
  * WGSL counterpart of `glsl/ribbon.vert` + `glsl/ribbon.frag`. Vertex and
  * fragment entry points share one source per WGSL convention, and the
  * per-vertex attributes bind by `@location`, matching the declaration order and
- * byte offsets of {@link RibbonParticles.geometry}.
+ * byte offsets of {@link RibbonParticles.dataLayout}.
  *
  * The uniform struct is the one the WebGPU particle renderer writes for every
  * mode, so `localBounds` and `uvBounds` are declared but unused here: the strip
@@ -137,18 +138,16 @@ export class RibbonParticles extends ParticleRenderMode {
 
   /**
    * A strip has no fixed vertex count — the draw covers whatever {@link build}
-   * emitted this frame — so the geometry describes only the layout and carries
-   * an empty placeholder. Non-indexed by construction: the strip's own vertex
-   * order is its topology, and an indexed geometry would pin the draw to a fixed
+   * emitted this frame. Non-indexed by construction: the strip's own vertex
+   * order is its topology, and an index list would pin the draw to a fixed
    * index count.
    */
-  public readonly geometry = new Geometry({
+  public readonly dataLayout = new ParticleBufferLayout({
     attributes: [
       { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
       { name: 'a_texcoord', size: 2, type: 'f32', normalized: false, offset: 8 },
       { name: 'a_color', size: 4, type: 'u8', normalized: true, offset: 16 },
     ],
-    vertexData: new ArrayBuffer(0),
     stride: vertexStrideBytes,
     topology: 'triangle-strip',
     usage: 'stream',
@@ -289,7 +288,6 @@ export class RibbonParticles extends ParticleRenderMode {
   public override destroy(): void {
     this._material?.destroy();
     this._material = null;
-    this.geometry.destroy();
   }
 
   protected override _onBufferGrown(data: ArrayBuffer): void {

--- a/packages/exojs-particles/src/renderModes/glsl/mesh.vert
+++ b/packages/exojs-particles/src/renderModes/glsl/mesh.vert
@@ -1,0 +1,41 @@
+#version 300 es
+precision highp float;
+precision highp int;
+
+// Per-instance attributes (one entry per particle, 40 bytes total).
+layout(location = 0) in vec2 a_position;         // particle position in system-local space
+layout(location = 1) in vec2 a_scale;            // particle scale
+layout(location = 2) in float a_rotation;        // particle rotation in degrees
+layout(location = 3) in vec4 a_color;            // RGBA tint
+layout(location = 4) in vec2 a_uvMin;            // top-left UV (u, v) — pre-resolved per instance
+layout(location = 5) in vec2 a_uvMax;            // bottom-right UV (u, v) — pre-resolved per instance
+
+// Per-vertex attributes from the mode's mesh geometry, normalised to (x, y)
+// and (u, v) so this shader is the same for every mesh.
+layout(location = 6) in vec2 a_meshPosition;
+layout(location = 7) in vec2 a_meshTexcoord;
+
+uniform mat3 u_projection;
+uniform mat3 u_systemTransform;
+
+out vec2 v_texcoord;
+out vec4 v_color;
+
+void main(void) {
+    // Per-particle scale + rotation, identical to the quad's.
+    vec2 rotation = vec2(sin(radians(a_rotation)), cos(radians(a_rotation)));
+    vec2 transformed = vec2(
+        (a_meshPosition.x * (a_scale.x * rotation.y)) + (a_meshPosition.y * (a_scale.y * rotation.x)),
+        (a_meshPosition.x * (a_scale.x * -rotation.x)) + (a_meshPosition.y * (a_scale.y * rotation.y))
+    );
+
+    vec3 worldPos = vec3(transformed + a_position, 1.0);
+
+    gl_Position = vec4((u_projection * u_systemTransform * worldPos).xy, 0.0, 1.0);
+
+    // The mesh's own UVs address the particle's frame rather than the whole
+    // texture, so a mesh particle still selects an atlas frame.
+    v_texcoord = mix(a_uvMin, a_uvMax, a_meshTexcoord);
+
+    v_color = vec4(a_color.rgb * a_color.a, a_color.a);
+}

--- a/packages/exojs-particles/src/renderers/WebGl2ParticleRenderer.ts
+++ b/packages/exojs-particles/src/renderers/WebGl2ParticleRenderer.ts
@@ -1,4 +1,4 @@
-import type { AttributeType, Geometry, GeometryUsage, Material, Topology } from '@codexo/exojs';
+import type { AttributeType, GeometryUsage, Material, Topology } from '@codexo/exojs';
 import type { BlendModes } from '@codexo/exojs/renderer-sdk';
 import type { Texture } from '@codexo/exojs/renderer-sdk';
 import type { View } from '@codexo/exojs/renderer-sdk';
@@ -11,6 +11,7 @@ import { createWebGl2ShaderProgram } from '@codexo/exojs/renderer-sdk';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from '@codexo/exojs/renderer-sdk';
 
 import type { ParticleSystem } from '#ParticleSystem';
+import { assertVertexGeometryCompatible } from '#renderModes/ParticleBufferLayout';
 import type { ParticleRenderMode } from '#renderModes/ParticleRenderMode';
 
 const resolvePrimitive = (topology: Topology): RenderingPrimitives => {
@@ -65,6 +66,10 @@ interface ParticleModeResources {
   readonly shader: Shader;
   readonly vao: WebGl2VertexArrayObject;
   readonly vertexBuffer: WebGl2RenderBuffer;
+  /** Per-vertex buffer for a mode that supplies its own geometry, else null. */
+  readonly meshBuffer: WebGl2RenderBuffer | null;
+  /** Geometry version last uploaded into {@link meshBuffer}; -1 when there is none. */
+  meshVersion: number;
   readonly indexBuffer: WebGl2RenderBuffer | null;
   readonly stride: number;
   readonly primitive: RenderingPrimitives;
@@ -88,11 +93,15 @@ interface ParticleModeResources {
  * texture) and asks the mode to build its vertex data. The next `flush()`
  * uploads that data and issues the single draw the mode declares.
  *
- * Everything mode-specific is read off the mode's `Geometry`/`Material`, so a
+ * Everything mode-specific is read off the mode's `dataLayout`/`Material`, so a
  * new primitive is a new mode rather than a change here: the vertex array
- * object is wired from the geometry's named attributes, the draw is instanced
- * or plain per `ParticleRenderMode.instanced`, and its primitive comes from the
- * geometry's topology.
+ * object is wired from the layout's named attributes, the draw is instanced or
+ * plain per `ParticleRenderMode.instanced`, and its primitive comes from the
+ * topology.
+ *
+ * A mode declaring a `vertexGeometry` adds a second buffer to that vertex array
+ * object, stepping per vertex (divisor 0) beside the per-instance one, and its
+ * geometry supplies the topology and indices instead.
  */
 export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSystem> {
   /**
@@ -200,6 +209,16 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
 
     resources.shader.sync();
     backend.bindVertexArrayObject(resources.vao);
+
+    // Re-upload the mode's own geometry only when it was mutated since the last
+    // draw. One integer comparison keeps an unchanging mesh off the bus.
+    const meshGeometry = mode.vertexGeometry;
+
+    if (meshGeometry !== null && resources.meshBuffer !== null && resources.meshVersion !== meshGeometry.version) {
+      resources.meshVersion = meshGeometry.version;
+      resources.meshBuffer.upload(meshGeometry.vertexData);
+    }
+
     resources.vertexBuffer.upload(this._resolveUpload(mode, resources));
 
     if (resources.instanced) {
@@ -310,14 +329,23 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
       throw new Error('Particle material shader has no `glsl` source; cannot render through the WebGL2 backend.');
     }
 
-    const geometry: Geometry = mode.geometry;
+    const layout = mode.dataLayout;
+    const meshGeometry = mode.vertexGeometry;
+
+    assertVertexGeometryCompatible(layout, meshGeometry, mode.instanced, mode.constructor.name);
+
     const shader = new Shader(glsl.vertex, glsl.fragment);
 
     shader.connect(createWebGl2ShaderProgram(gl));
     // Force the first finalize so the attribute/uniform maps read below are populated.
     shader.sync();
 
-    const indices = geometry.indices;
+    // A mode with its own per-vertex geometry draws that geometry's topology
+    // and indices; one without derives its vertices in the shader and carries
+    // both on its layout instead.
+    const indices = meshGeometry !== null ? meshGeometry.indices : layout.indices;
+    const topology = meshGeometry !== null ? meshGeometry.topology : layout.topology;
+    const indexCount = meshGeometry !== null ? meshGeometry.indexCount : layout.indexCount;
     const indexBuffer =
       indices !== null
         ? new WebGl2RenderBuffer(BufferTypes.ElementArrayBuffer, indices, BufferUsage.StaticDraw).connect(this._createBufferRuntime(connection))
@@ -328,9 +356,16 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
     // system drawing past the batch size still draws every particle.
     const vertexBuffer = new WebGl2RenderBuffer(
       BufferTypes.ArrayBuffer,
-      new ArrayBuffer(this._batchSize * geometry.stride),
-      usageByGeometryUsage[geometry.usage],
+      new ArrayBuffer(this._batchSize * layout.stride),
+      usageByGeometryUsage[layout.usage],
     ).connect(this._createBufferRuntime(connection));
+
+    const meshBuffer =
+      meshGeometry !== null
+        ? new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, meshGeometry.vertexData, usageByGeometryUsage[meshGeometry.usage]).connect(
+            this._createBufferRuntime(connection),
+          )
+        : null;
 
     const vaoHandle = gl.createVertexArray();
 
@@ -347,17 +382,35 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
       vao.addIndex(indexBuffer);
     }
 
-    for (const attribute of geometry.attributes) {
+    for (const attribute of layout.attributes) {
       vao.addAttribute(
         vertexBuffer,
         shader.getAttribute(attribute.name),
         resolveAttributeType(gl, attribute.type),
         attribute.normalized,
-        geometry.stride,
+        layout.stride,
         attribute.offset,
         !attribute.normalized && integerAttributeTypes.has(attribute.type),
         divisor,
       );
+    }
+
+    // The mesh's own vertices step once per vertex (divisor 0) beside the
+    // per-instance records above, which is what lets one instanced draw expand
+    // a shared shape per particle.
+    if (meshGeometry !== null && meshBuffer !== null) {
+      for (const attribute of meshGeometry.attributes) {
+        vao.addAttribute(
+          meshBuffer,
+          shader.getAttribute(attribute.name),
+          resolveAttributeType(gl, attribute.type),
+          attribute.normalized,
+          meshGeometry.stride,
+          attribute.offset,
+          !attribute.normalized && integerAttributeTypes.has(attribute.type),
+          0,
+        );
+      }
     }
 
     vao.connect(this._createVaoRuntime(connection, vaoHandle, indices instanceof Uint32Array ? gl.UNSIGNED_INT : gl.UNSIGNED_SHORT));
@@ -366,11 +419,13 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
       shader,
       vao,
       vertexBuffer,
+      meshBuffer,
+      meshVersion: meshGeometry?.version ?? -1,
       indexBuffer,
-      stride: geometry.stride,
-      primitive: resolvePrimitive(geometry.topology),
+      stride: layout.stride,
+      primitive: resolvePrimitive(topology),
       instanced: mode.instanced,
-      indexCount: geometry.indexCount,
+      indexCount,
       bytes: new Uint8Array(0),
       source: null,
       view: null,
@@ -381,6 +436,7 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
   private _destroyResources(resources: ParticleModeResources): void {
     resources.vao.destroy();
     resources.vertexBuffer.destroy();
+    resources.meshBuffer?.destroy();
     resources.indexBuffer?.destroy();
     resources.shader.destroy();
   }

--- a/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
+++ b/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
@@ -1,6 +1,6 @@
 /// <reference types="@webgpu/types" />
 
-import type { Geometry, GeometryAttribute, Material } from '@codexo/exojs';
+import type { GeometryAttribute, Material } from '@codexo/exojs';
 import type { BlendModes } from '@codexo/exojs/renderer-sdk';
 import type { WebGpuBackend } from '@codexo/exojs/renderer-sdk';
 import { DataTexture } from '@codexo/exojs/renderer-sdk';
@@ -10,6 +10,7 @@ import { getWebGpuBlendState } from '@codexo/exojs/renderer-sdk';
 import { stencilContentDepthStencilState } from '@codexo/exojs/renderer-sdk';
 
 import type { ParticleSystem } from '#ParticleSystem';
+import { assertVertexGeometryCompatible } from '#renderModes/ParticleBufferLayout';
 import type { ParticleRenderMode } from '#renderModes/ParticleRenderMode';
 
 const uniformByteLength = 176;
@@ -58,13 +59,19 @@ const resolveVertexFormat = (attribute: GeometryAttribute): GPUVertexFormat => {
 
 /**
  * The WebGPU-side realisation of one render mode: its compiled shader module,
- * the vertex layout its geometry declares, its index buffer and the vertex
- * buffer its built data is uploaded into. Cached per {@link Material} — the
- * mode's material is its stable identity, and its `destroy()` evicts the entry.
+ * the vertex layouts it declares, its index buffer and the buffers its data is
+ * uploaded into. Cached per {@link Material} — the mode's material is its
+ * stable identity, and its `destroy()` evicts the entry.
  */
 interface ParticleModeResources {
   readonly shaderModule: GPUShaderModule;
   readonly vertexLayout: GPUVertexBufferLayout;
+  /** Per-vertex layout for a mode that supplies its own geometry, else null. */
+  readonly meshLayout: GPUVertexBufferLayout | null;
+  /** Buffer behind {@link meshLayout}. */
+  meshBuffer: GPUBuffer | null;
+  /** Geometry version last written into {@link meshBuffer}; -1 when there is none. */
+  meshVersion: number;
   readonly stride: number;
   readonly topology: GPUPrimitiveTopology;
   readonly stripIndexFormat: GPUIndexFormat | undefined;
@@ -93,16 +100,18 @@ interface WebGpuParticleDrawCall {
  * uniforms (projection, transform, local bounds, texture flags), uploads what
  * the mode built and issues the draw the mode declares.
  *
- * Everything mode-specific is read off the core `Geometry`/`Material` types
+ * Everything mode-specific is read off the mode's `dataLayout`/`Material`
  * rather than hard-coded: the render pipeline's vertex layout comes from the
- * geometry's attributes and stride, its primitive from the geometry's topology,
- * its shader from the material's WGSL, and the draw is instanced or plain per
- * `ParticleRenderMode.instanced`.
+ * layout's attributes and stride, its shader from the material's WGSL, and the
+ * draw is instanced or plain per `ParticleRenderMode.instanced`. A mode
+ * declaring a `vertexGeometry` gets a second buffer stepping per vertex, and
+ * that geometry supplies the topology and indices instead.
  *
  * WGSL binds vertex inputs by number rather than by name, and `GeometryAttribute`
  * carries no location, so the binding rule is positional: `@location(i)` is
- * `geometry.attributes[i]`. This is the WebGPU counterpart of the WebGL2
- * renderer's name lookup through the compiled program.
+ * `dataLayout.attributes[i]`, with any per-vertex attributes taking the
+ * locations after them. This is the WebGPU counterpart of the WebGL2 renderer's
+ * name lookup through the compiled program.
  *
  * A system running in GPU compute mode bypasses the mode's builder entirely:
  * its compute pipeline has already written the interleaved instance data
@@ -273,6 +282,11 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
       pass.setBindGroup(1, textureBindGroup);
       pass.setVertexBuffer(0, vertexBuffer);
 
+      if (resources.meshBuffer !== null) {
+        this._syncMeshBuffer(device, resources, mode);
+        pass.setVertexBuffer(1, resources.meshBuffer);
+      }
+
       // `mode.count` is instance count for an instanced mode and vertex count
       // otherwise, so it drives exactly one of the two draw arguments.
       const instanceCount = resources.instanced ? drawCount : 1;
@@ -412,8 +426,15 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
       throw new Error('Particle material shader has no `wgsl` source; cannot render through the WebGPU backend.');
     }
 
-    const geometry: Geometry = mode.geometry;
-    const indices = geometry.indices;
+    const layout = mode.dataLayout;
+    const meshGeometry = mode.vertexGeometry;
+
+    assertVertexGeometryCompatible(layout, meshGeometry, mode.instanced, mode.constructor.name);
+
+    // A mode with its own per-vertex geometry draws that geometry's topology
+    // and indices; one without derives its vertices in the shader and carries
+    // both on its layout instead.
+    const indices = meshGeometry !== null ? meshGeometry.indices : layout.indices;
     let indexBuffer: GPUBuffer | null = null;
 
     if (indices !== null) {
@@ -430,30 +451,59 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
       device.queue.writeBuffer(indexBuffer, 0, indexData.buffer, indexData.byteOffset, indexData.byteLength);
     }
 
-    const topology: GPUPrimitiveTopology = geometry.topology;
+    const topology: GPUPrimitiveTopology = meshGeometry !== null ? meshGeometry.topology : layout.topology;
     const indexFormat: GPUIndexFormat = indices instanceof Uint32Array ? 'uint32' : 'uint16';
     const indexedStrip = topology === 'triangle-strip' && indexBuffer !== null;
+
+    // Instance attributes keep locations 0..n-1 so the compute-emitted layout
+    // and the modes that derive their vertices in the shader stay untouched;
+    // the mesh's own attributes take the locations after them.
+    let meshBuffer: GPUBuffer | null = null;
+    let meshLayout: GPUVertexBufferLayout | null = null;
+
+    if (meshGeometry !== null) {
+      const meshData = meshGeometry.vertexData;
+
+      meshLayout = {
+        arrayStride: meshGeometry.stride,
+        stepMode: 'vertex',
+        attributes: meshGeometry.attributes.map((attribute, index) => ({
+          shaderLocation: layout.attributes.length + index,
+          offset: attribute.offset,
+          format: resolveVertexFormat(attribute),
+        })),
+      };
+
+      meshBuffer = device.createBuffer({
+        size: Math.ceil(meshData.byteLength / 4) * 4,
+        usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+      });
+      device.queue.writeBuffer(meshBuffer, 0, meshData instanceof Float32Array ? meshData.buffer : meshData, 0, meshData.byteLength);
+    }
 
     return {
       shaderModule: device.createShaderModule({ code: wgsl }),
       vertexLayout: {
-        arrayStride: geometry.stride,
+        arrayStride: layout.stride,
         // Per-instance for an instanced mode, per-vertex otherwise — the same
         // interleaved layout serves both draw models.
         stepMode: mode.instanced ? 'instance' : 'vertex',
-        attributes: geometry.attributes.map((attribute, location) => ({
+        attributes: layout.attributes.map((attribute, location) => ({
           shaderLocation: location,
           offset: attribute.offset,
           format: resolveVertexFormat(attribute),
         })),
       },
-      stride: geometry.stride,
+      meshLayout,
+      meshBuffer,
+      meshVersion: meshGeometry?.version ?? -1,
+      stride: layout.stride,
       topology,
       // Required by WebGPU for indexed strip draws, and forbidden otherwise.
       stripIndexFormat: indexedStrip ? indexFormat : undefined,
       indexBuffer,
       indexFormat,
-      indexCount: geometry.indexCount,
+      indexCount: meshGeometry !== null ? meshGeometry.indexCount : layout.indexCount,
       instanced: mode.instanced,
       pipelines: new Map<string, GPURenderPipeline>(),
       vertexBuffer: null,
@@ -461,11 +511,30 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
     };
   }
 
+  /**
+   * Re-write the mode's own geometry only when it was mutated since the last
+   * draw. One integer comparison keeps an unchanging mesh off the bus.
+   */
+  private _syncMeshBuffer(device: GPUDevice, resources: ParticleModeResources, mode: ParticleRenderMode): void {
+    const meshGeometry = mode.vertexGeometry;
+
+    if (meshGeometry === null || resources.meshBuffer === null || resources.meshVersion === meshGeometry.version) {
+      return;
+    }
+
+    const meshData = meshGeometry.vertexData;
+
+    resources.meshVersion = meshGeometry.version;
+    device.queue.writeBuffer(resources.meshBuffer, 0, meshData instanceof Float32Array ? meshData.buffer : meshData, 0, meshData.byteLength);
+  }
+
   private _destroyResources(resources: ParticleModeResources): void {
     resources.vertexBuffer?.destroy();
+    resources.meshBuffer?.destroy();
     resources.indexBuffer?.destroy();
     resources.pipelines.clear();
     resources.vertexBuffer = null;
+    resources.meshBuffer = null;
     resources.vertexBufferByteLength = 0;
   }
 
@@ -584,7 +653,9 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
       vertex: {
         module: resources.shaderModule,
         entryPoint: 'vertexMain',
-        buffers: [resources.vertexLayout],
+        // Instance data stays at slot 0: a GPU-mode system binds its compute
+        // pipeline's own instance buffer straight into it.
+        buffers: resources.meshLayout !== null ? [resources.vertexLayout, resources.meshLayout] : [resources.vertexLayout],
       },
       fragment: {
         module: resources.shaderModule,

--- a/packages/exojs-particles/test/particle-buffer-layout.test.ts
+++ b/packages/exojs-particles/test/particle-buffer-layout.test.ts
@@ -1,0 +1,110 @@
+import { Geometry } from '@codexo/exojs';
+import { describe, expect, test } from 'vitest';
+
+import { assertVertexGeometryCompatible, ParticleBufferLayout } from '../src/renderModes/ParticleBufferLayout';
+
+const attribute = (name: string, offset: number) => ({ name, size: 2, type: 'f32' as const, normalized: false, offset });
+
+const triangleMesh = (): Geometry =>
+  new Geometry({
+    attributes: [attribute('a_meshPosition', 0)],
+    vertexData: new Float32Array([0, 0, 1, 0, 0, 1]),
+    stride: 8,
+  });
+
+describe('ParticleBufferLayout', () => {
+  test('applies the documented defaults', () => {
+    const layout = new ParticleBufferLayout({ attributes: [attribute('a_position', 0)], stride: 8 });
+
+    expect(layout.usage).toBe('stream');
+    expect(layout.topology).toBe('triangle-list');
+    expect(layout.indices).toBeNull();
+    expect(layout.indexCount).toBe(0);
+  });
+
+  test('accepts an attribute set with no position attribute', () => {
+    // The reason this is not a Geometry: a per-instance record has no position
+    // in the geometric sense, and Geometry would reject the layout outright.
+    expect(() => new ParticleBufferLayout({ attributes: [attribute('a_scale', 0)], stride: 8 })).not.toThrow();
+  });
+
+  test('accepts indices with no vertex data to validate them against', () => {
+    const layout = new ParticleBufferLayout({
+      attributes: [attribute('a_position', 0)],
+      stride: 8,
+      indices: new Uint16Array([0, 1, 2, 0, 2, 3]),
+    });
+
+    expect(layout.indexCount).toBe(6);
+  });
+
+  test('copies the attribute objects it is handed', () => {
+    const source = [attribute('a_position', 0)];
+    const layout = new ParticleBufferLayout({ attributes: source, stride: 8 });
+
+    expect(layout.attributes[0]).not.toBe(source[0]);
+    expect(layout.attributes[0]).toEqual(source[0]);
+  });
+
+  test('rejects a non-positive stride', () => {
+    expect(() => new ParticleBufferLayout({ attributes: [attribute('a_position', 0)], stride: 0 })).toThrow(/stride/i);
+  });
+
+  test('rejects an empty attribute list', () => {
+    expect(() => new ParticleBufferLayout({ attributes: [], stride: 8 })).toThrow(/non-empty/i);
+  });
+
+  test('rejects a duplicate attribute name', () => {
+    expect(() => new ParticleBufferLayout({ attributes: [attribute('a_position', 0), attribute('a_position', 8)], stride: 16 })).toThrow(
+      /declared more than once/i,
+    );
+  });
+
+  test('rejects overlapping attribute ranges', () => {
+    expect(() => new ParticleBufferLayout({ attributes: [attribute('a_position', 0), attribute('a_scale', 4)], stride: 16 })).toThrow(/overlaps/i);
+  });
+
+  test('rejects an attribute reaching past the stride', () => {
+    expect(() => new ParticleBufferLayout({ attributes: [attribute('a_position', 4)], stride: 8 })).toThrow(/exceeds stride/i);
+  });
+
+  test('rejects an unknown topology', () => {
+    expect(() => new ParticleBufferLayout({ attributes: [attribute('a_position', 0)], stride: 8, topology: 'points' as never })).toThrow(/topology/i);
+  });
+});
+
+describe('assertVertexGeometryCompatible', () => {
+  const layout = new ParticleBufferLayout({ attributes: [attribute('a_position', 0)], stride: 8 });
+
+  test('passes for an instanced mode with no name collision', () => {
+    const mesh = triangleMesh();
+
+    expect(() => assertVertexGeometryCompatible(layout, mesh, true, 'TestMode')).not.toThrow();
+
+    mesh.destroy();
+  });
+
+  test('passes when there is no vertex geometry at all', () => {
+    expect(() => assertVertexGeometryCompatible(layout, null, false, 'TestMode')).not.toThrow();
+  });
+
+  test('rejects a vertex geometry on a non-instanced mode', () => {
+    const mesh = triangleMesh();
+
+    expect(() => assertVertexGeometryCompatible(layout, mesh, false, 'TestMode')).toThrow(/instanced/i);
+
+    mesh.destroy();
+  });
+
+  test('rejects an attribute name present in both buffers', () => {
+    const colliding = new Geometry({
+      attributes: [attribute('a_position', 0)],
+      vertexData: new Float32Array([0, 0, 1, 0, 0, 1]),
+      stride: 8,
+    });
+
+    expect(() => assertVertexGeometryCompatible(layout, colliding, true, 'TestMode')).toThrow(/a_position/);
+
+    colliding.destroy();
+  });
+});

--- a/packages/exojs-particles/test/render-mode-mesh.test.ts
+++ b/packages/exojs-particles/test/render-mode-mesh.test.ts
@@ -2,7 +2,7 @@ import { Geometry } from '@codexo/exojs';
 import { describe, expect, it } from 'vitest';
 
 import { ParticleSystem } from '../src/ParticleSystem';
-import { MeshParticles } from '../src/renderModes/MeshParticles';
+import { MeshParticles, meshParticleWgsl } from '../src/renderModes/MeshParticles';
 import { QuadParticles } from '../src/renderModes/QuadParticles';
 
 /** A right triangle with the right angle top-left, UVs spanning its bounds. */
@@ -49,7 +49,7 @@ describe('MeshParticles', () => {
 
     expect(mode.instanced).toBe(true);
     expect(mode.gpuEligible).toBe(true);
-    expect(mode.geometry.topology).toBe('triangle-list');
+    expect(mode.vertexGeometry.topology).toBe('triangle-list');
   });
 
   it('keeps the supplied geometry as its mesh and draws one instance of it', () => {
@@ -58,23 +58,23 @@ describe('MeshParticles', () => {
 
     expect(mode.mesh).toBe(mesh);
     // Non-indexed: the draw covers the mesh's own vertices per instance.
-    expect(mode.geometry.indices).toBeNull();
-    expect(mode.geometry.indexCount).toBe(mesh.vertexCount);
+    expect(mode.vertexGeometry.indices).toBeNull();
+    expect(mode.vertexGeometry.indexCount).toBe(mesh.vertexCount);
   });
 
   it('adopts the mesh index buffer when it has one', () => {
     const mesh = makeTriangle(true);
     const mode = new MeshParticles({ geometry: mesh });
 
-    expect(mode.geometry.indices).toBe(mesh.indices);
-    expect(mode.geometry.indexCount).toBe(3);
+    expect(mode.vertexGeometry.indices).toBe(mesh.indices);
+    expect(mode.vertexGeometry.indexCount).toBe(3);
   });
 
   it('declares the shared 40-byte per-instance layout rather than the mesh layout', () => {
     const mode = new MeshParticles({ geometry: makeTriangle() });
 
-    expect(mode.geometry.stride).toBe(40);
-    expect(mode.geometry.attributes.map(attribute => attribute.name)).toEqual(['a_position', 'a_scale', 'a_rotation', 'a_color', 'a_uvMin', 'a_uvMax']);
+    expect(mode.dataLayout.stride).toBe(40);
+    expect(mode.dataLayout.attributes.map(attribute => attribute.name)).toEqual(['a_position', 'a_scale', 'a_rotation', 'a_color', 'a_uvMin', 'a_uvMax']);
   });
 
   it('builds one 40-byte instance per live particle', () => {
@@ -117,30 +117,50 @@ describe('MeshParticles', () => {
     expect(mode.count).toBe(0);
   });
 
-  it('bakes the mesh vertices into both shader sources', () => {
+  it('normalises the mesh into a per-vertex geometry of (x, y, u, v)', () => {
     const mode = new MeshParticles({ geometry: makeTriangle() });
-    const shader = mode.material.shader;
+    const table = mode.vertexGeometry.vertexData as Float32Array;
 
-    expect(shader.glsl?.vertex).toContain('const vec4 c_meshVertices[3]');
-    expect(shader.glsl?.vertex).toContain('vec4(16.0, -16.0, 1.0, 0.0)');
-    expect(shader.wgsl).toContain('array<vec4<f32>, 3>');
-    expect(shader.wgsl).toContain('vec4<f32>(16.0, -16.0, 1.0, 0.0)');
+    expect(mode.vertexGeometry.stride).toBe(16);
+    expect(mode.vertexGeometry.attributes.map(attribute => attribute.name)).toEqual(['a_meshPosition', 'a_meshTexcoord']);
+    // First two vertices of the triangle, each as position then UV.
+    expect(Array.from(table.subarray(0, 8))).toEqual([-16, -16, 0, 0, 16, -16, 1, 0]);
+  });
+
+  it('carries no geometry-dependent literals in its shader source', () => {
+    // A constant rather than a function of the mesh is what lets any number of
+    // modes drawing different shapes share one compiled program per backend.
+    // The old baked table declared a fixed-size array of vertex literals.
+    expect(meshParticleWgsl).not.toContain('array<vec4<f32>,');
+    expect(meshParticleWgsl).toContain('@location(6) meshPosition: vec2<f32>');
+    expect(meshParticleWgsl).toContain('@location(7) meshTexcoord: vec2<f32>');
   });
 
   it('mixes the mesh UV across the particle frame rather than the whole texture', () => {
-    const mode = new MeshParticles({ geometry: makeTriangle() });
-    const shader = mode.material.shader;
-
-    expect(shader.glsl?.vertex).toContain('mix(a_uvMin, a_uvMax, meshVertex.zw)');
-    expect(shader.wgsl).toContain('mix(input.uvMin, input.uvMax, meshVertex.zw)');
+    expect(meshParticleWgsl).toContain('mix(input.uvMin, input.uvMax, input.meshTexcoord)');
   });
 
-  it('bakes zero UVs for a mesh without a texcoord attribute', () => {
+  it('carries zero UVs for a mesh without a texcoord attribute', () => {
     const mode = new MeshParticles({ geometry: makeUntexturedTriangle() });
+    const table = mode.vertexGeometry.vertexData as Float32Array;
 
     // Every vertex carries UV (0, 0), so the mix collapses to uvMin and the
     // mesh samples one texel of its frame.
-    expect(mode.material.shader.glsl?.vertex).toContain('vec4(-4.0, -4.0, 0.0, 0.0)');
-    expect(mode.material.shader.glsl?.vertex).toContain('vec4(4.0, -4.0, 0.0, 0.0)');
+    expect(Array.from(table.subarray(0, 8))).toEqual([-4, -4, 0, 0, 4, -4, 0, 0]);
+  });
+
+  it('re-reads the mesh after an in-place mutation', () => {
+    const mesh = makeTriangle();
+    const mode = new MeshParticles({ geometry: mesh });
+    const system = new ParticleSystem({ capacity: 8 });
+    const before = mode.vertexGeometry.version;
+
+    (mesh.vertexData as Float32Array)[0] = 32;
+    mesh.invalidate();
+    mode.build(system);
+
+    expect((mode.vertexGeometry.vertexData as Float32Array)[0]).toBe(32);
+    // A bumped version is what tells the executors to re-upload the buffer.
+    expect(mode.vertexGeometry.version).toBeGreaterThan(before);
   });
 });

--- a/packages/exojs-particles/test/render-mode-quad.test.ts
+++ b/packages/exojs-particles/test/render-mode-quad.test.ts
@@ -9,7 +9,7 @@ describe('QuadParticles', () => {
 
     expect(mode.instanced).toBe(true);
     expect(mode.gpuEligible).toBe(true);
-    expect(mode.geometry.topology).toBe('triangle-list');
+    expect(mode.dataLayout.topology).toBe('triangle-list');
   });
 
   it('builds one 40-byte instance per live particle', () => {

--- a/packages/exojs-particles/test/render-mode-ribbon.test.ts
+++ b/packages/exojs-particles/test/render-mode-ribbon.test.ts
@@ -21,7 +21,7 @@ describe('RibbonParticles', () => {
 
     expect(mode.instanced).toBe(false);
     expect(mode.gpuEligible).toBe(false);
-    expect(mode.geometry.topology).toBe('triangle-strip');
+    expect(mode.dataLayout.topology).toBe('triangle-strip');
   });
 
   it('emits two vertices per particle', () => {

--- a/packages/exojs-particles/test/render-mode-sharing.test.ts
+++ b/packages/exojs-particles/test/render-mode-sharing.test.ts
@@ -26,7 +26,7 @@ describe('default render mode sharing', () => {
 
     expect(second.renderMode).toBe(first.renderMode);
     expect(second.renderMode.material).toBe(first.renderMode.material);
-    expect(second.renderMode.geometry).toBe(first.renderMode.geometry);
+    expect(second.renderMode.dataLayout).toBe(first.renderMode.dataLayout);
   });
 
   it('keeps a supplied mode out of the shared default', () => {
@@ -42,17 +42,14 @@ describe('default render mode sharing', () => {
     const mode = survivor.renderMode;
     const material = mode.material;
     const materialDisposed = vi.fn();
-    const geometryDisposed = vi.fn();
 
     material._onDispose(materialDisposed);
-    mode.geometry._onDispose(geometryDisposed);
 
     destroyed.destroy();
 
     // No dispose fired means no renderer evicted its cached resources, so the
     // survivor still draws through the program that was already compiled.
     expect(materialDisposed).not.toHaveBeenCalled();
-    expect(geometryDisposed).not.toHaveBeenCalled();
     expect(survivor.renderMode.material).toBe(material);
 
     spawnParticle(survivor);

--- a/site/src/content/api/mesh-particles-options.json
+++ b/site/src/content/api/mesh-particles-options.json
@@ -47,7 +47,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "The shape one particle draws, in system-local units before the per-particle scale and rotation are applied. Read once, at construction: mutating it afterwards does not re-bake the shader. Its position attribute (a_position/position) supplies the vertex positions and its texcoord attribute (a_texcoord/texcoord/a_uv/uv) the UVs. See MeshParticles for what a geometry without the latter renders as."
+          "description": "The shape one particle draws, in system-local units before the per-particle scale and rotation are applied. Its position attribute (a_position/position) supplies the vertex positions and its texcoord attribute (a_texcoord/texcoord/a_uv/uv) the UVs. See MeshParticles for what a geometry without the latter renders as, and for how to make a mutation take effect."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/mesh-particles.json
+++ b/site/src/content/api/mesh-particles.json
@@ -1,16 +1,16 @@
 {
   "title": "MeshParticles",
-  "description": "One caller-supplied mesh per particle, drawn as a single instanced draw. The cheap counterpart to `RibbonParticles`: the relationship stays one particle, one instance, and the per-instance data is byte-identical to `QuadParticles`'s — instanceAttributes, filled by the same writer. Only the shape changes. That is what makes this mode **GPU-eligible** without touching the compute pipeline: the pipeline emits precisely that layout, so a system on the GPU path binds its instance buffer directly and never calls build. **The mesh is baked into the shader**, read once at construction. Its vertices become a constant `(x, y, u, v)` table addressed by the vertex index, which is the same thing the quad does with its four corners — from the shader's side a mesh is just a quad with more vertices. Consequences worth knowing: - One `MeshParticles` instance means one compiled program per backend, so share a single instance across the systems that draw the same shape rather than constructing one per system. - Mutating the geometry after construction changes nothing. Construct a new mode instead. - The table is shader source, so a mesh of a few hundred vertices is the sensible ceiling; this mode is for sparks, shards, leaves and petals, not for detailed models. **Atlas frames still work.** The mesh's own UVs are treated exactly like the quad's 0..1 corners: the shader mixes them across the particle's resolved frame (`uv = mix(uvMin, uvMax, meshUV)`), so `system.frames` plus a per-particle `textureIndex` selects a frame the same way. A geometry with **no texcoord attribute** therefore carries UV `(0, 0)` on every vertex and the mix degenerates to `uvMin` — the whole mesh samples the single texel at the frame's top-left corner, which on the default 1×1 white texture is exactly \"untextured, tinted by the particle's `color`\". **Sizing is the mesh's own.** Unlike the quad, which derives its footprint from the texture frame, a mesh particle's footprint is whatever its vertex positions say, in system-local units, multiplied by the per-particle `scaleX`/`scaleY`. The texture only supplies colour.",
+  "description": "One caller-supplied mesh per particle, drawn as a single instanced draw. The cheap counterpart to `RibbonParticles`: the relationship stays one particle, one instance, and the per-instance data is byte-identical to `QuadParticles`'s — instanceAttributes, filled by the same writer. Only the shape changes. That is what makes this mode **GPU-eligible** without touching the compute pipeline: the pipeline emits precisely that layout, so a system on the GPU path binds its instance buffer directly and never calls build. **The mesh rides in its own vertex buffer**, alongside the per-instance one. The shader is fixed and shared, so any number of `MeshParticles` compile one program per backend regardless of how many distinct shapes they draw, and a mesh is limited only by what a vertex buffer holds. **Mutating the mesh works.** Its vertices are read into a normalised `(x, y, u, v)` table — the shader binds fixed names, a caller's geometry may use any — and re-read whenever the geometry's `version` changes. Edit the geometry in place, call `invalidate()` on it, and the next draw picks it up. Changing the vertex *count* is equally fine. **Atlas frames still work.** The mesh's own UVs are treated exactly like the quad's 0..1 corners: the shader mixes them across the particle's resolved frame (`uv = mix(uvMin, uvMax, meshUV)`), so `system.frames` plus a per-particle `textureIndex` selects a frame the same way. A geometry with **no texcoord attribute** therefore carries UV `(0, 0)` on every vertex and the mix degenerates to `uvMin` — the whole mesh samples the single texel at the frame's top-left corner, which on the default 1×1 white texture is exactly \"untextured, tinted by the particle's `color`\". **Sizing is the mesh's own.** Unlike the quad, which derives its footprint from the texture frame, a mesh particle's footprint is whatever its vertex positions say, in system-local units, multiplied by the per-particle `scaleX`/`scaleY`. The texture only supplies colour.",
   "symbol": "MeshParticles",
   "kind": "class",
   "subsystem": "particles",
   "importPath": "@codexo/exojs-particles",
   "tier": "stable",
-  "memberCount": 13,
+  "memberCount": 14,
   "counts": {
     "constructors": 1,
     "methods": 5,
-    "properties": 7,
+    "properties": 8,
     "events": 0
   },
   "sections": [
@@ -21,8 +21,8 @@
       "paragraphs": [
         "One caller-supplied mesh per particle, drawn as a single instanced draw.",
         "The cheap counterpart to `RibbonParticles`: the relationship stays one particle, one instance, and the per-instance data is byte-identical to `QuadParticles`'s — instanceAttributes, filled by the same writer. Only the shape changes. That is what makes this mode **GPU-eligible** without touching the compute pipeline: the pipeline emits precisely that layout, so a system on the GPU path binds its instance buffer directly and never calls build.",
-        "**The mesh is baked into the shader**, read once at construction. Its vertices become a constant `(x, y, u, v)` table addressed by the vertex index, which is the same thing the quad does with its four corners — from the shader's side a mesh is just a quad with more vertices. Consequences worth knowing:",
-        "- One `MeshParticles` instance means one compiled program per backend, so share a single instance across the systems that draw the same shape rather than constructing one per system. - Mutating the geometry after construction changes nothing. Construct a new mode instead. - The table is shader source, so a mesh of a few hundred vertices is the sensible ceiling; this mode is for sparks, shards, leaves and petals, not for detailed models.",
+        "**The mesh rides in its own vertex buffer**, alongside the per-instance one. The shader is fixed and shared, so any number of `MeshParticles` compile one program per backend regardless of how many distinct shapes they draw, and a mesh is limited only by what a vertex buffer holds.",
+        "**Mutating the mesh works.** Its vertices are read into a normalised `(x, y, u, v)` table — the shader binds fixed names, a caller's geometry may use any — and re-read whenever the geometry's `version` changes. Edit the geometry in place, call `invalidate()` on it, and the next draw picks it up. Changing the vertex *count* is equally fine.",
         "**Atlas frames still work.** The mesh's own UVs are treated exactly like the quad's 0..1 corners: the shader mixes them across the particle's resolved frame (`uv = mix(uvMin, uvMax, meshUV)`), so `system.frames` plus a per-particle `textureIndex` selects a frame the same way. A geometry with **no texcoord attribute** therefore carries UV `(0, 0)` on every vertex and the mix degenerates to `uvMin` — the whole mesh samples the single texel at the frame's top-left corner, which on the default 1×1 white texture is exactly \"untextured, tinted by the particle's `color`\".",
         "**Sizing is the mesh's own.** Unlike the quad, which derives its footprint from the texture frame, a mesh particle's footprint is whatever its vertex positions say, in system-local units, multiplied by the per-particle `scaleX`/`scaleY`. The texture only supplies colour."
       ],
@@ -316,11 +316,11 @@
       "title": "Properties",
       "members": [
         {
-          "name": "geometry",
-          "signature": "geometry: Geometry",
+          "name": "dataLayout",
+          "signature": "dataLayout: ParticleBufferLayout",
           "signatureTokens": [
             {
-              "text": "geometry",
+              "text": "dataLayout",
               "kind": "name"
             },
             {
@@ -328,13 +328,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "ParticleBufferLayout",
               "kind": "type"
             }
           ],
           "params": [],
           "returnType": null,
-          "description": "The base geometry the executors draw with. It carries the mesh's topology and index buffer — that is what turns the mesh's vertices into triangles — while its attributes describe the per-instance buffer build fills, because that buffer is the only one bound. The placeholder vertexData is sized to the mesh's vertex count so a mesh without indices still draws all of its vertices per instance."
+          "description": "Per-instance layout, byte-identical to the quad's and to the compute output."
         },
         {
           "name": "gpuEligible",
@@ -376,7 +376,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Draw model. true issues an instanced draw against geometry; false a plain draw over the built vertex buffer. Declared here because Geometry carries topology but has no instancing concept."
+          "description": "Draw model. true issues an instanced draw, false a plain draw over the built vertex buffer. Declared here because a layout carries topology but has no instancing concept."
         },
         {
           "name": "mesh",
@@ -398,6 +398,27 @@
           "params": [],
           "returnType": null,
           "description": "The geometry this mode was constructed with — the shape one particle draws. Owned by the caller: destroy leaves it alone, so one mesh can back several modes."
+        },
+        {
+          "name": "vertexGeometry",
+          "signature": "vertexGeometry: Geometry",
+          "signatureTokens": [
+            {
+              "text": "vertexGeometry",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "The normalised mesh the executors bind as the per-vertex buffer: the caller's mesh reduced to (x, y, u, v) per vertex, keeping its topology and index list. Owned by this mode and disposed with it."
         },
         {
           "name": "count",

--- a/site/src/content/api/particle-buffer-layout-options.json
+++ b/site/src/content/api/particle-buffer-layout-options.json
@@ -1,0 +1,219 @@
+{
+  "title": "ParticleBufferLayoutOptions",
+  "description": "Construction options for ParticleBufferLayout.",
+  "symbol": "ParticleBufferLayoutOptions",
+  "kind": "interface",
+  "subsystem": "particles",
+  "importPath": "@codexo/exojs-particles",
+  "tier": "stable",
+  "memberCount": 5,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 5,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Construction options for ParticleBufferLayout."
+      ],
+      "importLine": "import { ParticleBufferLayoutOptions } from '@codexo/exojs-particles'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "attributes",
+          "signature": "attributes: readonly GeometryAttribute[]",
+          "signatureTokens": [
+            {
+              "text": "attributes",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GeometryAttribute",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Interleaved attributes, in declaration order. Shader locations follow this order."
+        },
+        {
+          "name": "indices",
+          "signature": "indices?: Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | null",
+          "signatureTokens": [
+            {
+              "text": "indices",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Uint16Array",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ArrayBufferLike",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Uint32Array",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ArrayBufferLike",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Index list for the draw, used only when the mode declares no per-vertex geometry to take it from. Defaults to none."
+        },
+        {
+          "name": "stride",
+          "signature": "stride: number",
+          "signatureTokens": [
+            {
+              "text": "stride",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Bytes one record occupies. Must be a positive integer."
+        },
+        {
+          "name": "topology",
+          "signature": "topology?: Topology",
+          "signatureTokens": [
+            {
+              "text": "topology",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Topology",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Topology of the draw, used only when the mode declares no per-vertex geometry to take it from. Defaults to triangle-list."
+        },
+        {
+          "name": "usage",
+          "signature": "usage?: GeometryUsage",
+          "signatureTokens": [
+            {
+              "text": "usage",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GeometryUsage",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Upload hint for the buffer this layout describes. Defaults to stream."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-particles/src/renderModes/ParticleBufferLayout.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/ParticleBufferLayout.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-particles/src/renderModes/ParticleBufferLayout.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/ParticleBufferLayout.ts"
+}

--- a/site/src/content/api/particle-buffer-layout.json
+++ b/site/src/content/api/particle-buffer-layout.json
@@ -1,0 +1,287 @@
+{
+  "title": "ParticleBufferLayout",
+  "description": "Describes the interleaved buffer a render mode's `build()` fills each frame. Deliberately not a `Geometry`. A `Geometry` requires a position attribute, requires that attribute to carry at least two components, and validates any index list against the vertex count implied by its `vertexData` — three rules that are meaningful for geometry and meaningless for a per-instance record. Satisfying them used to cost the instanced modes a zero-filled placeholder buffer that was never uploaded, sized purely to keep the index check quiet. What is checked here is the subset that protects a real GPU binding: a positive stride, at least one attribute, unique names, and ranges that neither overlap each other nor reach past the stride. A layout is a description rather than a resource: it owns no GPU handle and needs no disposal.",
+  "symbol": "ParticleBufferLayout",
+  "kind": "class",
+  "subsystem": "particles",
+  "importPath": "@codexo/exojs-particles",
+  "tier": "stable",
+  "memberCount": 7,
+  "counts": {
+    "constructors": 1,
+    "methods": 0,
+    "properties": 6,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Describes the interleaved buffer a render mode's `build()` fills each frame.",
+        "Deliberately not a `Geometry`. A `Geometry` requires a position attribute, requires that attribute to carry at least two components, and validates any index list against the vertex count implied by its `vertexData` — three rules that are meaningful for geometry and meaningless for a per-instance record. Satisfying them used to cost the instanced modes a zero-filled placeholder buffer that was never uploaded, sized purely to keep the index check quiet.",
+        "What is checked here is the subset that protects a real GPU binding: a positive stride, at least one attribute, unique names, and ranges that neither overlap each other nor reach past the stride.",
+        "A layout is a description rather than a resource: it owns no GPU handle and needs no disposal."
+      ],
+      "importLine": "import { ParticleBufferLayout } from '@codexo/exojs-particles'",
+      "sourceLink": null
+    },
+    {
+      "id": "constructors",
+      "title": "Constructors",
+      "members": [
+        {
+          "name": "new",
+          "signature": "new(options: ParticleBufferLayoutOptions): ParticleBufferLayout",
+          "signatureTokens": [
+            {
+              "text": "new",
+              "kind": "keyword"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "options",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ParticleBufferLayoutOptions",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ParticleBufferLayout",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "options",
+              "type": "ParticleBufferLayoutOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "ParticleBufferLayout",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "attributes",
+          "signature": "attributes: readonly GeometryAttribute[]",
+          "signatureTokens": [
+            {
+              "text": "attributes",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GeometryAttribute",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "indices",
+          "signature": "indices: Uint16Array<ArrayBufferLike> | Uint32Array<ArrayBufferLike> | null",
+          "signatureTokens": [
+            {
+              "text": "indices",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Uint16Array",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ArrayBufferLike",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Uint32Array",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ArrayBufferLike",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "stride",
+          "signature": "stride: number",
+          "signatureTokens": [
+            {
+              "text": "stride",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "topology",
+          "signature": "topology: Topology",
+          "signatureTokens": [
+            {
+              "text": "topology",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Topology",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "usage",
+          "signature": "usage: GeometryUsage",
+          "signatureTokens": [
+            {
+              "text": "usage",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GeometryUsage",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "indexCount",
+          "signature": "indexCount: number",
+          "signatureTokens": [
+            {
+              "text": "indexCount",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Elements one draw consumes from indices, or 0 when there are none."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-particles/src/renderModes/ParticleBufferLayout.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/ParticleBufferLayout.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-particles/src/renderModes/ParticleBufferLayout.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-particles/src/renderModes/ParticleBufferLayout.ts"
+}

--- a/site/src/content/api/particle-render-mode.json
+++ b/site/src/content/api/particle-render-mode.json
@@ -1,16 +1,16 @@
 {
   "title": "ParticleRenderMode",
-  "description": "Turns a particle system's SoA storage into drawable vertex data. A mode owns the whole \"how\": the vertex layout, the shader pair, the draw model, and the loop that fills the buffer. The backend renderers only upload what it produces and issue the draw it declares, so a new primitive is a new mode rather than a renderer change. Implementations are fixed at system construction (see `ParticleSystemOptions.render`) and default to `QuadParticles`. **Limits of the seam.** The executors are deliberately thin, so a new mode has to stay inside what they can express: - The geometry's `stride` must be a multiple of 4. WebGPU's `queue.writeBuffer` validates its copy size against that alignment and rejects anything else, so a mode with, say, a 38-byte stride draws on WebGL2 and fails validation on WebGPU. - An **indexed, non-instanced** mode always draws the geometry's fixed `indexCount` and ignores count on both backends. That is right for a fixed-topology mode and wrong for one whose element count varies per frame; such a mode needs the executors taught to derive an index count from count first. No mode ships in that shape today. - The **instanced, non-indexed** path draws `geometry.indexCount` vertices per instance, which for a geometry without indices is the vertex count its placeholder `vertexData` implies. A mode on that path therefore has to size `vertexData` to its vertices-per-instance rather than leave it empty.",
+  "description": "Turns a particle system's SoA storage into drawable vertex data. A mode owns the whole \"how\": the vertex layout, the shader pair, the draw model, and the loop that fills the buffer. The backend renderers only upload what it produces and issue the draw it declares, so a new primitive is a new mode rather than a renderer change. Implementations are fixed at system construction (see `ParticleSystemOptions.render`) and default to `QuadParticles`. **Limits of the seam.** The executors are deliberately thin, so a new mode has to stay inside what they can express: - The geometry's `stride` must be a multiple of 4. WebGPU's `queue.writeBuffer` validates its copy size against that alignment and rejects anything else, so a mode with, say, a 38-byte stride draws on WebGL2 and fails validation on WebGPU. - An **indexed, non-instanced** mode always draws the geometry's fixed `indexCount` and ignores count on both backends. That is right for a fixed-topology mode and wrong for one whose element count varies per frame; such a mode needs the executors taught to derive an index count from count first. No mode ships in that shape today. - An **instanced** mode that declares no vertexGeometry has to derive its vertices in the shader from the vertex index, and its dataLayout must carry the indices that address them. Without either there is nothing to tell the executors how many vertices one instance spans.",
   "symbol": "ParticleRenderMode",
   "kind": "class",
   "subsystem": "particles",
   "importPath": "@codexo/exojs-particles",
   "tier": "stable",
-  "memberCount": 12,
+  "memberCount": 13,
   "counts": {
     "constructors": 1,
     "methods": 5,
-    "properties": 6,
+    "properties": 7,
     "events": 0
   },
   "sections": [
@@ -23,7 +23,7 @@
         "A mode owns the whole \"how\": the vertex layout, the shader pair, the draw model, and the loop that fills the buffer. The backend renderers only upload what it produces and issue the draw it declares, so a new primitive is a new mode rather than a renderer change.",
         "Implementations are fixed at system construction (see `ParticleSystemOptions.render`) and default to `QuadParticles`.",
         "**Limits of the seam.** The executors are deliberately thin, so a new mode has to stay inside what they can express:",
-        "- The geometry's `stride` must be a multiple of 4. WebGPU's `queue.writeBuffer` validates its copy size against that alignment and rejects anything else, so a mode with, say, a 38-byte stride draws on WebGL2 and fails validation on WebGPU. - An **indexed, non-instanced** mode always draws the geometry's fixed `indexCount` and ignores count on both backends. That is right for a fixed-topology mode and wrong for one whose element count varies per frame; such a mode needs the executors taught to derive an index count from count first. No mode ships in that shape today. - The **instanced, non-indexed** path draws `geometry.indexCount` vertices per instance, which for a geometry without indices is the vertex count its placeholder `vertexData` implies. A mode on that path therefore has to size `vertexData` to its vertices-per-instance rather than leave it empty."
+        "- The geometry's `stride` must be a multiple of 4. WebGPU's `queue.writeBuffer` validates its copy size against that alignment and rejects anything else, so a mode with, say, a 38-byte stride draws on WebGL2 and fails validation on WebGPU. - An **indexed, non-instanced** mode always draws the geometry's fixed `indexCount` and ignores count on both backends. That is right for a fixed-topology mode and wrong for one whose element count varies per frame; such a mode needs the executors taught to derive an index count from count first. No mode ships in that shape today. - An **instanced** mode that declares no vertexGeometry has to derive its vertices in the shader from the vertex index, and its dataLayout must carry the indices that address them. Without either there is nothing to tell the executors how many vertices one instance spans."
       ],
       "importLine": "import { ParticleRenderMode } from '@codexo/exojs-particles'",
       "sourceLink": null
@@ -297,11 +297,11 @@
       "title": "Properties",
       "members": [
         {
-          "name": "geometry",
-          "signature": "geometry: Geometry",
+          "name": "dataLayout",
+          "signature": "dataLayout: ParticleBufferLayout",
           "signatureTokens": [
             {
-              "text": "geometry",
+              "text": "dataLayout",
               "kind": "name"
             },
             {
@@ -309,13 +309,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "ParticleBufferLayout",
               "kind": "type"
             }
           ],
           "params": [],
           "returnType": null,
-          "description": "Base geometry: topology, named attributes, buffer usage."
+          "description": "Layout of the buffer build fills each frame: attributes, stride, upload hint, and — when this mode declares no vertexGeometry — the topology and index list the draw uses. Named after data, the buffer it describes. It holds per-instance records for an instanced mode and per-vertex records otherwise, so a name fixed to either would be wrong for one of the two draw models."
         },
         {
           "name": "gpuEligible",
@@ -357,7 +357,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Draw model. true issues an instanced draw against geometry; false a plain draw over the built vertex buffer. Declared here because Geometry carries topology but has no instancing concept."
+          "description": "Draw model. true issues an instanced draw, false a plain draw over the built vertex buffer. Declared here because a layout carries topology but has no instancing concept."
         },
         {
           "name": "material",
@@ -379,6 +379,35 @@
           "params": [],
           "returnType": null,
           "description": "Shader pair plus uniforms/textures for this mode."
+        },
+        {
+          "name": "vertexGeometry",
+          "signature": "vertexGeometry: Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "vertexGeometry",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Fixed per-vertex geometry this mode instances, or null when it derives its vertices in the shader from the vertex index — which is what QuadParticles and RibbonParticles do. When set, it supplies the topology, index list and index count for the draw in place of dataLayout's, and the executors bind its vertexData as a second vertex buffer stepping per vertex beside the per-instance one. Only meaningful on an instanced mode: without instancing both buffers would step per vertex and no draw is expressible. Attribute names must not collide with dataLayout's, since both sets bind into the same shader. Mutating the geometry is picked up on the next draw through its version, so invalidate() after an in-place edit is enough to reach the GPU."
         },
         {
           "name": "count",

--- a/site/src/content/api/quad-particles.json
+++ b/site/src/content/api/quad-particles.json
@@ -6,11 +6,11 @@
   "subsystem": "particles",
   "importPath": "@codexo/exojs-particles",
   "tier": "stable",
-  "memberCount": 12,
+  "memberCount": 13,
   "counts": {
     "constructors": 1,
     "methods": 5,
-    "properties": 6,
+    "properties": 7,
     "events": 0
   },
   "sections": [
@@ -295,11 +295,11 @@
       "title": "Properties",
       "members": [
         {
-          "name": "geometry",
-          "signature": "geometry: Geometry",
+          "name": "dataLayout",
+          "signature": "dataLayout: ParticleBufferLayout",
           "signatureTokens": [
             {
-              "text": "geometry",
+              "text": "dataLayout",
               "kind": "name"
             },
             {
@@ -307,13 +307,13 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "ParticleBufferLayout",
               "kind": "type"
             }
           ],
           "params": [],
           "returnType": null,
-          "description": "The quad's four corners are derived in the shader — from gl_VertexID on WebGL2 and from vertex_index on WebGPU — so this geometry describes the per-instance layout and carries a zero-filled placeholder large enough for the four corner slots the index buffer addresses."
+          "description": "The quad's four corners are derived in the shader — from gl_VertexID on WebGL2 and from vertex_index on WebGPU — so this mode declares no per-vertex geometry and its layout carries the indices that address those four corner slots."
         },
         {
           "name": "gpuEligible",
@@ -355,7 +355,36 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Draw model. true issues an instanced draw against geometry; false a plain draw over the built vertex buffer. Declared here because Geometry carries topology but has no instancing concept."
+          "description": "Draw model. true issues an instanced draw, false a plain draw over the built vertex buffer. Declared here because a layout carries topology but has no instancing concept."
+        },
+        {
+          "name": "vertexGeometry",
+          "signature": "vertexGeometry: Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "vertexGeometry",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Fixed per-vertex geometry this mode instances, or null when it derives its vertices in the shader from the vertex index — which is what QuadParticles and RibbonParticles do. When set, it supplies the topology, index list and index count for the draw in place of dataLayout's, and the executors bind its vertexData as a second vertex buffer stepping per vertex beside the per-instance one. Only meaningful on an instanced mode: without instancing both buffers would step per vertex and no draw is expressible. Attribute names must not collide with dataLayout's, since both sets bind into the same shader. Mutating the geometry is picked up on the next draw through its version, so invalidate() after an in-place edit is enough to reach the GPU."
         },
         {
           "name": "count",

--- a/site/src/content/api/ribbon-particles.json
+++ b/site/src/content/api/ribbon-particles.json
@@ -6,11 +6,11 @@
   "subsystem": "particles",
   "importPath": "@codexo/exojs-particles",
   "tier": "stable",
-  "memberCount": 13,
+  "memberCount": 14,
   "counts": {
     "constructors": 1,
     "methods": 5,
-    "properties": 7,
+    "properties": 8,
     "events": 0
   },
   "sections": [
@@ -316,6 +316,27 @@
       "title": "Properties",
       "members": [
         {
+          "name": "dataLayout",
+          "signature": "dataLayout: ParticleBufferLayout",
+          "signatureTokens": [
+            {
+              "text": "dataLayout",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ParticleBufferLayout",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "A strip has no fixed vertex count — the draw covers whatever build emitted this frame. Non-indexed by construction: the strip's own vertex order is its topology, and an index list would pin the draw to a fixed index count."
+        },
+        {
           "name": "floatsPerVertex",
           "signature": "floatsPerVertex: number",
           "signatureTokens": [
@@ -335,27 +356,6 @@
           "params": [],
           "returnType": null,
           "description": "Floats spanned by one vertex. Exposed so callers reading data can step through it without hard-coding the stride."
-        },
-        {
-          "name": "geometry",
-          "signature": "geometry: Geometry",
-          "signatureTokens": [
-            {
-              "text": "geometry",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Geometry",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "A strip has no fixed vertex count — the draw covers whatever build emitted this frame — so the geometry describes only the layout and carries an empty placeholder. Non-indexed by construction: the strip's own vertex order is its topology, and an indexed geometry would pin the draw to a fixed index count."
         },
         {
           "name": "gpuEligible",
@@ -397,7 +397,36 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Draw model. true issues an instanced draw against geometry; false a plain draw over the built vertex buffer. Declared here because Geometry carries topology but has no instancing concept."
+          "description": "Draw model. true issues an instanced draw, false a plain draw over the built vertex buffer. Declared here because a layout carries topology but has no instancing concept."
+        },
+        {
+          "name": "vertexGeometry",
+          "signature": "vertexGeometry: Geometry | null",
+          "signatureTokens": [
+            {
+              "text": "vertexGeometry",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Geometry",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Fixed per-vertex geometry this mode instances, or null when it derives its vertices in the shader from the vertex index — which is what QuadParticles and RibbonParticles do. When set, it supplies the topology, index list and index count for the draw in place of dataLayout's, and the executors bind its vertexData as a second vertex buffer stepping per vertex beside the per-instance one. Only meaningful on an instanced mode: without instancing both buffers would step per vertex and no draw is expressible. Attribute names must not collide with dataLayout's, since both sets bind into the same shader. Mutating the geometry is picked up on the next draw through its version, so invalidate() after an in-place edit is enough to reach the GPU."
         },
         {
           "name": "count",

--- a/test/rendering/browser/_glslMocks.ts
+++ b/test/rendering/browser/_glslMocks.ts
@@ -52,6 +52,9 @@ vi.mock('../../../packages/exojs-particles/src/renderers/glsl/particle.frag', as
 vi.mock('../../../packages/exojs-particles/src/renderers/glsl/particle.vert', async () => ({
   default: (await import('../../../packages/exojs-particles/src/renderers/glsl/particle.vert?raw')).default,
 }));
+vi.mock('../../../packages/exojs-particles/src/renderModes/glsl/mesh.vert', async () => ({
+  default: (await import('../../../packages/exojs-particles/src/renderModes/glsl/mesh.vert?raw')).default,
+}));
 vi.mock('../../../packages/exojs-particles/src/renderModes/glsl/ribbon.frag', async () => ({
   default: (await import('../../../packages/exojs-particles/src/renderModes/glsl/ribbon.frag?raw')).default,
 }));

--- a/test/rendering/browser/webgl2-particles.test.ts
+++ b/test/rendering/browser/webgl2-particles.test.ts
@@ -445,3 +445,52 @@ describe('WebGL2 ParticleSystem — mesh', () => {
     }
   });
 });
+
+describe('WebGL2 ParticleSystem — mesh mutation', () => {
+  test('an in-place edit to the mesh reaches the GPU on the next draw', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture('#ffffff');
+    const mesh = createTriangleMesh();
+    const root = new Container();
+    const system = new ParticleSystem(texture, { capacity: 4, render: new MeshParticles({ geometry: mesh }) });
+
+    try {
+      const slot = system.spawn();
+
+      system.posX[slot] = 0;
+      system.posY[slot] = 0;
+      system.scaleX[slot] = 1;
+      system.scaleY[slot] = 1;
+      system.rotations[slot] = 0;
+      system.color[slot] = new Color(0, 255, 0).toRgba();
+      system.lifetime[slot] = 1;
+
+      system.setPosition(32, 32);
+      root.addChild(system);
+
+      render(backend, root);
+
+      // The right angle sits top-left, so the near corner is filled and the far
+      // one is past the hypotenuse.
+      expectPixelNear(readWebGl2Pixel(backend, 24, 24), [0, 255, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 44, 44), [0, 0, 0, 255]);
+
+      // Flip the triangle so the right angle sits bottom-right instead. The two
+      // sample points swap roles, which no stale buffer can reproduce.
+      const vertices = mesh.vertexData as Float32Array;
+
+      vertices.set([16, 16, 1, 1, -16, 16, 0, 1, 16, -16, 1, 0]);
+      mesh.invalidate();
+
+      render(backend, root);
+
+      expectPixelNear(readWebGl2Pixel(backend, 44, 44), [0, 255, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 24, 24), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      mesh.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});


### PR DESCRIPTION
Both particle executors bound exactly one vertex buffer with a single divisor — `buffers: [vertexLayout]` on WebGPU, one `divisor` for every attribute on WebGL2 — so a render mode could not supply per-vertex data alongside per-instance data, the standard instancing arrangement. `MeshParticles` worked around it by baking its vertices into a constant table in generated shader source. That rendered correctly but cost one compiled program per instance, made the geometry immutable after construction, and capped a mesh at a few hundred vertices.

**A mode now declares two things.** `dataLayout: ParticleBufferLayout` describes the buffer `build()` fills each frame; `vertexGeometry: Geometry | null` is fixed per-vertex data beside it. The executors bind the latter at slot 1 stepping per vertex. **The instance buffer stays at slot 0** — a GPU-mode system binds its compute pipeline's own buffer straight into it, and instance attributes keep shader locations `0..n-1`, so the compute-emitted layout and the quad and ribbon shaders are byte-identical to before.

**`ParticleBufferLayout` replaces the `Geometry` modes used to declare for this.** `Geometry` requires a position attribute, requires it to carry two components, and validates indices against the vertex count implied by its `vertexData` — none of which apply to a per-instance record. That last rule was the actual reason `MeshParticles` carried a placeholder `vertexData` sized to `mesh.vertexCount * instanceStrideBytes`: not to derive a vertex count, but to keep the index check quiet. It was never uploaded. `instanceGeometry` was considered and rejected as a name, since `RibbonParticles` is `instanced: false` and its buffer holds vertices.

**`MeshParticles` still normalises** a caller's mesh to `(x, y, u, v)` — a fixed shader needs fixed attribute names while a caller's geometry may use any — but the result fills a vertex buffer instead of shader source, and is re-read whenever the geometry's `version` changes. Editing a mesh in place and calling `invalidate()` now reaches the GPU on the next draw. Public API is unchanged: `new MeshParticles({ geometry })`.

## Verification

9000 node tests, 272 WebGL2 and 297 WebGPU browser tests, plus `lint:packages`, `typecheck` and `verify:quick`.

The four mesh browser specs from #490 are **unchanged** and green — they assert drawn pixels rather than the route taken, which is what shows the replacement is faithful. Both new capabilities were confirmed to have teeth: binding the wrong buffer at slot 1 fails exactly the three WebGPU mesh specs, and disabling the version comparison fails exactly the new mutation spec.

Follow-up context: this is the two-buffer instanced arrangement Immediate-Render v2's per-instance-attributes blocker needs as a blueprint — proven on both backends, though not shared code.