### PR TITLE
fix(core,debug): bonus batch — timestep alpha, logger dedup, lifecycle isolation, debug layer

### DIFF
--- a/site/src/content/api/debug-overlay.json
+++ b/site/src/content/api/debug-overlay.json
@@ -1,6 +1,6 @@
 {
   "title": "DebugOverlay",
-  "description": "Canvas-native debug overlay. Instantiate AFTER Application is constructed: import { DebugOverlay } from '@codexo/exojs/debug'; const debug = new DebugOverlay(app); debug.layers.performance.visible = true; // or press F1 The overlay subscribes to `app.onFrame` and renders its visible layers. World-space layers render first (under text panels) in the scene view; screen-space layers then render in the overlay's pixel-space view. Keybindings (while canvas has focus): F1 — toggle Performance layer F2 — toggle BoundingBoxes layer F3 — toggle HitTest layer F4 — toggle PointerStack layer NOTE: F-keys only fire while the canvas has focus (engine convention). The master `visible` switch suppresses all layer rendering when false without changing individual layer visibility flags.",
+  "description": "Canvas-native debug overlay. Instantiate AFTER Application is constructed: import { DebugOverlay } from '@codexo/exojs/debug'; const debug = new DebugOverlay(app); debug.layers.performance.visible = true; // or press F1 The overlay subscribes to `app.onFrame` and renders its visible layers. World-space layers render first (under text panels) in the scene view; screen-space layers then render in the overlay's pixel-space view. Keybindings (while canvas has focus): F1 — toggle Performance layer F2 — toggle BoundingBoxes layer F3 — toggle HitTest layer F4 — toggle PointerStack layer F6 — toggle RenderPassInspector layer NOTE: F-keys only fire while the canvas has focus (engine convention). F5 is deliberately left unbound: browsers reload the page on it, which would tear down the very session being inspected. The master `visible` switch suppresses all layer rendering when false without changing individual layer visibility flags.",
   "symbol": "DebugOverlay",
   "kind": "class",
   "subsystem": "debug",
@@ -22,8 +22,8 @@
         "Canvas-native debug overlay. Instantiate AFTER Application is constructed:",
         "import { DebugOverlay } from '@codexo/exojs/debug'; const debug = new DebugOverlay(app); debug.layers.performance.visible = true; // or press F1",
         "The overlay subscribes to `app.onFrame` and renders its visible layers. World-space layers render first (under text panels) in the scene view; screen-space layers then render in the overlay's pixel-space view.",
-        "Keybindings (while canvas has focus): F1 — toggle Performance layer F2 — toggle BoundingBoxes layer F3 — toggle HitTest layer F4 — toggle PointerStack layer",
-        "NOTE: F-keys only fire while the canvas has focus (engine convention).",
+        "Keybindings (while canvas has focus): F1 — toggle Performance layer F2 — toggle BoundingBoxes layer F3 — toggle HitTest layer F4 — toggle PointerStack layer F6 — toggle RenderPassInspector layer",
+        "NOTE: F-keys only fire while the canvas has focus (engine convention). F5 is deliberately left unbound: browsers reload the page on it, which would tear down the very session being inspected.",
         "The master `visible` switch suppresses all layer rendering when false without changing individual layer visibility flags."
       ],
       "importLine": "import { DebugOverlay } from '@codexo/exojs/debug'",
