### PR TITLE
docs: correct documentation that contradicts the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ A TypeScript-first 2D engine for games and interactive apps. Explicit scene grap
 **Scene & UI**
 
 - `Application`, `Scene`, `SceneDirector` — one active scene with `change`/`restore`/`preload`/`unload` navigation, `pause`/`resume`, and fade, slide, or cross-fade transitions (or your own `SceneTransition`)
-- `scene.ui` — screen-fixed widget layer with `Label`, `Panel`, `Button`, `ProgressBar`, `Stack`, anchoring, and a `FocusManager` with keyboard navigation
+- `scene.ui` — screen-fixed widget layer with `Label`, `Panel`, `Button`, `ProgressBar`, `Stack`, `ScrollContainer`, `Tooltip`, and anchoring
+- Keyboard focus through `app.interaction` — `focus`, `blur`, `focusNext`/`focusPrevious` Tab traversal, and scoped focus traps for modals
 
 **Physics** (`@codexo/exojs-physics`)
 

--- a/examples/getting-started/resize-and-dpr.js
+++ b/examples/getting-started/resize-and-dpr.js
@@ -47,8 +47,8 @@ const app = new Application({
 document.body.style.margin = '0';
 // #region guide:resize
 // This example demonstrates manual resize handling: the canvas is resized to
-// fill the window on every `resize` event. (For a hands-off alternative, enable
-// the `autosize` canvas option instead.)
+// fill the window on every `resize` event. (For a hands-off alternative, set the
+// `sizingMode` canvas option to `'fill'` and let the engine track the parent.)
 window.addEventListener('resize', () => {
     app.resize(window.innerWidth, window.innerHeight);
 });

--- a/examples/getting-started/resize-and-dpr.ts
+++ b/examples/getting-started/resize-and-dpr.ts
@@ -58,8 +58,8 @@ document.body.style.margin = '0';
 
 // #region guide:resize
 // This example demonstrates manual resize handling: the canvas is resized to
-// fill the window on every `resize` event. (For a hands-off alternative, enable
-// the `autosize` canvas option instead.)
+// fill the window on every `resize` event. (For a hands-off alternative, set the
+// `sizingMode` canvas option to `'fill'` and let the engine track the parent.)
 window.addEventListener('resize', () => {
     app.resize(window.innerWidth, window.innerHeight);
 });

--- a/packages/exojs-ldtk/README.md
+++ b/packages/exojs-ldtk/README.md
@@ -6,11 +6,13 @@ Official ExoJS extension for loading [LDtk](https://ldtk.io) level files (`.ldtk
 ## Installation
 
 ```sh
-npm install @codexo/exojs @codexo/exojs-ldtk
+npm install @codexo/exojs @codexo/exojs-tilemap @codexo/exojs-ldtk
 ```
 
-`@codexo/exojs` is a peer dependency. `@codexo/exojs-tilemap` is a regular dependency and is
-installed transitively — you do not need to install it manually.
+Both `@codexo/exojs` and `@codexo/exojs-tilemap` are **peer** dependencies, so install them
+explicitly alongside the adapter. Nothing is pulled in transitively: strict package managers
+(pnpm, Yarn PnP) will not resolve an unlisted peer, and npm's auto-install of peers still leaves
+the versions outside your control. Keep the engine and every adapter on the same version.
 
 ## What this package provides
 

--- a/packages/exojs-tiled/README.md
+++ b/packages/exojs-tiled/README.md
@@ -6,11 +6,13 @@ into a generic runtime `TileMap` or a typed parsed source model.
 ## Installation
 
 ```sh
-npm install @codexo/exojs @codexo/exojs-tiled
+npm install @codexo/exojs @codexo/exojs-tilemap @codexo/exojs-tiled
 ```
 
-`@codexo/exojs` is a peer dependency. `@codexo/exojs-tilemap` is a regular dependency and is
-installed transitively by `@codexo/exojs-tiled` — you do not need to install it manually.
+Both `@codexo/exojs` and `@codexo/exojs-tilemap` are **peer** dependencies, so install them
+explicitly alongside the adapter. Nothing is pulled in transitively: strict package managers
+(pnpm, Yarn PnP) will not resolve an unlisted peer, and npm's auto-install of peers still leaves
+the versions outside your control. Keep the engine and every adapter on the same version.
 
 If you want the generic tilemap runtime without the Tiled adapter:
 

--- a/packages/exojs-tilemap/README.md
+++ b/packages/exojs-tilemap/README.md
@@ -11,9 +11,10 @@ parse their format and hand this runtime fully-resolved tiles.
 npm install @codexo/exojs @codexo/exojs-tilemap
 ```
 
-`@codexo/exojs` is a peer dependency. Most users load Tiled maps and get this package
-transitively through `@codexo/exojs-tiled` — install it directly only for procedural or
-custom-format maps.
+`@codexo/exojs` is a peer dependency, so install it explicitly. This package is itself a peer of
+the format adapters (`@codexo/exojs-tiled`, `@codexo/exojs-ldtk`) rather than something they pull
+in transitively — install it whether you use an adapter or build procedural / custom-format maps
+directly.
 
 ## What this package provides
 

--- a/site/src/content/api/application.json
+++ b/site/src/content/api/application.json
@@ -1368,7 +1368,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Device/render pixel ratio applied to the backing buffer. Defaults to the host devicePixelRatio clamped to 2 (crisp on HiDPI out of the box, but capped to avoid a runaway fill-rate cost on DPR-3 phones) unless an explicit canvas.pixelRatio option was given. Holds the invariant app.canvas.width === Math.round(app.width × app.pixelRatio)."
+          "description": "Device/render pixel ratio applied to the backing buffer. Defaults to the host devicePixelRatio clamped to 2 (crisp on HiDPI out of the box, but capped to avoid a runaway fill-rate cost on DPR-3 phones) unless an explicit canvas.pixelRatio option was given. Holds the invariant app.canvas.width === Math.round(app.width × app.pixelRatio) in every sizing mode except 'letterbox', where the backing store instead tracks the parent's fitted CSS content rect (contentWidthCss × pixelRatio, see computeLetterboxLayout) while Application.width stays fixed at the design size — the GL viewport is recomputed separately to map the design space onto that backing store."
         },
         {
           "name": "recentErrors",

--- a/site/src/content/api/audio-sprite-clip.json
+++ b/site/src/content/api/audio-sprite-clip.json
@@ -1,6 +1,6 @@
 {
   "title": "AudioSpriteClip",
-  "description": "Named sub-region of an AudioBuffer used as an audio sprite sheet. `start` / `end` are seconds into the buffer; `loop` makes Sound.playSprite loop the sprite indefinitely.",
+  "description": "Named sub-region of an AudioBuffer used as an audio sprite sheet. `start` / `end` are seconds into the buffer; `loop` makes the clip loop indefinitely when played.",
   "symbol": "AudioSpriteClip",
   "kind": "interface",
   "subsystem": "audio",
@@ -19,7 +19,7 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Named sub-region of an AudioBuffer used as an audio sprite sheet. `start` / `end` are seconds into the buffer; `loop` makes Sound.playSprite loop the sprite indefinitely."
+        "Named sub-region of an AudioBuffer used as an audio sprite sheet. `start` / `end` are seconds into the buffer; `loop` makes the clip loop indefinitely when played."
       ],
       "importLine": "import { AudioSpriteClip } from '@codexo/exojs'",
       "sourceLink": null

--- a/site/src/content/api/game-cube-gamepad-mapping.json
+++ b/site/src/content/api/game-cube-gamepad-mapping.json
@@ -1,6 +1,6 @@
 {
   "title": "GameCubeGamepadMapping",
-  "description": "Mapping for Nintendo GameCube controllers (typically connected via a USB adapter such as the official Nintendo adapter for Wii U / Switch). Inherits the full GenericDualAnalogGamepadMapping button and axis layout. Note that the GameCube controller has no right-stick click, no D-pad as discrete buttons on all adapters, and uses analog shoulders — the exact channel availability depends on the adapter's HID report.",
+  "description": "Mapping for Nintendo GameCube controllers (typically connected via a USB adapter such as the official Nintendo adapter for Wii U / Switch). Inherits the full GenericDualAnalogGamepadMapping button and axis layout unchanged; `family` is the only distinguishing factor from the generic mapping. The real GameCube controller's channel availability (e.g. right-stick click, D-pad as discrete buttons, digital vs. analog shoulders) differs by adapter and is not modeled here — treat GenericDualAnalogGamepadMapping.hasChannel results for this mapping as the generic dual-analog layout, not a verified GameCube-accurate one.",
   "symbol": "GameCubeGamepadMapping",
   "kind": "class",
   "subsystem": "input",
@@ -20,7 +20,7 @@
       "members": [],
       "paragraphs": [
         "Mapping for Nintendo GameCube controllers (typically connected via a USB adapter such as the official Nintendo adapter for Wii U / Switch).",
-        "Inherits the full GenericDualAnalogGamepadMapping button and axis layout. Note that the GameCube controller has no right-stick click, no D-pad as discrete buttons on all adapters, and uses analog shoulders — the exact channel availability depends on the adapter's HID report."
+        "Inherits the full GenericDualAnalogGamepadMapping button and axis layout unchanged; `family` is the only distinguishing factor from the generic mapping. The real GameCube controller's channel availability (e.g. right-stick click, D-pad as discrete buttons, digital vs. analog shoulders) differs by adapter and is not modeled here — treat GenericDualAnalogGamepadMapping.hasChannel results for this mapping as the generic dual-analog layout, not a verified GameCube-accurate one."
       ],
       "importLine": "import { GameCubeGamepadMapping } from '@codexo/exojs'",
       "sourceLink": null

--- a/site/src/content/api/gamepad-axis-options.json
+++ b/site/src/content/api/gamepad-axis-options.json
@@ -51,7 +51,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Skip the deadzone clamp. Used for aggregate signed channels (LeftStickX, LeftStickY, ...) that need to preserve the full [-1, +1] range and apply their own deadzone client-side. Default false."
+          "description": "Use a symmetric (absolute-value) deadzone that preserves sign, instead of the one-sided value > threshold check used for unipolar 0..1 axes. Used for aggregate signed channels (LeftStickX, LeftStickY, ...) that need the full [-1, +1] range, with values on either side of zero passing once past threshold. Default false."
         },
         {
           "name": "invert",

--- a/site/src/content/api/gamepad-axis.json
+++ b/site/src/content/api/gamepad-axis.json
@@ -182,7 +182,7 @@
             }
           ],
           "returnType": "number",
-          "description": "Apply the axis transform pipeline to a raw browser axis value (typically Gamepad.axes[i], in -1..1). Pipeline: clamp to [-1, 1] → optional invert → optional normalize to [0, 1] → bipolar passthrough OR deadzone (returns 0 when the absolute value is at or below threshold)."
+          "description": "Apply the axis transform pipeline to a raw browser axis value (typically Gamepad.axes[i], in -1..1). Pipeline: clamp to [-1, 1] → optional invert → optional normalize to [0, 1] → deadzone. bipolar picks a symmetric, sign-preserving deadzone (returns 0 when the absolute value is at or below threshold); otherwise a one-sided check is used (returns 0 unless the value exceeds threshold)."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/sound-play-options.json
+++ b/site/src/content/api/sound-play-options.json
@@ -1,6 +1,6 @@
 {
   "title": "SoundPlayOptions",
-  "description": "Per-call overrides for Sound.play and Sound.playSprite.",
+  "description": "Per-call overrides for AudioManager.play.",
   "symbol": "SoundPlayOptions",
   "kind": "interface",
   "subsystem": "audio",
@@ -19,7 +19,7 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Per-call overrides for Sound.play and Sound.playSprite."
+        "Per-call overrides for AudioManager.play."
       ],
       "importLine": "import { SoundPlayOptions } from '@codexo/exojs'",
       "sourceLink": null

--- a/site/src/content/guide/assets/ldtk.mdx
+++ b/site/src/content/guide/assets/ldtk.mdx
@@ -14,10 +14,10 @@ image, and converting **each LDtk level** into a runtime [`TileMap`](/ExoJS/en/a
 can drop straight into the scene graph.
 
 > **Note:** `LdtkMap` ships as an official ExoJS extension package, separate from the core. It is
-> built on `@codexo/exojs-tilemap` (a regular dependency, installed transitively — you do not need
-> to add it yourself). Install `@codexo/exojs-ldtk` alongside `@codexo/exojs`:
+> built on `@codexo/exojs-tilemap`, and both that package and `@codexo/exojs` are peer
+> dependencies — install all three explicitly, on the same version:
 > ```sh
-> npm install @codexo/exojs @codexo/exojs-ldtk
+> npm install @codexo/exojs @codexo/exojs-tilemap @codexo/exojs-ldtk
 > ```
 
 Because each LDtk level becomes a generic `TileMap`, you render LDtk worlds with the same tilemap

--- a/site/src/content/guide/assets/tiled-maps.mdx
+++ b/site/src/content/guide/assets/tiled-maps.mdx
@@ -13,10 +13,11 @@ format (`.tmj`) through the normal [`Loader`](/ExoJS/en/api/loader/) pipeline â€
 map, resolving its tileset image references, and returning a `TiledMap` you can read for layer
 and tile data.
 
-> **Note:** `TiledMap` ships as an official ExoJS extension package, separate from the core.
-> Install `@codexo/exojs-tiled` alongside `@codexo/exojs`:
+> **Note:** `TiledMap` ships as an official ExoJS extension package, separate from the core. It is
+> built on `@codexo/exojs-tilemap`, and both that package and `@codexo/exojs` are peer
+> dependencies â€” install all three explicitly, on the same version:
 > ```sh
-> npm install @codexo/exojs @codexo/exojs-tiled
+> npm install @codexo/exojs @codexo/exojs-tilemap @codexo/exojs-tiled
 > ```
 
 <Callout type="pitfall" title="TiledMap is data, not something you can draw">

--- a/site/src/content/guide/rendering/text.mdx
+++ b/site/src/content/guide/rendering/text.mdx
@@ -7,7 +7,9 @@ import ExamplePreview from '../../../components/ExamplePreview.astro';
 
 # Text
 
-[`Text`](/ExoJS/en/api/text/) renders GPU-accelerated text strings as nodes in the scene graph. Each `Text` instance rasterizes its glyphs into the engine's shared glyph atlas and draws them as a single `Mesh` — one draw call per text node, regardless of string length. The node extends `Container` and inherits full transform, filter, blend, and mask support.
+[`Text`](/ExoJS/en/api/text/) renders GPU-accelerated text strings as nodes in the scene graph. Each `Text` instance rasterizes its glyphs into a shared glyph atlas and hands the resulting quads to the text renderer, which merges every quad that shares a shader type and an atlas page into one draw call — across text nodes, not just within a single one.
+
+`Text` is a [`Drawable`](/ExoJS/en/api/drawable/) (via [`AbstractText`](/ExoJS/en/api/abstract-text/)), not a [`Container`](/ExoJS/en/api/container/): it carries the full transform, tint, blend mode, pixel-snap, filter, and mask surface of any other drawable, but it holds no children of its own. Nest it inside a `Container` when you need to group it with other nodes.
 
 ## A minimal text node
 
@@ -21,15 +23,15 @@ const label = new Text('Hello', {
 });
 ```
 
-The second argument is a `TextOptions` object — a flat merge of [`TextStyleOptions`](/ExoJS/en/api/text-style/) (visual appearance) and `LayoutOptions` (flow and overflow). All properties are optional and have defaults. The live `TextStyle` is stored as `text.style`; mutating its fields is cheap and is applied automatically before the next render pass — no manual rebuild call is needed:
+The second argument is a [`TextOptions`](/ExoJS/en/api/text-options/) object — a flat merge of [`TextStyleOptions`](/ExoJS/en/api/text-style-options/) (visual appearance) and [`LayoutOptions`](/ExoJS/en/api/layout-options/) (flow and overflow). All properties are optional and have defaults. The live [`TextStyle`](/ExoJS/en/api/text-style/) is stored as `text.style`; mutating its fields is cheap and is applied automatically before the next render pass — no manual rebuild call is needed:
 
 ```ts
 import { Color, Text } from '@codexo/exojs';
 
 const label = new Text('Hello', { fillColor: Color.black, fontSize: 24 });
 
-label.style.fontSize = 32;            // rebuilds the glyph mesh on the next draw
-label.style.fillColor = Color.tomato; // updates only the mesh tint — no atlas work
+label.style.fontSize = 32;            // re-lays out the glyphs on the next draw
+label.style.fillColor = Color.tomato; // shader-side colour only — no atlas work
 ```
 
 ## Font loading
@@ -52,12 +54,25 @@ init() {
 
 Loading resolves to a `FontFace`, registered with the document's `document.fonts` set. Once loaded, it becomes available to all `Text` instances via the `fontFamily` style property.
 
+You can also hand the loaded face to the node directly through the `font` style option. `Text` registers it with `document.fonts` itself and rebuilds once it is ready, which removes the ordering requirement between loading and construction:
+
+```ts
+async load() {
+    const face = await this.loader.load(Asset.type('font', 'font/MyFont.woff2', { family: 'MyFont' }));
+
+    this.title = new Text('Custom Font', { font: face, fontSize: 48 });
+}
+```
+
+`font` takes precedence over `fontFamily` when both are set.
+
 ## Style properties
 
-The visual appearance comes from [`TextStyleOptions`](/ExoJS/en/api/text-style/). All properties are optional:
+The visual appearance comes from [`TextStyleOptions`](/ExoJS/en/api/text-style-options/). All properties are optional:
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
+| `font` | `FontFace` | — | Pre-loaded font face; takes precedence over `fontFamily` |
 | `fontFamily` | `string` | `'Arial'` | CSS font family name |
 | `fontWeight` | `FontWeight` | `'normal'` | CSS font weight (`'normal'`, `'bold'`, or `'100'`–`'900'`) |
 | `fontStyle` | `'normal' \| 'italic'` | `'normal'` | Font style |
@@ -65,7 +80,7 @@ The visual appearance comes from [`TextStyleOptions`](/ExoJS/en/api/text-style/)
 | `fillColor` | `Color` | `Color.white` | Glyph fill colour |
 | `outlineColor` | `Color` | `Color.black` | SDF outline colour |
 | `outlineWidth` | `number` | `0` | Outline width in SDF units (`0`–`0.5`); `0` disables the outline |
-| `align` | `'left' \| 'center' \| 'right'` | `'left'` | Horizontal alignment |
+| `align` | [`TextAlignment`](/ExoJS/en/api/text-alignment/) — `'left' \| 'center' \| 'right' \| 'justify'` | `'left'` | Horizontal alignment |
 | `lineHeight` | `number` | `1.2` | Line-height multiplier on `fontSize` |
 | `leading` | `number` | `0` | Extra pixel gap between lines |
 | `shadowColor` | `Color` | `Color.black` | Drop-shadow colour |
@@ -76,18 +91,21 @@ The visual appearance comes from [`TextStyleOptions`](/ExoJS/en/api/text-style/)
 | `gradientColors` | `[Color, Color] \| null` | `null` | Two-stop fill gradient `[top, bottom]`; overrides `fillColor` |
 | `gradientAxis` | `'vertical' \| 'horizontal'` | `'vertical'` | Gradient orientation |
 
-Text flow and overflow come from `LayoutOptions`, merged into the same options object:
+Text flow and overflow come from [`LayoutOptions`](/ExoJS/en/api/layout-options/), merged into the same options object:
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `maxWidth` | `number` | — | Word-wrap boundary in pixels; longer lines break at word boundaries |
-| `maxHeight` | `number` | — | Clip boundary in pixels |
-| `overflow` | `'visible' \| 'clip' \| 'ellipsis'` | `'visible'` | Behaviour when text exceeds `maxHeight` |
+| `maxHeight` | `number` | — | Vertical boundary in pixels; only whole lines that fit are kept. No effect on its own — pair it with `overflow` |
+| `overflow` | `'visible' \| 'clip' \| 'ellipsis'` | `'visible'` | What happens to lines that do not fit `maxHeight`: keep them all, drop them, or drop them and mark the last visible line with `…` |
 | `letterSpacing` | `number` | `0` | Extra pixel gap between glyphs |
+| `direction` | `'ltr' \| 'rtl'` | `'ltr'` | `'rtl'` reverses each line's glyphs after wrapping; no full bidi or Arabic shaping, and `align` stays literal |
 | `breakWords` | `boolean` | `false` | Break words wider than `maxWidth` at character boundaries |
 | `whiteSpace` | `'normal' \| 'pre' \| 'pre-line'` | `'pre-line'` | Whitespace handling |
 
-Glyphs are rasterized into the shared SDF atlas; the mesh tint is initialized from `fillColor` when the mesh is built.
+Layout options stay reachable as `text.layout`. Unlike `style`, this is a plain options object with no change tracking: assigning a new one rebuilds the geometry, mutating the existing one in place does not.
+
+Glyphs are rasterized white into the shared SDF atlas and coloured at draw time, so `fillColor`, `outlineColor`, the shadow, and the gradient are shader work only — changing them never touches the atlas.
 
 ## Multiline text and wrap settings
 
@@ -135,9 +153,11 @@ centered.setPosition(400, 20);
 
 A center-aligned text node at `(400, 20)` centers its glyphs horizontally around `x=400` in local space.
 
+`'justify'` is the fourth mode: it spreads the extra space of a line evenly across its inter-word gaps so every line reaches the width of the widest line. The last line and any line with a single word are left alone, so a justified block never stretches a trailing fragment.
+
 ## Text in the scene graph
 
-`Text` extends `Container`, so it carries position, rotation, scale, origin, and anchor. You can rotate text, tint the whole node, apply filters, and nest it inside other containers:
+As a `Drawable`, `Text` carries position, rotation, scale, origin, and anchor like any other scene node. You can rotate text, tint the whole node, apply filters, and add it to a container — but not add children to it:
 
 ```ts
 this.hud = new Container();
@@ -147,15 +167,32 @@ this.hud.addChild(this.scoreLabel);
 this.addChild(this.hud);
 ```
 
-The text node's internal mesh is a `Container` child. Assigning to `text.text` rebuilds the glyph mesh. This means:
-- Changing text every frame is fine — the mesh is rebuilt on demand, at most once per frame.
-- Mutating `style` fields (e.g. `text.style.fillColor = ...`) is also picked up automatically before the next draw — no manual rebuild needed.
+The glyph geometry is not a child node — it lives on the `Text` itself as per-atlas-page quad data the text renderer consumes. Two rebuild paths feed it:
+- Assigning `text.text` (or `text.layout`, or a whole new `text.style`) re-lays out immediately. Assigning the same string is a no-op, so changing the text every frame only costs a rebuild on the frames it actually changes.
+- Mutating `style` fields (e.g. `text.style.fillColor = ...`) only raises a dirty flag. Any number of mutations in one frame coalesce into at most one rebuild, applied automatically before the next draw — no manual call needed. `text.syncDirty()` forces it early, which is what you want before reading bounds right after a style change.
+
+The node's local bounds track the laid-out text, so an anchored label re-derives its origin whenever the string changes width — a centred score readout stays centred as it grows.
+
+## Measuring text
+
+`text.textBounds` reports the pixel dimensions of the laid-out block in local space as a [`TextSize`](/ExoJS/en/api/text-size/) (`{ width, height }`) — use it to size a panel around a label or to position something next to it:
+
+```ts
+this.label = new Text('Ready', { fontSize: 24 });
+
+this.backdrop = new Panel({
+    width: this.label.textBounds.width + 16,
+    height: this.label.textBounds.height + 8,
+});
+```
+
+Reading it right after a style mutation returns the pre-change size, because style changes are only applied on the next draw. Call `this.label.syncDirty()` first to force the pending rebuild.
 
 ## Text constraints
 
-- The glyph atlas is shared across all `Text` instances and has a fixed default size. Large sets of unique glyph/style combinations can exhaust atlas space.
+- One glyph atlas is shared per font variant (family, style, weight, colour mode, SDF radius), so nodes that differ only in size or colour reuse the same atlas — and nodes that differ in family or weight do not. The atlas grows by adding 1024×1024 pages as needed; large sets of unique glyph/size combinations cost VRAM rather than failing, but a single glyph larger than one page throws.
 - `Text` does not expose per-character styling. Use separate `Text` instances for mixed-style strings.
-- `Text` does not measure or report its pixel dimensions through the public API — the mesh bounds reflect the glyph quad size but measured width/height in pixels is not exposed as a public getter.
+- `Text` is a leaf drawable, not a container — it takes no children.
 - Loader-based `FontAsset` loading is the built-in path for custom fonts; any font family available to the browser's canvas text engine can be used once loaded.
 
 ## Examples

--- a/src/audio/Sound.ts
+++ b/src/audio/Sound.ts
@@ -39,8 +39,8 @@ interface NormalizedAudioSpriteClip {
 
 /**
  * Named sub-region of an {@link AudioBuffer} used as an audio sprite sheet.
- * `start` / `end` are seconds into the buffer; `loop` makes
- * {@link Sound.playSprite} loop the sprite indefinitely.
+ * `start` / `end` are seconds into the buffer; `loop` makes the clip loop
+ * indefinitely when played.
  */
 export interface AudioSpriteClip {
   start: number;
@@ -64,7 +64,7 @@ export interface SoundOptions {
   muted?: boolean;
 }
 
-/** Per-call overrides for {@link Sound.play} and {@link Sound.playSprite}. */
+/** Per-call overrides for {@link AudioManager.play}. */
 export interface SoundPlayOptions extends PlayOptions {
   /**
    * When `true`, all currently-playing instances of this sound are stopped
@@ -419,12 +419,12 @@ export class Sound implements Playable {
    */
   private _notLoadedVoice(bus: AudioBus): Voice | null {
     if (this._loadState.value === 'failed') {
-      logger.warn('Sound.play() called on a sound that failed to load; playing silence.', { source: 'Sound' });
+      logger.warn('AudioManager.play() called on a sound that failed to load; playing silence.', { source: 'Sound' });
       return new NoopVoice(bus);
     }
 
     if (this._audioBuffer === null || this._loadState.value === 'loading') {
-      logger.warn('Sound.play() called on a sound that is not yet loaded; playing silence. Await sound.loaded or use loader.load().', { source: 'Sound' });
+      logger.warn('AudioManager.play() called on a sound that is not yet loaded; playing silence. Await sound.loaded or use loader.load().', { source: 'Sound' });
       return new NoopVoice(bus);
     }
 

--- a/src/audio/Sound.ts
+++ b/src/audio/Sound.ts
@@ -424,7 +424,9 @@ export class Sound implements Playable {
     }
 
     if (this._audioBuffer === null || this._loadState.value === 'loading') {
-      logger.warn('AudioManager.play() called on a sound that is not yet loaded; playing silence. Await sound.loaded or use loader.load().', { source: 'Sound' });
+      logger.warn('AudioManager.play() called on a sound that is not yet loaded; playing silence. Await sound.loaded or use loader.load().', {
+        source: 'Sound',
+      });
       return new NoopVoice(bus);
     }
 

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -735,7 +735,12 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
    * host `devicePixelRatio` clamped to `2` (crisp on HiDPI out of the box, but
    * capped to avoid a runaway fill-rate cost on DPR-3 phones) unless an
    * explicit `canvas.pixelRatio` option was given. Holds the invariant
-   * `app.canvas.width === Math.round(app.width × app.pixelRatio)`.
+   * `app.canvas.width === Math.round(app.width × app.pixelRatio)` in every
+   * sizing mode except `'letterbox'`, where the backing store instead tracks
+   * the parent's fitted CSS content rect (`contentWidthCss × pixelRatio`,
+   * see {@link computeLetterboxLayout}) while {@link Application.width} stays
+   * fixed at the design size — the GL viewport is recomputed separately to
+   * map the design space onto that backing store.
    */
   public get pixelRatio(): number {
     return this._pixelRatio;

--- a/src/core/PhasedSceneTransition.ts
+++ b/src/core/PhasedSceneTransition.ts
@@ -298,7 +298,10 @@ export class PhasedSceneTransitionSession implements SceneTransitionSession {
   }
 
   public destroy(): void {
-    // No resources of its own — pooled textures/input gate are Director-owned.
+    // Owns `_identitySprite`, but it only references pooled textures
+    // (Director-owned) and is never attached to a scene graph — dropping the
+    // session's own reference is enough for GC to reclaim it, no explicit
+    // Sprite.destroy() needed here.
   }
 }
 

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -1374,10 +1374,9 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
    * per-frame ticking is done by `Application.update()` (or manually in
    * tests). The input gate is held open for the session's whole lifetime.
    *
-   * KNOWN LIMITATION: a transitioned navigation run as part of the very first
-   * navigation inside `Application.start()` deadlocks — nothing drives the per-frame methods
-   * yet (the frame loop has not started). Do not exercise a transitioned
-   * navigation through `Application.start()`; drive `SceneDirector` directly.
+   * Safe to exercise as the very first navigation inside `Application.start()`:
+   * the frame loop goes live before the initial navigation runs, so a
+   * frame-driven session always has something to drive it.
    */
   private async _runTransitionedAction(commit: () => Promise<void>, context: SceneTransitionContext, transition: SceneTransition): Promise<void> {
     const requirements = transition.getRequirements(context);

--- a/src/core/transitions/CrossFadeSceneTransition.ts
+++ b/src/core/transitions/CrossFadeSceneTransition.ts
@@ -74,7 +74,10 @@ class CrossFadeSession implements SceneTransitionSession {
   }
 
   public destroy(): void {
-    // No owned resources — pooled textures are Director-owned.
+    // Owns `_currentSprite`/`_snapshotSprite`, but they only reference
+    // pooled textures (Director-owned) and are never attached to a scene
+    // graph — dropping the session's own reference is enough for GC to
+    // reclaim them, no explicit Sprite.destroy() needed here.
   }
 
   /** Draw `texture` full-frame (no offset — a crossfade only blends opacity) via `sprite` at `alpha`. */

--- a/src/input/GameCubeGamepadMapping.ts
+++ b/src/input/GameCubeGamepadMapping.ts
@@ -6,9 +6,13 @@ import { GenericDualAnalogGamepadMapping } from './GenericDualAnalogGamepadMappi
  * USB adapter such as the official Nintendo adapter for Wii U / Switch).
  *
  * Inherits the full {@link GenericDualAnalogGamepadMapping} button and axis
- * layout. Note that the GameCube controller has no right-stick click, no
- * D-pad as discrete buttons on all adapters, and uses analog shoulders —
- * the exact channel availability depends on the adapter's HID report.
+ * layout unchanged; `family` is the only distinguishing factor from the
+ * generic mapping. The real GameCube controller's channel availability
+ * (e.g. right-stick click, D-pad as discrete buttons, digital vs. analog
+ * shoulders) differs by adapter and is not modeled here — treat
+ * {@link GenericDualAnalogGamepadMapping.hasChannel} results for this
+ * mapping as the generic dual-analog layout, not a verified
+ * GameCube-accurate one.
  */
 export class GameCubeGamepadMapping extends GenericDualAnalogGamepadMapping {
   public override readonly family = GamepadMappingFamily.GameCube;

--- a/src/input/GamepadAxis.ts
+++ b/src/input/GamepadAxis.ts
@@ -75,9 +75,11 @@ export interface GamepadAxisOptions {
    */
   threshold?: number;
   /**
-   * Skip the deadzone clamp. Used for aggregate signed channels
-   * (`LeftStickX`, `LeftStickY`, ...) that need to preserve the full
-   * [-1, +1] range and apply their own deadzone client-side.
+   * Use a symmetric (absolute-value) deadzone that preserves sign, instead of
+   * the one-sided `value > threshold` check used for unipolar 0..1 axes. Used
+   * for aggregate signed channels (`LeftStickX`, `LeftStickY`, ...) that need
+   * the full [-1, +1] range, with values on either side of zero passing once
+   * past `threshold`.
    * Default `false`.
    */
   bipolar?: boolean;
@@ -126,8 +128,9 @@ export class GamepadAxis {
    * (typically `Gamepad.axes[i]`, in -1..1).
    *
    * Pipeline: clamp to [-1, 1] → optional invert → optional normalize to
-   * [0, 1] → bipolar passthrough OR deadzone (returns 0 when the absolute
-   * value is at or below `threshold`).
+   * [0, 1] → deadzone. `bipolar` picks a symmetric, sign-preserving deadzone
+   * (returns 0 when the absolute value is at or below `threshold`); otherwise
+   * a one-sided check is used (returns 0 unless the value exceeds `threshold`).
    */
   public transformValue(value: number): number {
     let result = clamp(value, -1, 1);

--- a/src/rendering/RenderBackend.ts
+++ b/src/rendering/RenderBackend.ts
@@ -81,8 +81,10 @@ export interface RenderBackend {
    * shape. Nested clips intersect (ref-incremented). Used internally by the
    * `Geometry` `clipShape` path on {@link RenderNode.clip}.
    *
-   * Composes freely with the scissor stack. Backends without stencil support
-   * (currently WebGPU) throw a clear error rather than rendering incorrectly.
+   * Composes freely with the scissor stack. Both backends implement this
+   * with matching pixel-level behavior — WebGL2 via a stencil renderbuffer,
+   * WebGPU via a shared `depth24plus-stencil8` attachment and stencil-enabled
+   * pipeline variants.
    */
   pushStencilClip(shape: Geometry, transform: Matrix): this;
 

--- a/src/rendering/sprite/spriteMaterialSources.ts
+++ b/src/rendering/sprite/spriteMaterialSources.ts
@@ -27,7 +27,7 @@
 /**
  * GLSL ES 3.00 vertex shader for the custom sprite-material path. Identical
  * corner expansion and attribute contract to the default sprite vertex shader
- * (tint read from the shared transform slot's texel 2, no per-instance color).
+ * (tint read from the separate `u_tintTexture`, no per-instance color).
  * @internal
  */
 export const spriteVertexGlsl = `#version 300 es

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -36,12 +36,13 @@ import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './
  *
  * Neither the per-instance world transform nor the tint live in this buffer:
  * both are fetched in the vertex shader from the shared {@link TransformBuffer}
- * texture (`u_transforms`) keyed by `a_nodeIndex`, exactly like the mesh
- * renderer (transform = texels 0/1, tint = texel 2). The render-group upload
- * boundary already packs every draw command's transform AND tint into that
- * buffer at its stable `nodeIndex`, so the sprite reads both back instead of
- * duplicating a per-instance color stream. The vertex shader still expands one
- * instance into four corners on the GPU.
+ * state, keyed by `a_nodeIndex`, exactly like the mesh renderer — the
+ * transform (`u_transforms`, 2 texels/row) and the tint (`u_tintTexture`, its
+ * own rgba8 texel/row) are separate textures, both written at the
+ * render-group upload boundary at the draw command's stable `nodeIndex`, so
+ * the sprite reads both back instead of duplicating a per-instance color
+ * stream. The vertex shader still expands one instance into four corners on
+ * the GPU.
  *
  * # Default vs custom-material path
  *
@@ -594,7 +595,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     u32[offset + 5] = uMax | (vMax << 16);
 
     // textureSlot (u32) at word 6. The tint is NOT packed here: the vertex
-    // shader reads it from the shared transform slot's texel 2 (same value the
+    // shader reads it from the separate u_tintTexture (same value the
     // transform-buffer upload boundary wrote from this sprite's tint).
     u32[offset + 6] = slot;
 

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -1182,8 +1182,9 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     u32[offset + 5] = uMax | (vMax << 16);
 
     // packedSlotFlags (u32) at word 6 (offset 24). The tint is NOT packed here:
-    // the vertex shader reads it from the shared transform slot's texel 2 (m2),
-    // the same value the transform-storage upload wrote from this sprite's tint.
+    // the vertex shader reads it from the separate `tints` storage buffer
+    // (unpacked via unpack4x8unorm), the same value the transform-storage
+    // upload wrote from this sprite's tint.
     u32[offset + 6] = packedSlotFlags;
 
     // nodeIndex (u32) at word 7 (offset 28) — row into the shared transform buffer.

--- a/test/core/transitions/cross-fade-scene-transition.test.ts
+++ b/test/core/transitions/cross-fade-scene-transition.test.ts
@@ -155,7 +155,7 @@ describe('CrossFadeSceneTransition', () => {
     expect(session.done).toBe(true);
   });
 
-  test('destroy() does not throw (no owned resources — pooled textures are Director-owned)', () => {
+  test('destroy() does not throw (its sprites only reference Director-owned pooled textures)', () => {
     const crossFade = new CrossFadeSceneTransition();
     const session = crossFade.beginSession(makeEnvironment());
 


### PR DESCRIPTION
Fixes the thirteen pure documentation defects from the independent architecture review — places where JSDoc, guides or READMEs claim something the code does not do. No behaviour changes: the only non-comment edits are two `logger.warn` message texts naming a method that no longer exists, and one stale test title.

## JSDoc

- `SceneDirector._runTransitionedAction` warned about a deadlock that the current startup order rules out — `_startFrameLoop()` runs before the initial navigation and `update()` gates on `_frameLoopActive`. A regression test for this already exists, so the warning is simply gone.
- `pixelRatio` stated an invariant that does not hold in `'letterbox'` mode, where the backing store follows the fitted CSS content rect.
- `RenderBackend.pushStencilClip` claimed WebGPU throws on stencil clipping. WebGPU implements it fully, with parity coverage.
- Four comments still described the pre-split combined transform/tint buffer layout ("tint as texel 2"). Tint has since moved to its own texture/storage buffer.
- `PhasedSceneTransitionSession` and `CrossFadeSession` claimed "no owned resources" while holding their own sprites. They are not a leak — the sprites only reference Director-owned pooled textures and never enter a scene graph — but the comment said the wrong thing.
- `Sound` referenced `Sound.play()`/`Sound.playSprite()`, neither of which exists any more.
- `GamepadAxisOptions.bipolar` documented skipping the deadzone; `transformValue` always applies one.
- `GameCubeGamepadMapping` documented a device-specific layout it does not have — it inherits the generic dual-analog mapping unchanged, so `hasChannel()` answers accordingly. The JSDoc now says so instead of contradicting it.

## Guides and READMEs

- `rendering/text.mdx` claimed `Text extends Container` (it is a `Drawable` via `AbstractText`), that the glyph mesh is a child node (geometry lives on the node itself), that pixel dimensions are not exposed (`textBounds` does), and listed `align` without `'justify'`. Two further claims turned out wrong while verifying: the glyph atlas is per font variant rather than global, and the renderer batches across text nodes per shader type and atlas page.
- The README advertised a `FocusManager`. The real class is `FocusController`, which is `@internal` and not exported — the README now documents the actual entry point, `app.interaction`.
- The README's widget list omitted `ScrollContainer` and `Tooltip`.
- An example comment named a non-existent `autosize` canvas option; the real one is `sizingMode`.
- The Tiled and LDtk READMEs promised `@codexo/exojs` as a transitively installed regular dependency. Both packages declare it — and `@codexo/exojs-tilemap` — as peers only, so the documented model breaks under pnpm and Yarn PnP. The install commands were incomplete for the same reason. The same claim in `exojs-tilemap`'s README and in the LDtk/Tiled guides is corrected too; the remaining adapter packages already state it correctly.

## Verification

`pnpm verify:quick` passes in full: typechecks across all packages, `typecheck:guides` (256 snippets), `typecheck:examples`, `astro check` (82 files, 0 errors), lint at `--max-warnings=0`, `docs:api:check`, `examples:sync:check`. Affected test files run green.