### PR TITLE
fix(audio,animation): follow-ups — shared-element guards, tween retention, effect ownership

### DIFF
--- a/site/src/content/api/audio-bus.json
+++ b/site/src/content/api/audio-bus.json
@@ -227,7 +227,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Append a effect to the end of the chain (before the pan stage). The chain is rebuilt in place; existing audio routes through the new effect on the next frame."
+          "description": "Append a effect to the end of the chain (before the pan stage). The chain is rebuilt in place; existing audio routes through the new effect on the next frame. Attaching does not transfer ownership: the caller keeps it and must destroy() the effect once it is no longer used anywhere. Neither AudioBus.removeEffect nor AudioBus.destroy destroys it."
         },
         {
           "name": "destroy",
@@ -256,7 +256,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": ""
+          "description": "Tear the bus down: drop pending setup work, detach every attached effect and disconnect this bus's own nodes from the graph. Attached effects are detached, **not** destroyed — a bus never owns them (see AudioBus.addEffect), and the same instance may still be in use on a voice or another bus. Destroy each effect yourself once it is no longer needed anywhere."
         },
         {
           "name": "fadeIn",
@@ -501,7 +501,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Remove effect from the chain. No-op if not present. Caller still owns + must destroy() it."
+          "description": "Remove effect from the chain. No-op if not present. The caller still owns it and must destroy() it — the same contract AudioBus.destroy follows for whatever is still attached when the bus goes away."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/audio-manager.json
+++ b/site/src/content/api/audio-manager.json
@@ -329,7 +329,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": "Tear the mix down: stop every voice still playing, then the listener and every bus. Terminal — AudioManager.play and AudioManager.open throw afterwards."
+          "description": "Tear the mix down: stop every voice still playing, then the listener and every bus. Terminal — AudioManager.play and AudioManager.open throw afterwards. Effects you attached to a bus or a voice are detached but not destroyed — they are yours (see AudioBus.addEffect), so destroy() each one yourself as part of your own teardown."
         },
         {
           "name": "getBus",
@@ -755,7 +755,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Unregister and AudioBus.destroy a previously registered bus. Throws if you attempt to unregister one of the three built-ins (master, music, sound). No-op if the bus is unknown."
+          "description": "Unregister and AudioBus.destroy a previously registered bus. Throws if you attempt to unregister one of the three built-ins (master, music, sound). No-op if the bus is unknown. Effects attached to that bus are only detached, never destroyed — they belong to whoever created them (see AudioBus.addEffect)."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/tween-manager.json
+++ b/site/src/content/api/tween-manager.json
@@ -1,6 +1,6 @@
 {
   "title": "TweenManager",
-  "description": "Owns and advances a collection of Tween instances, driving them once per frame from Application.update. A tween created here enters the update list when Tween.start is called and leaves it again on completion or Tween.stop, so the manager only ever holds tweens that are running or paused. Manually constructed tweens can be opted in via TweenManager.add. Custom updatables (such as TweenSequencer) can be registered via TweenManager.addTicker so they share the same frame tick. Update iteration uses a snapshot so callbacks may freely add or remove tweens during the same frame without corrupting the loop. Completed and stopped tweens are evicted automatically.",
+  "description": "Owns and advances a collection of Tween instances, driving them once per frame from Application.update. A tween enters the update list when Tween.start is called and leaves it again on completion or Tween.stop, so the manager only ever holds tweens that are running or paused — regardless of whether it was created here or handed over via TweenManager.add. Custom updatables (such as TweenSequencer) can be registered via TweenManager.addTicker so they share the same frame tick. Update iteration uses a snapshot so callbacks may freely add or remove tweens during the same frame without corrupting the loop. Completed and stopped tweens are evicted automatically.",
   "symbol": "TweenManager",
   "kind": "class",
   "subsystem": "animation",
@@ -19,7 +19,7 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Owns and advances a collection of Tween instances, driving them once per frame from Application.update. A tween created here enters the update list when Tween.start is called and leaves it again on completion or Tween.stop, so the manager only ever holds tweens that are running or paused. Manually constructed tweens can be opted in via TweenManager.add.",
+        "Owns and advances a collection of Tween instances, driving them once per frame from Application.update. A tween enters the update list when Tween.start is called and leaves it again on completion or Tween.stop, so the manager only ever holds tweens that are running or paused — regardless of whether it was created here or handed over via TweenManager.add.",
         "Custom updatables (such as TweenSequencer) can be registered via TweenManager.addTicker so they share the same frame tick.",
         "Update iteration uses a snapshot so callbacks may freely add or remove tweens during the same frame without corrupting the loop. Completed and stopped tweens are evicted automatically."
       ],
@@ -113,7 +113,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Explicitly add a stand-alone Tween (created via new Tween(target)) to this manager so it participates in the update loop."
+          "description": "Take ownership of a stand-alone Tween (created via new Tween(target), or previously bound to a different manager) so it participates in this update loop: from here on, Tween.start enters it and completion or Tween.stop evicts it again. Binding and entering are two separate steps. A tween that is already running or paused is live — nothing will call start() on it again to enter it — so it goes into the update list right away. An idle, completed or stopped tween is bound only: retaining it would pin it, and through it its target, in this manager for the lifetime of the application while the update loop has nothing to do with it."
         },
         {
           "name": "addTicker",

--- a/site/src/content/api/tween.json
+++ b/site/src/content/api/tween.json
@@ -589,7 +589,7 @@
           ],
           "params": [],
           "returnType": "this",
