### PR TITLE
docs: correct JSDoc tags that misreport the public API surface

### DIFF
--- a/site/src/content/api/abstract-text.json
+++ b/site/src/content/api/abstract-text.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 89,
+  "memberCount": 87,
   "counts": {
     "constructors": 1,
-    "methods": 39,
+    "methods": 37,
     "properties": 35,
     "events": 14
   },
@@ -85,64 +85,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/audio-manager.json
+++ b/site/src/content/api/audio-manager.json
@@ -542,7 +542,7 @@
             }
           ],
           "returnType": "Voice",
-          "description": "Play a Playable asset and return a Voice handle. Each call creates an independent playback instance. Call play() again to start another concurrent voice. The returned Voice lets you control this specific instance (stop(), volume, fade(), capabilities)."
+          "description": "Play a Playable asset and return a Voice handle. Each call creates an independent playback instance. Call play() again to start another concurrent voice. The returned Voice lets you control this specific instance (stop(), volume, fade(), capabilities). When source is a Sound, options widens to SoundPlayOptions and additionally accepts replace: true, which stops all currently-playing instances of that sound before the new one starts (singleton-replace mode)."
         },
         {
           "name": "play",
@@ -614,7 +614,7 @@
             }
           ],
           "returnType": "Voice",
-          "description": "Play a Playable asset and return a Voice handle. Each call creates an independent playback instance. Call play() again to start another concurrent voice. The returned Voice lets you control this specific instance (stop(), volume, fade(), capabilities)."
+          "description": "Play a Playable asset and return a Voice handle. Each call creates an independent playback instance. Call play() again to start another concurrent voice. The returned Voice lets you control this specific instance (stop(), volume, fade(), capabilities). When source is a Sound, options widens to SoundPlayOptions and additionally accepts replace: true, which stops all currently-playing instances of that sound before the new one starts (singleton-replace mode)."
         },
         {
           "name": "preUpdate",

--- a/site/src/content/api/bitmap-text.json
+++ b/site/src/content/api/bitmap-text.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 97,
+  "memberCount": 95,
   "counts": {
     "constructors": 1,
-    "methods": 40,
+    "methods": 38,
     "properties": 42,
     "events": 14
   },
@@ -130,64 +130,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/button.json
+++ b/site/src/content/api/button.json
@@ -6,10 +6,10 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 111,
+  "memberCount": 109,
   "counts": {
     "constructors": 1,
-    "methods": 50,
+    "methods": 48,
     "properties": 45,
     "events": 15
   },
@@ -151,64 +151,6 @@
           ],
           "returnType": "void",
           "description": ""
-        },
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
         },
         {
           "name": "_onEnabledChanged",

--- a/site/src/content/api/container.json
+++ b/site/src/content/api/container.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 97,
+  "memberCount": 95,
   "counts": {
     "constructors": 1,
-    "methods": 45,
+    "methods": 43,
     "properties": 37,
     "events": 14
   },
@@ -69,64 +69,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/drawable.json
+++ b/site/src/content/api/drawable.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 85,
+  "memberCount": 83,
   "counts": {
     "constructors": 1,
-    "methods": 37,
+    "methods": 35,
     "properties": 33,
     "events": 14
   },
@@ -67,64 +67,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/graphics.json
+++ b/site/src/content/api/graphics.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 118,
+  "memberCount": 116,
   "counts": {
     "constructors": 1,
-    "methods": 60,
+    "methods": 58,
     "properties": 43,
     "events": 14
   },
@@ -70,64 +70,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/htmltext.json
+++ b/site/src/content/api/htmltext.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 104,
+  "memberCount": 102,
   "counts": {
     "constructors": 1,
-    "methods": 48,
+    "methods": 46,
     "properties": 41,
     "events": 14
   },
@@ -109,64 +109,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/image-layer-node.json
+++ b/site/src/content/api/image-layer-node.json
@@ -6,10 +6,10 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "advanced",
-  "memberCount": 99,
+  "memberCount": 97,
   "counts": {
     "constructors": 1,
-    "methods": 45,
+    "methods": 43,
     "properties": 39,
     "events": 14
   },
@@ -88,64 +88,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/label.json
+++ b/site/src/content/api/label.json
@@ -6,10 +6,10 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 107,
+  "memberCount": 105,
   "counts": {
     "constructors": 1,
-    "methods": 50,
+    "methods": 48,
     "properties": 42,
     "events": 14
   },
@@ -172,64 +172,6 @@
           ],
           "returnType": "void",
           "description": ""
