### PR TITLE
fix(audio,animation): Batch D — effect teardown, voice lifetime, clip windows and envelope release

### DIFF
--- a/site/src/content/api/audio-manager.json
+++ b/site/src/content/api/audio-manager.json
@@ -6,10 +6,10 @@
   "subsystem": "audio",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 21,
+  "memberCount": 23,
   "counts": {
     "constructors": 1,
-    "methods": 12,
+    "methods": 14,
     "properties": 7,
     "events": 1
   },
@@ -162,6 +162,53 @@
           "description": "Internal: register a spatial voice for per-frame position updates. Called by a Voice the first time it is spatialized (position set or follow)."
         },
         {
+          "name": "_registerVoice",
+          "signature": "_registerVoice(voice: Voice): void",
+          "signatureTokens": [
+            {
+              "text": "_registerVoice",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "voice",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Voice",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "voice",
+              "type": "Voice",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Internal: track a live voice so AudioManager.destroy can stop it. Called from the voice's own constructor, which covers every creation path — play(), open(), sprite playback, and pooled replays alike."
+        },
+        {
           "name": "_unregisterSpatial",
           "signature": "_unregisterSpatial(voice: SpatialVoice): void",
           "signatureTokens": [
@@ -207,6 +254,53 @@
           ],
           "returnType": "void",
           "description": "Internal: stop ticking a voice that returned to a direct graph."
+        },
+        {
+          "name": "_unregisterVoice",
+          "signature": "_unregisterVoice(voice: Voice): void",
+          "signatureTokens": [
+            {
+              "text": "_unregisterVoice",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "voice",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Voice",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "voice",
+              "type": "Voice",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Internal: drop a voice that has ended. Called from the voice's own teardown."
         },
         {
           "name": "destroy",

--- a/site/src/content/api/audio-manager.json
+++ b/site/src/content/api/audio-manager.json
@@ -329,7 +329,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Tear the mix down: stop every voice still playing, then the listener and every bus. Terminal — AudioManager.play and AudioManager.open throw afterwards."
         },
         {
           "name": "getBus",

--- a/site/src/content/api/audio-stream.json
+++ b/site/src/content/api/audio-stream.json
@@ -6,11 +6,11 @@
   "subsystem": "audio",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 9,
+  "memberCount": 10,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 6,
+    "properties": 7,
     "events": 0
   },
   "sections": [
@@ -190,7 +190,7 @@
             }
           ],
           "returnType": "Voice",
-          "description": "Implements Playable. Called by AudioManager.play. Stops any previously active voice (a stream has a single playhead), then starts a fresh AudioStreamVoice."
+          "description": "Implements Playable. Called by AudioManager.play. Stops any previously active voice (a stream has a single playhead), then starts a fresh AudioStreamVoice. Throws on a destroyed stream. The check is unconditional, not __DEV__-only: createMediaElementSource() may be called exactly once per media element, and the second call raises InvalidStateError in the browser — a hard, hard-to-trace runtime failure that a production build must not walk into."
         },
         {
           "name": "destroy",
@@ -219,7 +219,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": "Stop the active voice and release the media graph."
+          "description": "Stop the active voice and release the media graph. Terminal: the stream cannot be played again afterwards (see AudioStream.destroyed)."
         }
       ],
       "paragraphs": [],
@@ -334,6 +334,27 @@
           "params": [],
           "returnType": null,
           "description": "The backing HTMLAudioElement."
+        },
+        {
+          "name": "destroyed",
+          "signature": "destroyed: boolean",
+          "signatureTokens": [
+            {
+              "text": "destroyed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "true once AudioStream.destroy has run. A destroyed stream is not reusable — playing it throws. Load the asset again to get a fresh stream."
         },
         {
           "name": "duration",

--- a/site/src/content/api/envelope.json
+++ b/site/src/content/api/envelope.json
@@ -181,7 +181,7 @@
             }
           ],
           "returnType": "void",
-          "description": "Schedule release → 0 starting at atTime. Call this when the note should stop (e.g., key release, sound dismissed)."
+          "description": "Schedule release → 0 starting at atTime. Call this when the note should stop (e.g., key release, sound dismissed). The release starts from wherever the envelope actually is, including mid-attack and mid-decay. A bare cancelScheduledValues would drop the in-flight ramp and snap the parameter back to the previous event's value (0 during attack) — an audible click."
         },
         {
           "name": "trigger",

--- a/site/src/content/api/tween-manager.json
+++ b/site/src/content/api/tween-manager.json
@@ -518,7 +518,7 @@
             }
           ],
           "returnType": "Tween",
-          "description": "Chain tweens in sequence: each tween starts automatically when the previous one completes. Returns the first tween; call .start() on it to kick off the whole sequence. All tweens are registered with this manager (idempotent — already-added tweens are not double-added)."
+          "description": "Chain tweens in sequence: each tween starts automatically when the previous one completes. Returns the first tween; call .start() on it to kick off the whole sequence. All tweens are bound to this manager, but only enter the update list when they are actually started — the first through your own .start() call, every later one through the chain. A sequence that is composed and never started therefore leaves nothing behind here."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/tween-manager.json
+++ b/site/src/content/api/tween-manager.json
@@ -1,6 +1,6 @@
 {
   "title": "TweenManager",
-  "description": "Owns and advances a collection of Tween instances, driving them once per frame from Application.update. Created tweens are tracked automatically; manually constructed tweens can be opted in via TweenManager.add. Custom updatables (such as TweenSequencer) can be registered via TweenManager.addTicker so they share the same frame tick. Update iteration uses a snapshot so callbacks may freely add or remove tweens during the same frame without corrupting the loop. Completed and stopped tweens are evicted automatically.",
+  "description": "Owns and advances a collection of Tween instances, driving them once per frame from Application.update. A tween created here enters the update list when Tween.start is called and leaves it again on completion or Tween.stop, so the manager only ever holds tweens that are running or paused. Manually constructed tweens can be opted in via TweenManager.add. Custom updatables (such as TweenSequencer) can be registered via TweenManager.addTicker so they share the same frame tick. Update iteration uses a snapshot so callbacks may freely add or remove tweens during the same frame without corrupting the loop. Completed and stopped tweens are evicted automatically.",
   "symbol": "TweenManager",
   "kind": "class",
   "subsystem": "animation",
@@ -19,7 +19,7 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Owns and advances a collection of Tween instances, driving them once per frame from Application.update. Created tweens are tracked automatically; manually constructed tweens can be opted in via TweenManager.add.",
+        "Owns and advances a collection of Tween instances, driving them once per frame from Application.update. A tween created here enters the update list when Tween.start is called and leaves it again on completion or Tween.stop, so the manager only ever holds tweens that are running or paused. Manually constructed tweens can be opted in via TweenManager.add.",
         "Custom updatables (such as TweenSequencer) can be registered via TweenManager.addTicker so they share the same frame tick.",
         "Update iteration uses a snapshot so callbacks may freely add or remove tweens during the same frame without corrupting the loop. Completed and stopped tweens are evicted automatically."
       ],
@@ -248,7 +248,7 @@
             }
           ],
           "returnType": "Tween<T>",
-          "description": "Create a new Tween targeting target, register it with this manager, and return it. Call .to(...).start() on the result to begin animating."
+          "description": "Create a new Tween bound to this manager and return it. Call .to(...).start() on the result to begin animating. The tween is only entered into the update list by Tween.start — a tween that is configured but never started is not retained here, so it cannot keep its target alive for the lifetime of the application."
         },
         {
           "name": "createSequencer",

--- a/site/src/content/api/tween.json
+++ b/site/src/content/api/tween.json
@@ -1,6 +1,6 @@
 {
   "title": "Tween",
-  "description": "Animates numeric properties of `target` from their current value to a configured end value over a duration in seconds. Supports easing, delay, repeat (with optional yoyo), chaining, and lifecycle callbacks (Tween.onStart, Tween.onUpdate, Tween.onComplete, Tween.onRepeat). Tweens are typically created via TweenManager.create, which attaches them to the manager so they advance once per frame. Stand-alone usage is supported by calling Tween.update manually with a frame delta. Start values are captured lazily on the first update after Tween.start, so target properties may be mutated between configuration and start without affecting the captured baseline. Only number-typed properties on `target` are interpolated; non-number properties listed in Tween.to emit a console warning and are skipped.",
+  "description": "Animates numeric properties of `target` from their current value to a configured end value over a duration in seconds. Supports easing, delay, repeat (with optional yoyo), chaining, and lifecycle callbacks (Tween.onStart, Tween.onUpdate, Tween.onComplete, Tween.onRepeat). Tweens are typically created via TweenManager.create, which binds them to that manager; Tween.start then enters them into its update loop so they advance once per frame. Stand-alone usage is supported by calling Tween.update manually with a frame delta. Start values are captured lazily on the first update after Tween.start, so target properties may be mutated between configuration and start without affecting the captured baseline. Only number-typed properties on `target` are interpolated; non-number properties listed in Tween.to emit a console warning and are skipped.",
   "symbol": "Tween",
   "kind": "class",
   "subsystem": "animation",
@@ -20,7 +20,7 @@
       "members": [],
       "paragraphs": [
         "Animates numeric properties of `target` from their current value to a configured end value over a duration in seconds. Supports easing, delay, repeat (with optional yoyo), chaining, and lifecycle callbacks (Tween.onStart, Tween.onUpdate, Tween.onComplete, Tween.onRepeat).",
-        "Tweens are typically created via TweenManager.create, which attaches them to the manager so they advance once per frame. Stand-alone usage is supported by calling Tween.update manually with a frame delta.",
+        "Tweens are typically created via TweenManager.create, which binds them to that manager; Tween.start then enters them into its update loop so they advance once per frame. Stand-alone usage is supported by calling Tween.update manually with a frame delta.",
         "Start values are captured lazily on the first update after Tween.start, so target properties may be mutated between configuration and start without affecting the captured baseline.",
         "Only number-typed properties on `target` are interpolated; non-number properties listed in Tween.to emit a console warning and are skipped."
       ],
@@ -560,7 +560,7 @@
           ],
           "params": [],
           "returnType": "this",
-          "description": "Start or restart the tween. Resets all elapsed time, the start-value snapshot, playback direction, and repeat counter. If this tween was previously owned by a manager but was evicted after natural completion or Tween.stop, it is automatically re-registered so it continues to receive frame updates. Stand-alone tweens (no manager) are unaffected."
+          "description": "Start or restart the tween. Resets all elapsed time, the start-value snapshot, playback direction, and repeat counter. Registers the tween with its manager, if one is assigned — both for the first start and after an eviction caused by natural completion or Tween.stop, so it (re)starts receiving frame updates either way. Stand-alone tweens (no manager) are unaffected."
         },
         {
           "name": "stop",
@@ -589,7 +589,7 @@
           ],
           "params": [],
           "returnType": "this",
