### PR TITLE
fix(scene-graph): Batch B — container bounds, structural atomicity, rotated culling, math scratch aliasing

### DIFF
--- a/site/src/content/api/button.json
+++ b/site/src/content/api/button.json
@@ -473,7 +473,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/container.json
+++ b/site/src/content/api/container.json
@@ -314,7 +314,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/flags.json
+++ b/site/src/content/api/flags.json
@@ -6,10 +6,10 @@
   "subsystem": "math",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 8,
+  "memberCount": 12,
   "counts": {
     "constructors": 1,
-    "methods": 6,
+    "methods": 10,
     "properties": 1,
     "events": 0
   },
@@ -101,6 +101,53 @@
       "id": "methods",
       "title": "Methods",
       "members": [
+        {
+          "name": "addMask",
+          "signature": "addMask(mask: number): this",
+          "signatureTokens": [
+            {
+              "text": "addMask",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "mask",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "mask",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": "Set every bit of mask (bitwise OR). Mutates in place and returns this for chaining. Prefer this over push on hot paths: a rest parameter allocates an array on every call, and the scene graph's transform invalidation runs one of these per ancestor per mutation."
+        },
         {
           "name": "clear",
           "signature": "clear(): this",
@@ -208,7 +255,54 @@
             }
           ],
           "returnType": "boolean",
-          "description": "Return true when **any** of the supplied flags are currently set (bitwise OR test)."
+          "description": "Return true when **any** of the supplied flags are currently set (bitwise OR test). Allocates a rest array and a closure per call — use hasMask on hot paths."
+        },
+        {
+          "name": "hasMask",
+          "signature": "hasMask(mask: number): boolean",
+          "signatureTokens": [
+            {
+              "text": "hasMask",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "mask",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "mask",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "description": "Return true when **any** bit of mask is currently set. Allocation-free counterpart of has."
         },
         {
           "name": "pop",
@@ -256,6 +350,53 @@
           ],
           "returnType": "boolean",
           "description": "Remove flag and return true if it was active before removal, false otherwise. Useful for one-shot consumption of a flag."
+        },
+        {
+          "name": "popMask",
+          "signature": "popMask(mask: number): boolean",
+          "signatureTokens": [
+            {
+              "text": "popMask",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "mask",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "mask",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "boolean",
+          "description": "Clear every bit of mask and return whether any of them was set before. Allocation-free counterpart of pop."
         },
         {
           "name": "push",
@@ -306,7 +447,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set one or more flags (bitwise OR). Mutates in place and returns this for chaining."
+          "description": "Set one or more flags (bitwise OR). Mutates in place and returns this for chaining. Allocates a rest array per call — use addMask on hot paths."
         },
         {
           "name": "remove",
@@ -357,7 +498,54 @@
             }
           ],
           "returnType": "this",
-          "description": "Clear one or more flags (bitwise AND NOT). Mutates in place and returns this for chaining."
+          "description": "Clear one or more flags (bitwise AND NOT). Mutates in place and returns this for chaining. Allocates a rest array per call — use removeMask on hot paths."
+        },
+        {
+          "name": "removeMask",
+          "signature": "removeMask(mask: number): this",
+          "signatureTokens": [
+            {
+              "text": "removeMask",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "mask",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "mask",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "this",
+          "description": "Clear every bit of mask (bitwise AND NOT). Mutates in place and returns this for chaining. Allocation-free counterpart of remove."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/flags.json
+++ b/site/src/content/api/flags.json
@@ -1,6 +1,6 @@
 {
   "title": "Flags",
-  "description": "Type-safe bitfield utility for managing sets of numeric enum flags. `T` should be a numeric const-enum or a type whose values are `number`. Internally stores the combined flags as a single 32-bit integer.",
+  "description": "Type-safe bitfield utility for managing sets of numeric enum flags. `T` should be a numeric const-enum or a type whose values are `number`. Internally stores the combined flags as a single 32-bit integer. Pass the enum TYPE as `T`, not `typeof MyEnum` — the reverse mapping of a numeric enum object carries string values and does not satisfy the constraint. Rest-argument methods (push, remove, has) allocate an array per call. On hot paths use the mask forms (addMask, removeMask, hasMask, popMask) with a pre-combined mask instead.",
   "symbol": "Flags",
   "kind": "class",
   "subsystem": "math",
@@ -20,7 +20,9 @@
       "members": [],
       "paragraphs": [
         "Type-safe bitfield utility for managing sets of numeric enum flags.",
-        "`T` should be a numeric const-enum or a type whose values are `number`. Internally stores the combined flags as a single 32-bit integer."
+        "`T` should be a numeric const-enum or a type whose values are `number`. Internally stores the combined flags as a single 32-bit integer.",
+        "Pass the enum TYPE as `T`, not `typeof MyEnum` — the reverse mapping of a numeric enum object carries string values and does not satisfy the constraint.",
+        "Rest-argument methods (push, remove, has) allocate an array per call. On hot paths use the mask forms (addMask, removeMask, hasMask, popMask) with a pre-combined mask instead."
       ],
       "importLine": "import { Flags } from '@codexo/exojs'",
       "sourceLink": null

--- a/site/src/content/api/graphics.json
+++ b/site/src/content/api/graphics.json
@@ -311,7 +311,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/htmltext.json
+++ b/site/src/content/api/htmltext.json
@@ -354,7 +354,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/image-layer-node.json
+++ b/site/src/content/api/image-layer-node.json
@@ -333,7 +333,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/label.json
+++ b/site/src/content/api/label.json
@@ -494,7 +494,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/panel.json
+++ b/site/src/content/api/panel.json
@@ -473,7 +473,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/progress-bar.json
+++ b/site/src/content/api/progress-bar.json
@@ -473,7 +473,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -390,7 +390,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -475,7 +475,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/stack.json
+++ b/site/src/content/api/stack.json
@@ -473,7 +473,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/tile-layer-node.json
+++ b/site/src/content/api/tile-layer-node.json
@@ -358,7 +358,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/tile-map-band.json
+++ b/site/src/content/api/tile-map-band.json
@@ -279,7 +279,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/tile-map-node.json
+++ b/site/src/content/api/tile-map-node.json
@@ -357,7 +357,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/uiroot.json
+++ b/site/src/content/api/uiroot.json
@@ -313,7 +313,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/site/src/content/api/widget.json
+++ b/site/src/content/api/widget.json
@@ -456,7 +456,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op."
+          "description": "Insert child at index in the child list. The child is detached from any previous parent first. Throws if index is out of bounds, if child has already been destroy()ed, or if child is an ancestor of this container (would create a cycle). Self-as-child is a no-op. When child already belongs to this container the call is a pure reorder: the node keeps its parent, its stage and its keyboard focus."
         },
         {
           "name": "addFilter",

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -467,23 +467,23 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   public getTransform(): Matrix {
-    if (this.flags.has(SceneNodeTransformFlags.Transform)) {
+    if (this.flags.hasMask(SceneNodeTransformFlags.Transform)) {
       this.updateTransform();
-      this.flags.remove(SceneNodeTransformFlags.Transform);
+      this.flags.removeMask(SceneNodeTransformFlags.Transform);
     }
 
     return this._transform;
   }
 
   public updateTransform(): this {
-    if (this.flags.has(SceneNodeTransformFlags.Rotation)) {
+    if (this.flags.hasMask(SceneNodeTransformFlags.Rotation)) {
       const radians = degreesToRadians(this._rotation);
 
       this._cos = Math.cos(radians);
       this._sin = Math.sin(radians);
     }
 
-    if (this.flags.has(SceneNodeTransformFlags.Rotation | SceneNodeTransformFlags.Scaling | SceneNodeTransformFlags.Skew)) {
+    if (this.flags.hasMask(SceneNodeTransformFlags.Rotation | SceneNodeTransformFlags.Scaling | SceneNodeTransformFlags.Skew)) {
       const { x, y } = this._scale;
 
       if (this._skewX !== 0 || this._skewY !== 0) {
@@ -569,9 +569,9 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   public getBounds(): Rectangle {
     this.getGlobalTransform(); // ensures this node's own _globalTransformVersion is current
 
-    if (this.flags.has(SceneNodeTransformFlags.BoundsRect) || this._boundsBuiltAtVersion !== this._globalTransformVersion) {
+    if (this.flags.hasMask(SceneNodeTransformFlags.BoundsRect) || this._boundsBuiltAtVersion !== this._globalTransformVersion) {
       this.updateBounds();
-      this.flags.remove(SceneNodeTransformFlags.BoundsRect);
+      this.flags.removeMask(SceneNodeTransformFlags.BoundsRect);
       this._boundsBuiltAtVersion = this._globalTransformVersion;
     }
 
@@ -635,7 +635,7 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     const boundary = parent !== null && parent._isTransformGroupBoundary && !this._escapesTransformGroup();
     const parentTransform = parent !== null && !boundary ? parent.getGlobalTransform() : null;
     const parentVersion = parent !== null && !boundary ? parent._globalTransformVersion : NO_PARENT_VERSION;
-    const stale = this.flags.has(SceneNodeTransformFlags.GlobalTransform) || this._combinedParentVersion !== parentVersion;
+    const stale = this.flags.hasMask(SceneNodeTransformFlags.GlobalTransform) || this._combinedParentVersion !== parentVersion;
 
     if (stale) {
       this._globalTransform.copy(this.getTransform());
@@ -645,7 +645,7 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
       }
 
       this._combinedParentVersion = parentVersion;
-      this.flags.remove(SceneNodeTransformFlags.GlobalTransform);
+      this.flags.removeMask(SceneNodeTransformFlags.GlobalTransform);
       this._globalTransformVersion++;
     }
 
@@ -962,7 +962,7 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
 
   /** Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk. */
   public _invalidateSubtreeTransform(): void {
-    this.flags.push(SceneNodeTransformFlags.GlobalTransform | SceneNodeTransformFlags.BoundsRect);
+    this.flags.addMask(SceneNodeTransformFlags.GlobalTransform | SceneNodeTransformFlags.BoundsRect);
   }
 
   /** Mark own Bounds dirty AND propagate up to Container ancestors' Bounds. */
@@ -988,7 +988,7 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     // Mark own bounds + notify interaction for THIS node unconditionally —
     // the manager filters to tracked interactive nodes so this call is O(1)
     // for the common case (non-interactive node — fast Set.has miss).
-    this.flags.push(SceneNodeTransformFlags.BoundsRect);
+    this.flags.addMask(SceneNodeTransformFlags.BoundsRect);
     this._stage?.interaction._notifyBoundsInvalidated(this as unknown as RenderNode);
 
     // Walk up, but stop at the first ancestor already flagged dirty: if a parent
@@ -996,8 +996,8 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     // so re-walking it is redundant work.
     let ancestor = this._parentNode;
 
-    while (ancestor !== null && !ancestor.flags.has(SceneNodeTransformFlags.BoundsRect)) {
-      ancestor.flags.push(SceneNodeTransformFlags.BoundsRect);
+    while (ancestor !== null && !ancestor.flags.hasMask(SceneNodeTransformFlags.BoundsRect)) {
+      ancestor.flags.addMask(SceneNodeTransformFlags.BoundsRect);
       ancestor._stage?.interaction._notifyBoundsInvalidated(ancestor);
       ancestor = ancestor.parent;
     }
@@ -1195,31 +1195,31 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   private _setPositionDirty(): void {
-    this.flags.push(SceneNodeTransformFlags.Translation);
+    this.flags.addMask(SceneNodeTransformFlags.Translation);
     this._invalidateSubtreeTransform();
     this._markOwnTransformDirty();
   }
 
   private _setRotationDirty(): void {
-    this.flags.push(SceneNodeTransformFlags.Rotation);
+    this.flags.addMask(SceneNodeTransformFlags.Rotation);
     this._invalidateSubtreeTransform();
     this._markOwnTransformDirty();
   }
 
   private _setScalingDirty(): void {
-    this.flags.push(SceneNodeTransformFlags.Scaling);
+    this.flags.addMask(SceneNodeTransformFlags.Scaling);
     this._invalidateSubtreeTransform();
     this._markOwnTransformDirty();
   }
 
   private _setOriginDirty(): void {
-    this.flags.push(SceneNodeTransformFlags.Origin);
+    this.flags.addMask(SceneNodeTransformFlags.Origin);
     this._invalidateSubtreeTransform();
     this._markOwnTransformDirty();
   }
 
   private _setSkewDirty(): void {
-    this.flags.push(SceneNodeTransformFlags.Skew);
+    this.flags.addMask(SceneNodeTransformFlags.Skew);
     this._invalidateSubtreeTransform();
     this._markOwnTransformDirty();
   }

--- a/src/input/InputManager.ts
+++ b/src/input/InputManager.ts
@@ -849,7 +849,7 @@ export class InputManager {
     }
 
     this.keyEvents.push({ channel, pressed: true });
-    this.flags.push(InputManagerFlag.KeyChange);
+    this.flags.addMask(InputManagerFlag.KeyChange);
 
     if (capturedByAggregate || this.capturedKeyChannels.has(channel)) {
       stopEvent(event);
@@ -887,7 +887,7 @@ export class InputManager {
     }
 
     this.keyEvents.push({ channel, pressed: false });
-    this.flags.push(InputManagerFlag.KeyChange);
+    this.flags.addMask(InputManagerFlag.KeyChange);
 
     if (capturedByAggregate || this.capturedKeyChannels.has(channel)) {
       stopEvent(event);
@@ -1088,7 +1088,7 @@ export class InputManager {
     // would be silently lost. `updateEvents` resets this to zero once the
     // accumulated total has been dispatched for the frame.
     this.wheelOffset.add(normalizeWheelDelta(event.deltaX, event.deltaMode), normalizeWheelDelta(event.deltaY, event.deltaMode));
-    this.flags.push(InputManagerFlag.MouseWheel);
+    this.flags.addMask(InputManagerFlag.MouseWheel);
 
     stopEvent(event);
   }
@@ -1124,7 +1124,7 @@ export class InputManager {
         this.channels[channel] = 0;
         this._recordChannelChanges(channel, 1);
         this.keyEvents.push({ channel, pressed: false });
-        this.flags.push(InputManagerFlag.KeyChange);
+        this.flags.addMask(InputManagerFlag.KeyChange);
       }
     }
   }
@@ -1310,7 +1310,7 @@ export class InputManager {
   }
 
   private updateEvents(): this {
-    if (this.flags.pop(InputManagerFlag.KeyChange)) {
+    if (this.flags.popMask(InputManagerFlag.KeyChange)) {
       // In true arrival order — a Shift-up followed by a Tab-down must
       // dispatch in that same order, or FocusController would still see
       // Shift held when Tab's handler runs and misread it as Shift+Tab.
@@ -1325,7 +1325,7 @@ export class InputManager {
       this.keyEvents.length = 0;
     }
 
-    if (this.flags.pop(InputManagerFlag.MouseWheel)) {
+    if (this.flags.popMask(InputManagerFlag.MouseWheel)) {
       this.onMouseWheel.dispatch(this.wheelOffset);
       this.wheelOffset.set(0, 0);
     }

--- a/src/math/Flags.ts
+++ b/src/math/Flags.ts
@@ -6,12 +6,25 @@ import type { TypedEnum } from '#core/types';
  * `T` should be a numeric const-enum or a type whose values are `number`.
  * Internally stores the combined flags as a single 32-bit integer.
  *
+ * Pass the enum TYPE as `T`, not `typeof MyEnum` — the reverse mapping of a
+ * numeric enum object carries string values and does not satisfy the
+ * constraint.
+ *
+ * Rest-argument methods ({@link push}, {@link remove}, {@link has}) allocate an
+ * array per call. On hot paths use the mask forms ({@link addMask},
+ * {@link removeMask}, {@link hasMask}, {@link popMask}) with a pre-combined
+ * mask instead.
+ *
  * @example
  * ```ts
- * const flags = new Flags<typeof MyEnum>(MyEnum.A, MyEnum.B);
+ * const flags = new Flags<MyEnum>(MyEnum.A, MyEnum.B);
  * flags.has(MyEnum.A); // true
  * flags.remove(MyEnum.A);
  * flags.push(MyEnum.C);
+ *
+ * // Hot path: no rest array.
+ * flags.addMask(MyEnum.A | MyEnum.C);
+ * flags.hasMask(MyEnum.A | MyEnum.B); // true when EITHER is set
  * ```
  */
 export class Flags<T extends TypedEnum<T, number>> {

--- a/src/math/Flags.ts
+++ b/src/math/Flags.ts
@@ -23,14 +23,59 @@ export class Flags<T extends TypedEnum<T, number>> {
   }
 
   public constructor(...flags: number[]) {
-    if (flags.length) {
-      this.push(...flags);
+    for (const flag of flags) {
+      this._value |= flag;
     }
   }
 
   /**
-   * Set one or more flags (bitwise OR). Mutates in place and returns `this`
+   * Set every bit of `mask` (bitwise OR). Mutates in place and returns `this`
    * for chaining.
+   *
+   * Prefer this over {@link push} on hot paths: a rest parameter allocates an
+   * array on every call, and the scene graph's transform invalidation runs one
+   * of these per ancestor per mutation.
+   */
+  public addMask(mask: number): this {
+    this._value |= mask;
+
+    return this;
+  }
+
+  /**
+   * Clear every bit of `mask` (bitwise AND NOT). Mutates in place and returns
+   * `this` for chaining. Allocation-free counterpart of {@link remove}.
+   */
+  public removeMask(mask: number): this {
+    this._value &= ~mask;
+
+    return this;
+  }
+
+  /**
+   * Return `true` when **any** bit of `mask` is currently set. Allocation-free
+   * counterpart of {@link has}.
+   */
+  public hasMask(mask: number): boolean {
+    return (this._value & mask) !== 0;
+  }
+
+  /**
+   * Clear every bit of `mask` and return whether any of them was set before.
+   * Allocation-free counterpart of {@link pop}.
+   */
+  public popMask(mask: number): boolean {
+    const active = this.hasMask(mask);
+
+    this.removeMask(mask);
+
+    return active;
+  }
+
+  /**
+   * Set one or more flags (bitwise OR). Mutates in place and returns `this`
+   * for chaining. Allocates a rest array per call — use {@link addMask} on hot
+   * paths.
    */
   public push<V extends number = T[keyof T]>(...flags: V[]): this {
     for (const flag of flags) {
@@ -45,16 +90,13 @@ export class Flags<T extends TypedEnum<T, number>> {
    * otherwise. Useful for one-shot consumption of a flag.
    */
   public pop<V extends number = T[keyof T]>(flag: V): boolean {
-    const active = this.has(flag);
-
-    this.remove(flag);
-
-    return active;
+    return this.popMask(flag);
   }
 
   /**
    * Clear one or more flags (bitwise AND NOT). Mutates in place and returns
-   * `this` for chaining.
+   * `this` for chaining. Allocates a rest array per call — use
+   * {@link removeMask} on hot paths.
    */
   public remove<V extends number = T[keyof T]>(...flags: V[]): this {
     for (const flag of flags) {
@@ -66,10 +108,17 @@ export class Flags<T extends TypedEnum<T, number>> {
 
   /**
    * Return `true` when **any** of the supplied flags are currently set
-   * (bitwise OR test).
+   * (bitwise OR test). Allocates a rest array and a closure per call — use
+   * {@link hasMask} on hot paths.
    */
   public has<V extends number = T[keyof T]>(...flags: V[]): boolean {
-    return flags.some(flag => (this._value & flag) !== 0);
+    for (const flag of flags) {
+      if ((this._value & flag) !== 0) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   public clear(): this {

--- a/src/math/Matrix.ts
+++ b/src/math/Matrix.ts
@@ -153,7 +153,20 @@ export class Matrix implements Cloneable {
    * returns `this` for chaining.
    */
   public translate(x: number, y: number = x): Matrix {
-    return this.combine(Matrix.temp.set(1, 0, x, 0, 1, y, 0, 0, 1));
+    // Expanded from `combine(translationMatrix)` with the zero terms dropped.
+    // Routing this through `Matrix.temp` made the shared scratch self-aliasing:
+    // `Matrix.temp.translate(...)` overwrote the receiver with the translation
+    // matrix and then combined that with itself, and any caller parking a value
+    // in the scratch had it clobbered by an unrelated transform.
+    return this.set(
+      this.a + this.e * x,
+      this.b + this.f * x,
+      this.x + this.z * x,
+
+      this.c + this.e * y,
+      this.d + this.f * y,
+      this.y + this.z * y,
+    );
   }
 
   /**
@@ -164,8 +177,19 @@ export class Matrix implements Cloneable {
     const radian = degreesToRadians(angle);
     const cos = Math.cos(radian);
     const sin = Math.sin(radian);
+    const offsetX = centerX * (1 - cos) + centerY * sin;
+    const offsetY = centerY * (1 - cos) - centerX * sin;
 
-    return this.combine(Matrix.temp.set(cos, -sin, centerX * (1 - cos) + centerY * sin, sin, cos, centerY * (1 - cos) - centerX * sin, 0, 0, 1));
+    // Expanded from `combine(rotationMatrix)` — see the note on {@link translate}.
+    return this.set(
+      this.a * cos - this.c * sin + this.e * offsetX,
+      this.b * cos - this.d * sin + this.f * offsetX,
+      this.x * cos - this.y * sin + this.z * offsetX,
+
+      this.a * sin + this.c * cos + this.e * offsetY,
+      this.b * sin + this.d * cos + this.f * offsetY,
+      this.x * sin + this.y * cos + this.z * offsetY,
+    );
   }
 
   /**
@@ -173,7 +197,19 @@ export class Matrix implements Cloneable {
    * matrix. Mutates in place and returns `this` for chaining.
    */
   public scale(scaleX: number, scaleY: number = scaleX, centerX = 0, centerY: number = centerX): Matrix {
-    return this.combine(Matrix.temp.set(scaleX, 0, centerX * (1 - scaleX), 0, scaleY, centerY * (1 - scaleY), 0, 0, 1));
+    const offsetX = centerX * (1 - scaleX);
+    const offsetY = centerY * (1 - scaleY);
+
+    // Expanded from `combine(scaleMatrix)` — see the note on {@link translate}.
+    return this.set(
+      this.a * scaleX + this.e * offsetX,
+      this.b * scaleX + this.f * offsetX,
+      this.x * scaleX + this.z * offsetX,
+
+      this.c * scaleY + this.e * offsetY,
+      this.d * scaleY + this.f * offsetY,
+      this.y * scaleY + this.z * offsetY,
+    );
   }
 
   /**

--- a/src/math/Vector.ts
+++ b/src/math/Vector.ts
@@ -86,7 +86,12 @@ export class Vector extends AbstractVector implements ShapeLike {
   }
 
   public contains(x: number, y: number): boolean {
-    return intersectionPointPoint(Vector.temp.set(x, y), this);
+    // Point-vs-point containment is exact equality (the shared threshold is 0).
+    // Routing the probe through `Vector.temp` made this self-aliasing: calling
+    // it ON the scratch overwrote the receiver with the probe and then measured
+    // its distance to itself, so it always answered `true` — and any other call
+    // clobbered whatever the scratch was holding.
+    return this.x === x && this.y === y;
   }
 
   public getNormals(): Vector[] {

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -184,7 +184,7 @@ export class Container extends RenderNode {
    */
   public addChild(...children: RenderNode[]): this {
     for (const child of children) {
-      this.addChildAt(child, this._childList.length);
+      this._attachChild(child, null);
     }
 
     return this;
@@ -195,12 +195,26 @@ export class Container extends RenderNode {
    * from any previous parent first. Throws if `index` is out of bounds, if
    * `child` has already been `destroy()`ed, or if `child` is an ancestor of
    * this container (would create a cycle). Self-as-child is a no-op.
+   *
+   * When `child` already belongs to this container the call is a pure reorder:
+   * the node keeps its parent, its stage and its keyboard focus.
    */
   public addChildAt(child: RenderNode, index: number): this {
     if (index < 0 || index > this._childList.length) {
       throw new Error(`The index ${index} is out of bounds ${this._childList.length}`);
     }
 
+    return this._attachChild(child, index);
+  }
+
+  /**
+   * Shared insert path for {@link addChild} and {@link addChildAt}. A `null`
+   * index means "append", and the position is resolved only after the child is
+   * detached from its previous parent — that detach dispatches focus and
+   * interaction callbacks, i.e. arbitrary user code that can grow or shrink
+   * this container's list while the insert is still in flight.
+   */
+  private _attachChild(child: RenderNode, index: number | null): this {
     if (child === this) {
       return this;
     }
@@ -228,12 +242,18 @@ export class Container extends RenderNode {
       );
     }
 
+    if (child.parent === this) {
+      return this._reorderChild(child, index);
+    }
+
     if (child.parent) {
       child.parent.removeChild(child);
     }
 
+    const insertAt = this._resolveInsertIndex(index);
+
     child._setParent(this);
-    this._childList.splice(index, 0, child);
+    this._childList.splice(insertAt, 0, child);
     this._invalidateChildOrder();
     this.invalidateCache();
     this._markStructureDirty();
@@ -245,6 +265,30 @@ export class Container extends RenderNode {
     this._stage?.interaction._notifyNodeAdded(child);
 
     return this;
+  }
+
+  /**
+   * Move a node that already belongs to this container to `index`. Routing a
+   * same-parent insert through `removeChild()` would tear the node off the
+   * stage and blur it, so a pure reorder used to steal keyboard focus and
+   * re-announce the node to the interaction manager. Neither the child's
+   * transform nor the aggregate bounds change, so only the order-dependent
+   * caches are invalidated.
+   */
+  private _reorderChild(child: RenderNode, index: number | null): this {
+    removeArrayItems(this._childList, this.getChildIndex(child), 1);
+
+    this._childList.splice(this._resolveInsertIndex(index), 0, child);
+    this._invalidateChildOrder();
+    this.invalidateCache();
+    this._markStructureDirty();
+
+    return this;
+  }
+
+  /** Clamp an insert position against the CURRENT list length; `null` appends. */
+  private _resolveInsertIndex(index: number | null): number {
+    return index === null ? this._childList.length : Math.min(index, this._childList.length);
   }
 
   public swapChildren(firstChild: RenderNode, secondChild: RenderNode): this {
@@ -351,15 +395,25 @@ export class Container extends RenderNode {
       throw new Error('Values are outside the acceptable range.');
     }
 
-    // Cascade bounds before clearing any parent references.
-    if (range > 0) {
-      this._invalidateBoundsCascade();
+    if (range === 0) {
+      return this;
     }
 
-    for (let i = begin; i < end; i++) {
-      const child = this._childList[i];
+    // Cascade bounds before clearing any parent references.
+    this._invalidateBoundsCascade();
 
-      if (child?.parent === this) {
+    const removed = this._childList.slice(begin, end);
+
+    // Same ordering rule as `removeChildAt`: commit the array write and drop
+    // the children-view cache BEFORE any notify below can run user code (an
+    // `onBlur` handler reading `container.children`). Running every notify
+    // first and splicing afterwards handed that handler a list that still held
+    // every node being removed.
+    removeArrayItems(this._childList, begin, range);
+    this._invalidateChildOrder();
+
+    for (const child of removed) {
+      if (child.parent === this) {
         child._setParent(null);
         child._invalidateSubtreeTransform();
         this._stage?.interaction._notifyNodeRemoved(child);
@@ -368,8 +422,6 @@ export class Container extends RenderNode {
       }
     }
 
-    removeArrayItems(this._childList, begin, range);
-    this._invalidateChildOrder();
     this.invalidateCache();
     this._markStructureDirty();
 

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -523,12 +523,33 @@ export class Container extends RenderNode {
   }
 
   public override updateBounds(): this {
-    this._bounds.reset().addRect(this.getLocalBounds(), this.getGlobalTransform());
+    const localBounds = this.getLocalBounds();
+    // A plain container carries no geometry of its own: its local rect is the
+    // empty 0x0 box at the local origin. Merging that unconditionally pins the
+    // origin into every aggregate, so a container whose children all sit far
+    // away would report an AABB stretching back to its own position.
+    const hasLocalContent = localBounds.width !== 0 || localBounds.height !== 0;
+    let hasContent = hasLocalContent;
+
+    this._bounds.reset();
+
+    if (hasLocalContent) {
+      this._bounds.addRect(localBounds, this.getGlobalTransform());
+    }
 
     for (const child of this._childList) {
       if (child.visible) {
         this._bounds.addRect(child.getBounds());
+        hasContent = true;
       }
+    }
+
+    // Nothing contributed an extent. Fall back to the degenerate local rect so
+    // the aggregate stays a real rectangle at this container's own transform —
+    // handing out the untouched accumulator would leak its Infinity/-Infinity
+    // seed into width/height and every edge accessor.
+    if (!hasContent) {
+      this._bounds.addRect(localBounds, this.getGlobalTransform());
     }
 
     return this;

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -214,6 +214,7 @@ export class RetainedContainer extends Container {
   private _aggregateContentRevision = -1;
   private _aggregateStructureRevision = -1;
   private _aggregateTransformRevision = -1;
+  private _groupAggregateEmpty = true;
 
   /**
    * World AABB of the group: children aggregate in group-local space, so
@@ -255,7 +256,11 @@ export class RetainedContainer extends Container {
       this._aggregateTransformRevision = transformRevision;
     }
 
-    this._bounds.reset().addRect(this._groupAggregate.getRect(), world);
+    this._bounds.reset();
+
+    if (!this._groupAggregateEmpty) {
+      this._bounds.addRect(this._groupAggregate.getRect(), world);
+    }
 
     // Index loop, no iterator allocation: this runs on every group move.
     for (let index = 0; index < this._liveBoundsChildren.length; index++) {
@@ -270,13 +275,29 @@ export class RetainedContainer extends Container {
       }
     }
 
+    // No aggregate and no live children: keep a degenerate rect at the group's
+    // own transform instead of the untouched Infinity/-Infinity accumulator.
+    if (this._groupAggregateEmpty && this._liveBoundsChildren.length === 0) {
+      this._bounds.addRect(this.getLocalBounds(), world);
+    }
+
     return this;
   }
 
   /** Rebuild the cached group-local aggregate + the live-children list (see the block comment above {@link updateBounds}). */
   private _rebuildGroupAggregate(): void {
-    this._groupAggregate.reset().addRect(this.getLocalBounds());
+    const localBounds = this.getLocalBounds();
+    // Same origin-pinning trap as `Container.updateBounds`: a group without own
+    // geometry must not seed its aggregate with the empty local rect.
+    const hasLocalContent = localBounds.width !== 0 || localBounds.height !== 0;
+
+    this._groupAggregate.reset();
+    this._groupAggregateEmpty = !hasLocalContent;
     this._liveBoundsChildren.length = 0;
+
+    if (hasLocalContent) {
+      this._groupAggregate.addRect(localBounds);
+    }
 
     for (let index = 0; index < this._children.length; index++) {
       const child = this._children[index]!;
@@ -292,6 +313,7 @@ export class RetainedContainer extends Container {
         this._liveBoundsChildren.push(child);
       } else {
         this._groupAggregate.addRect(child.getBounds());
+        this._groupAggregateEmpty = false;
       }
     }
   }

--- a/src/rendering/View.ts
+++ b/src/rendering/View.ts
@@ -591,15 +591,35 @@ export class View implements ObservableVectorOwner {
   }
 
   protected updateBounds(): this {
-    const centerX = this._center.x + this._shakeOffsetX;
-    const centerY = this._center.y + this._shakeOffsetY;
-    const offsetX = this.width / 2;
-    const offsetY = this.height / 2;
+    const m = this.getTransform();
+    const determinant = m.a * m.d - m.b * m.c;
+
+    this._bounds.reset();
+
+    if (!Number.isFinite(determinant) || determinant === 0) {
+      // Degenerate projection (a zero-sized view): keep a real rectangle at the
+      // camera centre instead of letting the solve below decay into NaN.
+      return this._bounds.addCoords(this._center.x + this._shakeOffsetX, this._center.y + this._shakeOffsetY), this;
+    }
+
+    // Map the four clip-space corners back to world space and take their AABB.
+    // Deriving the box from centre ± half-size ignores `rotation` entirely, so
+    // a rotated camera got a cull rect strictly smaller than the area it
+    // renders and content popped in at the rotated corners. Going through the
+    // projection keeps rotation, zoom and shake correct by construction.
+    //
+    // Same inlined 2x2 solve as `screenToWorld` — no Matrix allocation on a
+    // path that reruns whenever the camera moves.
+    const dxLeft = -1 - m.x;
+    const dxRight = 1 - m.x;
+    const dyTop = -1 - m.y;
+    const dyBottom = 1 - m.y;
 
     this._bounds
-      .reset()
-      .addCoords(centerX - offsetX, centerY - offsetY)
-      .addCoords(centerX + offsetX, centerY + offsetY);
+      .addCoords((dxLeft * m.d - dyTop * m.b) / determinant, (dyTop * m.a - dxLeft * m.c) / determinant)
+      .addCoords((dxRight * m.d - dyTop * m.b) / determinant, (dyTop * m.a - dxRight * m.c) / determinant)
+      .addCoords((dxRight * m.d - dyBottom * m.b) / determinant, (dyBottom * m.a - dxRight * m.c) / determinant)
+      .addCoords((dxLeft * m.d - dyBottom * m.b) / determinant, (dyBottom * m.a - dxLeft * m.c) / determinant);
 
     return this;
   }

--- a/src/rendering/View.ts
+++ b/src/rendering/View.ts
@@ -105,7 +105,7 @@ export class View implements ObservableVectorOwner {
     this._size = new ObservableSize(this._setScalingDirty.bind(this), width, height);
     this._zoomBaseWidth = width;
     this._zoomBaseHeight = height;
-    this._flags.push(ViewFlags.Transform, ViewFlags.TransformInverse, ViewFlags.BoundingBox);
+    this._flags.addMask(ViewFlags.Transform | ViewFlags.TransformInverse | ViewFlags.BoundingBox);
   }
 
   /**
@@ -412,7 +412,7 @@ export class View implements ObservableVectorOwner {
     this._sin = 0;
     this._cos = 1;
 
-    this._flags.push(ViewFlags.Transform);
+    this._flags.addMask(ViewFlags.Transform);
 
     return this;
   }
@@ -422,9 +422,9 @@ export class View implements ObservableVectorOwner {
    * The returned matrix is owned by this view — do not store a reference across frames.
    */
   public getTransform(): Matrix {
-    if (this._flags.has(ViewFlags.Transform)) {
+    if (this._flags.hasMask(ViewFlags.Transform)) {
       this.updateTransform();
-      this._flags.remove(ViewFlags.Transform);
+      this._flags.removeMask(ViewFlags.Transform);
     }
 
     return this._transform;
@@ -436,14 +436,14 @@ export class View implements ObservableVectorOwner {
     const x = 2 / this.width;
     const y = -2 / this.height;
 
-    if (this._flags.has(ViewFlags.Rotation)) {
+    if (this._flags.hasMask(ViewFlags.Rotation)) {
       const radians = degreesToRadians(this._rotation);
 
       this._cos = Math.cos(radians);
       this._sin = Math.sin(radians);
     }
 
-    if (this._flags.has(ViewFlags.Rotation | ViewFlags.Scaling)) {
+    if (this._flags.hasMask(ViewFlags.Rotation | ViewFlags.Scaling)) {
       this._transform.a = x * this._cos;
       this._transform.b = x * this._sin;
 
@@ -462,10 +462,10 @@ export class View implements ObservableVectorOwner {
    * Use this to convert screen-space coordinates (e.g. mouse position) to world space.
    */
   public getInverseTransform(): Matrix {
-    if (this._flags.has(ViewFlags.TransformInverse)) {
+    if (this._flags.hasMask(ViewFlags.TransformInverse)) {
       this.getTransform().getInverse(this._inverseTransform);
 
-      this._flags.remove(ViewFlags.TransformInverse);
+      this._flags.removeMask(ViewFlags.TransformInverse);
     }
 
     return this._inverseTransform;
@@ -582,9 +582,9 @@ export class View implements ObservableVectorOwner {
    * Used for frustum culling by {@link Drawable.render}.
    */
   public getBounds(): Rectangle {
-    if (this._flags.has(ViewFlags.BoundingBox)) {
+    if (this._flags.hasMask(ViewFlags.BoundingBox)) {
       this.updateBounds();
-      this._flags.remove(ViewFlags.BoundingBox);
+      this._flags.removeMask(ViewFlags.BoundingBox);
     }
 
     return this._bounds.getRect();
@@ -655,22 +655,22 @@ export class View implements ObservableVectorOwner {
   }
 
   private _setDirty(): void {
-    this._flags.push(ViewFlags.TransformInverse, ViewFlags.BoundingBox);
+    this._flags.addMask(ViewFlags.TransformInverse | ViewFlags.BoundingBox);
     this._updateId++;
   }
 
   private _setPositionDirty(): void {
-    this._flags.push(ViewFlags.Translation);
+    this._flags.addMask(ViewFlags.Translation);
     this._setDirty();
   }
 
   private _setRotationDirty(): void {
-    this._flags.push(ViewFlags.Rotation);
+    this._flags.addMask(ViewFlags.Rotation);
     this._setDirty();
   }
 
   private _setScalingDirty(): void {
-    this._flags.push(ViewFlags.Scaling);
+    this._flags.addMask(ViewFlags.Scaling);
     this._setDirty();
   }
 

--- a/src/rendering/View.ts
+++ b/src/rendering/View.ts
@@ -599,7 +599,9 @@ export class View implements ObservableVectorOwner {
     if (!Number.isFinite(determinant) || determinant === 0) {
       // Degenerate projection (a zero-sized view): keep a real rectangle at the
       // camera centre instead of letting the solve below decay into NaN.
-      return this._bounds.addCoords(this._center.x + this._shakeOffsetX, this._center.y + this._shakeOffsetY), this;
+      this._bounds.addCoords(this._center.x + this._shakeOffsetX, this._center.y + this._shakeOffsetY);
+
+      return this;
     }
 
     // Map the four clip-space corners back to world space and take their AABB.

--- a/src/rendering/View.ts
+++ b/src/rendering/View.ts
@@ -451,8 +451,8 @@ export class View implements ObservableVectorOwner {
       this._transform.d = y * this._cos;
     }
 
-    this._transform.x = x * -this._transform.a - y * this._transform.b + -x * centerX;
-    this._transform.y = x * -this._transform.c - y * this._transform.d + -y * centerY;
+    this._transform.x = -x * centerX;
+    this._transform.y = -y * centerY;
 
     return this;
   }

--- a/src/rendering/sprite/Sprite.ts
+++ b/src/rendering/sprite/Sprite.ts
@@ -64,7 +64,7 @@ export class Sprite extends Drawable {
     super();
 
     // Mark vertices and normals dirty from the start.
-    this.flags.push(SpriteFlags.Vertices | SpriteFlags.Normals);
+    this.flags.addMask(SpriteFlags.Vertices | SpriteFlags.Normals);
 
     if (texture !== null) {
       this.setTexture(texture);
@@ -141,7 +141,7 @@ export class Sprite extends Drawable {
     // which the lazy cascade no longer eagerly flags on this sprite.
     const transform = this.getGlobalTransform();
 
-    if (this.flags.has(SpriteFlags.Vertices) || this._verticesBuiltAtVersion !== this._globalTransformVersion) {
+    if (this.flags.hasMask(SpriteFlags.Vertices) || this._verticesBuiltAtVersion !== this._globalTransformVersion) {
       const { left, top, right, bottom } = this.getLocalBounds();
       const { a, b, x, c, d, y } = transform;
 
@@ -157,7 +157,7 @@ export class Sprite extends Drawable {
       this._vertices[6] = left * a + bottom * b + x;
       this._vertices[7] = left * c + bottom * d + y;
 
-      this.flags.remove(SpriteFlags.Vertices);
+      this.flags.removeMask(SpriteFlags.Vertices);
       this._verticesBuiltAtVersion = this._globalTransformVersion;
     }
 
@@ -175,7 +175,7 @@ export class Sprite extends Drawable {
       throw new Error('texCoords can only be calculated when the sprite has a texture');
     }
 
-    if (this.flags.pop(SpriteFlags.TextureCoords)) {
+    if (this.flags.popMask(SpriteFlags.TextureCoords)) {
       const { width, height } = this._texture;
       const { left, top, right, bottom } = this._textureFrame;
       const minX = ((left / width) * 65535) & 65535;
@@ -288,7 +288,7 @@ export class Sprite extends Drawable {
     const height = this.height;
 
     this._textureFrame.copy(frame);
-    this.flags.push(SpriteFlags.TextureCoords);
+    this.flags.addMask(SpriteFlags.TextureCoords);
     this._setLocalBounds(0, 0, frame.width, frame.height);
 
     if (resetSize) {
@@ -333,7 +333,7 @@ export class Sprite extends Drawable {
     // vertices is a fixed 8-element Float32Array (4 corners).
     const v = this.vertices;
 
-    if (this.flags.has(SpriteFlags.Normals) || this._normalsBuiltAtVersion !== this._globalTransformVersion) {
+    if (this.flags.hasMask(SpriteFlags.Normals) || this._normalsBuiltAtVersion !== this._globalTransformVersion) {
       const x1 = v[0]!;
       const y1 = v[1]!;
       const x2 = v[2]!;
@@ -360,7 +360,7 @@ export class Sprite extends Drawable {
         .rperp()
         .normalize();
 
-      this.flags.remove(SpriteFlags.Normals);
+      this.flags.removeMask(SpriteFlags.Normals);
       this._normalsBuiltAtVersion = this._globalTransformVersion;
     }
 
@@ -426,13 +426,13 @@ export class Sprite extends Drawable {
   /** @internal */
   public override _invalidateSubtreeTransform(): void {
     super._invalidateSubtreeTransform();
-    this.flags.push(SpriteFlags.Vertices | SpriteFlags.Normals);
+    this.flags.addMask(SpriteFlags.Vertices | SpriteFlags.Normals);
   }
 
   /** @internal */
   public override _invalidateBoundsCascade(): void {
     super._invalidateBoundsCascade();
-    this.flags.push(SpriteFlags.Vertices | SpriteFlags.Normals);
+    this.flags.addMask(SpriteFlags.Vertices | SpriteFlags.Normals);
   }
 
   public override destroy(): void {

--- a/test/core/scene-node-cache.test.ts
+++ b/test/core/scene-node-cache.test.ts
@@ -158,12 +158,16 @@ describe('SceneNode.getBounds() — dirty-flag cache', () => {
     parent.addChild(child);
     child.setPosition(0, 0);
 
-    const parentBoundsW1 = parent.getBounds().width;
+    const parentBoundsX1 = parent.getBounds().x;
 
     child.setPosition(200, 200);
     const parentBoundsAfter = parent.getBounds();
 
-    expect(parentBoundsAfter.width).toBeGreaterThan(parentBoundsW1);
+    // A structural container spans exactly its children, so a moved child
+    // translates the parent rect rather than growing it.
+    expect(parentBoundsAfter.x).toBeGreaterThan(parentBoundsX1);
+    expect(parentBoundsAfter.x).toBeCloseTo(200);
+    expect(parentBoundsAfter.y).toBeCloseTo(200);
 
     parent.destroy();
   });
@@ -256,16 +260,16 @@ describe('SceneNode.getBounds() — dirty-flag cache', () => {
     // ancestor; the short-circuit may only stop at an already-dirty one.
     leaf.setPosition(300, 400);
 
-    // Each level must report the grown bounds — none may be skipped. The leaf
-    // itself merely translates (width unchanged), but every container's union
-    // with the far-moved leaf must now span out to the leaf.
+    // Each level must report the moved bounds — none may be skipped. The leaf
+    // merely translates, and every structural container spans exactly its
+    // children, so each ancestor rect must follow the leaf out to (300, 400).
     expect(leaf.getBounds().x).toBeCloseTo(300);
     expect(leaf.getBounds().y).toBeCloseTo(400);
 
-    expect(parent.getBounds().width).toBeCloseTo(310);
-    expect(parent.getBounds().height).toBeCloseTo(410);
-    expect(grandparent.getBounds().width).toBeCloseTo(310);
-    expect(grandparent.getBounds().height).toBeCloseTo(410);
+    expect(parent.getBounds().x).toBeCloseTo(300);
+    expect(parent.getBounds().y).toBeCloseTo(400);
+    expect(grandparent.getBounds().x).toBeCloseTo(300);
+    expect(grandparent.getBounds().y).toBeCloseTo(400);
 
     leaf.destroy();
     parent.destroy();

--- a/test/core/scene-node-transform.test.ts
+++ b/test/core/scene-node-transform.test.ts
@@ -360,7 +360,9 @@ describe('SceneNode bounds after transform changes', () => {
 
     const view = { getBounds: () => new Rectangle(400, 0, 300, 300) } as unknown as View;
 
-    expect(container.getBounds().width).toBe(600);
+    // The container spans exactly its single child (500..600), not the origin.
+    expect(container.getBounds().x).toBe(500);
+    expect(container.getBounds().width).toBe(100);
     expect(container.inView(view)).toBe(true);
 
     child.visible = false;

--- a/test/math/flags-mask-api.test.ts
+++ b/test/math/flags-mask-api.test.ts
@@ -1,6 +1,6 @@
 import { Flags } from '#math/Flags';
 
-const enum TestFlags {
+enum TestFlags {
   None = 0x00,
   A = 0x01,
   B = 0x02,
@@ -10,7 +10,7 @@ const enum TestFlags {
 
 describe('Flags mask API', () => {
   test('hasMask answers "any bit of the mask is set"', () => {
-    const flags = new Flags<typeof TestFlags>(TestFlags.A, TestFlags.C);
+    const flags = new Flags<TestFlags>(TestFlags.A, TestFlags.C);
 
     expect(flags.hasMask(TestFlags.A)).toBe(true);
     expect(flags.hasMask(TestFlags.B)).toBe(false);
@@ -20,7 +20,7 @@ describe('Flags mask API', () => {
   });
 
   test('addMask sets every bit of the mask and returns this', () => {
-    const flags = new Flags<typeof TestFlags>();
+    const flags = new Flags<TestFlags>();
 
     expect(flags.addMask(TestFlags.A | TestFlags.B)).toBe(flags);
     expect(flags.value).toBe(TestFlags.A | TestFlags.B);
@@ -31,7 +31,7 @@ describe('Flags mask API', () => {
   });
 
   test('removeMask clears every bit of the mask and returns this', () => {
-    const flags = new Flags<typeof TestFlags>(TestFlags.A, TestFlags.B, TestFlags.C);
+    const flags = new Flags<TestFlags>(TestFlags.A, TestFlags.B, TestFlags.C);
 
     expect(flags.removeMask(TestFlags.A | TestFlags.C)).toBe(flags);
     expect(flags.value).toBe(TestFlags.B);
@@ -42,8 +42,8 @@ describe('Flags mask API', () => {
   });
 
   test('the mask forms agree with the rest-argument forms', () => {
-    const viaRest = new Flags<typeof TestFlags>().push(TestFlags.A, TestFlags.C);
-    const viaMask = new Flags<typeof TestFlags>().addMask(TestFlags.A | TestFlags.C);
+    const viaRest = new Flags<TestFlags>().push(TestFlags.A, TestFlags.C);
+    const viaMask = new Flags<TestFlags>().addMask(TestFlags.A | TestFlags.C);
 
     expect(viaMask.value).toBe(viaRest.value);
     expect(viaMask.hasMask(TestFlags.A | TestFlags.B)).toBe(viaRest.has(TestFlags.A, TestFlags.B));
@@ -51,7 +51,7 @@ describe('Flags mask API', () => {
   });
 
   test('popMask reports and clears in one step', () => {
-    const flags = new Flags<typeof TestFlags>(TestFlags.A);
+    const flags = new Flags<TestFlags>(TestFlags.A);
 
     expect(flags.popMask(TestFlags.A)).toBe(true);
     expect(flags.hasMask(TestFlags.A)).toBe(false);

--- a/test/math/flags-mask-api.test.ts
+++ b/test/math/flags-mask-api.test.ts
@@ -1,0 +1,60 @@
+import { Flags } from '#math/Flags';
+
+const enum TestFlags {
+  None = 0x00,
+  A = 0x01,
+  B = 0x02,
+  C = 0x04,
+  D = 0x08,
+}
+
+describe('Flags mask API', () => {
+  test('hasMask answers "any bit of the mask is set"', () => {
+    const flags = new Flags<typeof TestFlags>(TestFlags.A, TestFlags.C);
+
+    expect(flags.hasMask(TestFlags.A)).toBe(true);
+    expect(flags.hasMask(TestFlags.B)).toBe(false);
+    expect(flags.hasMask(TestFlags.B | TestFlags.C)).toBe(true);
+    expect(flags.hasMask(TestFlags.B | TestFlags.D)).toBe(false);
+    expect(flags.hasMask(TestFlags.None)).toBe(false);
+  });
+
+  test('addMask sets every bit of the mask and returns this', () => {
+    const flags = new Flags<typeof TestFlags>();
+
+    expect(flags.addMask(TestFlags.A | TestFlags.B)).toBe(flags);
+    expect(flags.value).toBe(TestFlags.A | TestFlags.B);
+
+    flags.addMask(TestFlags.B | TestFlags.C);
+
+    expect(flags.value).toBe(TestFlags.A | TestFlags.B | TestFlags.C);
+  });
+
+  test('removeMask clears every bit of the mask and returns this', () => {
+    const flags = new Flags<typeof TestFlags>(TestFlags.A, TestFlags.B, TestFlags.C);
+
+    expect(flags.removeMask(TestFlags.A | TestFlags.C)).toBe(flags);
+    expect(flags.value).toBe(TestFlags.B);
+
+    flags.removeMask(TestFlags.D);
+
+    expect(flags.value).toBe(TestFlags.B);
+  });
+
+  test('the mask forms agree with the rest-argument forms', () => {
+    const viaRest = new Flags<typeof TestFlags>().push(TestFlags.A, TestFlags.C);
+    const viaMask = new Flags<typeof TestFlags>().addMask(TestFlags.A | TestFlags.C);
+
+    expect(viaMask.value).toBe(viaRest.value);
+    expect(viaMask.hasMask(TestFlags.A | TestFlags.B)).toBe(viaRest.has(TestFlags.A, TestFlags.B));
+    expect(viaMask.removeMask(TestFlags.A).value).toBe(viaRest.remove(TestFlags.A).value);
+  });
+
+  test('popMask reports and clears in one step', () => {
+    const flags = new Flags<typeof TestFlags>(TestFlags.A);
+
+    expect(flags.popMask(TestFlags.A)).toBe(true);
+    expect(flags.hasMask(TestFlags.A)).toBe(false);
+    expect(flags.popMask(TestFlags.A)).toBe(false);
+  });
+});

--- a/test/math/matrix-temp-aliasing.test.ts
+++ b/test/math/matrix-temp-aliasing.test.ts
@@ -1,0 +1,74 @@
+import { Matrix } from '#math/Matrix';
+
+const fields = (matrix: Matrix): number[] => [matrix.a, matrix.b, matrix.x, matrix.c, matrix.d, matrix.y, matrix.e, matrix.f, matrix.z];
+
+describe('Matrix.temp is safe to transform in place', () => {
+  test('translate on Matrix.temp matches translate on any other matrix', () => {
+    const expected = new Matrix(2, 0, 5, 0, 3, 7).translate(10, 20);
+    const actual = Matrix.temp.set(2, 0, 5, 0, 3, 7, 0, 0, 1).translate(10, 20);
+
+    // `translate` used `Matrix.temp` as its own scratch, so calling it ON
+    // `Matrix.temp` overwrote the receiver with the translation matrix and then
+    // combined that with itself.
+    expect(fields(actual)).toEqual(fields(expected));
+  });
+
+  test('rotate on Matrix.temp matches rotate on any other matrix', () => {
+    const expected = new Matrix(2, 0, 5, 0, 3, 7).rotate(30, 4, 9);
+    const actual = Matrix.temp.set(2, 0, 5, 0, 3, 7, 0, 0, 1).rotate(30, 4, 9);
+
+    expect(fields(actual)).toEqual(fields(expected));
+  });
+
+  test('scale on Matrix.temp matches scale on any other matrix', () => {
+    const expected = new Matrix(2, 0, 5, 0, 3, 7).scale(1.5, 0.5, 4, 9);
+    const actual = Matrix.temp.set(2, 0, 5, 0, 3, 7, 0, 0, 1).scale(1.5, 0.5, 4, 9);
+
+    expect(fields(actual)).toEqual(fields(expected));
+  });
+
+  test('transforming a matrix leaves Matrix.temp untouched', () => {
+    const marker = Matrix.temp.set(11, 12, 13, 14, 15, 16, 17, 18, 19);
+    const before = fields(marker);
+
+    new Matrix().translate(3, 4).rotate(15).scale(2);
+
+    // A caller parking a value in the shared scratch must not have it silently
+    // clobbered by an unrelated transform elsewhere.
+    expect(fields(Matrix.temp)).toEqual(before);
+  });
+
+  // The tests above prove only that the scratch is gone. These pin the algebra
+  // itself against `combine()` with an explicit matrix — the definition the
+  // expanded forms were derived from — using a base whose homogeneous row is
+  // NOT `0, 0, 1`, so a dropped `e`/`f`/`z` term cannot hide.
+  describe('the expanded forms equal an explicit combine', () => {
+    const base = (): Matrix => new Matrix(2, 0.5, 5, -1, 3, 7, 0.25, -0.5, 2);
+
+    test('translate', () => {
+      expect(fields(base().translate(10, 20))).toEqual(fields(base().combine(new Matrix(1, 0, 10, 0, 1, 20, 0, 0, 1))));
+    });
+
+    test('rotate', () => {
+      const radian = (30 * Math.PI) / 180;
+      const cos = Math.cos(radian);
+      const sin = Math.sin(radian);
+      const reference = new Matrix(cos, -sin, 4 * (1 - cos) + 9 * sin, sin, cos, 9 * (1 - cos) - 4 * sin, 0, 0, 1);
+
+      expect(fields(base().rotate(30, 4, 9))).toEqual(fields(base().combine(reference)));
+    });
+
+    test('scale', () => {
+      const reference = new Matrix(1.5, 0, 4 * (1 - 1.5), 0, 0.5, 9 * (1 - 0.5), 0, 0, 1);
+
+      expect(fields(base().scale(1.5, 0.5, 4, 9))).toEqual(fields(base().combine(reference)));
+    });
+  });
+
+  test('chained transforms on Matrix.temp match the same chain elsewhere', () => {
+    const expected = new Matrix().translate(10, 20).rotate(45).scale(2, 3);
+    const actual = Matrix.temp.copy(Matrix.identity).translate(10, 20).rotate(45).scale(2, 3);
+
+    expect(fields(actual)).toEqual(fields(expected));
+  });
+});

--- a/test/math/vector-temp-aliasing.test.ts
+++ b/test/math/vector-temp-aliasing.test.ts
@@ -1,0 +1,30 @@
+import { Vector } from '#math/Vector';
+
+describe('Vector.contains is safe against the shared scratch', () => {
+  test('contains on Vector.temp does not compare the scratch with itself', () => {
+    Vector.temp.set(3, 4);
+
+    // Routing the probe point through `Vector.temp` made this self-aliasing:
+    // the receiver was overwritten with the probe and then measured against
+    // itself, so every call on the scratch answered `true`.
+    expect(Vector.temp.contains(99, 99)).toBe(false);
+    expect(Vector.temp.contains(3, 4)).toBe(true);
+  });
+
+  test('contains leaves Vector.temp untouched', () => {
+    Vector.temp.set(3, 4);
+
+    new Vector(1, 2).contains(5, 6);
+
+    expect(Vector.temp.x).toBe(3);
+    expect(Vector.temp.y).toBe(4);
+  });
+
+  test('contains still answers plain point equality', () => {
+    const vector = new Vector(7, -2);
+
+    expect(vector.contains(7, -2)).toBe(true);
+    expect(vector.contains(7, -2.0001)).toBe(false);
+    expect(vector.contains(NaN, -2)).toBe(false);
+  });
+});

--- a/test/perf/rendering/allocation.test.ts
+++ b/test/perf/rendering/allocation.test.ts
@@ -69,7 +69,15 @@ const TOLERANCE = 1.15;
  */
 const BASELINE_KB = {
   static: 248,
-  moving: 574,
+  // Ratcheted down from 574 after the scene-graph flag invalidation stopped
+  // allocating: `Flags.has/push/remove` took rest parameters, so every
+  // transform mutation allocated one array per ancestor walked, and this is the
+  // only scene that mutates transforms every frame. Measured on this dev box
+  // (Windows): 425.85 KB/frame median before, 276.66 after — a 35% drop, with
+  // the other four scenes unmoved. Unlike `mesh` below, the sprite scenes track
+  // between this box and CI (static/nested match their baselines here), so the
+  // Windows median is used directly.
+  moving: 277,
   nested: 363,
   // Mesh bundles sync a second per-instance DataTexture (tint) alongside
   // transform every frame — a deliberate, permanent cost of the transform/tint

--- a/test/perf/rendering/counter-gates.test.ts
+++ b/test/perf/rendering/counter-gates.test.ts
@@ -81,10 +81,13 @@ const EXPECTED = {
   // Plain Container, 10 of the 1000 sprites moved every frame. A child move
   // content-dirties the container, busting the retained-plan cache → full re-collect
   // (1001 visits, 1000 material keys) PLUS the extra world-transform resolutions
-  // the moved sprites' invalidation cascade forces (gt 8022 vs the 6001 of a
+  // the moved sprites' invalidation cascade forces (gt 8021 vs the 6001 of a
   // pure pan). Pins the dirty-path shape: the early-out-epoch dirty-walk rework
   // is expected to cut `collect`/`globalTransform` here — update deliberately.
-  mutate10: { collect: 1001, inView: 1001, globalTransform: 8022, materialKey: 1000, submittedNodes: 1000, culledNodes: 0, drawCalls: 1, batches: 1 },
+  // The one resolution below the former 8022: a structural container no longer
+  // folds its own empty local rect into the aggregate, so `updateBounds` stops
+  // resolving the container's world matrix for a rect that contributed nothing.
+  mutate10: { collect: 1001, inView: 1001, globalTransform: 8021, materialKey: 1000, submittedNodes: 1000, culledNodes: 0, drawCalls: 1, batches: 1 },
 } as const;
 
 const withHarness = (fn: (harness: WebGl2Harness) => void): void => {

--- a/test/rendering/container-bounds-origin.test.ts
+++ b/test/rendering/container-bounds-origin.test.ts
@@ -1,0 +1,129 @@
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+
+/** A 100x100 local-space box, so a container has a nontrivial extent to aggregate. */
+class SizedDrawable extends Drawable {
+  public override updateBounds(): this {
+    this._setLocalBounds(0, 0, 100, 100);
+
+    return super.updateBounds();
+  }
+
+  public override render(_backend: RenderBackend): this {
+    return this;
+  }
+}
+
+describe('Container bounds do not pin the origin', () => {
+  test('a purely structural container spans only its children', () => {
+    const container = new Container();
+    const child = new SizedDrawable();
+
+    child.setPosition(500, 400);
+    container.addChild(child);
+
+    const bounds = container.getBounds();
+
+    // Merging the container's own empty 0x0 local rect would stretch the
+    // aggregate from (0, 0) all the way to the child, reporting 600x500.
+    expect(bounds.left).toBe(500);
+    expect(bounds.top).toBe(400);
+    expect(bounds.width).toBe(100);
+    expect(bounds.height).toBe(100);
+
+    container.destroy();
+  });
+
+  test('a structural container with several far-away children unions only them', () => {
+    const container = new Container();
+    const first = new SizedDrawable();
+    const second = new SizedDrawable();
+
+    first.setPosition(500, 400);
+    second.setPosition(700, 300);
+    container.addChild(first, second);
+
+    const bounds = container.getBounds();
+
+    expect(bounds.left).toBe(500);
+    expect(bounds.top).toBe(300);
+    expect(bounds.width).toBe(300);
+    expect(bounds.height).toBe(200);
+
+    container.destroy();
+  });
+
+  test('an invisible child leaves the aggregate to its visible siblings', () => {
+    const container = new Container();
+    const visible = new SizedDrawable();
+    const hidden = new SizedDrawable();
+
+    visible.setPosition(500, 400);
+    hidden.setPosition(0, 0);
+    hidden.visible = false;
+    container.addChild(visible, hidden);
+
+    const bounds = container.getBounds();
+
+    expect(bounds.left).toBe(500);
+    expect(bounds.top).toBe(400);
+
+    container.destroy();
+  });
+
+  test('an empty container still reports a degenerate rect at its own position', () => {
+    const container = new Container();
+
+    container.setPosition(120, 60);
+
+    const bounds = container.getBounds();
+
+    // No content at all: the aggregate must stay a real (degenerate) rect at
+    // the container's own transform rather than collapsing to the empty
+    // Infinity/-Infinity accumulator, which would poison width/height.
+    expect(bounds.left).toBe(120);
+    expect(bounds.top).toBe(60);
+    expect(bounds.width).toBe(0);
+    expect(bounds.height).toBe(0);
+
+    container.destroy();
+  });
+
+  test('a container whose children are all invisible falls back to its own position', () => {
+    const container = new Container();
+    const hidden = new SizedDrawable();
+
+    hidden.setPosition(500, 400);
+    hidden.visible = false;
+    container.setPosition(120, 60);
+    container.addChild(hidden);
+
+    const bounds = container.getBounds();
+
+    expect(bounds.left).toBe(120);
+    expect(bounds.top).toBe(60);
+    expect(bounds.width).toBe(0);
+    expect(bounds.height).toBe(0);
+
+    container.destroy();
+  });
+
+  test('RetainedContainer aggregates its children without pinning the origin', () => {
+    const container = new RetainedContainer();
+    const child = new SizedDrawable();
+
+    child.setPosition(500, 400);
+    container.addChild(child);
+
+    const bounds = container.getBounds();
+
+    expect(bounds.left).toBe(500);
+    expect(bounds.top).toBe(400);
+    expect(bounds.width).toBe(100);
+    expect(bounds.height).toBe(100);
+
+    container.destroy();
+  });
+});

--- a/test/rendering/container-structural-atomicity.test.ts
+++ b/test/rendering/container-structural-atomicity.test.ts
@@ -1,0 +1,189 @@
+import type { Application } from '#core/Application';
+import type { InteractionHooks, Stage } from '#core/Stage';
+import { FocusController } from '#input/FocusController';
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import type { RenderNode } from '#rendering/RenderNode';
+
+class DummyDrawable extends Drawable {
+  public override render(_backend: RenderBackend): this {
+    return this;
+  }
+}
+
+const noopInteraction: InteractionHooks = {
+  _notifyNodeAdded() {},
+  _notifyNodeRemoved() {},
+  _notifyInteractiveChanged() {},
+  _notifyBoundsInvalidated() {},
+  _notifyTransformGroupMoved() {},
+};
+
+/**
+ * A stage whose focus controller really dispatches `onBlur`, so removal side
+ * effects run genuine user code from inside the structural methods.
+ */
+const createStage = (): { stage: Stage; focus: FocusController } => {
+  const stubInput = { onKeyDown: { add() {}, remove() {} }, onKeyUp: { add() {}, remove() {} } };
+  const focus = new FocusController({ input: stubInput } as unknown as Application);
+
+  return { stage: { interaction: noopInteraction, focus }, focus };
+};
+
+describe('Container structural methods are atomic against user callbacks', () => {
+  test('removeChildren has already committed the array when a synchronous onBlur handler runs', () => {
+    const { stage, focus } = createStage();
+    const container = new Container();
+
+    container._setStage(stage);
+
+    const first = new DummyDrawable();
+    const second = new DummyDrawable();
+    const survivor = new DummyDrawable();
+
+    first.focusable = true;
+    container.addChild(first, second, survivor);
+    focus.focus(first);
+
+    // Populate the view cache before the removal: with a null cache the getter
+    // would recompute a correct array on first read regardless of where the
+    // invalidation sits, which would defeat the check.
+    const before = container.children;
+
+    expect(before).toContain(first);
+
+    let seenDuringBlur: readonly RenderNode[] | undefined;
+    let indexDuringBlur: number | undefined;
+
+    first.onBlur.add(() => {
+      seenDuringBlur = container.children;
+      indexDuringBlur = container.getChildIndex(survivor);
+    });
+
+    container.removeChildren(0, 2);
+
+    // `removeChildAt` already commits the splice before notifying; the ranged
+    // form ran every notify first and spliced afterwards, so a handler saw a
+    // list that still held both nodes being removed.
+    expect(seenDuringBlur).toBeDefined();
+    expect(seenDuringBlur).not.toContain(first);
+    expect(seenDuringBlur).not.toContain(second);
+    expect(seenDuringBlur).toEqual([survivor]);
+    expect(indexDuringBlur).toBe(0);
+
+    container.destroy();
+  });
+
+  test('a same-parent addChildAt reorders without blurring the moved child', () => {
+    const { stage, focus } = createStage();
+    const container = new Container();
+
+    container._setStage(stage);
+
+    const moved = new DummyDrawable();
+    const other = new DummyDrawable();
+
+    moved.focusable = true;
+    container.addChild(moved, other);
+    focus.focus(moved);
+
+    expect(focus.focused).toBe(moved);
+
+    container.addChildAt(moved, 1);
+
+    // Routing a same-parent insert through removeChild() detaches the node
+    // from the stage and blurs it, so a pure reorder silently stole focus.
+    expect(container.children).toEqual([other, moved]);
+    expect(focus.focused).toBe(moved);
+
+    container.destroy();
+  });
+
+  test('a same-parent addChildAt keeps the child attached to the stage throughout', () => {
+    const { stage, focus } = createStage();
+    const container = new Container();
+
+    container._setStage(stage);
+
+    const moved = new DummyDrawable();
+    const other = new DummyDrawable();
+
+    moved.focusable = true;
+    container.addChild(moved, other);
+    focus.focus(moved);
+
+    let detached = false;
+
+    moved.onBlur.add(() => {
+      detached = true;
+    });
+
+    container.addChildAt(moved, 1);
+
+    expect(detached).toBe(false);
+    expect(moved.parent).toBe(container);
+
+    container.destroy();
+  });
+
+  test('addChild appends even when the previous parent`s removal inserts into the target', () => {
+    const { stage, focus } = createStage();
+    const source = new Container();
+    const target = new Container();
+
+    source._setStage(stage);
+    target._setStage(stage);
+
+    const existing = new DummyDrawable();
+    const injected = new DummyDrawable();
+    const moving = new DummyDrawable();
+
+    target.addChild(existing);
+    moving.focusable = true;
+    source.addChild(moving);
+    focus.focus(moving);
+
+    // Detaching `moving` from `source` blurs it, and the handler grows the
+    // TARGET list. The append index was captured before that, so the child
+    // landed in the middle of the list instead of at the end.
+    moving.onBlur.add(() => {
+      target.addChild(injected);
+    });
+
+    target.addChild(moving);
+
+    expect(target.children).toEqual([existing, injected, moving]);
+
+    source.destroy();
+    target.destroy();
+  });
+
+  test('addChildAt still honours an explicit index after the previous parent`s removal shrank the list', () => {
+    const { stage, focus } = createStage();
+    const source = new Container();
+    const target = new Container();
+
+    source._setStage(stage);
+    target._setStage(stage);
+
+    const doomed = new DummyDrawable();
+    const moving = new DummyDrawable();
+
+    target.addChild(doomed);
+    moving.focusable = true;
+    source.addChild(moving);
+    focus.focus(moving);
+
+    moving.onBlur.add(() => {
+      target.removeChild(doomed);
+    });
+
+    target.addChildAt(moving, 1);
+
+    expect(target.children).toEqual([moving]);
+
+    source.destroy();
+    target.destroy();
+  });
+});

--- a/test/rendering/retained-group-fragment.test.ts
+++ b/test/rendering/retained-group-fragment.test.ts
@@ -377,17 +377,21 @@ describe('builder: transformNode marking, cull suppression, snapshot/replay roun
     const backend = createTestBackend();
     const root = new Container();
     const group = new BoundaryContainer();
+    const nearLeaf = new LeafDrawable('near');
     const farLeaf = new LeafDrawable('far');
 
-    // Group-relative position far outside the 800x600 view: without
-    // suppression this child would be culled against a space it is not in.
+    // The near leaf keeps the group's own AABB inside the view, so the group
+    // survives container-level culling and per-child culling is what this test
+    // actually exercises. Group-relative position far outside the 800x600
+    // view: without suppression the far child would be culled against a space
+    // it is not in.
     farLeaf.setPosition(5000, 5000);
-    group.addChild(farLeaf);
+    group.addChild(nearLeaf, farLeaf);
     root.addChild(group);
 
     const draws = collectDraws(root, backend);
 
-    expect(draws.map(d => (d.drawable as LeafDrawable).id)).toEqual(['far']);
+    expect(draws.map(d => (d.drawable as LeafDrawable).id)).toEqual(['near', 'far']);
 
     root.destroy();
     backend.destroy();

--- a/test/rendering/view-projection-exactness.test.ts
+++ b/test/rendering/view-projection-exactness.test.ts
@@ -1,0 +1,54 @@
+import { View } from '#rendering/View';
+
+describe('View projection maps its own viewport exactly', () => {
+  test('the camera center lands in the middle of the viewport', () => {
+    const view = new View(120, -60, 800, 600);
+    const screen = view.worldToScreen(120, -60);
+
+    expect(screen.x).toBeCloseTo(400, 9);
+    expect(screen.y).toBeCloseTo(300, 9);
+
+    view.destroy();
+  });
+
+  test('the viewport corners map to the camera rectangle', () => {
+    const view = new View(0, 0, 800, 600);
+
+    // A stray `x * -a - y * b` term shifted the whole projection by `2 / width`
+    // world units, so the corner a camera claims to show was not the corner it
+    // actually showed. Small, but it makes every derived rectangle wrong.
+    expect(view.screenToWorld(0, 0).x).toBeCloseTo(-400, 9);
+    expect(view.screenToWorld(0, 0).y).toBeCloseTo(-300, 9);
+    expect(view.screenToWorld(800, 600).x).toBeCloseTo(400, 9);
+    expect(view.screenToWorld(800, 600).y).toBeCloseTo(300, 9);
+
+    view.destroy();
+  });
+
+  test('the offset does not scale with the view size', () => {
+    const small = new View(0, 0, 100, 100);
+    const large = new View(0, 0, 4000, 4000);
+
+    // The stray term was `2 / size`, so a small view drifted much further than
+    // a large one — the error grew exactly where precision matters most.
+    expect(small.screenToWorld(0, 0).x).toBeCloseTo(-50, 9);
+    expect(large.screenToWorld(0, 0).x).toBeCloseTo(-2000, 9);
+
+    small.destroy();
+    large.destroy();
+  });
+
+  test('worldToScreen round-trips screenToWorld', () => {
+    const view = new View(37, -14, 640, 480);
+
+    view.setZoom(1.5);
+
+    const world = view.screenToWorld(123, 456);
+    const screen = view.worldToScreen(world.x, world.y);
+
+    expect(screen.x).toBeCloseTo(123, 9);
+    expect(screen.y).toBeCloseTo(456, 9);
+
+    view.destroy();
+  });
+});

--- a/test/rendering/view-rotated-cull-bounds.test.ts
+++ b/test/rendering/view-rotated-cull-bounds.test.ts
@@ -7,7 +7,12 @@ import { View } from '#rendering/View';
  * in play, and independent of how the projection composes them.
  */
 const visibleAreaFromCorners = (view: View): { left: number; top: number; right: number; bottom: number } => {
-  const corners = [view.screenToWorld(0, 0), view.screenToWorld(view.width, 0), view.screenToWorld(view.width, view.height), view.screenToWorld(0, view.height)];
+  const corners = [
+    view.screenToWorld(0, 0),
+    view.screenToWorld(view.width, 0),
+    view.screenToWorld(view.width, view.height),
+    view.screenToWorld(0, view.height),
+  ];
   const xs = corners.map(corner => corner.x);
   const ys = corners.map(corner => corner.y);
 

--- a/test/rendering/view-rotated-cull-bounds.test.ts
+++ b/test/rendering/view-rotated-cull-bounds.test.ts
@@ -1,0 +1,116 @@
+import { View } from '#rendering/View';
+
+/**
+ * The world-space AABB of the four viewport corners, mapped through the view's
+ * own `screenToWorld`. This is by definition the area the camera renders, so
+ * the cull bounds must cover exactly it — whatever rotation, zoom or centre is
+ * in play, and independent of how the projection composes them.
+ */
+const visibleAreaFromCorners = (view: View): { left: number; top: number; right: number; bottom: number } => {
+  const corners = [view.screenToWorld(0, 0), view.screenToWorld(view.width, 0), view.screenToWorld(view.width, view.height), view.screenToWorld(0, view.height)];
+  const xs = corners.map(corner => corner.x);
+  const ys = corners.map(corner => corner.y);
+
+  return {
+    left: Math.min(...xs),
+    top: Math.min(...ys),
+    right: Math.max(...xs),
+    bottom: Math.max(...ys),
+  };
+};
+
+const expectBoundsCoverVisibleArea = (view: View): void => {
+  const bounds = view.getBounds();
+  const visible = visibleAreaFromCorners(view);
+
+  expect(bounds.left).toBeCloseTo(visible.left, 6);
+  expect(bounds.top).toBeCloseTo(visible.top, 6);
+  expect(bounds.right).toBeCloseTo(visible.right, 6);
+  expect(bounds.bottom).toBeCloseTo(visible.bottom, 6);
+};
+
+describe('View cull bounds account for rotation', () => {
+  test('an unrotated view spans exactly its size', () => {
+    const view = new View(0, 0, 800, 600);
+
+    expectBoundsCoverVisibleArea(view);
+    expect(view.getBounds().width).toBeCloseTo(800, 3);
+    expect(view.getBounds().height).toBeCloseTo(600, 3);
+
+    view.destroy();
+  });
+
+  test('a 45-degree view grows to cover its rotated corners', () => {
+    const view = new View(0, 0, 800, 600);
+
+    view.setRotation(45);
+
+    // Centre +- half-size ignores rotation, so a rotated camera got a cull rect
+    // strictly smaller than the area it renders and content popped in at the
+    // rotated corners. The rotated AABB of a 800x600 box is ~989.9 square.
+    const expected = (400 + 300) * Math.SQRT2;
+
+    expect(view.getBounds().width).toBeCloseTo(expected, 2);
+    expect(view.getBounds().height).toBeCloseTo(expected, 2);
+    expectBoundsCoverVisibleArea(view);
+
+    view.destroy();
+  });
+
+  test('a 90-degree view swaps its extents', () => {
+    const view = new View(0, 0, 800, 600);
+
+    view.setRotation(90);
+
+    expect(view.getBounds().width).toBeCloseTo(600, 2);
+    expect(view.getBounds().height).toBeCloseTo(800, 2);
+    expectBoundsCoverVisibleArea(view);
+
+    view.destroy();
+  });
+
+  test('a negative rotation covers the same area as its positive counterpart', () => {
+    const positive = new View(0, 0, 800, 600);
+    const negative = new View(0, 0, 800, 600);
+
+    positive.setRotation(45);
+    negative.setRotation(-45);
+
+    expect(negative.getBounds().width).toBeCloseTo(positive.getBounds().width, 6);
+    expect(negative.getBounds().height).toBeCloseTo(positive.getBounds().height, 6);
+
+    positive.destroy();
+    negative.destroy();
+  });
+
+  test.each([
+    { angle: 0, centerX: 0, centerY: 0, zoom: 1 },
+    { angle: 30, centerX: 120, centerY: -60, zoom: 1 },
+    { angle: 45, centerX: 0, centerY: 0, zoom: 2 },
+    { angle: 17, centerX: -400, centerY: 250, zoom: 0.5 },
+    { angle: 200, centerX: 75, centerY: 75, zoom: 1.5 },
+  ])('cull bounds cover the rendered area at $angle deg, centre ($centerX, $centerY), zoom $zoom', ({ angle, centerX, centerY, zoom }) => {
+    const view = new View(centerX, centerY, 800, 600);
+
+    view.setRotation(angle);
+    view.setZoom(zoom);
+
+    expectBoundsCoverVisibleArea(view);
+
+    view.destroy();
+  });
+
+  test('a zero-sized view still reports a degenerate rect at its center', () => {
+    const view = new View(50, 70, 0, 0);
+    const bounds = view.getBounds();
+
+    // The projection is degenerate here; the bounds must stay a real rectangle
+    // rather than decaying into NaN.
+    expect(bounds.x).toBe(50);
+    expect(bounds.y).toBe(70);
+    expect(bounds.width).toBe(0);
+    expect(bounds.height).toBe(0);
+
+    view.destroy();
+  });
+});


### PR DESCRIPTION
Batch B of the consolidated architecture review: the five Scene-Graph / Math points ME-13 through ME-17, plus three findings the work uncovered along the way.

## Review points

**ME-13 — container bounds no longer pin the origin.** `Container.updateBounds` merged the container's own empty local rect into the aggregate unconditionally, stretching the AABB from the container's position out to its children. A container whose children all sit far away reported an extent that was mostly empty space. `RetainedContainer` seeded its group-local aggregate the same way and is fixed alongside. A container with no content at all still reports a degenerate rect at its own transform, so the empty accumulator never leaks into `width`/`height`.

**ME-14 — structural methods are atomic against user callbacks.** `removeChildAt` already committed its splice before notifying; the other two did not. `removeChildren` ran every notify first, so an `onBlur` handler saw a list that still held every node being removed. `addChildAt` captured its insert position before detaching the child from its previous parent — and that detach dispatches `onBlur`, so a handler that inserted into the target shifted the list underneath the pending splice. Both entry points now share `_attachChild`, which resolves the position after the detach. A same-parent `addChildAt` is now a real reorder instead of a detach/re-attach, so it no longer steals keyboard focus.

**ME-15 — view culling accounts for rotation.** `View.updateBounds` built its AABB as centre ± half-size, which ignores `rotation` outright: at 45° an 800×600 view covers a ~990×990 world box, so roughly a third of what reached the screen was outside the cull rect. The bounds now come from the four clip-space corners mapped back through the projection, using the same inlined 2×2 solve `screenToWorld` uses, so the path stays allocation-free.

**ME-16 — Matrix transforms no longer alias the shared scratch.** `translate/rotate/scale` built their operand in `Matrix.temp` and fed it to `combine()`, so calling any of them ON the public scratch combined it with itself. `Matrix.temp` stays public; the three methods compute with local scalars instead.

**ME-17 — `Flags` is allocation-free on the transform hot path.** `has/push/remove` take rest parameters, so every call allocated an array, and `has` allocated a closure on top. Those calls sit in the ancestor walk of the scene graph's bounds invalidation. New `hasMask`/`addMask`/`removeMask`/`popMask` do plain bitwise work; the rest forms stay for cold call sites. Measured on the existing allocation gate: the `sprite/1000 moving` scene drops from **425.85 to 276.66 KB/frame (−35%)**, with the other four scenes unmoved. The gate's baseline is ratcheted from 574 to 277 to hold the win.

## Findings uncovered while fixing the above

**View projection carried a stray offset (fixed).** `updateTransform` folded an `x * -a - y * b` term into the translation on top of the camera centre. Nothing in the orthographic mapping calls for it: it shifted the whole projection by `2 / width` world units, so the rectangle a camera claimed to show was never quite the one it showed. This surfaced because exact cull bounds inherit the skew — it put content flush against a viewport edge on the wrong side of every derived rectangle.

**`Vector.contains` aliased the shared scratch (fixed).** Same class as ME-16: it built its probe point in `Vector.temp` and passed it alongside `this`, so `Vector.temp.contains(x, y)` answered `true` for every coordinate.

**View rotation turns around the world origin, not the camera centre (open, not fixed here).** At `rotation = 30` with `center = (120, -60)`, the middle of the viewport maps to `(133.93, 8.04)` — the projection applies `R · world - centre` rather than `R · (world - centre)`, so a rotated camera does not look at the position it was told to look at. Fixing it changes visible camera behaviour and belongs in its own change; the cull bounds here are derived from the projection, so they stay correct either way.

## Verification

- TDD throughout: every fix has a test verified failing against the preceding state first.
- `pnpm test` — 9184 passed, 1 skipped.
- `pnpm verify:quick` — exit 0.
- `pnpm typecheck:test` — within budget, baseline untouched.
- `pnpm docs:api:generate` — regenerated and committed (`Flags` gained public methods).

Four existing tests asserted behaviour that was the bug rather than the property they were written to check (container aggregates growing when a child moved away, a boundary container surviving cull only because of the pinned origin); they now assert the intended property. The `mutate10` counter gate drops one world-transform resolution, since a structural container no longer resolves its own matrix for a rect that contributed nothing.