-        },
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
         },
         {
           "name": "_onEnabledChanged",

--- a/site/src/content/api/mesh.json
+++ b/site/src/content/api/mesh.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 95,
+  "memberCount": 93,
   "counts": {
     "constructors": 1,
-    "methods": 38,
+    "methods": 36,
     "properties": 42,
     "events": 14
   },
@@ -88,64 +88,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/nine-slice-sprite.json
+++ b/site/src/content/api/nine-slice-sprite.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 96,
+  "memberCount": 94,
   "counts": {
     "constructors": 1,
-    "methods": 41,
+    "methods": 39,
     "properties": 40,
     "events": 14
   },
@@ -113,64 +113,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/panel.json
+++ b/site/src/content/api/panel.json
@@ -6,10 +6,10 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 110,
+  "memberCount": 108,
   "counts": {
     "constructors": 1,
-    "methods": 50,
+    "methods": 48,
     "properties": 45,
     "events": 14
   },
@@ -151,64 +151,6 @@
           ],
           "returnType": "void",
           "description": ""
-        },
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
         },
         {
           "name": "_onEnabledChanged",

--- a/site/src/content/api/particle-system.json
+++ b/site/src/content/api/particle-system.json
@@ -6,10 +6,10 @@
   "subsystem": "particles",
   "importPath": "@codexo/exojs-particles",
   "tier": "stable",
-  "memberCount": 128,
+  "memberCount": 126,
   "counts": {
     "constructors": 4,
-    "methods": 49,
+    "methods": 47,
     "properties": 61,
     "events": 14
   },
@@ -343,64 +343,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/playable.json
+++ b/site/src/content/api/playable.json
@@ -1,0 +1,120 @@
+{
+  "title": "Playable",
+  "description": "Implemented by audio assets (Sound, AudioStream, AudioGenerator) to support manager-driven playback via AudioManager.play. Assets are **data descriptors** — they hold the audio data and default playback parameters. The playback machinery lives in the Voice returned by `_createVoice`; the manager is injected at play time, so assets never reach for a global. `_createVoice` is a low-level hook meant for asset implementations; consumers should call `audioManager.play(asset)` instead of invoking it directly.",
+  "symbol": "Playable",
+  "kind": "interface",
+  "subsystem": "audio",
+  "importPath": "@codexo/exojs",
+  "tier": "advanced",
+  "memberCount": 1,
+  "counts": {
+    "constructors": 0,
+    "methods": 1,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Implemented by audio assets (Sound, AudioStream, AudioGenerator) to support manager-driven playback via AudioManager.play.",
+        "Assets are **data descriptors** — they hold the audio data and default playback parameters. The playback machinery lives in the Voice returned by `_createVoice`; the manager is injected at play time, so assets never reach for a global.",
+        "`_createVoice` is a low-level hook meant for asset implementations; consumers should call `audioManager.play(asset)` instead of invoking it directly."
+      ],
+      "importLine": "import { Playable } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "methods",
+      "title": "Methods",
+      "members": [
+        {
+          "name": "_createVoice",
+          "signature": "_createVoice(manager: AudioManager, options: PlayOptions): Voice",
+          "signatureTokens": [
+            {
+              "text": "_createVoice",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "manager",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AudioManager",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "options",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PlayOptions",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Voice",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "manager",
+              "type": "AudioManager",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "PlayOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "Voice",
+          "description": "Create and start a new playback instance. Called by AudioManager.play; do not call directly."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/audio/Playable.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/audio/Playable.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/audio/Playable.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/audio/Playable.ts"
+}

--- a/site/src/content/api/playback-options.json
+++ b/site/src/content/api/playback-options.json
@@ -47,7 +47,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "When true the audio or video loops. Defaults to false."
         },
         {
           "name": "muted",
@@ -68,7 +68,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "When true the audio or video is muted. Defaults to false."
         },
         {
           "name": "playbackRate",
@@ -89,7 +89,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Playback speed multiplier, clamped to 0.1..20. 1 is normal speed. Defaults to 1."
         },
         {
           "name": "time",
@@ -110,7 +110,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Seek position in seconds from the start. Defaults to 0."
         },
         {
           "name": "volume",
@@ -131,7 +131,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Volume level in 0..1. Defaults to 1."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/progress-bar.json
+++ b/site/src/content/api/progress-bar.json
@@ -6,10 +6,10 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 109,
+  "memberCount": 107,
   "counts": {
     "constructors": 1,
-    "methods": 50,
+    "methods": 48,
     "properties": 44,
     "events": 14
   },
@@ -151,64 +151,6 @@
           ],
           "returnType": "void",
           "description": ""
-        },
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
         },
         {
           "name": "_onEnabledChanged",

--- a/site/src/content/api/render-node.json
+++ b/site/src/content/api/render-node.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 80,
+  "memberCount": 78,
   "counts": {
     "constructors": 1,
-    "methods": 35,
+    "methods": 33,
     "properties": 30,
     "events": 14
   },
@@ -68,64 +68,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/render-to-options.json
+++ b/site/src/content/api/render-to-options.json
@@ -1,6 +1,6 @@
 {
   "title": "RenderToOptions",
-  "description": "Caller-owned, per-frame off-screen render target. Unlike RenderingContext.capture, the RenderTexture is supplied by the caller and reused across frames (no per-call allocation).",
+  "description": "Options for DrawContext.renderTo: a caller-owned, per-frame off-screen RenderTexture target, reused across frames (no per-call allocation). Unlike RenderingContext.capture, the texture is supplied by the caller.",
   "symbol": "RenderToOptions",
   "kind": "interface",
   "subsystem": "rendering",
@@ -19,7 +19,7 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Caller-owned, per-frame off-screen render target. Unlike RenderingContext.capture, the RenderTexture is supplied by the caller and reused across frames (no per-call allocation)."
+        "Options for DrawContext.renderTo: a caller-owned, per-frame off-screen RenderTexture target, reused across frames (no per-call allocation). Unlike RenderingContext.capture, the texture is supplied by the caller."
       ],
       "importLine": "import { RenderToOptions } from '@codexo/exojs'",
       "sourceLink": null

--- a/site/src/content/api/repeating-sprite.json
+++ b/site/src/content/api/repeating-sprite.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 98,
+  "memberCount": 96,
   "counts": {
     "constructors": 1,
-    "methods": 39,
+    "methods": 37,
     "properties": 44,
     "events": 14
   },
@@ -121,64 +121,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "advanced",
-  "memberCount": 99,
+  "memberCount": 97,
   "counts": {
     "constructors": 1,
-    "methods": 47,
+    "methods": 45,
     "properties": 37,
     "events": 14
   },
@@ -115,64 +115,6 @@
           ],
           "returnType": "void",
           "description": "The descendant transform-move seam: a descendant's own transform moved. Queue its row on the fragment; _collectContent patches the queued rows in place on a content/structure-clean frame instead of re-collecting. The group's OWN move does not route here — _markOwnTransformDirty above handles it as a one-matrix group move. Gated on a live committed recording: only the recorded-instruction tier ever consumes a queued row. On every tier without one — entry replay, and a recording-less group (e.g. an escaped-branch group, whose _fragment.dispose() drops any recording) — transforms are re-read live and _reconcileTransformRows would just drain the queue unread on the next collect. Skipping the enqueue there is free: nothing else observes the queue between now and that drain. (A recording backend lacking patch support DOES still enqueue here — hasRecording is true — and _reconcileTransformRows is the one that drops the recording and falls back to entry replay.)"
-        },
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
         },
         {
           "name": "_markOwnTransformDirty",

--- a/site/src/content/api/scene-node.json
+++ b/site/src/content/api/scene-node.json
@@ -6,10 +6,10 @@
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 46,
+  "memberCount": 44,
   "counts": {
     "constructors": 1,
-    "methods": 26,
+    "methods": 24,
     "properties": 19,
     "events": 0
   },
@@ -70,64 +70,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -6,10 +6,10 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 111,
+  "memberCount": 109,
   "counts": {
     "constructors": 1,
-    "methods": 52,
+    "methods": 50,
     "properties": 44,
     "events": 14
   },
@@ -153,64 +153,6 @@
           ],
           "returnType": "void",
           "description": ""