-          "description": "Stop the tween without finishing. Target properties stay at their current interpolated values. onComplete does NOT fire. The tween is removed from its manager if one is assigned."
+          "description": "Stop the tween without finishing. Target properties stay at their current interpolated values. onComplete does NOT fire. The tween is removed from its manager if one is assigned — in every state, so an idle or already-finished tween that was handed to a manager explicitly is released too."
         },
         {
           "name": "to",

--- a/src/animation/Tween.ts
+++ b/src/animation/Tween.ts
@@ -16,9 +16,10 @@ type NumericKeys<T> = {
  * ({@link Tween.onStart}, {@link Tween.onUpdate}, {@link Tween.onComplete},
  * {@link Tween.onRepeat}).
  *
- * Tweens are typically created via {@link TweenManager.create}, which attaches
- * them to the manager so they advance once per frame. Stand-alone usage is
- * supported by calling {@link Tween.update} manually with a frame delta.
+ * Tweens are typically created via {@link TweenManager.create}, which binds
+ * them to that manager; {@link Tween.start} then enters them into its update
+ * loop so they advance once per frame. Stand-alone usage is supported by
+ * calling {@link Tween.update} manually with a frame delta.
  *
  * Start values are captured lazily on the first update after {@link Tween.start},
  * so target properties may be mutated between configuration and start without
@@ -210,10 +211,10 @@ export class Tween<T extends object = object> {
    * Start or restart the tween. Resets all elapsed time, the start-value
    * snapshot, playback direction, and repeat counter.
    *
-   * If this tween was previously owned by a manager but was evicted after
-   * natural completion or {@link Tween.stop}, it is automatically
-   * re-registered so it continues to receive frame updates. Stand-alone
-   * tweens (no manager) are unaffected.
+   * Registers the tween with its manager, if one is assigned — both for the
+   * first start and after an eviction caused by natural completion or
+   * {@link Tween.stop}, so it (re)starts receiving frame updates either way.
+   * Stand-alone tweens (no manager) are unaffected.
    */
   public start(): this {
     this._state = TweenState.Active;
@@ -249,13 +250,16 @@ export class Tween<T extends object = object> {
   /**
    * Stop the tween without finishing. Target properties stay at their
    * current interpolated values. onComplete does NOT fire. The tween is
-   * removed from its manager if one is assigned.
+   * removed from its manager if one is assigned — in every state, so an
+   * idle or already-finished tween that was handed to a manager explicitly
+   * is released too.
    */
   public stop(): this {
     if (this._state === TweenState.Active || this._state === TweenState.Paused) {
       this._state = TweenState.Stopped;
-      this._manager?.remove(this);
     }
+
+    this._manager?.remove(this);
 
     return this;
   }

--- a/src/animation/TweenManager.ts
+++ b/src/animation/TweenManager.ts
@@ -10,8 +10,10 @@ interface Ticker {
 
 /**
  * Owns and advances a collection of {@link Tween} instances, driving them
- * once per frame from {@link Application.update}. Created tweens are tracked
- * automatically; manually constructed tweens can be opted in via
+ * once per frame from {@link Application.update}. A tween created here enters
+ * the update list when {@link Tween.start} is called and leaves it again on
+ * completion or {@link Tween.stop}, so the manager only ever holds tweens that
+ * are running or paused. Manually constructed tweens can be opted in via
  * {@link TweenManager.add}.
  *
  * Custom updatables (such as {@link TweenSequencer}) can be registered via
@@ -28,13 +30,16 @@ export class TweenManager {
   private _destroyed = false;
 
   /**
-   * Create a new Tween targeting `target`, register it with this manager, and
-   * return it. Call .to(...).start() on the result to begin animating.
+   * Create a new Tween bound to this manager and return it. Call
+   * `.to(...).start()` on the result to begin animating.
+   *
+   * The tween is only entered into the update list by {@link Tween.start} — a
+   * tween that is configured but never started is not retained here, so it
+   * cannot keep its target alive for the lifetime of the application.
    */
   public create<T extends object>(target: T): Tween<T> {
     const tween = new Tween(target);
     tween._attachManager(this);
-    this._tweens.push(tween);
 
     return tween;
   }

--- a/src/animation/TweenManager.ts
+++ b/src/animation/TweenManager.ts
@@ -47,8 +47,12 @@ export class TweenManager {
   /**
    * Chain `tweens` in sequence: each tween starts automatically when the
    * previous one completes. Returns the first tween; call `.start()` on it
-   * to kick off the whole sequence. All tweens are registered with this
-   * manager (idempotent — already-added tweens are not double-added).
+   * to kick off the whole sequence.
+   *
+   * All tweens are bound to this manager, but only enter the update list when
+   * they are actually started — the first through your own `.start()` call,
+   * every later one through the chain. A sequence that is composed and never
+   * started therefore leaves nothing behind here.
    *
    * @example
    * ```ts
@@ -70,8 +74,12 @@ export class TweenManager {
       if (current !== undefined && next !== undefined) current.chain(next);
     }
 
+    // Bind only — `Tween.start` does the registering, and every link after the
+    // first is started by `_complete()` on its predecessor. Pre-registering
+    // them here would be redundant and would pin an unstarted sequence (and
+    // its targets) in the application-wide manager for good.
     for (const tween of tweens) {
-      this.add(tween);
+      tween._attachManager(this);
     }
 
     return first;

--- a/src/audio/AudioBus.ts
+++ b/src/audio/AudioBus.ts
@@ -157,6 +157,16 @@ export class AudioBus {
     const index = this._effects.indexOf(effect);
     if (index !== -1) {
       this._effects.splice(index, 1);
+      // Detach the removed effect's output from the graph before rewiring: the
+      // rebuild below only touches the effects still in the chain, so an
+      // outgoing edge left live would keep feeding the pan stage and let a
+      // delay/reverb tail bleed through after removal. Its internal input
+      // wiring is deliberately left intact so the caller can reuse the effect
+      // (same contract as `BaseVoice.removeEffect`). Skipped for an effect
+      // whose own nodes have not been created yet — it was never wired in.
+      if (_isEffectReady(effect)) {
+        effect.outputNode.disconnect();
+      }
       this._rebuildEffectChain();
     }
     return this;

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -46,6 +46,13 @@ export class AudioManager {
 
   private readonly _registered = new Map<string, AudioBus>();
   private readonly _spatial = new Set<SpatialVoice>();
+  /**
+   * Every voice created against this manager that has not ended yet — the
+   * registry {@link AudioManager.destroy} needs in order to actually silence
+   * playback. `_spatial` only ever holds the subset that is being panned per
+   * frame, which is why it cannot serve this purpose.
+   */
+  private readonly _voices = new Set<Voice>();
   private _muteOnHidden = false;
 
   public constructor() {
@@ -177,6 +184,20 @@ export class AudioManager {
     this._spatial.delete(voice);
   }
 
+  /**
+   * Internal: track a live voice so {@link AudioManager.destroy} can stop it.
+   * Called from the voice's own constructor, which covers every creation path —
+   * `play()`, `open()`, sprite playback, and pooled replays alike.
+   */
+  public _registerVoice(voice: Voice): void {
+    this._voices.add(voice);
+  }
+
+  /** Internal: drop a voice that has ended. Called from the voice's own teardown. */
+  public _unregisterVoice(voice: Voice): void {
+    this._voices.delete(voice);
+  }
+
   /** Internal: called by Application when visibility changes. */
   public _applyVisibility(visible: boolean): void {
     if (this._muteOnHidden) {
@@ -231,6 +252,15 @@ export class AudioManager {
   }
 
   public destroy(): void {
+    // Voices first: tearing down the buses only detaches nodes from the graph,
+    // it does not stop a source. An `<audio>` element in particular keeps
+    // decoding and a buffer source keeps rendering until its voice is stopped,
+    // so an unstopped voice would outlive the application it belonged to.
+    // Iterated over a copy — each `stop()` deregisters the voice via `onEnd`.
+    for (const voice of [...this._voices]) {
+      voice.stop();
+    }
+    this._voices.clear();
     this.listener.destroy();
     this._spatial.clear();
     for (const bus of this._registered.values()) {

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -1,3 +1,4 @@
+import { logger } from '#core/logging';
 import { Signal } from '#core/Signal';
 import type { Time } from '#core/Time';
 
@@ -54,6 +55,7 @@ export class AudioManager {
    */
   private readonly _voices = new Set<Voice>();
   private _muteOnHidden = false;
+  private _destroyed = false;
 
   public constructor() {
     this.master = new AudioBus('master', { parent: null });
@@ -120,6 +122,8 @@ export class AudioManager {
    * voice.stop();
    * ```
    *
+   * Throws once the manager has been destroyed — see {@link AudioManager.destroy}.
+   *
    * @param source - Any {@link Playable} asset (Sound, AudioStream, AudioGenerator).
    * @param options - Per-play overrides (bus, volume, loop, playbackRate, detune, time, muted).
    * @returns A {@link Voice} handle for the new instance.
@@ -127,6 +131,7 @@ export class AudioManager {
   public play(source: Sound, options?: SoundPlayOptions): Voice;
   public play(source: Playable, options?: PlayOptions): Voice;
   public play(source: Playable, options?: PlayOptions): Voice {
+    this._assertLive('play');
     return source._createVoice(this, options ?? {});
   }
 
@@ -143,6 +148,8 @@ export class AudioManager {
    * ```
    */
   public open(input: AudioInput): InputVoice {
+    this._assertLive('open');
+
     const audioContext = getAudioContext();
     const sourceNode = audioContext.createMediaStreamSource(input.stream);
     const output = audioContext.createGain();
@@ -251,15 +258,41 @@ export class AudioManager {
     return this._registered.has(name);
   }
 
+  /**
+   * Tear the mix down: stop every voice still playing, then the listener and
+   * every bus. Terminal — {@link AudioManager.play} and
+   * {@link AudioManager.open} throw afterwards.
+   */
   public destroy(): void {
+    // Set before the drain so nothing can start new playback from an `onEnd`
+    // handler, which is also what bounds the loop below.
+    this._destroyed = true;
+
+    const failures: unknown[] = [];
+
     // Voices first: tearing down the buses only detaches nodes from the graph,
     // it does not stop a source. An `<audio>` element in particular keeps
     // decoding and a buffer source keeps rendering until its voice is stopped,
     // so an unstopped voice would outlive the application it belonged to.
-    // Iterated over a copy — each `stop()` deregisters the voice via `onEnd`.
-    for (const voice of [...this._voices]) {
-      voice.stop();
+    //
+    // Drained rather than iterated over a snapshot: a voice's `onEnd` handler
+    // may register another voice, which a copy taken up front would miss and
+    // the clear below would then drop while it is still playing. A Set
+    // iterator visits values added after the current position, and removing
+    // each entry before stopping it keeps the loop making progress.
+    for (const voice of this._voices) {
+      this._voices.delete(voice);
+      try {
+        voice.stop();
+      } catch (error) {
+        // A voice whose construction failed part-way through can throw out of
+        // its own teardown. That must not abort the rest of the shutdown, so
+        // failures are collected and reported once the tail has run — the same
+        // shape as `SystemRegistry.destroy()`.
+        failures.push(error);
+      }
     }
+
     this._voices.clear();
     this.listener.destroy();
     this._spatial.clear();
@@ -268,5 +301,22 @@ export class AudioManager {
       bus.destroy();
     }
     this._registered.clear();
+
+    for (const error of failures) {
+      logger.error('AudioManager.destroy(): a voice threw while being stopped.', {
+        source: 'AudioManager',
+        ...(error instanceof Error && { error }),
+      });
+    }
+  }
+
+  private _assertLive(method: string): void {
+    if (this._destroyed) {
+      throw new Error(
+        `AudioManager.${method}() was called on a destroyed AudioManager. Its buses and listener are gone and it no ` +
+          'longer tracks what it starts, so the voice would render into a dead graph with nothing left to stop it. ' +
+          'Check the teardown order — the owning Application has already been destroyed.',
+      );
+    }
   }
 }

--- a/src/audio/AudioStream.ts
+++ b/src/audio/AudioStream.ts
@@ -39,6 +39,7 @@ export class AudioStream implements Playable {
 
   private _sourceNode: MediaElementAudioSourceNode | null = null;
   private _activeVoice: AudioStreamVoice | null = null;
+  private _destroyed = false;
 
   public constructor(audioElement: HTMLAudioElement, options?: Partial<PlaybackOptions>) {
     this._audioElement = audioElement;
@@ -63,12 +64,33 @@ export class AudioStream implements Playable {
   }
 
   /**
+   * `true` once {@link AudioStream.destroy} has run. A destroyed stream is not
+   * reusable — playing it throws. Load the asset again to get a fresh stream.
+   */
+  public get destroyed(): boolean {
+    return this._destroyed;
+  }
+
+  /**
    * Implements {@link Playable}. Called by {@link AudioManager.play}.
    *
    * Stops any previously active voice (a stream has a single playhead), then
    * starts a fresh {@link AudioStreamVoice}.
+   *
+   * Throws on a destroyed stream. The check is unconditional, not `__DEV__`-only:
+   * `createMediaElementSource()` may be called exactly once per media element,
+   * and the second call raises `InvalidStateError` in the browser — a hard,
+   * hard-to-trace runtime failure that a production build must not walk into.
    */
   public _createVoice(manager: AudioManager, options: PlayOptions): Voice {
+    if (this._destroyed) {
+      throw new Error(
+        'Cannot play a destroyed AudioStream. `destroy()` releases the MediaElementAudioSourceNode that is ' +
+          'permanently bound to the backing media element, and the Web Audio API allows only one such node per ' +
+          'element — re-sourcing it would throw InvalidStateError. Load the asset again to obtain a fresh stream.',
+      );
+    }
+
     const bus = options.bus ?? manager.music;
     const audioContext = getAudioContext();
 
@@ -111,8 +133,13 @@ export class AudioStream implements Playable {
     return voice;
   }
 
-  /** Stop the active voice and release the media graph. */
+  /**
+   * Stop the active voice and release the media graph. Terminal: the stream
+   * cannot be played again afterwards (see {@link AudioStream.destroyed}).
+   */
   public destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
     if (this._activeVoice !== null) {
       this._activeVoice.stop();
       this._activeVoice = null;

--- a/src/audio/BaseVoice.ts
+++ b/src/audio/BaseVoice.ts
@@ -124,6 +124,11 @@ export abstract class BaseVoice implements Voice, SpatialVoice {
     if (init.autoConnect !== false) {
       this._connectOutput();
     }
+
+    // Registered here rather than in `AudioManager.play` so that every voice is
+    // covered regardless of how it was constructed — `open()`, sprite playback
+    // and pooled replays all go through this constructor. `_finish` deregisters.
+    this._manager._registerVoice(this);
   }
 
   // -------------------------------------------------------------------------
@@ -723,6 +728,8 @@ export abstract class BaseVoice implements Voice, SpatialVoice {
       this._spatialRegistered = false;
       this._manager._unregisterSpatial(this);
     }
+
+    this._manager._unregisterVoice(this);
 
     this.onEnd.dispatch();
     this.onEnd.destroy();

--- a/src/audio/Envelope.ts
+++ b/src/audio/Envelope.ts
@@ -29,6 +29,15 @@ export class Envelope {
   public sustainLevel: number;
   public releaseMs: number;
 
+  /**
+   * The time each currently-scheduled param was triggered at, so
+   * {@link Envelope.release} can reconstruct the running envelope value on
+   * browsers without `cancelAndHoldAtTime`. Keyed per param rather than stored
+   * once, because a single Envelope is shared across every voice of an
+   * {@link AudioGenerator} and those voices trigger at different times.
+   */
+  private readonly _triggeredAt = new WeakMap<AudioParam, number>();
+
   public constructor(options: EnvelopeOptions = {}) {
     this.attackMs = Math.max(0, options.attackMs ?? 10);
     this.decayMs = Math.max(0, options.decayMs ?? 100);
@@ -49,19 +58,57 @@ export class Envelope {
     gainParam.linearRampToValueAtTime(1, attackEnd);
     gainParam.linearRampToValueAtTime(this.sustainLevel, decayEnd);
     // Sustain held at sustainLevel until release()
+
+    this._triggeredAt.set(gainParam, atTime);
   }
 
   /**
    * Schedule release → 0 starting at `atTime`. Call this when the note
    * should stop (e.g., key release, sound dismissed).
+   *
+   * The release starts from wherever the envelope actually is, including
+   * mid-attack and mid-decay. A bare `cancelScheduledValues` would drop the
+   * in-flight ramp and snap the parameter back to the previous event's value
+   * (0 during attack) — an audible click.
    */
   public release(gainParam: AudioParam, atTime: number): void {
-    const releaseEnd = atTime + this.releaseMs / 1000;
-    void releaseEnd; // computed for documentation purposes; setTargetAtTime handles the curve
-    gainParam.cancelScheduledValues(atTime);
-    // Don't snap to current value; assume gainParam.value is at sustain.
+    // `cancelAndHoldAtTime` freezes the automation at its current value in one
+    // step. Firefox still does not implement it, hence the analytical fallback:
+    // reconstruct the value from the attack/decay geometry and pin it there
+    // before the release ramp starts.
+    if (typeof gainParam.cancelAndHoldAtTime === 'function') {
+      gainParam.cancelAndHoldAtTime(atTime);
+    } else {
+      const held = this._valueAt(gainParam, atTime);
+      gainParam.cancelScheduledValues(atTime);
+      gainParam.setValueAtTime(held, atTime);
+    }
+
+    this._triggeredAt.delete(gainParam);
+
     gainParam.setTargetAtTime(0, atTime, this.releaseMs / 1000 / 3);
     // setTargetAtTime is exponential; tau = releaseMs/3 reaches ~95% of target in releaseMs.
+  }
+
+  /**
+   * The envelope value this schedule reaches at `time`, derived from the
+   * attack/decay geometry recorded by {@link Envelope.trigger}. Falls back to
+   * the parameter's live value when this envelope never scheduled it (or has
+   * already released it), which is the best available reading.
+   */
+  private _valueAt(gainParam: AudioParam, time: number): number {
+    const triggeredAt = this._triggeredAt.get(gainParam);
+
+    if (triggeredAt === undefined) return gainParam.value;
+
+    const attackEnd = triggeredAt + this.attackMs / 1000;
+    const decayEnd = attackEnd + this.decayMs / 1000;
+
+    if (time >= decayEnd) return this.sustainLevel;
+    if (time >= attackEnd) return 1 + (this.sustainLevel - 1) * ((time - attackEnd) / (decayEnd - attackEnd));
+    if (time <= triggeredAt) return 0;
+
+    return (time - triggeredAt) / (attackEnd - triggeredAt);
   }
 
   /** Total time from trigger to fully-released (attack + decay + release). */

--- a/src/audio/SoundVoice.ts
+++ b/src/audio/SoundVoice.ts
@@ -120,11 +120,27 @@ export class SoundVoice extends BaseVoice implements Seekable, Loopable, RatePit
       this._loop = value;
       return;
     }
+
+    // Read the playhead before the flag flips — `time` wraps modulo the span
+    // while looping, and the value needed below is the pre-change position.
+    const position = this.time;
+
     this._loop = value;
     this._source.loop = value;
-    if (value) {
-      this._source.loopStart = this._window.loopStart;
-      this._source.loopEnd = this._window.loopEnd;
+
+    if (value) return;
+
+    // The clip window is an invariant of the voice, not a property of the loop
+    // flag: a source started in loop mode carries no end bound, so switching
+    // loop off would let it run on to the end of the whole buffer and bleed
+    // into whatever sprite comes next in the atlas. Convert the remaining clip
+    // time into an explicit stop. Buffer-time remainder over the playback rate
+    // gives the wall-clock instant to stop at.
+    const remaining = Math.max(0, this.duration - position) / this._playbackRate;
+    try {
+      this._source.stop(this._audioContext.currentTime + remaining);
+    } catch {
+      // already stopped
     }
   }
 
@@ -200,10 +216,11 @@ export class SoundVoice extends BaseVoice implements Seekable, Loopable, RatePit
     source.playbackRate.value = this._playbackRate;
     source.detune.value = this._detune;
 
-    if (this._loop) {
-      source.loopStart = this._window.loopStart;
-      source.loopEnd = this._window.loopEnd;
-    }
+    // Always stamped, not only for a looping start: the loop window belongs to
+    // the voice's clip, so enabling loop later must not have to reconstruct it
+    // from state the source no longer carries.
+    source.loopStart = this._window.loopStart;
+    source.loopEnd = this._window.loopEnd;
 
     source.connect(this._panner ?? this._output);
     source.onended = (): void => this._finish();

--- a/src/audio/SoundVoice.ts
+++ b/src/audio/SoundVoice.ts
@@ -31,9 +31,10 @@ export interface SoundVoiceInit extends BaseVoiceInit {
  * `AudioBufferSourceNode`. Each `AudioManager.play(sound)` creates an
  * independent SoundVoice; concurrent plays each get their own.
  *
- * Mixes in {@link Seekable} (live seek recreates the buffer source at the new
- * offset — buffer sources cannot be repositioned in place), {@link Loopable},
- * {@link RatePitched}, and (via {@link BaseVoice}) {@link Spatializable}.
+ * Mixes in {@link Seekable} and {@link Loopable} — both recreate the buffer
+ * source at the current position, since a source can be neither repositioned
+ * nor re-bounded in place — plus {@link RatePitched} and (via
+ * {@link BaseVoice}) {@link Spatializable}.
  *
  * @internal
  */
@@ -90,21 +91,7 @@ export class SoundVoice extends BaseVoice implements Seekable, Loopable, RatePit
   public seek(t: number): void {
     if (this._ended) return;
 
-    const offset = this._window.base + clamp(t, 0, this.duration);
-
-    // Buffer sources can't be repositioned — stop the current one (without
-    // letting its onended finish the voice) and start a fresh source.
-    this._source.onended = null;
-    try {
-      this._source.stop(0);
-    } catch {
-      // already stopped
-    }
-    this._source.disconnect();
-
-    this._source = this._startSource(offset);
-    this._offsetAtStart = offset;
-    this._startedAt = this._audioContext.currentTime;
+    this._restartSourceAt(this._window.base + clamp(t, 0, this.duration));
   }
 
   // -------------------------------------------------------------------------
@@ -126,22 +113,26 @@ export class SoundVoice extends BaseVoice implements Seekable, Loopable, RatePit
     const position = this.time;
 
     this._loop = value;
-    this._source.loop = value;
-
-    if (value) return;
 
     // The clip window is an invariant of the voice, not a property of the loop
-    // flag: a source started in loop mode carries no end bound, so switching
-    // loop off would let it run on to the end of the whole buffer and bleed
-    // into whatever sprite comes next in the atlas. Convert the remaining clip
-    // time into an explicit stop. Buffer-time remainder over the playback rate
-    // gives the wall-clock instant to stop at.
-    const remaining = Math.max(0, this.duration - position) / this._playbackRate;
-    try {
-      this._source.stop(this._audioContext.currentTime + remaining);
-    } catch {
-      // already stopped
-    }
+    // flag — and a buffer source can be neither repositioned nor re-bounded in
+    // place, so flipping `loop` on the live source is not enough in either
+    // direction:
+    //
+    // - A non-looping start is capped by `start()`'s `duration`, which the
+    //   spec measures over all played content "including any whole or partial
+    //   loop iterations". Enabling loop would not lift that cap; the source
+    //   would still end at the clip end and finish the voice.
+    // - A looping start carries no cap at all. Disabling loop would let the
+    //   source run on to the end of the whole buffer and bleed into whatever
+    //   sprite comes next in the atlas.
+    //
+    // Rebuilding at the current position settles both: the fresh source gets
+    // exactly the bound the new mode calls for, expressed in buffer time and
+    // therefore immune to later rate changes and to the per-frame Doppler
+    // modulation, and the restart rebases the playhead so `time` keeps
+    // reporting correctly across the switch.
+    this._restartSourceAt(this._window.base + position);
   }
 
   // -------------------------------------------------------------------------
@@ -207,6 +198,27 @@ export class SoundVoice extends BaseVoice implements Seekable, Loopable, RatePit
     this._source.disconnect();
   }
 
+  /**
+   * Retire the running buffer source and start a fresh one at `offset`
+   * (absolute buffer seconds), rebasing the playhead bookkeeping. Buffer
+   * sources can be neither repositioned nor re-bounded in place, so this is
+   * the only way to change where playback sits or where it must end. The old
+   * source's `onended` is cleared first so the swap does not finish the voice.
+   */
+  private _restartSourceAt(offset: number): void {
+    this._source.onended = null;
+    try {
+      this._source.stop(0);
+    } catch {
+      // already stopped
+    }
+    this._source.disconnect();
+
+    this._source = this._startSource(offset);
+    this._offsetAtStart = offset;
+    this._startedAt = this._audioContext.currentTime;
+  }
+
   /** Create, connect, and start a buffer source at `offset` seconds. */
   private _startSource(offset: number): AudioBufferSourceNode {
     const ctx = this._audioContext;
@@ -225,11 +237,14 @@ export class SoundVoice extends BaseVoice implements Seekable, Loopable, RatePit
     source.connect(this._panner ?? this._output);
     source.onended = (): void => this._finish();
 
-    const playDuration = this._loop ? undefined : this._window.end - offset;
-    if (!this._loop && playDuration !== undefined && playDuration > 0) {
-      source.start(0, offset, playDuration);
-    } else {
+    if (this._loop) {
       source.start(0, offset);
+    } else {
+      // Always capped, including when nothing is left to play: `seek()` clamps
+      // inclusively, so an offset exactly at the window end must render silence
+      // and end the voice rather than fall through to an uncapped start that
+      // would spill into the rest of the atlas buffer.
+      source.start(0, offset, Math.max(0, this._window.end - offset));
     }
 
     return source;

--- a/test/animation/tween-manager.test.ts
+++ b/test/animation/tween-manager.test.ts
@@ -6,6 +6,8 @@ import { Time } from '#core/Time';
 /** TweenManager.update() takes a Time; tests express their deltas in seconds. */
 const sec = (seconds: number): Time => new Time(seconds, Time.seconds);
 const makeTarget = () => ({ x: 0, y: 0 });
+/** Number of tweens the manager currently holds a reference to. */
+const trackedCount = (manager: TweenManager): number => (manager as unknown as { _tweens: unknown[] })._tweens.length;
 
 describe('TweenManager', () => {
   test('create() returns a Tween bound to the manager', () => {
@@ -177,5 +179,56 @@ describe('TweenManager', () => {
 
     expect(() => manager.preUpdate(sec(1.0))).not.toThrow();
     expect(tweenA.state).toBe(TweenState.Complete);
+  });
+
+  // ---- the manager only holds tweens that are actually running ----
+
+  test('create() does not retain a tween that is never started', () => {
+    const manager = new TweenManager();
+
+    manager.create(makeTarget()).to({ x: 100 }, 1.0);
+
+    // The tween (and through it, the target node) must not stay referenced by
+    // the application-wide manager just because it was configured.
+    expect(trackedCount(manager)).toBe(0);
+  });
+
+  test('start() registers a created tween so it is advanced each frame', () => {
+    const manager = new TweenManager();
+    const target = makeTarget();
+
+    const tween = manager.create(target).to({ x: 100 }, 1.0).start();
+
+    expect(trackedCount(manager)).toBe(1);
+    manager.preUpdate(sec(0.5));
+    expect(target.x).toBeCloseTo(50, 5);
+    expect(tween.state).toBe(TweenState.Active);
+  });
+
+  test('stop() evicts a tween that was added but never started', () => {
+    const manager = new TweenManager();
+    const tween = new Tween(makeTarget()).to({ x: 100 }, 1.0);
+
+    manager.add(tween);
+    expect(trackedCount(manager)).toBe(1);
+
+    tween.stop();
+
+    expect(trackedCount(manager)).toBe(0);
+  });
+
+  test('stop() evicts an already-completed tween that was re-added', () => {
+    const manager = new TweenManager();
+    const tween = manager.create(makeTarget()).to({ x: 100 }, 1.0).start();
+
+    manager.preUpdate(sec(1.0));
+    expect(tween.state).toBe(TweenState.Complete);
+
+    manager.add(tween);
+    expect(trackedCount(manager)).toBe(1);
+
+    tween.stop();
+
+    expect(trackedCount(manager)).toBe(0);
   });
 });

--- a/test/animation/tween-manager.test.ts
+++ b/test/animation/tween-manager.test.ts
@@ -94,7 +94,7 @@ describe('TweenManager', () => {
   });
 
   describe('sequence()', () => {
-    test('chains tweens in order and registers all of them with the manager', () => {
+    test('chains tweens in order and drives the whole chain, one link per frame', () => {
       const manager = new TweenManager();
       const a = makeTarget();
       const b = makeTarget();
@@ -107,19 +107,43 @@ describe('TweenManager', () => {
       const first = manager.sequence([t1, t2, t3]);
       expect(first).toBe(t1);
 
+      // Composing the sequence binds the tweens to the manager but does not
+      // enter them into the update list — each link registers itself when the
+      // preceding one chain-starts it.
+      expect(trackedCount(manager)).toBe(0);
+
       first.start();
+      expect(trackedCount(manager)).toBe(1);
 
-      // All three tweens are registered with the manager up front and are
-      // iterated in insertion order within a single snapshot. Since delta
-      // exactly matches each tween's duration, completing t1 chain-starts
-      // t2, which is then ticked later in the very same snapshot pass and
-      // also completes, cascading into t3 — all within one update() call.
       manager.preUpdate(sec(1.0));
-
       expect(t1.state).toBe(TweenState.Complete);
+      expect(t2.state).toBe(TweenState.Active);
+      expect(a.x).toBe(100);
+
+      manager.preUpdate(sec(1.0));
       expect(t2.state).toBe(TweenState.Complete);
+      expect(t3.state).toBe(TweenState.Active);
+      expect(b.x).toBe(200);
+
+      manager.preUpdate(sec(1.0));
       expect(t3.state).toBe(TweenState.Complete);
       expect(c.x).toBe(300);
+
+      // Nothing is left behind once the chain has run out.
+      expect(trackedCount(manager)).toBe(0);
+    });
+
+    test('does not retain tweens of a sequence that is never started', () => {
+      const manager = new TweenManager();
+      const t1 = new Tween(makeTarget()).to({ x: 100 }, 1.0);
+      const t2 = new Tween(makeTarget()).to({ x: 200 }, 1.0);
+
+      manager.sequence([t1, t2]);
+
+      expect(trackedCount(manager)).toBe(0);
+      manager.preUpdate(sec(1.0));
+      expect(t1.state).toBe(TweenState.Idle);
+      expect(t2.state).toBe(TweenState.Idle);
     });
 
     test('throws when given an empty array', () => {
@@ -138,8 +162,8 @@ describe('TweenManager', () => {
       const t3 = new Tween(makeTarget()).to({ x: 100 }, 1.0);
       const sparse = [t1, undefined, t3] as unknown as readonly Tween[];
 
-      // The subsequent unconditional add() loop calls add(undefined) for the
-      // hole, which throws — but the chain loop's guard runs first.
+      // The subsequent unconditional bind loop dereferences the hole, which
+      // throws — but the chain loop's guard runs first.
       expect(() => manager.sequence(sparse)).toThrow();
     });
   });

--- a/test/audio/audio-bus.test.ts
+++ b/test/audio/audio-bus.test.ts
@@ -795,4 +795,62 @@ describe('AudioBus', () => {
 
     bus.destroy();
   });
+
+  // A removed effect is no longer part of the chain, so the rebuild never
+  // touches it — leaving its outgoing edge live would let a delay/reverb tail
+  // keep bleeding into the pan stage after the effect was taken out.
+  test('removeEffect() cuts the removed effect outgoing edge', () => {
+    const bus = new AudioBus('remove-effect-edge');
+    const filter = new WiredFilter();
+
+    bus.addEffect(filter);
+    filter.outputDisconnect.mockClear();
+
+    bus.removeEffect(filter);
+
+    expect(filter.outputDisconnect).toHaveBeenCalled();
+    // The caller still owns the effect, so its internal wiring stays intact.
+    expect(filter.inputDisconnect).not.toHaveBeenCalled();
+
+    bus.destroy();
+  });
+
+  test('removeEffect() cuts the outgoing edge of an effect removed from the middle of the chain', () => {
+    const bus = new AudioBus('remove-effect-middle');
+    const first = new WiredFilter();
+    const middle = new WiredFilter();
+    const last = new WiredFilter();
+
+    bus.addEffect(first);
+    bus.addEffect(middle);
+    bus.addEffect(last);
+    middle.outputDisconnect.mockClear();
+
+    bus.removeEffect(middle);
+
+    expect(middle.outputDisconnect).toHaveBeenCalled();
+    expect(middle.inputDisconnect).not.toHaveBeenCalled();
+
+    bus.destroy();
+  });
+
+  test('removeEffect() tolerates an effect whose nodes are not ready yet', () => {
+    const bus = new AudioBus('remove-effect-unready');
+    const unready = {
+      get inputNode(): AudioNode {
+        throw new Error('not yet initialized');
+      },
+      get outputNode(): AudioNode {
+        throw new Error('not yet initialized');
+      },
+      ready: Promise.resolve(),
+      destroy: (): void => undefined,
+    } as unknown as AudioEffect;
+
+    bus.addEffect(unready);
+
+    expect(() => bus.removeEffect(unready)).not.toThrow();
+
+    bus.destroy();
+  });
 });

--- a/test/audio/audio-manager.test.ts
+++ b/test/audio/audio-manager.test.ts
@@ -5,7 +5,9 @@ import { AudioBus } from '#audio/AudioBus';
 import type { AudioInput } from '#audio/AudioInput';
 import { AudioManager } from '#audio/AudioManager';
 import { AudioStream } from '#audio/AudioStream';
+import type { Voice } from '#audio/Playable';
 import { Sound } from '#audio/Sound';
+import { logger } from '#core/logging';
 import { Signal } from '#core/Signal';
 
 // ---------------------------------------------------------------------------
@@ -352,5 +354,73 @@ describe('AudioManager', () => {
     manager.destroy();
 
     expect(voice.ended).toBe(true);
+  });
+
+  // ---- teardown hardening ----
+
+  test('destroy() also drains a voice registered while the teardown is running', () => {
+    const manager = new AudioManager();
+    const sound = new Sound(createAudioBufferStub());
+    const first = manager.play(sound);
+
+    // A voice appearing after the drain started. Reproduced through the
+    // internal registration hook because `play()` is refused once destroyed;
+    // an iteration over a snapshot would drop this one still running.
+    const late = { ended: false, stop: vi.fn() };
+    first.onEnd.add((): void => {
+      manager._registerVoice(late as unknown as Voice);
+    });
+
+    manager.destroy();
+
+    expect(late.stop).toHaveBeenCalledTimes(1);
+    expect(liveVoiceCount(manager)).toBe(0);
+
+    sound.destroy();
+  });
+
+  test('destroy() completes the teardown even when a voice throws while stopping', () => {
+    const manager = new AudioManager();
+    const sound = new Sound(createAudioBufferStub());
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+    // Registered first so the throw happens before the healthy voice is reached.
+    const broken = {
+      ended: false,
+      stop: vi.fn(() => {
+        throw new Error('half-built voice');
+      }),
+    };
+    manager._registerVoice(broken as unknown as Voice);
+    const healthy = manager.play(sound);
+
+    expect(() => manager.destroy()).not.toThrow();
+
+    // The loop carried on past the throw...
+    expect(healthy.ended).toBe(true);
+    // ...and the tail (listener + buses) still ran.
+    expect(manager.hasBus('master')).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+
+    sound.destroy();
+  });
+
+  test('play() after destroy() throws instead of registering an untracked voice', () => {
+    const manager = new AudioManager();
+    const sound = new Sound(createAudioBufferStub());
+
+    manager.destroy();
+
+    expect(() => manager.play(sound)).toThrow(/destroyed AudioManager/);
+    expect(liveVoiceCount(manager)).toBe(0);
+
+    sound.destroy();
+  });
+
+  test('open() after destroy() throws', () => {
+    const manager = new AudioManager();
+    manager.destroy();
+
+    expect(() => manager.open({ stream: {} as MediaStream } as AudioInput)).toThrow(/destroyed AudioManager/);
   });
 });

--- a/test/audio/audio-manager.test.ts
+++ b/test/audio/audio-manager.test.ts
@@ -2,7 +2,10 @@
 
 import { getAudioContext } from '#audio/audio-context';
 import { AudioBus } from '#audio/AudioBus';
+import type { AudioInput } from '#audio/AudioInput';
 import { AudioManager } from '#audio/AudioManager';
+import { AudioStream } from '#audio/AudioStream';
+import { Sound } from '#audio/Sound';
 import { Signal } from '#core/Signal';
 
 // ---------------------------------------------------------------------------
@@ -58,6 +61,21 @@ const makeFakeAudioContext = (): AudioContext =>
         pan: makeFakeParam(),
       }) as unknown as StereoPannerNode,
   }) as unknown as AudioContext;
+
+const createAudioBufferStub = (duration = 2): AudioBuffer => ({ duration }) as AudioBuffer;
+
+const createAudioElementStub = (): HTMLAudioElement => {
+  const el = document.createElement('audio');
+  Object.defineProperty(el, 'duration', { configurable: true, value: 30 });
+  Object.defineProperty(el, 'currentTime', { configurable: true, writable: true, value: 0 });
+  Object.defineProperty(el, 'loop', { configurable: true, writable: true, value: false });
+  Object.defineProperty(el, 'playbackRate', { configurable: true, writable: true, value: 1 });
+  Object.defineProperty(el, 'paused', { configurable: true, writable: true, value: true });
+  return el;
+};
+
+/** Size of the manager's internal live-voice registry. */
+const liveVoiceCount = (manager: AudioManager): number => (manager as unknown as { _voices: Set<unknown> })._voices.size;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -263,5 +281,76 @@ describe('AudioManager', () => {
     await Promise.resolve(); // the already-running dispatch is deferred one microtask
 
     expect(onUnlock).toHaveBeenCalledTimes(1);
+  });
+
+  // ---- live-voice registry ----
+
+  test('play() registers the new voice with the manager', () => {
+    const manager = new AudioManager();
+    const sound = new Sound(createAudioBufferStub());
+
+    expect(liveVoiceCount(manager)).toBe(0);
+    manager.play(sound);
+    expect(liveVoiceCount(manager)).toBe(1);
+
+    sound.destroy();
+  });
+
+  test('a voice that ends deregisters itself from the manager', () => {
+    const manager = new AudioManager();
+    const sound = new Sound(createAudioBufferStub());
+    const voice = manager.play(sound);
+
+    voice.stop();
+
+    expect(voice.ended).toBe(true);
+    expect(liveVoiceCount(manager)).toBe(0);
+
+    sound.destroy();
+  });
+
+  test('destroy() stops every voice that is still playing', () => {
+    const manager = new AudioManager();
+    const sound = new Sound(createAudioBufferStub());
+    const first = manager.play(sound);
+    const second = manager.play(sound);
+
+    expect(first.ended).toBe(false);
+    expect(second.ended).toBe(false);
+
+    manager.destroy();
+
+    expect(first.ended).toBe(true);
+    expect(second.ended).toBe(true);
+    expect(liveVoiceCount(manager)).toBe(0);
+
+    sound.destroy();
+  });
+
+  test('destroy() stops a stream voice so its media element stops decoding', () => {
+    const manager = new AudioManager();
+    const el = createAudioElementStub();
+    const stream = new AudioStream(el);
+    const voice = manager.play(stream);
+    const pauseSpy = vi.spyOn(el, 'pause');
+
+    manager.destroy();
+
+    expect(voice.ended).toBe(true);
+    expect(pauseSpy).toHaveBeenCalled();
+
+    stream.destroy();
+  });
+
+  test('destroy() stops an input voice opened through open()', () => {
+    const manager = new AudioManager();
+    const input = { stream: {} as MediaStream } as AudioInput;
+    const voice = manager.open(input);
+
+    expect(voice.ended).toBe(false);
+
+    manager.destroy();
+
+    expect(voice.ended).toBe(true);
   });
 });

--- a/test/audio/audio-stream.test.ts
+++ b/test/audio/audio-stream.test.ts
@@ -411,4 +411,43 @@ describe('AudioStream', () => {
 
     stream.destroy();
   });
+
+  // ---- destroyed streams are not reusable ----
+
+  test('destroyed is false while the stream is live and true after destroy()', () => {
+    const stream = new AudioStream(createAudioElementStub());
+
+    expect(stream.destroyed).toBe(false);
+    stream.destroy();
+    expect(stream.destroyed).toBe(true);
+  });
+
+  test('playing a destroyed stream throws instead of re-sourcing the media element', () => {
+    const manager = new AudioManager();
+    const el = createAudioElementStub();
+    const stream = new AudioStream(el);
+    const ctx = getAudioContext();
+
+    manager.play(stream);
+    stream.destroy();
+
+    const sourceSpy = vi.spyOn(ctx, 'createMediaElementSource');
+
+    expect(() => manager.play(stream)).toThrow(/destroyed AudioStream/);
+    // A second createMediaElementSource() on the same element is exactly the
+    // InvalidStateError this guard exists to prevent.
+    expect(sourceSpy).not.toHaveBeenCalled();
+
+    sourceSpy.mockRestore();
+  });
+
+  test('destroy() is idempotent', () => {
+    const manager = new AudioManager();
+    const stream = new AudioStream(createAudioElementStub());
+    manager.play(stream);
+
+    stream.destroy();
+    expect(() => stream.destroy()).not.toThrow();
+    expect(stream.destroyed).toBe(true);
+  });
 });

--- a/test/audio/envelope.test.ts
+++ b/test/audio/envelope.test.ts
@@ -18,6 +18,16 @@ const makeMockAudioParam = (): Mocked<AudioParam> =>
     minValue: -3.4028234663852886e38,
   }) as unknown as Mocked<AudioParam>;
 
+/**
+ * An `AudioParam` from a browser that does not implement
+ * `cancelAndHoldAtTime` — Firefox to this day.
+ */
+const makeLegacyAudioParam = (): Mocked<AudioParam> => {
+  const param = makeMockAudioParam() as unknown as Record<string, unknown>;
+  delete param.cancelAndHoldAtTime;
+  return param as unknown as Mocked<AudioParam>;
+};
+
 describe('Envelope', () => {
   test('default values match spec', () => {
     const env = new Envelope();
@@ -101,15 +111,74 @@ describe('Envelope', () => {
     expect(callOrder).toEqual(['cancel', 'setValue', 'ramp', 'ramp']);
   });
 
-  test('release() calls cancelScheduledValues then setTargetAtTime(0)', () => {
+  test('release() holds the running value via cancelAndHoldAtTime, then ramps to 0', () => {
     const env = new Envelope({ releaseMs: 300 });
     const param = makeMockAudioParam();
     const atTime = 2.0;
 
     env.release(param, atTime);
 
-    expect(param.cancelScheduledValues).toHaveBeenCalledWith(atTime);
+    expect(param.cancelAndHoldAtTime).toHaveBeenCalledWith(atTime);
+    // cancelScheduledValues would discard the in-flight ramp and snap the param
+    // back to the previous event's value — an audible click mid-attack.
+    expect(param.cancelScheduledValues).not.toHaveBeenCalled();
     expect(param.setTargetAtTime).toHaveBeenCalledWith(0, atTime, expect.any(Number));
+  });
+
+  // Firefox still ships no cancelAndHoldAtTime, so the analytical fallback is
+  // the path that actually runs there — not an optional extra.
+  describe('release() without cancelAndHoldAtTime (browser fallback)', () => {
+    test('releasing mid-attack holds the interpolated attack value', () => {
+      const env = new Envelope({ attackMs: 100, decayMs: 100, sustainLevel: 0.5 });
+      const param = makeLegacyAudioParam();
+
+      env.trigger(param, 0);
+      env.release(param, 0.05); // halfway through the 100ms attack
+
+      expect(param.cancelScheduledValues).toHaveBeenCalledWith(0.05);
+      expect(param.setValueAtTime).toHaveBeenCalledWith(expect.closeTo(0.5, 6), 0.05);
+      expect(param.setTargetAtTime).toHaveBeenCalledWith(0, 0.05, expect.any(Number));
+    });
+
+    test('releasing mid-decay holds the interpolated decay value', () => {
+      const env = new Envelope({ attackMs: 100, decayMs: 100, sustainLevel: 0.5 });
+      const param = makeLegacyAudioParam();
+
+      env.trigger(param, 0);
+      env.release(param, 0.15); // halfway through the decay: 1 -> 0.5
+
+      expect(param.setValueAtTime).toHaveBeenCalledWith(expect.closeTo(0.75, 6), 0.15);
+    });
+
+    test('releasing during sustain holds the sustain level', () => {
+      const env = new Envelope({ attackMs: 100, decayMs: 100, sustainLevel: 0.5 });
+      const param = makeLegacyAudioParam();
+
+      env.trigger(param, 0);
+      env.release(param, 1);
+
+      expect(param.setValueAtTime).toHaveBeenCalledWith(0.5, 1);
+    });
+
+    test('releasing an envelope that was never triggered holds the live param value', () => {
+      const env = new Envelope({ attackMs: 100, decayMs: 100, sustainLevel: 0.5 });
+      const param = makeLegacyAudioParam();
+      param.value = 0.3;
+
+      env.release(param, 1);
+
+      expect(param.setValueAtTime).toHaveBeenCalledWith(0.3, 1);
+    });
+
+    test('a zero-length attack and decay hold the sustain level immediately', () => {
+      const env = new Envelope({ attackMs: 0, decayMs: 0, sustainLevel: 0.4 });
+      const param = makeLegacyAudioParam();
+
+      env.trigger(param, 0);
+      env.release(param, 0);
+
+      expect(param.setValueAtTime).toHaveBeenCalledWith(0.4, 0);
+    });
   });
 
   test('release() uses tau = releaseMs / 3 / 1000', () => {

--- a/test/audio/sound-voice.test.ts
+++ b/test/audio/sound-voice.test.ts
@@ -11,6 +11,11 @@ import type { SoundVoice } from '#audio/SoundVoice';
 
 const createAudioBufferStub = (duration = 2): AudioBuffer => ({ duration }) as AudioBuffer;
 
+/** Move the shared mock context's clock. `currentTime` is readonly on the real type. */
+const setCurrentTime = (seconds: number): void => {
+  (getAudioContext() as unknown as { currentTime: number }).currentTime = seconds;
+};
+
 const makeParam = (value = 0) => ({
   value,
   setValueAtTime: vi.fn(),
@@ -398,7 +403,6 @@ describe('SoundVoice — capabilities', () => {
     const manager = new AudioManager();
     const sound = new Sound(createAudioBufferStub(10));
     sound.defineSprite('hit', { start: 2, end: 3, loop: true });
-    const ctx = getAudioContext();
 
     const voice = sound._createSpriteVoice(manager, 'hit') as SoundVoice;
     const source = factory.sources[0];
@@ -406,7 +410,7 @@ describe('SoundVoice — capabilities', () => {
     // A looping start passes no duration, so nothing bounds the source yet.
     expect(source.start).toHaveBeenCalledWith(0, 2);
 
-    ctx.currentTime = 0.25; // a quarter into the 1s clip
+    setCurrentTime(0.25); // a quarter into the 1s clip
 
     voice.loop = false;
 
@@ -415,7 +419,7 @@ describe('SoundVoice — capabilities', () => {
     // otherwise the next sprite in the atlas would bleed in.
     expect(source.stop).toHaveBeenCalledWith(1);
 
-    ctx.currentTime = 0;
+    setCurrentTime(0);
     factory.restore();
     sound.destroy();
   });
@@ -425,19 +429,18 @@ describe('SoundVoice — capabilities', () => {
     const manager = new AudioManager();
     const sound = new Sound(createAudioBufferStub(10));
     sound.defineSprite('hit', { start: 2, end: 3, loop: true });
-    const ctx = getAudioContext();
 
     const voice = sound._createSpriteVoice(manager, 'hit', { playbackRate: 2 }) as SoundVoice;
     const source = factory.sources[0];
 
-    ctx.currentTime = 0.25; // 0.5s of buffer time consumed at rate 2
+    setCurrentTime(0.25); // 0.5s of buffer time consumed at rate 2
 
     voice.loop = false;
 
     // 0.5s of clip left, played at rate 2 => 0.25s of wall-clock time.
     expect(source.stop).toHaveBeenCalledWith(0.5);
 
-    ctx.currentTime = 0;
+    setCurrentTime(0);
     factory.restore();
     sound.destroy();
   });

--- a/test/audio/sound-voice.test.ts
+++ b/test/audio/sound-voice.test.ts
@@ -376,6 +376,72 @@ describe('SoundVoice — capabilities', () => {
     sound.destroy();
   });
 
+  // ---- the clip window is a permanent invariant of the voice ----
+
+  test('a non-looping sprite voice still carries its clip window on the source', () => {
+    const factory = setupSourceSpy();
+    const manager = new AudioManager();
+    const sound = new Sound(createAudioBufferStub(10));
+    sound.defineSprite('hit', { start: 2, end: 3 });
+
+    sound._createSpriteVoice(manager, 'hit');
+
+    expect(factory.sources[0].loopStart).toBe(2);
+    expect(factory.sources[0].loopEnd).toBe(3);
+
+    factory.restore();
+    sound.destroy();
+  });
+
+  test('disabling loop keeps a sprite voice inside its clip window', () => {
+    const factory = setupSourceSpy();
+    const manager = new AudioManager();
+    const sound = new Sound(createAudioBufferStub(10));
+    sound.defineSprite('hit', { start: 2, end: 3, loop: true });
+    const ctx = getAudioContext();
+
+    const voice = sound._createSpriteVoice(manager, 'hit') as SoundVoice;
+    const source = factory.sources[0];
+
+    // A looping start passes no duration, so nothing bounds the source yet.
+    expect(source.start).toHaveBeenCalledWith(0, 2);
+
+    ctx.currentTime = 0.25; // a quarter into the 1s clip
+
+    voice.loop = false;
+
+    expect(source.loop).toBe(false);
+    // Stopped at the end of the clip window, not at the end of the 10s buffer —
+    // otherwise the next sprite in the atlas would bleed in.
+    expect(source.stop).toHaveBeenCalledWith(1);
+
+    ctx.currentTime = 0;
+    factory.restore();
+    sound.destroy();
+  });
+
+  test('disabling loop accounts for the current playback rate', () => {
+    const factory = setupSourceSpy();
+    const manager = new AudioManager();
+    const sound = new Sound(createAudioBufferStub(10));
+    sound.defineSprite('hit', { start: 2, end: 3, loop: true });
+    const ctx = getAudioContext();
+
+    const voice = sound._createSpriteVoice(manager, 'hit', { playbackRate: 2 }) as SoundVoice;
+    const source = factory.sources[0];
+
+    ctx.currentTime = 0.25; // 0.5s of buffer time consumed at rate 2
+
+    voice.loop = false;
+
+    // 0.5s of clip left, played at rate 2 => 0.25s of wall-clock time.
+    expect(source.stop).toHaveBeenCalledWith(0.5);
+
+    ctx.currentTime = 0;
+    factory.restore();
+    sound.destroy();
+  });
+
   test('detune setter is a no-op once the voice has ended', () => {
     const factory = setupSourceSpy();
     const manager = new AudioManager();

--- a/test/audio/sound-voice.test.ts
+++ b/test/audio/sound-voice.test.ts
@@ -115,6 +115,9 @@ const setupPannerSpy = (): { panners: MockPanner[]; restore: () => void } => {
 describe('SoundVoice — capabilities', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    // The mock context is a module-level singleton; a test that moves its clock
+    // must not leak that onto the next one, not even when it fails part-way.
+    setCurrentTime(0);
   });
 
   // ---- Seekable (source recreation) ----
@@ -169,17 +172,37 @@ describe('SoundVoice — capabilities', () => {
 
   // ---- Loopable ----
 
-  test('loop setter enables the source loop window live', () => {
+  // A non-looping start caps the source with a `duration`, and the Web Audio
+  // spec counts that cap over all played content "including any whole or
+  // partial loop iterations" — flipping `loop` on the live source would not
+  // lift it, the source would still end at the clip end and finish the voice.
+  // The only way to actually start looping is to rebuild the source, the same
+  // mechanism `seek()` uses.
+  test('enabling loop rebuilds the source without a duration cap', () => {
     const factory = setupSourceSpy();
     const manager = new AudioManager();
     const sound = new Sound(createAudioBufferStub(2));
 
     const voice = manager.play(sound) as SoundVoice;
+    const first = factory.sources[0];
+    expect(first.start).toHaveBeenCalledWith(0, 0, 2);
+
+    setCurrentTime(0.5);
     voice.loop = true;
 
-    expect(factory.sources[0].loop).toBe(true);
-    expect(factory.sources[0].loopStart).toBe(0);
-    expect(factory.sources[0].loopEnd).toBe(2);
+    expect(factory.sources).toHaveLength(2);
+    const second = factory.sources[1];
+
+    // The capped source is retired without ending the voice.
+    expect(first.stop).toHaveBeenCalled();
+    expect(first.onended).toBeNull();
+    expect(voice.ended).toBe(false);
+
+    // The replacement carries the loop window and, crucially, no duration.
+    expect(second.loop).toBe(true);
+    expect(second.loopStart).toBe(0);
+    expect(second.loopEnd).toBe(2);
+    expect(second.start).toHaveBeenCalledWith(0, 0.5);
     expect(voice.loop).toBe(true);
 
     factory.restore();
@@ -371,10 +394,10 @@ describe('SoundVoice — capabilities', () => {
 
     const voice = manager.play(sound) as SoundVoice;
     voice.loop = true;
-    expect(factory.sources[0].loopStart).toBe(0);
+    expect(factory.sources[1].loopStart).toBe(0);
 
     voice.loop = false; // value actually changes: true -> false
-    expect(factory.sources[0].loop).toBe(false);
+    expect(factory.sources[2].loop).toBe(false);
     expect(voice.loop).toBe(false);
 
     factory.restore();
@@ -405,42 +428,95 @@ describe('SoundVoice — capabilities', () => {
     sound.defineSprite('hit', { start: 2, end: 3, loop: true });
 
     const voice = sound._createSpriteVoice(manager, 'hit') as SoundVoice;
-    const source = factory.sources[0];
+    const first = factory.sources[0];
 
     // A looping start passes no duration, so nothing bounds the source yet.
-    expect(source.start).toHaveBeenCalledWith(0, 2);
+    expect(first.start).toHaveBeenCalledWith(0, 2);
 
     setCurrentTime(0.25); // a quarter into the 1s clip
 
     voice.loop = false;
 
-    expect(source.loop).toBe(false);
-    // Stopped at the end of the clip window, not at the end of the 10s buffer —
-    // otherwise the next sprite in the atlas would bleed in.
-    expect(source.stop).toHaveBeenCalledWith(1);
+    expect(factory.sources).toHaveLength(2);
+    const second = factory.sources[1];
+    expect(first.stop).toHaveBeenCalled();
+    expect(voice.ended).toBe(false);
+    expect(second.loop).toBe(false);
+    // Restarted at 0.25s into the clip and capped at the remaining 0.75s, so it
+    // ends at the clip end instead of running on into the next sprite.
+    expect(second.start).toHaveBeenCalledWith(0, 2.25, 0.75);
 
-    setCurrentTime(0);
     factory.restore();
     sound.destroy();
   });
 
-  test('disabling loop accounts for the current playback rate', () => {
+  // The window bound is a `duration` on `start()`, which the spec measures in
+  // buffer time. That makes it immune to a later rate change and to the
+  // per-frame Doppler modulation `_applyDopplerRate` writes straight to the
+  // rate param — neither of which an absolute `stop(when)` would survive.
+  test('the clip bound survives a later playback-rate change without rescheduling', () => {
     const factory = setupSourceSpy();
     const manager = new AudioManager();
     const sound = new Sound(createAudioBufferStub(10));
     sound.defineSprite('hit', { start: 2, end: 3, loop: true });
 
-    const voice = sound._createSpriteVoice(manager, 'hit', { playbackRate: 2 }) as SoundVoice;
-    const source = factory.sources[0];
+    const voice = sound._createSpriteVoice(manager, 'hit') as SoundVoice;
 
-    setCurrentTime(0.25); // 0.5s of buffer time consumed at rate 2
+    setCurrentTime(0.25);
+    voice.loop = false;
+    const bounded = factory.sources[1];
+    expect(bounded.start).toHaveBeenCalledWith(0, 2.25, 0.75);
+
+    voice.playbackRate = 4;
+
+    // No absolute stop was ever scheduled, so there is nothing that a rate
+    // change could invalidate — and no source rebuild either.
+    expect(bounded.stop).not.toHaveBeenCalled();
+    expect(factory.sources).toHaveLength(2);
+    expect(bounded.playbackRate.setTargetAtTime).toHaveBeenCalledWith(4, expect.any(Number), expect.any(Number));
+
+    factory.restore();
+    sound.destroy();
+  });
+
+  test('disabling loop rebases the reported playhead after the clip has wrapped', () => {
+    const factory = setupSourceSpy();
+    const manager = new AudioManager();
+    const sound = new Sound(createAudioBufferStub(10));
+    sound.defineSprite('hit', { start: 2, end: 3, loop: true });
+
+    const voice = sound._createSpriteVoice(manager, 'hit') as SoundVoice;
+
+    setCurrentTime(2.5); // 2.5 passes through the 1s clip
+    expect(voice.time).toBeCloseTo(0.5, 6);
 
     voice.loop = false;
 
-    // 0.5s of clip left, played at rate 2 => 0.25s of wall-clock time.
-    expect(source.stop).toHaveBeenCalledWith(0.5);
+    // Without a rebase the getter stops wrapping and clamps 2.5 to the span.
+    expect(voice.time).toBeCloseTo(0.5, 6);
 
-    setCurrentTime(0);
+    setCurrentTime(2.75);
+    expect(voice.time).toBeCloseTo(0.75, 6);
+
+    factory.restore();
+    sound.destroy();
+  });
+
+  // NEU-D6: `seek()` clamps inclusively, so seeking to the very end yields an
+  // offset equal to the window end. A zero-length remainder must play nothing,
+  // not fall back to an uncapped start that spills into the rest of the atlas.
+  test('seeking to the very end of a non-looping clip does not spill into the buffer', () => {
+    const factory = setupSourceSpy();
+    const manager = new AudioManager();
+    const sound = new Sound(createAudioBufferStub(10));
+    sound.defineSprite('hit', { start: 2, end: 3 });
+
+    const voice = sound._createSpriteVoice(manager, 'hit') as SoundVoice;
+    voice.seek(voice.duration);
+
+    expect(factory.sources).toHaveLength(2);
+    expect(factory.sources[1].start).toHaveBeenCalledWith(0, 3, 0);
+
     factory.restore();
     sound.destroy();
   });


### PR DESCRIPTION
Batch D of the architecture review: the six Audio/Tween points, plus what a review pass turned up on top.

## ME-32 — Removed bus effects stayed partially connected

`AudioBus.removeEffect` rebuilt the chain from `_effects`, which no longer contains the removed effect — so its outgoing edge stayed live and delay/reverb tails kept bleeding through. `BaseVoice.removeEffect` already did it correctly; the two implementations contradicted each other.

The outgoing edge is now cut before the rebuild. The incoming edge is deliberately left to the rebuild, which handles first, middle and last position.

## ME-33 — `AudioManager.destroy()` did not know all running voices

It tore down listener and buses, which detaches nodes but stops no source: `<audio>` elements kept decoding and buffer sources kept rendering into a detached graph after `Application.destroy()`.

Every voice now registers in the `BaseVoice` constructor — covering `play()`, `open()`, sprite playback and pooled replays alike — and deregisters in `_finish()`. `destroy()` drains the registry before the listener and buses, isolates each `stop()` so one throwing voice cannot abort the rest of the teardown, and marks the manager destroyed so a late `play()` cannot repopulate a set that will never be drained again. The isolate-and-always-run-the-tail shape follows the precedent set by `SystemRegistry.destroy()`.

## ME-36 — A destroyed `AudioStream` could throw `InvalidStateError`

Replaying after `destroy()` called `createMediaElementSource` a second time on the same element. Adds a `_destroyed` flag and an always-on guard, following the `Texture` precedent: destroyed streams are not reusable, and a reload produces a fresh stream through the loader.

## ME-37 — Never-started tweens stayed in the manager

`create()` registered immediately while `stop()` only evicted from Active/Paused, so a configured-but-never-started tween stayed in the application-wide manager forever and kept its target node alive. Registration moved to `start()`, and `stop()` now deregisters from every state.

`sequence()` pre-registered every link at composition time and kept the same leak; that registration was redundant, since a completing link starts and registers its successor anyway.

**Behaviour change:** a chained link now receives its first update in the frame *after* its predecessor completes, rather than in the same pass. This makes `sequence()` consistent with `create()` + `chain()`, which already behaves this way. `TweenManager.add()` keeps its documented semantics — `TweenSequencer` and `SceneTweens.restore()` rely on it as a binding operation for tweens that have not started.

## ME-38 + ME-40 — Clip windows and envelope release

A sound sprite could play past its clip end after `loop` was switched off, and — the mirror case, which the audit had not recorded — switching `loop` on never worked at all. The spec counts `start()`'s `duration` over all played buffer content "including any whole or partial loop iterations", so that cap cannot be lifted on a running source.

Both directions now go through one source rebuild at the current clip position, the way `seek()` already did. The clip window is therefore always expressed in buffer time via `duration`, never as a wall-clock stop — which matters because `_applyDopplerRate` modulates the real playback rate every frame, and a wall-clock stop would have to be rescheduled continuously to stay correct. The time base is rebased on every rebuild, so `time` no longer misreports after a loop that has wrapped. A non-looping source now always receives a cap, closing a pre-existing case where seeking exactly to the clip end played the rest of the atlas buffer.

`Envelope.release()` during attack or decay discarded the running ramp and dropped the parameter to its previous event — silence mid-attack, i.e. an audible click. Now uses `cancelAndHoldAtTime` where available, plus a mandatory analytical fallback that reconstructs the current value from the scheduled attack/decay geometry, since Firefox still does not implement the method. Trigger times are keyed per `AudioParam`, because one `Envelope` is shared across all voices of a generator and those trigger at different times.

## Verification

`pnpm test` 9224 green, `verify:quick` exit 0, API docs regenerated and committed.

An independent review on a different model checked all six: ME-32, ME-36 and ME-40 correct without reservation — for ME-32 all 23 effect implementations were walked to confirm every feedback loop sits upstream of `outputNode`; for ME-40 the fallback formula was verified against the geometry `trigger()` actually schedules, at both phase boundaries and outside them. Its findings on the other three are folded into this branch.

## Known gaps, deliberately not addressed here

- `AudioStreamVoice.loop` has no `_ended` guard, so an ended voice can retarget the loop behaviour of the next voice sharing the same element.
- `AudioBus.destroy()` destroys its attached effects while `BaseVoice._finish()` only detaches them and documents that the caller still owns them — an ownership contradiction, tracked separately.
- All audio tests run against mocks without Web Audio semantics; the spec claims above are argued from the specification text, not from an executed browser test.