-          "description": "Stop the tween without finishing. Target properties stay at their current interpolated values. onComplete does NOT fire. The tween is removed from its manager if one is assigned — in every state, so an idle or already-finished tween that was handed to a manager explicitly is released too."
+          "description": "Stop the tween without finishing. Target properties stay at their current interpolated values. onComplete does NOT fire. The tween is removed from its manager if one is assigned — unconditionally rather than state-gated, which for anything the manager does not hold (an idle or already-finished tween) is simply a no-op. The manager binding itself survives, so a later Tween.start re-enters the update list."
         },
         {
           "name": "to",

--- a/site/src/content/guide/audio/audio-effects.mdx
+++ b/site/src/content/guide/audio/audio-effects.mdx
@@ -43,6 +43,10 @@ application.audio.master.removeEffect(reverb);
 
 Filters are reusable — move one from bus to bus by removing it from the old bus and adding it to the new one. Destroy a filter with `filter.destroy()` when it's no longer needed anywhere.
 
+<Callout type="warning" title="You own every effect you create">
+Attaching an effect never transfers ownership. `removeEffect`, `bus.destroy()`, `unregisterBus` and `app.audio.destroy()` all only *detach* it — none of them calls `destroy()` on your effect, because the same instance may still be attached to a voice or to another bus. Call `filter.destroy()` yourself once it is no longer used anywhere.
+</Callout>
+
 <Callout type="info" title="Effect order is the order you add them">
 `addEffect` always appends to the end of the chain, so the sequence you add effects in is the sequence audio flows through — a compressor added before a reverb sounds different from one added after. To slot an effect in earlier, `removeEffect` the later ones and add them back in the order you want.
 </Callout>

--- a/src/animation/Tween.ts
+++ b/src/animation/Tween.ts
@@ -250,9 +250,10 @@ export class Tween<T extends object = object> {
   /**
    * Stop the tween without finishing. Target properties stay at their
    * current interpolated values. onComplete does NOT fire. The tween is
-   * removed from its manager if one is assigned — in every state, so an
-   * idle or already-finished tween that was handed to a manager explicitly
-   * is released too.
+   * removed from its manager if one is assigned — unconditionally rather
+   * than state-gated, which for anything the manager does not hold (an idle
+   * or already-finished tween) is simply a no-op. The manager binding itself
+   * survives, so a later {@link Tween.start} re-enters the update list.
    */
   public stop(): this {
     if (this._state === TweenState.Active || this._state === TweenState.Paused) {
@@ -277,8 +278,10 @@ export class Tween<T extends object = object> {
   }
 
   /**
-   * Attach this tween to a manager. Called by TweenManager.create() and
-   * TweenManager.add(). Not part of the public fluent API.
+   * Bind this tween to a manager, without entering it into that manager's
+   * update list — {@link Tween.start} does the entering. Called by
+   * TweenManager.create(), TweenManager.sequence(), TweenManager.add() and
+   * TweenSequencer. Not part of the public fluent API.
    * @internal
    */
   public _attachManager(manager: TweenManager): void {

--- a/src/animation/TweenManager.ts
+++ b/src/animation/TweenManager.ts
@@ -2,6 +2,7 @@ import type { Time } from '#core/Time';
 
 import { Tween } from './Tween';
 import { TweenSequencer } from './TweenSequencer';
+import { TweenState } from './types';
 
 /** Any object that can be driven each frame by a delta in seconds. @internal */
 interface Ticker {
@@ -10,10 +11,10 @@ interface Ticker {
 
 /**
  * Owns and advances a collection of {@link Tween} instances, driving them
- * once per frame from {@link Application.update}. A tween created here enters
- * the update list when {@link Tween.start} is called and leaves it again on
- * completion or {@link Tween.stop}, so the manager only ever holds tweens that
- * are running or paused. Manually constructed tweens can be opted in via
+ * once per frame from {@link Application.update}. A tween enters the update
+ * list when {@link Tween.start} is called and leaves it again on completion or
+ * {@link Tween.stop}, so the manager only ever holds tweens that are running
+ * or paused — regardless of whether it was created here or handed over via
  * {@link TweenManager.add}.
  *
  * Custom updatables (such as {@link TweenSequencer}) can be registered via
@@ -105,13 +106,24 @@ export class TweenManager {
   }
 
   /**
-   * Explicitly add a stand-alone Tween (created via `new Tween(target)`)
-   * to this manager so it participates in the update loop.
+   * Take ownership of a stand-alone Tween (created via `new Tween(target)`, or
+   * previously bound to a different manager) so it participates in this update
+   * loop: from here on, {@link Tween.start} enters it and completion or
+   * {@link Tween.stop} evicts it again.
+   *
+   * Binding and entering are two separate steps. A tween that is already
+   * running or paused is live — nothing will call `start()` on it again to
+   * enter it — so it goes into the update list right away. An idle, completed
+   * or stopped tween is bound only: retaining it would pin it, and through it
+   * its target, in this manager for the lifetime of the application while the
+   * update loop has nothing to do with it.
    */
   public add(tween: Tween): this {
     tween._attachManager(this);
 
-    if (!this._tweens.includes(tween)) {
+    const isLive = tween.state === TweenState.Active || tween.state === TweenState.Paused;
+
+    if (isLive && !this._tweens.includes(tween)) {
       this._tweens.push(tween);
     }
 

--- a/src/animation/TweenSequencer.ts
+++ b/src/animation/TweenSequencer.ts
@@ -292,8 +292,10 @@ export class TweenSequencer {
     if (stage.type === 'tweens') {
       for (const tween of stage.tweens) {
         if (this._manager !== null) {
-          // Register with manager so the manager ticks it each frame.
-          this._manager.add(tween);
+          // Bind only — a stage tween may have been built stand-alone and know
+          // no manager yet. The `start()` below is what enters it into the
+          // update list, so the manager ticks it each frame.
+          tween._attachManager(this._manager);
         }
         tween.start();
       }

--- a/src/audio/AudioBus.ts
+++ b/src/audio/AudioBus.ts
@@ -145,6 +145,10 @@ export class AudioBus {
    * Append a effect to the end of the chain (before the pan stage). The
    * chain is rebuilt in place; existing audio routes through the new
    * effect on the next frame.
+   *
+   * Attaching does not transfer ownership: the caller keeps it and must
+   * `destroy()` the effect once it is no longer used anywhere. Neither
+   * {@link AudioBus.removeEffect} nor {@link AudioBus.destroy} destroys it.
    */
   public addEffect(effect: AudioEffect): this {
     this._effects.push(effect);
@@ -152,7 +156,11 @@ export class AudioBus {
     return this;
   }
 
-  /** Remove `effect` from the chain. No-op if not present. Caller still owns + must `destroy()` it. */
+  /**
+   * Remove `effect` from the chain. No-op if not present. The caller still
+   * owns it and must `destroy()` it — the same contract {@link AudioBus.destroy}
+   * follows for whatever is still attached when the bus goes away.
+   */
   public removeEffect(effect: AudioEffect): this {
     const index = this._effects.indexOf(effect);
     if (index !== -1) {
@@ -217,6 +225,15 @@ export class AudioBus {
     return this;
   }
 
+  /**
+   * Tear the bus down: drop pending setup work, detach every attached effect
+   * and disconnect this bus's own nodes from the graph.
+   *
+   * Attached effects are detached, **not** destroyed — a bus never owns them
+   * (see {@link AudioBus.addEffect}), and the same instance may still be in
+   * use on a voice or another bus. Destroy each effect yourself once it is no
+   * longer needed anywhere.
+   */
   public destroy(): void {
     onAudioContextReady.remove(this._onAudioContextReady);
     this._parentSetupDispose?.();
@@ -225,8 +242,16 @@ export class AudioBus {
     // linger after teardown (AU3).
     this._pendingSetup = null;
     this._clearScheduledStop();
+    // Detach, never destroy: a bus does not own the effects handed to it. The
+    // same instance may also sit on a voice or on another bus, and destroying
+    // it here would pull it out from under them. Mirrors
+    // {@link AudioBus.removeEffect} and `BaseVoice._finish` — cut the outgoing
+    // edge, leave the effect's own internal wiring intact, skip an effect whose
+    // nodes were never created.
     for (const effect of this._effects) {
-      effect.destroy();
+      if (_isEffectReady(effect)) {
+        effect.outputNode.disconnect();
+      }
     }
     this._effects.length = 0;
     if (this._setup) {

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -229,6 +229,9 @@ export class AudioManager {
    * Unregister and {@link AudioBus.destroy} a previously registered bus.
    * Throws if you attempt to unregister one of the three built-ins
    * (`master`, `music`, `sound`). No-op if the bus is unknown.
+   *
+   * Effects attached to that bus are only detached, never destroyed — they
+   * belong to whoever created them (see {@link AudioBus.addEffect}).
    */
   public unregisterBus(bus: AudioBus): this {
     if (bus === this.master || bus === this.music || bus === this.sound) {
@@ -262,6 +265,10 @@ export class AudioManager {
    * Tear the mix down: stop every voice still playing, then the listener and
    * every bus. Terminal — {@link AudioManager.play} and
    * {@link AudioManager.open} throw afterwards.
+   *
+   * Effects you attached to a bus or a voice are detached but not destroyed —
+   * they are yours (see {@link AudioBus.addEffect}), so `destroy()` each one
+   * yourself as part of your own teardown.
    */
   public destroy(): void {
     // Set before the drain so nothing can start new playback from an `onEnd`

--- a/src/audio/AudioStreamVoice.ts
+++ b/src/audio/AudioStreamVoice.ts
@@ -107,6 +107,10 @@ export class AudioStreamVoice extends BaseVoice implements Seekable, Pausable, L
   }
 
   public set loop(value: boolean) {
+    // Guarded like `seek`/`pause`/`resume`: the `<audio>` element is shared by
+    // every voice of this stream, so an ended voice writing here would retarget
+    // the loop behaviour of whichever voice currently owns the element.
+    if (this._ended) return;
     this._element.loop = value;
   }
 

--- a/src/audio/AudioStreamVoice.ts
+++ b/src/audio/AudioStreamVoice.ts
@@ -21,6 +21,13 @@ export interface AudioStreamVoiceInit extends BaseVoiceInit {
  * element owns a single playhead, a stream has one active voice at a time —
  * starting a new voice stops the previous one.
  *
+ * The element outlives every individual voice and is handed on to the next
+ * one, so **every member that writes to it is a no-op once this voice has
+ * ended**: {@link AudioStreamVoice.seek}/`time`, {@link AudioStreamVoice.pause},
+ * {@link AudioStreamVoice.resume}, `loop` and `playbackRate`. Without that
+ * guard a stale handle could retarget playback it no longer owns. `detune` is
+ * voice-local state and therefore unguarded.
+ *
  * Mixes in {@link Seekable}, {@link Pausable}, {@link Loopable},
  * {@link RatePitched} (playback rate; `detune` is stored but inert — an
  * `HTMLMediaElement` has no detune control), and (via {@link BaseVoice})
@@ -107,9 +114,6 @@ export class AudioStreamVoice extends BaseVoice implements Seekable, Pausable, L
   }
 
   public set loop(value: boolean) {
-    // Guarded like `seek`/`pause`/`resume`: the `<audio>` element is shared by
-    // every voice of this stream, so an ended voice writing here would retarget
-    // the loop behaviour of whichever voice currently owns the element.
     if (this._ended) return;
     this._element.loop = value;
   }
@@ -123,6 +127,7 @@ export class AudioStreamVoice extends BaseVoice implements Seekable, Pausable, L
   }
 
   public set playbackRate(value: number) {
+    if (this._ended) return;
     this._basePlaybackRate = clamp(value, 0.1, 20);
     this._element.playbackRate = this._basePlaybackRate;
   }

--- a/src/core/scene/SceneTweens.ts
+++ b/src/core/scene/SceneTweens.ts
@@ -166,8 +166,10 @@ export class SceneTweens implements Destroyable {
    * activation flushing whatever was created while `Ready` (or a still-cold
    * `Suspended` registration), or a retention restore reinstating whatever
    * {@link SceneTweens.suspend} paused. Both converge on the same
-   * operation: attach every cold tween/sequencer to the app-wide manager
-   * (in whatever state it's currently in), then resume exactly the set
+   * operation: hand every cold tween/sequencer over to the app-wide manager
+   * (in whatever state it's currently in — one already running or paused
+   * while dormant is entered into the update list, one still idle is bound
+   * only and enters on its own `start()`), then resume exactly the set
    * `suspend()` paused and exactly the set `add()` paused while dormant —
    * each only if still in the exact state this facade left it in.
    * @internal

--- a/test/animation/tween-manager.test.ts
+++ b/test/animation/tween-manager.test.ts
@@ -229,11 +229,10 @@ describe('TweenManager', () => {
     expect(tween.state).toBe(TweenState.Active);
   });
 
-  test('stop() evicts a tween that was added but never started', () => {
+  test('stop() evicts a running tween', () => {
     const manager = new TweenManager();
-    const tween = new Tween(makeTarget()).to({ x: 100 }, 1.0);
+    const tween = manager.create(makeTarget()).to({ x: 100 }, 1.0).start();
 
-    manager.add(tween);
     expect(trackedCount(manager)).toBe(1);
 
     tween.stop();
@@ -241,18 +240,69 @@ describe('TweenManager', () => {
     expect(trackedCount(manager)).toBe(0);
   });
 
-  test('stop() evicts an already-completed tween that was re-added', () => {
+  // ---- add() binds ownership; only a live tween occupies the update list ----
+
+  test('add() binds an idle tween without retaining it', () => {
+    const manager = new TweenManager();
+    const target = makeTarget();
+    const tween = new Tween(target).to({ x: 100 }, 1.0);
+
+    manager.add(tween);
+
+    // Ownership was transferred (the tween now knows this manager), but an
+    // unstarted tween must not pin itself — and its target — in the
+    // application-wide manager.
+    expect(trackedCount(manager)).toBe(0);
+
+    tween.start();
+
+    expect(trackedCount(manager)).toBe(1);
+    manager.preUpdate(sec(0.5));
+    expect(target.x).toBeCloseTo(50, 5);
+  });
+
+  test('add() does not retain an already-completed tween', () => {
     const manager = new TweenManager();
     const tween = manager.create(makeTarget()).to({ x: 100 }, 1.0).start();
 
     manager.preUpdate(sec(1.0));
     expect(tween.state).toBe(TweenState.Complete);
+    expect(trackedCount(manager)).toBe(0);
 
     manager.add(tween);
-    expect(trackedCount(manager)).toBe(1);
-
-    tween.stop();
 
     expect(trackedCount(manager)).toBe(0);
+  });
+
+  test('add() does not retain a stopped tween', () => {
+    const manager = new TweenManager();
+    const tween = new Tween(makeTarget()).to({ x: 100 }, 1.0).start().stop();
+
+    manager.add(tween);
+
+    expect(trackedCount(manager)).toBe(0);
+  });
+
+  test('add() enters an already-running tween immediately', () => {
+    const manager = new TweenManager();
+    const tween = new Tween(makeTarget()).to({ x: 100 }, 1.0).start();
+
+    manager.add(tween);
+
+    expect(trackedCount(manager)).toBe(1);
+  });
+
+  test('add() enters a paused tween — it is live and must resume on the frame tick', () => {
+    const manager = new TweenManager();
+    const target = makeTarget();
+    const tween = new Tween(target).to({ x: 100 }, 1.0).start().pause();
+
+    manager.add(tween);
+
+    expect(trackedCount(manager)).toBe(1);
+
+    tween.resume();
+    manager.preUpdate(sec(0.5));
+    expect(target.x).toBeCloseTo(50, 5);
   });
 });

--- a/test/audio/audio-bus.test.ts
+++ b/test/audio/audio-bus.test.ts
@@ -298,19 +298,53 @@ describe('AudioBus', () => {
     bus.destroy();
   });
 
-  // 8. destroy disconnects nodes and clears filters
-  test('destroy disconnects all nodes and destroys filters', () => {
+  // 8. destroy disconnects nodes and detaches (but does not destroy) effects
+  test('destroy disconnects all nodes and detaches its effects without destroying them', () => {
+    // Built before the spy so it gets real nodes — while `spyOnBusCreation` is
+    // active every `createGain()` returns one of the two bus mocks.
+    const filter = new WiredFilter();
     const spy = spyOnBusCreation();
     const bus = new AudioBus('destroy-test');
-    const filter = new StubFilter();
     bus.addEffect(filter);
+    filter.outputDisconnect.mockClear();
+    filter.inputDisconnect.mockClear();
 
     bus.destroy();
 
     expect(spy.inputNode.disconnect).toHaveBeenCalled();
     expect(spy.outputNode.disconnect).toHaveBeenCalled();
     expect(spy.panNode.disconnect).toHaveBeenCalled();
-    expect(filter.destroyed).toBe(true);
+
+    // Same contract as `removeEffect` and `BaseVoice._finish`: cut the outgoing
+    // edge, leave the effect's own internal wiring alone, and leave ownership
+    // (and therefore `destroy()`) with the caller.
+    expect(filter.outputDisconnect).toHaveBeenCalled();
+    expect(filter.inputDisconnect).not.toHaveBeenCalled();
+    expect(filter.destroyed).toBe(false);
+
+    spy.restore();
+    filter.destroy();
+  });
+
+  test('destroy tolerates an effect whose own nodes were never created', () => {
+    const spy = spyOnBusCreation();
+    const bus = new AudioBus('destroy-unready');
+    const destroySpy = vi.fn();
+    const unready = {
+      get inputNode(): AudioNode {
+        throw new Error('not yet initialized');
+      },
+      get outputNode(): AudioNode {
+        throw new Error('not yet initialized');
+      },
+      ready: Promise.resolve(),
+      destroy: destroySpy,
+    } as unknown as AudioEffect;
+
+    bus.addEffect(unready);
+
+    expect(() => bus.destroy()).not.toThrow();
+    expect(destroySpy).not.toHaveBeenCalled();
 
     spy.restore();
   });

--- a/test/audio/audio-stream.test.ts
+++ b/test/audio/audio-stream.test.ts
@@ -256,6 +256,40 @@ describe('AudioStream', () => {
     expect(playSpy).not.toHaveBeenCalled();
   });
 
+  test('the loop setter is a no-op once the voice has ended', () => {
+    const manager = new AudioManager();
+    const el = createAudioElementStub();
+    const stream = new AudioStream(el, { loop: false });
+    const voice = manager.play(stream) as AudioStreamVoice;
+
+    voice.stop();
+    expect(voice.ended).toBe(true);
+
+    voice.loop = true;
+    expect(el.loop).toBe(false);
+
+    stream.destroy();
+  });
+
+  test('an ended voice cannot retarget the loop flag of the next voice on the same element', () => {
+    const manager = new AudioManager();
+    const el = createAudioElementStub();
+    const stream = new AudioStream(el, { loop: false });
+    const first = manager.play(stream) as AudioStreamVoice;
+
+    // Starting a second voice stops the first — both share one `<audio>` element.
+    const second = manager.play(stream) as AudioStreamVoice;
+    expect(first.ended).toBe(true);
+    expect(second.ended).toBe(false);
+
+    first.loop = true;
+
+    expect(el.loop).toBe(false);
+    expect(second.loop).toBe(false);
+
+    stream.destroy();
+  });
+
   test('construction while the audio context is not ready defers playback until unlock', () => {
     const ctx = getAudioContext();
     const originalState = ctx.state;

--- a/test/audio/audio-stream.test.ts
+++ b/test/audio/audio-stream.test.ts
@@ -290,6 +290,44 @@ describe('AudioStream', () => {
     stream.destroy();
   });
 
+  test('the playbackRate setter is a no-op once the voice has ended', () => {
+    const manager = new AudioManager();
+    const el = createAudioElementStub();
+    const stream = new AudioStream(el, { playbackRate: 1 });
+    const voice = manager.play(stream) as AudioStreamVoice;
+
+    voice.stop();
+    expect(voice.ended).toBe(true);
+
+    voice.playbackRate = 3;
+
+    expect(el.playbackRate).toBe(1);
+    // The cached base rate is not updated either — reporting a rate the voice
+    // never applied would be a lie, and `seek`/`pause`/`resume`/`loop` are all
+    // whole-setter no-ops after the end too.
+    expect(voice.playbackRate).toBe(1);
+
+    stream.destroy();
+  });
+
+  test('an ended voice cannot retarget the playback rate of the next voice on the same element', () => {
+    const manager = new AudioManager();
+    const el = createAudioElementStub();
+    const stream = new AudioStream(el, { playbackRate: 1 });
+    const first = manager.play(stream) as AudioStreamVoice;
+
+    const second = manager.play(stream) as AudioStreamVoice;
+    expect(first.ended).toBe(true);
+    expect(second.ended).toBe(false);
+
+    first.playbackRate = 3;
+
+    expect(el.playbackRate).toBe(1);
+    expect(second.playbackRate).toBe(1);
+
+    stream.destroy();
+  });
+
   test('construction while the audio context is not ready defers playback until unlock', () => {
     const ctx = getAudioContext();
     const originalState = ctx.state;

--- a/test/audio/voice-effects.test.ts
+++ b/test/audio/voice-effects.test.ts
@@ -1,6 +1,7 @@
 import type { MockInstance } from 'vitest';
 
 import { getAudioContext } from '#audio/audio-context';
+import { AudioBus } from '#audio/AudioBus';
 import type { AudioEffect } from '#audio/AudioEffect';
 import { AudioManager } from '#audio/AudioManager';
 import { Sound } from '#audio/Sound';
@@ -96,6 +97,27 @@ describe('Voice — per-voice effects', () => {
     expect((fx.outputNode as unknown as { disconnect: MockInstance }).disconnect).toHaveBeenCalled();
 
     sound.destroy();
+  });
+
+  test('an effect shared with a bus survives that bus being destroyed', () => {
+    const manager = new AudioManager();
+    const sound = new Sound(makeBufferStub());
+    const voice = manager.play(sound);
+    const fx = makeStubEffect();
+    const bus = new AudioBus('shared-effect-bus');
+
+    voice.addEffect(fx);
+    bus.addEffect(fx);
+
+    bus.destroy();
+
+    // A bus never owns the effects handed to it — destroying them here would
+    // pull the effect out from under the still-playing voice that also holds it.
+    expect(fx.destroy).not.toHaveBeenCalled();
+    expect(voice.ended).toBe(false);
+
+    sound.destroy();
+    fx.destroy();
   });
 
   test('stopping the voice detaches its effects', () => {

--- a/test/core/scene/scene-tweens.test.ts
+++ b/test/core/scene/scene-tweens.test.ts
@@ -1,9 +1,12 @@
 import { Tween } from '#animation/Tween';
+import { TweenManager } from '#animation/TweenManager';
 import { TweenSequencer } from '#animation/TweenSequencer';
+import { TweenState } from '#animation/types';
 import type { Application } from '#core/Application';
 import { SceneTweens } from '#core/scene/SceneTweens';
 import { SceneAvailability } from '#core/SceneAvailability';
 import { SceneState } from '#core/SceneState';
+import { Time } from '#core/Time';
 
 const createAppStub = (createResult: unknown, sequencerResult?: unknown): Application =>
   ({
@@ -347,5 +350,71 @@ describe('SceneTweens — dormancy (create/add/createSequencer while not Active)
 
     expect(app.tweens.create).toHaveBeenCalledTimes(1);
     expect(app.tweens.createSequencer).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SceneTweens — activation against a real TweenManager', () => {
+  const sec = (seconds: number): Time => new Time(seconds, Time.seconds);
+  const trackedCount = (manager: TweenManager): number => (manager as unknown as { _tweens: unknown[] })._tweens.length;
+  const createRealApp = (manager: TweenManager): Application => ({ tweens: manager }) as unknown as Application;
+
+  test('a cold tween started while dormant is entered into the update list on activate()', () => {
+    const manager = new TweenManager();
+    let state: SceneState = SceneState.Ready;
+    const tweens = new SceneTweens(createRealApp(manager), () => state);
+    const target = { x: 0 };
+
+    const tween = tweens.create(target).to({ x: 100 }, 1).start();
+
+    // Started while dormant — the app-wide manager must not drive it yet.
+    manager.preUpdate(sec(0.5));
+    expect(target.x).toBe(0);
+
+    state = SceneState.Active;
+    tweens.activate();
+
+    // Activation must hand a live tween over completely, not merely bind it:
+    // it never gets another `start()` call to enter it into the update list.
+    expect(trackedCount(manager)).toBe(1);
+    manager.preUpdate(sec(0.5));
+    expect(target.x).toBeCloseTo(50, 5);
+    expect(tween.state).toBe(TweenState.Active);
+  });
+
+  test('a cold tween that was never started is bound but not retained on activate()', () => {
+    const manager = new TweenManager();
+    let state: SceneState = SceneState.Ready;
+    const tweens = new SceneTweens(createRealApp(manager), () => state);
+    const target = { x: 0 };
+
+    const tween = tweens.create(target).to({ x: 100 }, 1);
+
+    state = SceneState.Active;
+    tweens.activate();
+
+    expect(trackedCount(manager)).toBe(0);
+
+    // The binding survived, so a later start() still reaches the manager.
+    tween.start();
+    expect(trackedCount(manager)).toBe(1);
+    manager.preUpdate(sec(0.5));
+    expect(target.x).toBeCloseTo(50, 5);
+  });
+
+  test('a cold tween paused by suspend() is restored into the update list', () => {
+    const manager = new TweenManager();
+    let state: SceneState = SceneState.Ready;
+    const tweens = new SceneTweens(createRealApp(manager), () => state);
+    const target = { x: 0 };
+
+    tweens.create(target).to({ x: 100 }, 1).start();
+    tweens.suspend();
+
+    state = SceneState.Active;
+    tweens.restore();
+
+    expect(trackedCount(manager)).toBe(1);
+    manager.preUpdate(sec(0.5));
+    expect(target.x).toBeCloseTo(50, 5);
   });
 });


### PR DESCRIPTION
The remaining findings from the Batch D review, plus one of the same class found while implementing them.

## NEU-D3 / NEU-E1 — writes from an ended voice on a shared `<audio>` element

`AudioStreamVoice`'s `loop` and `playbackRate` setters wrote to `_element` without the `_ended` check its siblings (`seek`, `pause`, `resume`, `_applyDopplerRate`) all perform. Since every voice of a stream shares one element, an already-ended voice could retarget the loop behaviour or playback rate of the *next* voice on that element.

Both setters are now no-ops after the voice ends — the whole setter, not just the element write, so the getter cannot report a rate the voice never applied. An audit of every write to the shared element found no further unguarded case: `detune` is voice-local and does not apply to a media element, `SoundVoice` and `AudioGeneratorVoice` own their source node per voice, and the constructor and teardown writes are legitimate.

## NEU-D4 — `TweenManager.add()` retained idle tweens

`add()` bound the tween *and* pushed it into the update list regardless of state, so via `SceneTweens.restore()` every never-started cold tween — and its target — stayed in the application-wide manager for the lifetime of the app. That was the remainder of the leak class ME-37 addressed.

The split happens inside `add()`: it still binds unconditionally, preserving its ownership semantics, but only enters tweens that are live. `TweenSequencer._startCurrentStage` now calls `_attachManager` directly, since binding was all it ever meant there.

`SceneTweens.restore()` deliberately keeps calling `add()`: a cold tween that received `.start()` while dormant is already `Active` and will never get a second `start()`, so a bind-only restore would silently strand exactly the case the class documents. Covered by a regression test against a real `TweenManager` rather than a mock.

## NEU-D5 — contradictory effect ownership

`AudioBus.destroy()` destroyed its attached effects while `BaseVoice._finish()` only detaches and documents that the caller still owns them — as does `AudioBus.removeEffect`. An effect attached to both was pulled out from under the voice on bus teardown.

The bus now only detaches, making all three paths agree. Nothing in the repo relied on the old behaviour: the `audio-fx/effect-chains` example already destroys its own effects, the other audio-fx examples never tear their application down, and the guide already said to destroy filters explicitly. One test encoded the old behaviour and was rewritten.

## Behaviour changes

- `manager.add(tween)` no longer retains an idle, complete or stopped tween. Animation behaviour is unchanged — a tween only runs while `Active` — but code inspecting the manager's list sees one entry fewer.
- Effects attached to a bus are no longer destroyed by `bus.destroy()`, `unregisterBus()` or `app.audio.destroy()`. Callers destroy their own effects. Clean break, no shim; the contract is stated in the JSDoc of `addEffect`, `removeEffect`, `AudioBus.destroy`, `AudioManager.unregisterBus` and `AudioManager.destroy`, and as a callout in the audio-effects guide.

## Verification

`pnpm test` green (9266), `verify:quick` exit 0, API docs regenerated and committed.

## Found while working, not fixed here

- `AudioBus.destroy()` sets no `_destroyed` flag, so `addEffect()` after teardown keeps pushing into `_effects` on a dead bus while `_rebuildEffectChain` silently bails.
- `BaseVoice.removeEffect`/`_finish` disconnect without the `_isEffectReady` probing `AudioBus` uses, so an effect whose own setup is still pending throws there. The ownership fix above makes this asymmetry more visible.
- `TweenManager.clear()`/`destroy()` empty the list but leave the tweens in `Active`, so `tween.state` keeps claiming it runs while nothing ticks it, and `resume()` does not re-enter it.