-        },
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
         },
         {
           "name": "_onEnabledChanged",

--- a/site/src/content/api/stack.json
+++ b/site/src/content/api/stack.json
@@ -6,10 +6,10 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 110,
+  "memberCount": 108,
   "counts": {
     "constructors": 1,
-    "methods": 52,
+    "methods": 50,
     "properties": 43,
     "events": 14
   },
@@ -151,64 +151,6 @@
           ],
           "returnType": "void",
           "description": ""
-        },
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
         },
         {
           "name": "_onEnabledChanged",

--- a/site/src/content/api/text.json
+++ b/site/src/content/api/text.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 96,
+  "memberCount": 94,
   "counts": {
     "constructors": 1,
-    "methods": 39,
+    "methods": 37,
     "properties": 42,
     "events": 14
   },
@@ -111,64 +111,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/tile-layer-node.json
+++ b/site/src/content/api/tile-layer-node.json
@@ -6,10 +6,10 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "advanced",
-  "memberCount": 100,
+  "memberCount": 98,
   "counts": {
     "constructors": 1,
-    "methods": 46,
+    "methods": 44,
     "properties": 39,
     "events": 14
   },
@@ -113,64 +113,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/tile-map-band.json
+++ b/site/src/content/api/tile-map-band.json
@@ -6,10 +6,10 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "advanced",
-  "memberCount": 99,
+  "memberCount": 97,
   "counts": {
     "constructors": 0,
-    "methods": 46,
+    "methods": 44,
     "properties": 39,
     "events": 14
   },
@@ -34,64 +34,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/tile-map-node.json
+++ b/site/src/content/api/tile-map-node.json
@@ -6,10 +6,10 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "advanced",
-  "memberCount": 102,
+  "memberCount": 100,
   "counts": {
     "constructors": 1,
-    "methods": 47,
+    "methods": 45,
     "properties": 40,
     "events": 14
   },
@@ -112,64 +112,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/uiroot.json
+++ b/site/src/content/api/uiroot.json
@@ -6,10 +6,10 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 100,
+  "memberCount": 98,
   "counts": {
     "constructors": 1,
-    "methods": 45,
+    "methods": 43,
     "properties": 39,
     "events": 15
   },
@@ -68,64 +68,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
-        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",

--- a/site/src/content/api/widget.json
+++ b/site/src/content/api/widget.json
@@ -6,10 +6,10 @@
   "subsystem": "ui",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 105,
+  "memberCount": 103,
   "counts": {
     "constructors": 1,
-    "methods": 50,
+    "methods": 48,
     "properties": 40,
     "events": 14
   },
@@ -134,64 +134,6 @@
           ],
           "returnType": "void",
           "description": ""
