### PR TITLE
fix(rendering): pivot view rotation around the camera center

### DIFF
--- a/src/rendering/View.ts
+++ b/src/rendering/View.ts
@@ -451,8 +451,15 @@ export class View implements ObservableVectorOwner {
       this._transform.d = y * this._cos;
     }
 
-    this._transform.x = -x * centerX;
-    this._transform.y = -y * centerY;
+    // Translate THEN rotate, i.e. `clip = R · (world - centre)`. Subtracting the
+    // centre in clip space instead — `R · world - centre` — pivots the camera
+    // around the world origin, so a rotated view looks at `R⁻¹ · centre` rather
+    // than the position it was given, and the error grows with the centre's
+    // distance from the origin. Folding the centre through the already-rotated
+    // basis rows is the same correction with no extra trigonometry; at
+    // `rotation = 0` the rows are axis-aligned and this reduces to `-x * centreX`.
+    this._transform.x = -(this._transform.a * centerX + this._transform.b * centerY);
+    this._transform.y = -(this._transform.c * centerX + this._transform.d * centerY);
 
     return this;
   }

--- a/test/rendering/view-rotation-pivot.test.ts
+++ b/test/rendering/view-rotation-pivot.test.ts
@@ -1,0 +1,86 @@
+import { View } from '#rendering/View';
+
+const WIDTH = 800;
+const HEIGHT = 600;
+
+describe('View rotation pivots around the camera center', () => {
+  test.each([
+    { angle: 0, centerX: 120, centerY: -60 },
+    { angle: 30, centerX: 120, centerY: -60 },
+    { angle: 45, centerX: 0, centerY: 0 },
+    { angle: 90, centerX: -400, centerY: 250 },
+    { angle: -60, centerX: 75, centerY: 75 },
+    { angle: 200, centerX: 1000, centerY: -1000 },
+  ])('the camera looks at its center at $angle deg, center ($centerX, $centerY)', ({ angle, centerX, centerY }) => {
+    const view = new View(centerX, centerY, WIDTH, HEIGHT);
+
+    view.setRotation(angle);
+
+    // The projection applied `R · world - centre` instead of
+    // `R · (world - centre)`, so a rotated camera looked at `R⁻¹ · centre`
+    // rather than the position it was told to look at — at 30 degrees with
+    // centre (120, -60) the middle of the viewport landed on (133.93, 8.04).
+    const world = view.screenToWorld(WIDTH / 2, HEIGHT / 2);
+
+    expect(world.x).toBeCloseTo(centerX, 6);
+    expect(world.y).toBeCloseTo(centerY, 6);
+
+    view.destroy();
+  });
+
+  test('worldToScreen puts the center in the middle of a rotated viewport', () => {
+    const view = new View(120, -60, WIDTH, HEIGHT);
+
+    view.setRotation(30);
+
+    const screen = view.worldToScreen(120, -60);
+
+    expect(screen.x).toBeCloseTo(WIDTH / 2, 6);
+    expect(screen.y).toBeCloseTo(HEIGHT / 2, 6);
+
+    view.destroy();
+  });
+
+  test('rotating a camera in place does not move what it looks at', () => {
+    const view = new View(300, -200, WIDTH, HEIGHT);
+
+    const before = view.screenToWorld(WIDTH / 2, HEIGHT / 2);
+
+    view.setRotation(75);
+
+    const after = view.screenToWorld(WIDTH / 2, HEIGHT / 2);
+
+    expect(after.x).toBeCloseTo(before.x, 6);
+    expect(after.y).toBeCloseTo(before.y, 6);
+
+    view.destroy();
+  });
+
+  test('the pivot holds under zoom', () => {
+    const view = new View(-250, 480, WIDTH, HEIGHT);
+
+    view.setRotation(37);
+    view.setZoom(2.5);
+
+    // Zoom shrinks the design space, so the middle of the viewport moves with it.
+    const world = view.screenToWorld(view.width / 2, view.height / 2);
+
+    expect(world.x).toBeCloseTo(-250, 6);
+    expect(world.y).toBeCloseTo(480, 6);
+
+    view.destroy();
+  });
+
+  test('the cull bounds of a rotated camera stay centred on it', () => {
+    const view = new View(120, -60, WIDTH, HEIGHT);
+
+    view.setRotation(30);
+
+    const bounds = view.getBounds();
+
+    expect(bounds.x + bounds.width / 2).toBeCloseTo(120, 6);
+    expect(bounds.y + bounds.height / 2).toBeCloseTo(-60, 6);
+
+    view.destroy();
+  });
+});


### PR DESCRIPTION
NEU-B3 from the consolidated architecture review — the finding Batch B (#497) uncovered but deliberately left open, because it changes visible camera behaviour and belongs in its own change.

## The bug

`View.updateTransform` subtracted the camera centre in clip space, after the rotation basis had already been applied:

```
clip = R · world - centre        // what it did
clip = R · (world - centre)      // what a camera means
```

That pivots the camera around the **world origin** rather than around itself. A rotated view therefore looks at `R⁻¹ · centre`, not at the position it was set to, and the error grows with the centre's distance from the origin:

| rotation | center | viewport middle actually mapped to |
|---|---|---|
| 30° | `(120, -60)` | `(133.93, 8.04)` — ~68 units off |
| 200° | `(1000, -1000)` | off by more than 2000 units |

Everything downstream inherits it: `setCenter`, follow targets, bounds constraints and shake all aim at a point the projection does not use, and `screenToWorld`/`worldToScreen` map through the same skew.

## The fix

The centre is folded through the already-rotated basis rows:

```ts
this._transform.x = -(this._transform.a * centerX + this._transform.b * centerY);
this._transform.y = -(this._transform.c * centerX + this._transform.d * centerY);
```

Same correction, no extra trigonometry, no extra branch. At `rotation = 0` the basis rows are axis-aligned and the expression reduces to the previous `-x * centerX`, so an **unrotated camera is bit-identical** — which is why nothing outside the new tests moved.

## Verification

- TDD: the new tests were verified failing against the preceding commit (8 of 10 red; the two that passed are the `rotation = 0` cases, which guard the no-change property).
- `pnpm test` — 9194 passed, 1 skipped. No existing test needed adjusting: the rotated-camera behaviour was nowhere pinned down, which is exactly how it survived.
- `pnpm verify:quick` — exit 0. No public API change, so no docs regeneration.

The cull bounds from #497 are derived from the projection, so they were correct before this change and stay correct after it — they now simply centre on the camera, which the new bounds test asserts.