### PR TITLE
fix(core): guard each system's destroy(), and always run the registry's reset tail

### DIFF
--- a/site/src/content/api/system-registry.json
+++ b/site/src/content/api/system-registry.json
@@ -167,7 +167,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": "Destroy every remaining registered system exactly once, in reverse registration order, then clear the registry. A system already removed via SystemRegistry.remove — even if not yet structurally finalized — is not destroyed: remove() never destroys."
+          "description": "Destroy every remaining registered system exactly once, in reverse registration order, then clear the registry. A system already removed via SystemRegistry.remove — even if not yet structurally finalized — is not destroyed: remove() never destroys. Each system is destroyed under its own guard and the clear-and-reset tail always runs, so one throwing system can neither skip the systems after it nor leave the registry live. Systems are the extension seam, which makes a throwing destroy() the case to expect rather than a remote one. Failures are logged, never propagated — including in development, where DisposalScope.destroy rethrows an AggregateError instead. The difference is the caller: Application._disposeManagedResources invokes this method unguarded, part-way through an ordered teardown, so a throw here would strand the rendering context, audio, input, backend, platform and clocks that come after it — reinstating the very leak this guard closes."
         },
         {
           "name": "has",

--- a/src/core/SystemRegistry.ts
+++ b/src/core/SystemRegistry.ts
@@ -425,12 +425,30 @@ export class SystemRegistry implements Destroyable {
    * registration order, then clear the registry. A system already removed
    * via {@link SystemRegistry.remove} — even if not yet structurally
    * finalized — is not destroyed: `remove()` never destroys.
+   *
+   * Each system is destroyed under its own guard and the clear-and-reset tail
+   * always runs, so one throwing system can neither skip the systems after it
+   * nor leave the registry live. Systems are the extension seam, which makes a
+   * throwing `destroy()` the case to expect rather than a remote one.
+   *
+   * Failures are logged, never propagated — including in development, where
+   * {@link DisposalScope.destroy} rethrows an `AggregateError` instead. The
+   * difference is the caller: `Application._disposeManagedResources` invokes
+   * this method unguarded, part-way through an ordered teardown, so a throw
+   * here would strand the rendering context, audio, input, backend, platform
+   * and clocks that come after it — reinstating the very leak this guard
+   * closes.
    */
   public destroy(): void {
     const remaining = [...this._registrations.values()].filter(registration => registration.active).sort((a, b) => b.sequence - a.sequence);
+    const failures: unknown[] = [];
 
     for (const registration of remaining) {
-      registration.system.destroy?.();
+      try {
+        registration.system.destroy?.();
+      } catch (error) {
+        failures.push(error);
+      }
     }
 
     this._registrations.clear();
@@ -443,6 +461,10 @@ export class SystemRegistry implements Destroyable {
     this._activeCount = 0;
     this.onAdd.destroy();
     this.onRemove.destroy();
+
+    for (const error of failures) {
+      logger.error('SystemRegistry.destroy(): a system threw while being destroyed.', { source: 'SystemRegistry', ...(error instanceof Error && { error }) });
+    }
   }
 
   private _insert(system: System, options?: SystemRegistrationOptions): void {

--- a/test/core/application-extension-systems.test.ts
+++ b/test/core/application-extension-systems.test.ts
@@ -143,6 +143,31 @@ describe('Application app-system extension bindings', () => {
     expect(order).toEqual(['user', 'extension']);
   });
 
+  test('a throwing extension system does not strand the teardown steps after systems.destroy()', async () => {
+    const extSystem: System = {
+      update: vi.fn(),
+      destroy: (): never => {
+        throw new Error('extension system blew up');
+      },
+    };
+    const binding: ApplicationSystemBinding = { create: () => extSystem };
+    const ext: Extension = { id: 'throwing-destroy', systems: [binding] };
+    const app = new Application({ backend: { type: 'webgl2' }, extensions: [ext] });
+
+    // onFrame is destroyed at the very end of _disposeManagedResources, well
+    // past systems.destroy() — a live handler afterwards means the chain that
+    // also releases rendering, audio, input, backend and platform was cut short.
+    app.onFrame.add(() => {});
+
+    app.destroy();
+
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(app.onFrame.count).toBe(0);
+  });
+
   test('a renderer-only extension adds no system of its own', () => {
     const ext: Extension = { id: 'renderer-only', renderers: [] };
     const baseline = new Application({ backend: { type: 'webgl2' } });

--- a/test/core/system-registry.test.ts
+++ b/test/core/system-registry.test.ts
@@ -1,3 +1,4 @@
+import { logger, LogSeverity } from '#core/logging';
 import type { System } from '#core/System';
 import { SystemRegistry } from '#core/SystemRegistry';
 import { Time } from '#core/Time';
@@ -112,5 +113,83 @@ describe('SystemRegistry ordering — before/after', () => {
 
     expect(() => tick(registry)).toThrow(/CycleSystemA/);
     expect(() => tick(registry)).toThrow(/CycleSystemB/);
+  });
+});
+
+describe('SystemRegistry.destroy() — a throwing system cannot strand the rest', () => {
+  test('every remaining system is destroyed even when an earlier one throws', () => {
+    const registry = new SystemRegistry();
+    const destroyed: string[] = [];
+
+    // Reverse registration order, so the thrower sits between two survivors.
+    registry.add({ update: (): void => {}, destroy: (): void => void destroyed.push('first') });
+    registry.add({
+      update: (): void => {},
+      destroy: (): never => {
+        throw new Error('extension system blew up');
+      },
+    });
+    registry.add({ update: (): void => {}, destroy: (): void => void destroyed.push('last') });
+
+    registry.destroy();
+
+    expect(destroyed).toEqual(['last', 'first']);
+  });
+
+  test('the clear-and-reset tail still runs, so the registry does not stay live', () => {
+    const registry = new SystemRegistry();
+    const survivor = { update: (): void => {} };
+
+    registry.add({
+      update: (): void => {},
+      destroy: (): never => {
+        throw new Error('extension system blew up');
+      },
+    });
+    registry.add(survivor);
+    registry.onRemove.add(() => {});
+
+    registry.destroy();
+
+    expect(registry.size).toBe(0);
+    expect(registry.has(survivor)).toBe(false);
+    expect(registry.onRemove.count).toBe(0);
+  });
+
+  test('destroy() does not propagate a system failure to its caller', () => {
+    const registry = new SystemRegistry();
+
+    registry.add({
+      update: (): void => {},
+      destroy: (): never => {
+        throw new Error('extension system blew up');
+      },
+    });
+
+    expect(() => registry.destroy()).not.toThrow();
+  });
+  test('the swallowed failure is reported through the logger, not lost', () => {
+    const registry = new SystemRegistry();
+    const reported: string[] = [];
+    const removeSink = logger.addSink(entry => {
+      if (entry.severity === LogSeverity.Error) reported.push(entry.message);
+    });
+
+    registry.add({
+      update: (): void => {},
+      destroy: (): never => {
+        throw new Error('extension system blew up');
+      },
+    });
+
+    try {
+      registry.destroy();
+    } finally {
+      removeSink();
+      logger._resetOnce();
+    }
+
+    expect(reported).toHaveLength(1);
+    expect(reported[0]).toMatch(/SystemRegistry\.destroy\(\)/);
   });
 });


### PR DESCRIPTION
`NEU-A1` from the consolidated architecture review — the one instance of the
Batch A error class that the batch itself did not close.

## The defect

`SystemRegistry.destroy()` called `registration.system.destroy?.()` in an
unguarded loop, with the entire clear-and-reset tail behind it:
`_registrations.clear()`, five list resets, `_activeCount`, and
`onAdd/onRemove.destroy()`. A single throwing system skipped the systems after
it *and* the tail — leaving the registry **live**, not merely half torn down.

The real exposure is one level up, in `Application._disposeManagedResources()`,
which calls `systems.destroy()` unguarded part-way through an ordered teardown.
One throwing extension system stranded rendering, animations, tweens, audio,
interaction, input, backend, platform, the three clocks and every
Application-level `Signal`. Systems are the extension seam, so a throwing
`destroy()` is the case to expect rather than a remote one.

On the construction-rollback path the same call is already contained by
`attempt()`. The regular `destroy()` path was not.

## The fix

Each system is destroyed under its own guard, the tail always runs, and the
collected failures are logged at the end.

Unlike `DisposalScope.destroy()`, nothing is rethrown in development builds.
That asymmetry is deliberate and documented on the method: the unguarded caller
above means a `__DEV__` `AggregateError` here would cut the very chain this
guard exists to keep running.

## Verification

`pnpm verify:quick` — exit 0. `pnpm typecheck:test` within budget (baseline
unchanged). API docs regenerated and in sync.

Five new pins, each verified to fail against the preceding commit: survivors
still destroyed, tail still runs, no propagation to the caller, failure
reported through the logger rather than swallowed, and an Application-level pin
that a throwing extension system no longer strands the steps after
`systems.destroy()`.