@@ -146,7 +146,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "The four built-in diagnostic layers. Toggle each layer's visible flag or use the F1–F4 keybindings."
+          "description": "The built-in diagnostic layers. Toggle each layer's visible flag or use the F1–F4/F6 keybindings."
         },
         {
           "name": "visible",

--- a/site/src/content/api/log-options.json
+++ b/site/src/content/api/log-options.json
@@ -1,6 +1,6 @@
 {
   "title": "LogOptions",
-  "description": "Per-call metadata for Logger.debug/Logger.info/Logger.warn/Logger.error. - `source` renders as `[ExoJS][source]` in the default console sink (omit it for a bare `[ExoJS]` prefix). - `once` deduplicates by key: the second and later calls sharing the same key are dropped before severity filtering or sink dispatch, so pass a stable per-callsite key (e.g. `` `bitmaptext:${fontId}:${codepoint}` ``) to avoid per-frame spam.",
+  "description": "Per-call metadata for Logger.debug/Logger.info/Logger.warn/Logger.error. - `source` renders as `[ExoJS][source]` in the default console sink (omit it for a bare `[ExoJS]` prefix). - `once` deduplicates by key: the second and later calls sharing the same key are dropped before sink dispatch, so pass a stable per-callsite key (e.g. `` `bitmaptext:${fontId}:${codepoint}` ``) to avoid per-frame spam. A key is claimed only by a call that survives severity filtering, so the `Debug`/`Info`/`Warning` calls a production build strips cost nothing and never shadow a later `error()` that reuses the key. The set of claimed keys is retained for the lifetime of the Logger and never evicted — that permanence is the guarantee `once` exists to provide, so keep keys drawn from a bounded, per-callsite vocabulary rather than from unbounded runtime data.",
   "symbol": "LogOptions",
   "kind": "interface",
   "subsystem": "core",
@@ -20,7 +20,7 @@
       "members": [],
       "paragraphs": [
         "Per-call metadata for Logger.debug/Logger.info/Logger.warn/Logger.error.",
-        "- `source` renders as `[ExoJS][source]` in the default console sink (omit it for a bare `[ExoJS]` prefix). - `once` deduplicates by key: the second and later calls sharing the same key are dropped before severity filtering or sink dispatch, so pass a stable per-callsite key (e.g. `` `bitmaptext:${fontId}:${codepoint}` ``) to avoid per-frame spam."
+        "- `source` renders as `[ExoJS][source]` in the default console sink (omit it for a bare `[ExoJS]` prefix). - `once` deduplicates by key: the second and later calls sharing the same key are dropped before sink dispatch, so pass a stable per-callsite key (e.g. `` `bitmaptext:${fontId}:${codepoint}` ``) to avoid per-frame spam. A key is claimed only by a call that survives severity filtering, so the `Debug`/`Info`/`Warning` calls a production build strips cost nothing and never shadow a later `error()` that reuses the key. The set of claimed keys is retained for the lifetime of the Logger and never evicted — that permanence is the guarantee `once` exists to provide, so keep keys drawn from a bounded, per-callsite vocabulary rather than from unbounded runtime data."
       ],
       "importLine": "import { LogOptions } from '@codexo/exojs'",
       "sourceLink": null

--- a/site/src/content/api/scene-director.json
+++ b/site/src/content/api/scene-director.json
@@ -1300,7 +1300,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Fires after pause() actually sets the active scene's paused flag."
+          "description": "Fires after pause() actually sets the active scene's paused flag. Pure observation: a throwing listener is reported through Application.onError and never propagates back out of pause(), which has already applied the pause policy by then."
         },
         {
           "name": "onResume",
@@ -1373,7 +1373,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Fires after resume() actually clears the active scene's paused flag."
+          "description": "Fires after resume() actually clears the active scene's paused flag. Same error contract as SceneDirector.onPause."
         },
         {
           "name": "onStartScene",

--- a/site/src/content/api/scene.json
+++ b/site/src/content/api/scene.json
@@ -1070,7 +1070,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Dispatched after this scene's Scene.paused flag is set. Same event as SceneDirector.onPause, exposed directly on the scene for convenience."
+          "description": "Dispatched after this scene's Scene.paused flag is set. Same event as SceneDirector.onPause, exposed directly on the scene for convenience, and the same exception-isolation contract as Scene.onActivate."
         },
         {
           "name": "onResume",
@@ -1107,7 +1107,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Dispatched after this scene's Scene.paused flag is cleared. Same event as SceneDirector.onResume, exposed directly on the scene for convenience."
+          "description": "Dispatched after this scene's Scene.paused flag is cleared. Same event as SceneDirector.onResume, exposed directly on the scene for convenience, and the same exception-isolation contract as Scene.onActivate."
         },
         {
           "name": "onSuspend",

--- a/site/src/content/guide/debugging/debugging-and-inspection.mdx
+++ b/site/src/content/guide/debugging/debugging-and-inspection.mdx
@@ -9,7 +9,7 @@ import Callout from '../../../components/Callout.astro';
 
 # Debugging & inspection
 
-ExoJS ships five diagnostic layers in the `@codexo/exojs/debug` optional entrypoint. Four are managed by `DebugOverlay` (performance, bounding boxes, hit-test, pointer stack), and `RenderPassInspectorLayer` is a standalone layer covered below. These tools render as overlays on top of your running scene — no scene-logic changes, no special draw-call instrumentation, no build flags.
+ExoJS ships five diagnostic layers in the `@codexo/exojs/debug` optional entrypoint, all managed by `DebugOverlay`: performance, bounding boxes, hit-test, pointer stack, and the render-pass inspector covered below. These tools render as overlays on top of your running scene — no scene-logic changes, no special draw-call instrumentation, no build flags.
 
 ## DebugOverlay
 
@@ -26,10 +26,20 @@ const debug = new DebugOverlay(app);
 debug.layers.performance.visible = true;
 debug.layers.boundingBoxes.visible = true;
 
-// Toggle with keyboard shortcuts (F1–F4 while canvas has focus)
+// Toggle with keyboard shortcuts (F1–F4 and F6, while canvas has focus)
 ```
 
-The overlay subscribes to `app.onFrame` and renders each visible layer. World-space layers (`boundingBoxes`, `hitTest`) render first under screen-space panels (`performance`, `pointerStack`). The overlay's `visible` flag suppresses all layers without changing individual visibility.
+The overlay subscribes to `app.onFrame` and renders each visible layer. World-space layers (`boundingBoxes`, `hitTest`) render first under screen-space panels (`performance`, `pointerStack`, `renderPassInspector`). The overlay's `visible` flag suppresses all layers without changing individual visibility.
+
+| Layer | Property | Shortcut |
+|-------|----------|----------|
+| Performance | `layers.performance` | F1 |
+| Bounding boxes | `layers.boundingBoxes` | F2 |
+| Hit-test | `layers.hitTest` | F3 |
+| Pointer stack | `layers.pointerStack` | F4 |
+| Render-pass inspector | `layers.renderPassInspector` | F6 |
+
+F5 is deliberately unbound — browsers reload the page on it, which would tear down the very session you are inspecting.
 
 ## Performance layer
 
@@ -154,9 +164,20 @@ The panel does not show drawables with zero filters — they are invisible to th
 
 ### Enabling the layer
 
-`RenderPassInspectorLayer` extends `DebugLayer` and is designed to be driven via `app.onFrame` — the same pattern used by `DebugOverlay` for the other debug layers. It is not added to the scene graph. The inspector walks `app.scenes.currentScene?.root` each frame, so it sees whichever scene is currently active.
+`DebugOverlay` manages the inspector alongside the other layers, so the usual route is a flag or the F6 shortcut:
 
-Import from the debug entrypoint, construct against the application, subscribe to `app.onFrame`, and toggle visibility:
+```ts
+import { DebugOverlay } from '@codexo/exojs/debug';
+
+declare const debug: DebugOverlay;
+debug.layers.renderPassInspector.visible = true;  // or F6
+```
+
+The inspector walks `app.scenes.currentScene?.root` each frame, so it sees whichever scene is currently active. It is never added to the scene graph.
+
+### Driving the layer without the overlay
+
+`RenderPassInspectorLayer` extends `DebugLayer` and can also be driven directly from `app.onFrame` — useful when you want the inspector without constructing an overlay, or when you need it on a view of your own. Import it from the debug entrypoint, construct it against the application, and render it yourself:
 
 ```ts
 import { Scene, View } from '@codexo/exojs';

--- a/src/core/FixedTimestep.ts
+++ b/src/core/FixedTimestep.ts
@@ -49,7 +49,11 @@ export class FixedTimestep {
 
     // Capped: drop the whole-step backlog, keep only the sub-step remainder so
     // alpha stays in [0, 1) and the next frame does not replay the lost time.
-    if (this._accumulatorMs > this._stepMs) {
+    // The comparison is `>=`, not `>`: a backlog that is an exact multiple of
+    // the step would otherwise be left untouched at exactly one whole step and
+    // report `alpha === 1`. The uncapped path never reaches here — the loop
+    // only exits below `stepMs - epsilon` unless `maxSteps` stopped it.
+    if (this._accumulatorMs >= this._stepMs) {
       this._accumulatorMs %= this._stepMs;
     }
 

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -88,9 +88,19 @@ export class Scene<Data = void, AppLike extends ApplicationLike = Application> {
    * {@link Scene.onActivate}.
    */
   public readonly onSuspend = new Signal();
-  /** Dispatched after this scene's {@link Scene.paused} flag is set. Same event as {@link SceneDirector.onPause}, exposed directly on the scene for convenience. */
+  /**
+   * Dispatched after this scene's {@link Scene.paused} flag is set. Same
+   * event as {@link SceneDirector.onPause}, exposed directly on the scene for
+   * convenience, and the same exception-isolation contract as
+   * {@link Scene.onActivate}.
+   */
   public readonly onPause = new Signal();
-  /** Dispatched after this scene's {@link Scene.paused} flag is cleared. Same event as {@link SceneDirector.onResume}, exposed directly on the scene for convenience. */
+  /**
+   * Dispatched after this scene's {@link Scene.paused} flag is cleared. Same
+   * event as {@link SceneDirector.onResume}, exposed directly on the scene
+   * for convenience, and the same exception-isolation contract as
+   * {@link Scene.onActivate}.
+   */
   public readonly onResume = new Signal();
 
   private _scope: SceneScope<Data> | null = null;

--- a/src/core/SceneDirector.ts
+++ b/src/core/SceneDirector.ts
@@ -195,9 +195,17 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
   public readonly onUpdateScene = new Signal<[Scene]>();
   /** Fires just before a scene is unloaded (`unload` then `destroy`). */
   public readonly onStopScene = new Signal<[Scene]>();
-  /** Fires after `pause()` actually sets the active scene's `paused` flag. */
+  /**
+   * Fires after `pause()` actually sets the active scene's `paused` flag.
+   * Pure observation: a throwing listener is reported through
+   * {@link Application.onError} and never propagates back out of `pause()`,
+   * which has already applied the pause policy by then.
+   */
   public readonly onPause = new Signal<[Scene]>();
-  /** Fires after `resume()` actually clears the active scene's `paused` flag. */
+  /**
+   * Fires after `resume()` actually clears the active scene's `paused` flag.
+   * Same error contract as {@link SceneDirector.onPause}.
+   */
   public readonly onResume = new Signal<[Scene]>();
   /**
    * Fires whenever a scene's {@link SceneState} changes, as
@@ -878,7 +886,7 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
     const changed = scope.pause();
 
     if (changed) {
-      this.onPause.dispatch(scope.scene as Scene);
+      this.onPause.dispatchIsolated(error => this._reportLifecycleError(error), scope.scene as Scene);
     }
 
     return changed;
@@ -898,7 +906,7 @@ export class SceneDirector<Registry extends SceneRegistryShape<Registry> = {}> {
     const changed = scope.resume();
 
     if (changed) {
-      this.onResume.dispatch(scope.scene as Scene);
+      this.onResume.dispatchIsolated(error => this._reportLifecycleError(error), scope.scene as Scene);
     }
 
     return changed;

--- a/src/core/SceneScope.ts
+++ b/src/core/SceneScope.ts
@@ -144,8 +144,10 @@ export class SceneScope<Data = unknown> {
   /**
    * Pause this scope: freezes `fixedUpdate`/`update` while `Active`, applies
    * the `when` pause policy to tweens/audio (see {@link SceneTweens.pause}/
-   * {@link SceneAudio.pause}), and dispatches {@link Scene.onPause}. Returns
-   * whether the flag actually changed.
+   * {@link SceneAudio.pause}), and dispatches {@link Scene.onPause}. Every
+   * stage is individually guarded and a throwing listener is reported through
+   * the application error pipeline rather than thrown, so the pause policy is
+   * never left half-applied. Returns whether the flag actually changed.
    */
   public pause(): boolean {
     if (this._state !== SceneState.Active || this._paused) {
@@ -158,10 +160,9 @@ export class SceneScope<Data = unknown> {
 
     this._guard(errors, () => this.tweens.pause());
     this._guard(errors, () => this.audio.pause());
+    this._guard(errors, () => this.scene.onPause.dispatchIsolated(error => this._reportError(error)));
 
     this._reportErrors(errors);
-
-    this.scene.onPause.dispatch();
 
     return true;
   }
@@ -169,8 +170,9 @@ export class SceneScope<Data = unknown> {
   /**
    * Resume this scope: undoes {@link SceneScope.pause} — including the
    * tweens/audio `when` policy (see {@link SceneTweens.resume}/
-   * {@link SceneAudio.resume}) — and dispatches {@link Scene.onResume}.
-   * Returns whether the flag actually changed.
+   * {@link SceneAudio.resume}) — and dispatches {@link Scene.onResume}. Same
+   * error-guarding contract as {@link SceneScope.pause}. Returns whether the
+   * flag actually changed.
    */
   public resume(): boolean {
     if (this._state !== SceneState.Active || !this._paused) {
@@ -183,10 +185,9 @@ export class SceneScope<Data = unknown> {
 
     this._guard(errors, () => this.tweens.resume());
     this._guard(errors, () => this.audio.resume());
+    this._guard(errors, () => this.scene.onResume.dispatchIsolated(error => this._reportError(error)));
 
     this._reportErrors(errors);
-
-    this.scene.onResume.dispatch();
 
     return true;
   }

--- a/src/core/logging.ts
+++ b/src/core/logging.ts
@@ -11,9 +11,15 @@ export enum LogSeverity {
  * - `source` renders as `[ExoJS][source]` in the default console sink (omit
  *   it for a bare `[ExoJS]` prefix).
  * - `once` deduplicates by key: the second and later calls sharing the same
- *   key are dropped before severity filtering or sink dispatch, so pass a
- *   stable per-callsite key (e.g. `` `bitmaptext:${fontId}:${codepoint}` ``)
- *   to avoid per-frame spam.
+ *   key are dropped before sink dispatch, so pass a stable per-callsite key
+ *   (e.g. `` `bitmaptext:${fontId}:${codepoint}` ``) to avoid per-frame spam.
+ *   A key is claimed only by a call that survives severity filtering, so the
+ *   `Debug`/`Info`/`Warning` calls a production build strips cost nothing and
+ *   never shadow a later `error()` that reuses the key. The set of claimed
+ *   keys is retained for the lifetime of the {@link Logger} and never
+ *   evicted — that permanence is the guarantee `once` exists to provide, so
+ *   keep keys drawn from a bounded, per-callsite vocabulary rather than from
+ *   unbounded runtime data.
  */
 export interface LogOptions {
   source?: string;
@@ -45,16 +51,21 @@ export class Logger {
   private readonly _seenOnce = new Set<string>();
 
   private _log(severity: LogSeverity, message: string, options?: LogOptions): void {
+    // Severity filtering comes first so a call that production drops never
+    // touches the dedup set: keys are recorded only for entries that are
+    // actually dispatched, which keeps `_seenOnce` from growing without bound
+    // in shipped builds and stops a stripped low-severity call from consuming
+    // the key a later `error()` needs.
+    if (!__DEV__ && severity < LogSeverity.Error) {
+      return;
+    }
+
     if (options?.once !== undefined) {
       if (this._seenOnce.has(options.once)) {
         return;
       }
 
       this._seenOnce.add(options.once);
-    }
-
-    if (!__DEV__ && severity < LogSeverity.Error) {
-      return;
     }
 
     const entry: LogEntry = {

--- a/src/debug/DebugOverlay.ts
+++ b/src/debug/DebugOverlay.ts
@@ -8,9 +8,10 @@ import type { DebugLayer } from './DebugLayer';
 import { HitTestLayer } from './HitTestLayer';
 import { PerformanceLayer } from './PerformanceLayer';
 import { PointerStackLayer } from './PointerStackLayer';
+import { RenderPassInspectorLayer } from './RenderPassInspectorLayer';
 
 /**
- * Typed map of the four built-in diagnostic layers managed by
+ * Typed map of the built-in diagnostic layers managed by
  * {@link DebugOverlay}. Access individual layers to toggle visibility or
  * interact with layer-specific state.
  */
@@ -19,6 +20,7 @@ export interface DebugLayers {
   readonly boundingBoxes: BoundingBoxesLayer;
   readonly hitTest: HitTestLayer;
   readonly pointerStack: PointerStackLayer;
+  readonly renderPassInspector: RenderPassInspectorLayer;
 }
 
 /**
@@ -37,8 +39,11 @@ export interface DebugLayers {
  *   F2 — toggle BoundingBoxes layer
  *   F3 — toggle HitTest layer
  *   F4 — toggle PointerStack layer
+ *   F6 — toggle RenderPassInspector layer
  *
  * NOTE: F-keys only fire while the canvas has focus (engine convention).
+ * F5 is deliberately left unbound: browsers reload the page on it, which
+ * would tear down the very session being inspected.
  *
  * The master `visible` switch suppresses all layer rendering when false
  * without changing individual layer visibility flags.
@@ -47,7 +52,7 @@ export class DebugOverlay {
   /** Master visibility switch. When false, no layers render regardless of their individual flags. */
   public visible = true;
 
-  /** The four built-in diagnostic layers. Toggle each layer's `visible` flag or use the F1–F4 keybindings. */
+  /** The built-in diagnostic layers. Toggle each layer's `visible` flag or use the F1–F4/F6 keybindings. */
   public readonly layers: DebugLayers;
 
   private readonly _app: Application;
@@ -65,6 +70,7 @@ export class DebugOverlay {
       boundingBoxes: new BoundingBoxesLayer(app),
       hitTest: new HitTestLayer(app),
       pointerStack: new PointerStackLayer(app),
+      renderPassInspector: new RenderPassInspectorLayer(app),
     };
 
     this._onFrameHandler = this._onFrame.bind(this);
@@ -147,6 +153,10 @@ export class DebugOverlay {
         break;
       case Keyboard.F4:
         this.layers.pointerStack.visible = !this.layers.pointerStack.visible;
+        break;
+      // F5 is skipped on purpose — see the keybinding note on the class.
+      case Keyboard.F6:
+        this.layers.renderPassInspector.visible = !this.layers.renderPassInspector.visible;
         break;
     }
   }

--- a/test/core/fixed-timestep.test.ts
+++ b/test/core/fixed-timestep.test.ts
@@ -49,6 +49,24 @@ describe('FixedTimestep', () => {
     expect(fixed.advance(STEP * 0.1)).toBeLessThanOrEqual(1); // no replay of the dropped backlog
   });
 
+  it('keeps alpha below 1 when capping leaves an exact whole-step remainder', () => {
+    // A step size that is exactly representable in binary floating point, and a
+    // delta that is an exact multiple of it, so the capped accumulator lands on
+    // precisely one whole step rather than a rounding-error away from it.
+    const fixed = new FixedTimestep(10, 2);
+
+    expect(fixed.advance(30)).toBe(2); // capped: 3 steps of backlog, 2 allowed
+    expect(fixed.alpha).toBeGreaterThanOrEqual(0);
+    expect(fixed.alpha).toBeLessThan(1);
+  });
+
+  it('keeps alpha below 1 when maxSteps is exhausted by an exact multi-step backlog', () => {
+    const fixed = new FixedTimestep(10, 1);
+
+    expect(fixed.advance(40)).toBe(1);
+    expect(fixed.alpha).toBeLessThan(1);
+  });
+
   it('reset() clears the accumulator', () => {
     const fixed = new FixedTimestep(STEP, 5);
 

--- a/test/core/logging-production-filter.test.ts
+++ b/test/core/logging-production-filter.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Production behaviour of `Logger`'s `once` dedup set.
+ *
+ * Vitest always compiles `__DEV__` to `true`, so the production severity
+ * filter (`!__DEV__ && severity < Error`) is dead code in the normal unit
+ * lane and cannot be exercised there. This suite instead runs `logging.ts`
+ * through the REAL production pipeline `rollup.config.ts` uses
+ * (`@rollup/plugin-replace` with `__DEV__ → false`, then `terser` with the
+ * repo's `pure_funcs`) and executes the minified output, the same recipe
+ * `scene-scope-sync-hooks.test.ts` uses for its guard.
+ *
+ * The contract under test: a call that the production filter drops must not
+ * consume its `once` key. Otherwise the dedup set grows without bound for
+ * dynamic keys in shipped builds — paying memory forever for entries that are
+ * never emitted — and a dropped low-severity call silently swallows a later
+ * `error()` that shares the key.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { runInNewContext } from 'node:vm';
+
+import replace from '@rollup/plugin-replace';
+import terser from '@rollup/plugin-terser';
+import { type Plugin, rollup } from 'rollup';
+import ts from 'typescript';
+
+import { createBuildDefines, resolveVersion } from '../../packages/exojs-config/build-defines/index.js';
+
+const rootDir = resolve(import.meta.dirname!, '..', '..');
+
+const readSource = (rel: string): string => readFileSync(resolve(rootDir, rel), 'utf8');
+
+/** Extracts the `pure_funcs` list from `rollup.config.ts` — never hard-coded here. */
+const extractPureFuncs = (): string[] => {
+  const config = readSource('rollup.config.ts');
+  const match = /pure_funcs:\s*\[([^\]]*)\]/.exec(config);
+
+  expect(match).not.toBeNull();
+
+  return [...match![1]!.matchAll(/'([^']+)'/g)].map(m => m[1]!);
+};
+
+/**
+ * Bundles `src/core/logging.ts` through the exact production transform chain
+ * and returns the minified IIFE. The module imports nothing, so this bundles
+ * one small file and stays fast.
+ */
+const buildProductionLogging = async (pureFuncs: string[]): Promise<string> => {
+  const virtualId = '\0virtual-logging.js';
+  const code = ts.transpileModule(readSource('src/core/logging.ts'), {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+
+  const virtualPlugin: Plugin = {
+    name: 'virtual-logging',
+    resolveId: id => (id === virtualId ? id : null),
+    load: id => (id === virtualId ? code : null),
+  };
+
+  const defines = createBuildDefines({ mode: 'production', version: resolveVersion(rootDir), revision: 'test' });
+
+  const bundle = await rollup({
+    input: virtualId,
+    plugins: [virtualPlugin, replace({ preventAssignment: true, values: defines }), terser({ compress: { pure_funcs: pureFuncs } })],
+    onwarn: () => {
+      // Silence rollup's treeshaking noise for this tiny synthetic entry.
+    },
+  });
+
+  try {
+    const { output } = await bundle.generate({ format: 'iife', name: 'logging' });
+
+    return output[0]!.code;
+  } finally {
+    await bundle.close();
+  }
+};
+
+interface ProductionLogEntry {
+  severity: number;
+  message: string;
+}
+
+interface ProductionLogger {
+  debug(message: string, options?: { once?: string }): void;
+  info(message: string, options?: { once?: string }): void;
+  warn(message: string, options?: { once?: string }): void;
+  error(message: string, options?: { once?: string }): void;
+  addSink(sink: (entry: ProductionLogEntry) => void): () => void;
+  _seenOnce: Set<string>;
+}
+
+interface ProductionLoggingModule {
+  Logger: new () => ProductionLogger;
+  LogSeverity: { Debug: number; Info: number; Warning: number; Error: number };
+}
+
+const loadProductionLogging = async (): Promise<ProductionLoggingModule> => {
+  const output = await buildProductionLogging(extractPureFuncs());
+  const sandbox: { logging?: ProductionLoggingModule; console: Console } = { console };
+
+  runInNewContext(output, sandbox);
+
+  expect(typeof sandbox.logging?.Logger).toBe('function');
+
+  return sandbox.logging!;
+};
+
+describe('Logger `once` dedup under the real production pipeline', () => {
+  let logging: ProductionLoggingModule;
+
+  beforeAll(async () => {
+    logging = await loadProductionLogging();
+  });
+
+  test('the production severity filter is genuinely active in the bundled output', () => {
+    // Guards the harness: if `__DEV__` were not replaced with `false`, every
+    // assertion below would pass for the wrong reason.
+    const instance = new logging.Logger();
+    const received: ProductionLogEntry[] = [];
+    instance.addSink(entry => received.push(entry));
+
+    instance.debug('dropped');
+    instance.info('dropped');
+    instance.warn('dropped');
+    instance.error('kept');
+
+    expect(received.map(entry => entry.message)).toEqual(['kept']);
+  });
+
+  test('a filtered-out call does not grow the `once` dedup set', () => {
+    const instance = new logging.Logger();
+
+    for (let i = 0; i < 100; i++) {
+      instance.warn(`per-frame diagnostic ${i}`, { once: `dynamic-key:${i}` });
+    }
+
+    expect(instance._seenOnce.size).toBe(0);
+  });
+
+  test('an emitted call still consumes its `once` key', () => {
+    const instance = new logging.Logger();
+    const received: ProductionLogEntry[] = [];
+    instance.addSink(entry => received.push(entry));
+
+    instance.error('first', { once: 'error-key' });
+    instance.error('duplicate', { once: 'error-key' });
+
+    expect(received.map(entry => entry.message)).toEqual(['first']);
+    expect(instance._seenOnce.size).toBe(1);
+  });
+
+  test('a filtered-out call does not swallow a later error sharing the key', () => {
+    const instance = new logging.Logger();
+    const received: ProductionLogEntry[] = [];
+    instance.addSink(entry => received.push(entry));
+
+    instance.warn('stripped in production', { once: 'shared-key' });
+    instance.error('must still reach the sink', { once: 'shared-key' });
+
+    expect(received.map(entry => entry.message)).toEqual(['must still reach the sink']);
+  });
+});

--- a/test/core/scene-director.test.ts
+++ b/test/core/scene-director.test.ts
@@ -614,6 +614,43 @@ describe('SceneDirector', () => {
     expect(update).toHaveBeenCalledTimes(1);
   });
 
+  test('a throwing onPause listener is reported through the app error pipeline and does not propagate out of pause()', async () => {
+    const app = createApplicationStub();
+    const TestScene = makeSceneClass();
+    const director = new SceneDirector(app, { test: TestScene });
+    const errorSpy = vi.fn();
+
+    await director.change(TestScene);
+
+    app.onError.add(errorSpy);
+    director.onPause.add(() => {
+      throw new Error('onPause listener failed');
+    });
+
+    expect(director.pause()).toBe(true);
+    expect(director.paused).toBe(true);
+    expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({ message: 'onPause listener failed' }));
+  });
+
+  test('a throwing onResume listener is reported through the app error pipeline and does not propagate out of resume()', async () => {
+    const app = createApplicationStub();
+    const TestScene = makeSceneClass();
+    const director = new SceneDirector(app, { test: TestScene });
+    const errorSpy = vi.fn();
+
+    await director.change(TestScene);
+    director.pause();
+
+    app.onError.add(errorSpy);
+    director.onResume.add(() => {
+      throw new Error('onResume listener failed');
+    });
+
+    expect(director.resume()).toBe(true);
+    expect(director.paused).toBe(false);
+    expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({ message: 'onResume listener failed' }));
+  });
+
   test('resume() is a no-op when the active scene is not paused', async () => {
     const app = createApplicationStub();
     const TestScene = makeSceneClass();

--- a/test/core/scene-scope.test.ts
+++ b/test/core/scene-scope.test.ts
@@ -681,6 +681,42 @@ describe('SceneScope', () => {
       expect(onResume).toHaveBeenCalledTimes(1);
     });
 
+    test('a throwing Scene.onPause listener is reported through the app error pipeline and does not propagate', async () => {
+      const app = createAppStub();
+      const scene = new Scene();
+      const scope = await activate(app, scene);
+      const errorSpy = vi.fn();
+
+      app.onError.add(errorSpy);
+      scene.onPause.add(() => {
+        throw new Error('onPause listener failed');
+      });
+
+      expect(() => scope.pause()).not.toThrow();
+
+      expect(scope.paused).toBe(true);
+      expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({ message: 'onPause listener failed' }));
+    });
+
+    test('a throwing Scene.onResume listener is reported through the app error pipeline and does not propagate', async () => {
+      const app = createAppStub();
+      const scene = new Scene();
+      const scope = await activate(app, scene);
+      const errorSpy = vi.fn();
+
+      scope.pause();
+
+      app.onError.add(errorSpy);
+      scene.onResume.add(() => {
+        throw new Error('onResume listener failed');
+      });
+
+      expect(() => scope.resume()).not.toThrow();
+
+      expect(scope.paused).toBe(false);
+      expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({ message: 'onResume listener failed' }));
+    });
+
     test('resume() is a no-op when not currently paused', async () => {
       const app = createAppStub();
       const scene = new Scene();

--- a/test/debug/debug-overlay.test.ts
+++ b/test/debug/debug-overlay.test.ts
@@ -8,6 +8,7 @@
 import { Signal } from '#core/Signal';
 import { DebugOverlay } from '#debug/DebugOverlay';
 import * as debugExports from '#debug/index';
+import { RenderPassInspectorLayer } from '#debug/RenderPassInspectorLayer';
 import * as rootExports from '#index';
 import { Keyboard } from '#input/types';
 import type { GlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
@@ -322,6 +323,70 @@ describe('DebugOverlay — F2/F3/F4 keybindings', () => {
     expect(debug.layers.pointerStack.visible).toBe(false);
 
     debug.destroy();
+  });
+});
+
+describe('DebugOverlay — render-pass inspector layer', () => {
+  test('layers.renderPassInspector is a managed RenderPassInspectorLayer', () => {
+    const app = makeApp();
+    const debug = new DebugOverlay(app);
+
+    expect(debug.layers.renderPassInspector).toBeInstanceOf(RenderPassInspectorLayer);
+    expect(debug.layers.renderPassInspector.visible).toBe(false);
+    expect(debug.layers.renderPassInspector.viewMode).toBe('screen');
+
+    debug.destroy();
+  });
+
+  test('F6 toggles the renderPassInspector layer', () => {
+    const app = makeApp();
+    const debug = new DebugOverlay(app);
+
+    app.input.onKeyDown.dispatch(Keyboard.F6);
+    expect(debug.layers.renderPassInspector.visible).toBe(true);
+
+    app.input.onKeyDown.dispatch(Keyboard.F6);
+    expect(debug.layers.renderPassInspector.visible).toBe(false);
+
+    debug.destroy();
+  });
+
+  test('F5 is deliberately unbound — it reloads the page in every browser', () => {
+    const app = makeApp();
+    const debug = new DebugOverlay(app);
+
+    app.input.onKeyDown.dispatch(Keyboard.F5);
+
+    for (const layer of Object.values(debug.layers)) {
+      expect(layer.visible).toBe(false);
+    }
+
+    debug.destroy();
+  });
+
+  test('the visible inspector renders through the screen-space view swap', () => {
+    const app = makeApp();
+    const debug = new DebugOverlay(app);
+
+    debug.layers.renderPassInspector.visible = true;
+
+    const fakeTime = { milliseconds: 16, seconds: 0.016 } as import('#core/Time').Time;
+
+    app.onFrame.dispatch(fakeTime);
+
+    expect(app.backend.setView).toHaveBeenCalledTimes(2);
+
+    debug.destroy();
+  });
+
+  test('destroy() tears the inspector down along with the other layers', () => {
+    const app = makeApp();
+    const debug = new DebugOverlay(app);
+    const spy = vi.spyOn(debug.layers.renderPassInspector, 'destroy');
+
+    debug.destroy();
+
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
Four LOW/NITPICK points from the architecture review, Core/Diagnostics slice.

## LOW-N22 — `FixedTimestep.alpha` could reach exactly 1.0

Documented as `[0,1)`, but the spiral guard after the step loop compared with `>` instead of `>=`, so a capped backlog landing exactly on a whole step survived untouched. One character.

Worth noting why nobody caught it: the existing tests use `STEP = 1000/60`, where floating-point rounding hides the case by accident. It only shows up with round numbers (`step=10, maxSteps=2, advance(30)`). The uncapped hot path is provably unaffected — the loop only exits below `stepMs - epsilon` unless `maxSteps` stopped it, and all existing tests stay green unchanged.

## LOW-N21 — the logger's `once` set grew for filtered-out production logs

The dedup set was read *and written* before the severity filter, so in production it grew without bound for dynamic keys even though nothing was emitted.

The finding understated the impact: a `warn` dropped in production still claimed its `once` key, which then swallowed a later `error()` with the same key entirely. The severity check now runs first, so only a delivered entry claims a key.

Testing this needed care — vitest compiles `__DEV__` to `true`, so the production path is dead code in the unit lane. The new test bundles `logging.ts` through the real production pipeline (`@rollup/plugin-replace` plus terser with the `pure_funcs` read from `rollup.config.ts`) and runs the minified result in a VM, following the pattern already established by `scene-scope-sync-hooks.test.ts`, with a harness guard proving the filter is actually active in the bundle.

The dedup cache is deliberately left unbounded: evicting entries would re-admit the per-frame spam `once` exists to prevent, turning "exactly once" into "occasionally again". With the filter in the right place, the remaining growth is bounded by the vocabulary of call sites that actually deliver. Documented on `LogOptions.once`, including the advice not to build keys from unbounded runtime data.

## LOW-N18 — pause/resume signals did not isolate exceptions

Present in two places, not one: `SceneScope.pause()/resume()` and `SceneDirector.pause()/resume()` were the last lifecycle signals dispatching bare. Both now use `dispatchIsolated` with the adjacent error reporter, and in `SceneScope` the dispatch sits inside the guard list before `_reportErrors`, exactly as `activate()`/`suspend()` do — so a listener failure is reported together with a facility failure rather than after it.

## LOW-N11 — `RenderPassInspectorLayer` was not managed by `DebugOverlay`

The largest debug layer was exported but absent from `DebugLayers`, had no key binding, and the JSDoc claimed there were "four built-in layers". Now constructed, registered, torn down with the others, and bound to **F6**.

Deliberately not F5: `DebugOverlay` listens on `app.input.onKeyDown` and `InputManager.handleKeyDown` never calls `preventDefault()`, so F5 would reload the page *and* toggle the panel — destroying the very session being inspected. A test pins that F5 stays unbound.

## Behaviour changes

- `DebugOverlay.layers` gains a fifth entry, and importing `DebugOverlay` now always pulls in `RenderPassInspectorLayer` (and with it `RenderPipeline`/`Graphics`/`Text`). Affects the `@codexo/exojs/debug` entry point only.
- In production, a filtered-out `warn`/`info`/`debug` no longer swallows a later `error()` sharing its `once` key.
- `pause()`/`resume()` no longer rethrow a listener error to the caller; it goes to `Application.onError`, and the return value now arrives at all in that case.
- `alpha` is never exactly 1.0 after a capped frame; unchanged in the normal path.

## Verification

`pnpm test:core` 6322 green, `verify:quick` exit 0, API docs and guide regenerated and committed.

## Found while working, not fixed here

- The debugging guide claims `Debug`/`Info`/`Warning` are "compiled out entirely" in production. They are not: `pure_funcs` lists only `assert`/`assertDefined`, so the calls remain, template strings and `data` objects are still built, and `_log` discards them at runtime. Either the wording or the `pure_funcs` list should change — that is a decision, not a typo.
- The F-key bindings collide with browser defaults generally (F1 help, F3 find bar), since `handleKeyDown` never calls `preventDefault()`.
- `size-limit` covers only `dist/exo.esm.js` and `dist/exo.iife.min.js`; the `debug` entry point has no budget, so the tree-shaking change above would never surface there.