-        },
-        {
-          "name": "_invalidateBoundsCascade",
-          "signature": "_invalidateBoundsCascade(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateBoundsCascade",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own Bounds dirty AND propagate up to Container ancestors' Bounds."
-        },
-        {
-          "name": "_invalidateSubtreeTransform",
-          "signature": "_invalidateSubtreeTransform(): void",
-          "signatureTokens": [
-            {
-              "text": "_invalidateSubtreeTransform",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "void",
-          "description": "Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk."
         },
         {
           "name": "_onEnabledChanged",

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -115,6 +115,11 @@ export class AudioManager {
    * to start another concurrent voice. The returned Voice lets you control
    * this specific instance (`stop()`, `volume`, `fade()`, capabilities).
    *
+   * When `source` is a {@link Sound}, `options` widens to
+   * {@link SoundPlayOptions} and additionally accepts `replace: true`, which
+   * stops all currently-playing instances of that sound before the new one
+   * starts (singleton-replace mode).
+   *
    * @example
    * ```ts
    * const voice = app.audio.play(shootSfx);
@@ -125,7 +130,8 @@ export class AudioManager {
    * Throws once the manager has been destroyed — see {@link AudioManager.destroy}.
    *
    * @param source - Any {@link Playable} asset (Sound, AudioStream, AudioGenerator).
-   * @param options - Per-play overrides (bus, volume, loop, playbackRate, detune, time, muted).
+   * @param options - Per-play overrides (bus, volume, loop, playbackRate, detune,
+   * time, muted, plus `position` and the spatial attenuation fields).
    * @returns A {@link Voice} handle for the new instance.
    */
   public play(source: Sound, options?: SoundPlayOptions): Voice;

--- a/src/audio/Playable.ts
+++ b/src/audio/Playable.ts
@@ -206,8 +206,10 @@ export interface PlayOptions {
  * returned by `_createVoice`; the manager is injected at play time, so assets
  * never reach for a global.
  *
- * @internal - `_createVoice` is a low-level hook; consumers should call
- * `audioManager.play(asset)` instead of calling `_createVoice` directly.
+ * `_createVoice` is a low-level hook meant for asset implementations;
+ * consumers should call `audioManager.play(asset)` instead of invoking it
+ * directly.
+ * @advanced
  */
 export interface Playable {
   /**

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -960,12 +960,20 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
     }
   }
 
-  /** Mark own GlobalTransform + Bounds dirty. Descendants detect staleness lazily via the parent-version compare in getGlobalTransform()/getBounds() — no eager subtree walk. */
+  /**
+   * Mark own GlobalTransform + Bounds dirty. Descendants detect staleness
+   * lazily via the parent-version compare in getGlobalTransform()/getBounds()
+   * — no eager subtree walk.
+   * @internal
+   */
   public _invalidateSubtreeTransform(): void {
     this.flags.addMask(SceneNodeTransformFlags.GlobalTransform | SceneNodeTransformFlags.BoundsRect);
   }
 
-  /** Mark own Bounds dirty AND propagate up to Container ancestors' Bounds. */
+  /**
+   * Mark own Bounds dirty AND propagate up to Container ancestors' Bounds.
+   * @internal
+   */
   public _invalidateBoundsCascade(): void {
     // A bounds change means this node's rendered extent changed, which makes any
     // retained draw slot captured for it (screen-space AABB + material key) stale.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -62,10 +62,15 @@ export type TextureSource = HTMLImageElement | HTMLCanvasElement | HTMLVideoElem
 
 /** Common playback configuration for {@link Sound} and {@link AudioStream}. */
 export interface PlaybackOptions {
+  /** Volume level in `0..1`. Defaults to `1`. */
   volume: number;
+  /** Playback speed multiplier, clamped to `0.1..20`. `1` is normal speed. Defaults to `1`. */
   playbackRate: number;
+  /** When `true` the audio or video loops. Defaults to `false`. */
   loop: boolean;
+  /** When `true` the audio or video is muted. Defaults to `false`. */
   muted: boolean;
+  /** Seek position in seconds from the start. Defaults to `0`. */
   time: number;
 }
 

--- a/src/rendering/DrawContext.ts
+++ b/src/rendering/DrawContext.ts
@@ -10,9 +10,10 @@ import type { RenderNode } from './RenderNode';
 import type { View } from './View';
 
 /**
- * Caller-owned, per-frame off-screen render target. Unlike
- * {@link RenderingContext.capture}, the {@link RenderTexture} is supplied by the
- * caller and reused across frames (no per-call allocation).
+ * Options for {@link DrawContext.renderTo}: a caller-owned, per-frame
+ * off-screen {@link RenderTexture} target, reused across frames (no per-call
+ * allocation). Unlike {@link RenderingContext.capture}, the texture is
+ * supplied by the caller.
  */
 export interface RenderToOptions {
   /** Destination texture, owned and kept stable by the caller. */

--- a/src/rendering/View.ts
+++ b/src/rendering/View.ts
@@ -357,6 +357,7 @@ export class View implements ObservableVectorOwner {
    *
    * @param intensity  - Maximum pixel displacement at peak amplitude.
    * @param durationMs - How long the shake lasts in milliseconds.
+   * @param options    - Shake behaviour overrides ({@link ViewShakeOptions}).
    */
   public shake(intensity: number, durationMs: number, options: ViewShakeOptions = {}): this {
     this._shakeIntensity = Math.max(0, intensity);

--- a/src/rendering/filters/WebGl2ShaderFilter.ts
+++ b/src/rendering/filters/WebGl2ShaderFilter.ts
@@ -374,7 +374,7 @@ export class WebGl2ShaderFilter extends Filter {
 
   /**
    * Marshal a non-texture uniform value to a TypedArray suitable for
-   * {@link ShaderUniform#setValue}.
+   * {@link ShaderUniform.setValue}.
    */
   private _marshalValue(value: Exclude<ShaderFilterUniformValue, Texture>): Float32Array | Int32Array {
     if (value instanceof Float32Array || value instanceof Int32Array) {


### PR DESCRIPTION
The generated API reference is driven by TypeDoc with `excludeInternal: true` and a custom modifier-tag set (`site/scripts/build-api.ts:538,784`), so a wrong tag silently changes what ships as public documentation. This corrects the tags whose effect was verifiable in the generated output.

- **`Playable` was dropped from the reference entirely.** It is exported from `src/audio/index.ts` and linked from `AudioManager.play`, but carried `@internal` — so `site/src/content/api/` had no `playable.json` at all and the link dangled. Now `@advanced`, with the "do not call `_createVoice` directly" note kept as prose.
- **Two `SceneNode` friend methods were listed as public API on every subclass page.** `_invalidateSubtreeTransform` and `_invalidateBoundsCascade` lacked the `@internal` tag the class comment already claims for all `_invalidate*` methods. All nine `public _*` methods carry it now; the regeneration removes them from 20+ class pages.
- **`AudioManager.play` documented a `spatial` option that does not exist** and used `@overload` as a prose tag, which the tag set does not define. Replaced with the actual field names and a plain paragraph describing the `SoundPlayOptions` widening.
- `RenderToOptions` described the usage pattern instead of the type it is.
- `View.shake` was missing `@param options`; `PlaybackOptions` had no field documentation at all — units, ranges and defaults verified against `Sound.ts:218-221` and `AudioStream.ts:45-48`, including the real `0.1..20` clamp on `playbackRate`.
- `{@link X#y}` normalized to the repo-wide `{@link X.y}` form. TypeDoc resolves instance members through the dot form, and the two hash-form links were the only ones in `src/`.

`site/src/content/api/` regenerated; `docs:api:check` reports in sync.

Deliberately not changed: `@stable` (a registered modifier tag, not a stray one), the `RenderPass.enabled` "field" wording, the `CallbackRenderPass` bridging sentence, the `Loader` section banner, and `ShaderProgram` (itself `@internal`, so its JSDoc never reaches the docs).