### PR TITLE
ci: let Codecov wait for both coverage uploads before it judges

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,19 @@
+# Coverage arrives in exactly two uploads: `unit` (jsdom lane) and `browser`
+# (Chromium-WebGL2 lane). Both jobs in `_ci-checks.yml` are gated on the same
+# `changes.outputs.engine == 'true'`, so they either both run or neither does —
+# there is no case where one upload arrives alone and the second never comes.
+#
+# Without this, Codecov judges the first upload it receives and posts a verdict
+# on jsdom-only coverage: every line the browser lane covers counts as a miss,
+# so `codecov/patch` goes red for several minutes and only flips to green once
+# the second upload lands. The verdict was always correct in the end — the red
+# was purely an artefact of judging half the data.
+codecov:
+  notify:
+    after_n_builds: 2
+    # Don't judge before the CI run itself has finished reporting.
+    wait_for_ci: true
+
 coverage:
   # Minimum project-wide coverage before Codecov reports a failure.
   # Start permissive; tighten once coverage grows above these floors.
@@ -27,6 +43,7 @@ comment:
   layout: 'reach,diff,flags,components,files'
   behavior: default
   require_changes: true # only comment when coverage actually changes
+  after_n_builds: 2 # same reason as `codecov.notify` — never comment on half the data
 
 # Upload flags — one per CI lane that uploads (see _ci-checks.yml).
 flags:


### PR DESCRIPTION
## What was actually wrong

`codecov/patch` was not "usually failing" — it was **usually correct, but
published too early**.

Coverage arrives in two uploads: `unit` from the jsdom lane and `browser` from
the Chromium-WebGL2 lane. Codecov judged whichever landed first, which meant the
patch verdict was computed against jsdom-only coverage — every line only the
browser lane reaches counted as a miss. The status went red for a few minutes on
most PRs, then flipped to green when the second upload arrived.

The measured record, over the last 30 merged PRs:

| | |
|---|---:|
| ended `success` | 19 |
| ended `failure` | 1 (#465) |
| no coverage status at all (docs-only, both lanes skipped) | 10 |

PR #494 — the one that prompted this — finished at **97.17% of diff hit against
a 60% target**. It was green well before it merged. The red I reported mid-run
was a verdict on half the data.

That is the real cost: a check that is red for a while on every PR and green by
the end trains everyone to stop reading it, and then the one genuine failure
(#465) goes unnoticed too.

## The change

`codecov.notify.after_n_builds: 2` holds the verdict until both uploads are in;
`comment.after_n_builds: 2` does the same for the PR comment.

Safe here because both jobs in `_ci-checks.yml` are gated on the same
`changes.outputs.engine == 'true'` — they either both run or neither does, so a
lone upload waiting forever for a partner that never comes cannot happen. A
docs-only PR skips both lanes and gets no coverage status, which is already
today's behaviour.

No thresholds were touched: the 60% patch target is met with room to spare, and
the hard regression gate remains the vitest coverage thresholds, not these
statuses.

Validated against `codecov.io/validate` (`Valid!`, both fields parsed).
