### PR TITLE
fix(ui,audio,animation): Batch G — ScrollContainer hit test, Tooltip lifetime, effect and tween teardown

### DIFF
--- a/site/src/content/api/audio-bus.json
+++ b/site/src/content/api/audio-bus.json
@@ -227,7 +227,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Append a effect to the end of the chain (before the pan stage). The chain is rebuilt in place; existing audio routes through the new effect on the next frame. Attaching does not transfer ownership: the caller keeps it and must destroy() the effect once it is no longer used anywhere. Neither AudioBus.removeEffect nor AudioBus.destroy destroys it."
+          "description": "Append a effect to the end of the chain (before the pan stage). The chain is rebuilt in place; existing audio routes through the new effect on the next frame. Attaching does not transfer ownership: the caller keeps it and must destroy() the effect once it is no longer used anywhere. Neither AudioBus.removeEffect nor AudioBus.destroy destroys it. A no-op once the bus has been AudioBus.destroyed — without this guard the effect would silently accumulate in the (otherwise unused) internal list forever."
         },
         {
           "name": "destroy",

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -813,7 +813,7 @@
             }
           ],
           "returnType": "boolean",
-          "description": "Hit-test the world-space point (x, y) against this node. For world-axis-aligned nodes (own and inherited rotation a multiple of 90° and no skew) the AABB equals the oriented box, so the cheap getBounds test is exact. For rotated or skewed nodes the point is mapped back into local space with the inverse of the global transform and tested against the untransformed getLocalBounds — i.e. a true oriented-box test. This is the exact inverse of the forward map that getBounds and the renderer use to place the node's corners, so picking matches the rendered quad instead of over-reporting hits in the empty AABB corners of a rotated node."
+          "description": "A point only hits this widget when it both falls within the viewport AND lands on a visible child (Container.contains's child-union check) — a scrolled-out child's own geometry no longer makes the ScrollContainer itself claim a point far outside what is actually rendered."
         },
         {
           "name": "destroy",
@@ -2490,7 +2490,7 @@
           ],
           "params": [],
           "returnType": "this",
-          "description": ""
+          "description": "Bounds this widget to its declared viewport — (0, 0, uiWidth, uiHeight) in world space — instead of Container.updateBounds's default union of content's (scrolled, often far larger) child extent. This is what ScrollContainer.clip clips descendants to (a null clipShape clips to getBounds()) and what mouse-wheel routing gates on, so both now agree with what is actually visible instead of the full, unclipped content extent."
         },
         {
           "name": "updateParentTransform",

--- a/site/src/content/api/tooltip.json
+++ b/site/src/content/api/tooltip.json
@@ -1,6 +1,6 @@
 {
   "title": "Tooltip",
-  "description": "Hover tooltip attached to a RenderNode. Shows a small text label near the pointer after a short delay when the pointer enters `target`, and hides it immediately on pointer-out. The tooltip node is parented to the nearest UIRoot ancestor of `target`, so it always renders in screen space above other content. The target must have `interactive = true` for the hover signals to fire.",
+  "description": "Hover tooltip attached to a RenderNode. Shows a small text label near the pointer after a short delay when the pointer enters `target`, and hides it immediately on pointer-out. The tooltip node is parented to the nearest UIRoot ancestor of `target`, so it always renders in screen space above other content. The target must have `interactive = true` for the hover signals to fire. The show delay is driven by the target's app's Application.onFrame rather than a wall-clock timer, so it freezes while `app.scenes.pause()` is active instead of finishing in the background — and only starts counting once the target is attached to a live app.",
   "symbol": "Tooltip",
   "kind": "class",
   "subsystem": "ui",
@@ -21,7 +21,7 @@
       "paragraphs": [
         "Hover tooltip attached to a RenderNode. Shows a small text label near the pointer after a short delay when the pointer enters `target`, and hides it immediately on pointer-out.",
         "The tooltip node is parented to the nearest UIRoot ancestor of `target`, so it always renders in screen space above other content.",
-        "The target must have `interactive = true` for the hover signals to fire."
+        "The target must have `interactive = true` for the hover signals to fire. The show delay is driven by the target's app's Application.onFrame rather than a wall-clock timer, so it freezes while `app.scenes.pause()` is active instead of finishing in the background — and only starts counting once the target is attached to a live app."
       ],
       "importLine": "import { Tooltip } from '@codexo/exojs'",
       "sourceLink": null

--- a/site/src/content/api/tween-manager.json
+++ b/site/src/content/api/tween-manager.json
@@ -189,7 +189,7 @@
           ],
           "params": [],
           "returnType": "this",
-          "description": "Remove all tweens and tickers immediately. No callbacks fire. The tweens' states are left as-is; they are simply evicted from the list."
+          "description": "Remove all tweens and tickers immediately. No callbacks fire. Each tracked tween is Tween.stopped first, so tween.state reflects the eviction instead of staying Active/Paused on a tween the manager no longer drives — a Stopped tween's own manager binding survives, so a later Tween.start re-enters it as usual."
         },
         {
           "name": "create",

--- a/src/animation/TweenManager.ts
+++ b/src/animation/TweenManager.ts
@@ -193,9 +193,19 @@ export class TweenManager {
 
   /**
    * Remove all tweens and tickers immediately. No callbacks fire.
-   * The tweens' states are left as-is; they are simply evicted from the list.
+   * Each tracked tween is {@link Tween.stop}ped first, so `tween.state`
+   * reflects the eviction instead of staying `Active`/`Paused` on a tween the
+   * manager no longer drives — a `Stopped` tween's own manager binding
+   * survives, so a later {@link Tween.start} re-enters it as usual.
    */
   public clear(): this {
+    // Snapshot first: `stop()` calls back into `remove()`, which splices the
+    // live `_tweens` array — iterating that array directly while it shrinks
+    // under us would skip entries.
+    for (const tween of [...this._tweens]) {
+      tween.stop();
+    }
+
     this._tweens = [];
     this._tickers = [];
 

--- a/src/audio/AudioBus.ts
+++ b/src/audio/AudioBus.ts
@@ -48,6 +48,7 @@ export class AudioBus {
   private _pan: number;
   private readonly _effects: AudioEffect[] = [];
   private _setup: AudioBusSetup | null = null;
+  private _destroyed = false;
   private _scheduledStopId: ReturnType<typeof setTimeout> | null = null;
   /**
    * Callbacks queued via {@link AudioBus.onceSetup} while the context is still
@@ -134,8 +135,13 @@ export class AudioBus {
    * Attaching does not transfer ownership: the caller keeps it and must
    * `destroy()` the effect once it is no longer used anywhere. Neither
    * {@link AudioBus.removeEffect} nor {@link AudioBus.destroy} destroys it.
+   *
+   * A no-op once the bus has been {@link AudioBus.destroy}ed — without this
+   * guard the effect would silently accumulate in the (otherwise unused)
+   * internal list forever.
    */
   public addEffect(effect: AudioEffect): this {
+    if (this._destroyed) return this;
     this._effects.push(effect);
     this._rebuildEffectChain();
     return this;
@@ -220,6 +226,7 @@ export class AudioBus {
    * longer needed anywhere.
    */
   public destroy(): void {
+    this._destroyed = true;
     onAudioContextReady.remove(this._onAudioContextReady);
     this._parentSetupDispose?.();
     this._parentSetupDispose = null;

--- a/src/audio/AudioBus.ts
+++ b/src/audio/AudioBus.ts
@@ -2,6 +2,7 @@ import { clamp } from '#math/utils';
 
 import { getAudioContext, isAudioContextReady, onAudioContextReady } from './audio-context';
 import type { AudioEffect } from './AudioEffect';
+import { isEffectReady } from './AudioEffect';
 
 /** Construction options for {@link AudioBus}. */
 export interface AudioBusOptions {
@@ -17,22 +18,6 @@ interface AudioBusSetup {
   readonly inputNode: GainNode; // bus input — sounds connect here
   readonly outputNode: GainNode; // bus output — connects to parent's input or destination
   readonly panNode: StereoPannerNode;
-}
-
-/**
- * Probe whether `effect` has finished creating its underlying node(s). Every
- * built-in `AudioEffect` throws a descriptive error from `inputNode`/`outputNode`
- * when accessed before its own (possibly deferred) setup has run — this reads
- * that as a plain boolean instead of letting `_rebuildEffectChain` throw.
- */
-function _isEffectReady(effect: AudioEffect): boolean {
-  try {
-    void effect.inputNode;
-    void effect.outputNode;
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 /**
@@ -172,7 +157,7 @@ export class AudioBus {
       // wiring is deliberately left intact so the caller can reuse the effect
       // (same contract as `BaseVoice.removeEffect`). Skipped for an effect
       // whose own nodes have not been created yet — it was never wired in.
-      if (_isEffectReady(effect)) {
+      if (isEffectReady(effect)) {
         effect.outputNode.disconnect();
       }
       this._rebuildEffectChain();
@@ -249,7 +234,7 @@ export class AudioBus {
     // edge, leave the effect's own internal wiring intact, skip an effect whose
     // nodes were never created.
     for (const effect of this._effects) {
-      if (_isEffectReady(effect)) {
+      if (isEffectReady(effect)) {
         effect.outputNode.disconnect();
       }
     }
@@ -362,7 +347,7 @@ export class AudioBus {
     // already run. An effect still not ready after the retry is a genuine
     // caller error (e.g. a custom effect that never wires itself up) and is
     // left to throw naturally instead of retrying forever.
-    if (!retried && this._effects.some(effect => !_isEffectReady(effect))) {
+    if (!retried && this._effects.some(effect => !isEffectReady(effect))) {
       queueMicrotask(() => this._rebuildEffectChain(true));
       return;
     }

--- a/src/audio/AudioEffect.ts
+++ b/src/audio/AudioEffect.ts
@@ -17,3 +17,21 @@ export abstract class AudioEffect {
   /** Disconnects all audio nodes and releases resources. Must be called when the effect is no longer needed. */
   public abstract destroy(): void;
 }
+
+/**
+ * Probe whether `effect` has finished creating its underlying node(s). Every
+ * built-in {@link AudioEffect} throws a descriptive error from `inputNode`/
+ * `outputNode` when accessed before its own (possibly deferred) setup has
+ * run — this reads that as a plain boolean instead of letting a caller that
+ * disconnects/reconnects effects (`AudioBus`, `BaseVoice`) throw on one still
+ * mid-setup.
+ */
+export function isEffectReady(effect: AudioEffect): boolean {
+  try {
+    void effect.inputNode;
+    void effect.outputNode;
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/audio/BaseVoice.ts
+++ b/src/audio/BaseVoice.ts
@@ -5,6 +5,7 @@ import { Vector } from '#math/Vector';
 
 import type { AudioBus } from './AudioBus';
 import type { AudioEffect } from './AudioEffect';
+import { isEffectReady } from './AudioEffect';
 import type { AudioManager } from './AudioManager';
 import type { DistanceModel, Spatializable, Voice } from './Playable';
 import {
@@ -182,8 +183,12 @@ export abstract class BaseVoice implements Voice, SpatialVoice {
       this._effects.splice(index, 1);
       // Detach the removed effect's output from the graph (its internal input
       // wiring is left intact so the caller can reuse it). The rebuild below
-      // only touches the effects still in the chain.
-      effect.outputNode.disconnect();
+      // only touches the effects still in the chain. Skipped for an effect
+      // whose own nodes have not been created yet — same probe `AudioBus`
+      // uses, since `outputNode` throws on an effect still mid-setup.
+      if (isEffectReady(effect)) {
+        effect.outputNode.disconnect();
+      }
       this._rebuildEffectChain();
     }
     return this;
@@ -709,8 +714,13 @@ export abstract class BaseVoice implements Voice, SpatialVoice {
     this._output.disconnect();
 
     // Detach per-voice effects from the chain (the caller still owns them).
+    // Skipped for an effect whose own nodes have not been created yet — same
+    // probe `AudioBus.destroy` uses, since `outputNode` throws on an effect
+    // still mid-setup.
     for (const effect of this._effects) {
-      effect.outputNode.disconnect();
+      if (isEffectReady(effect)) {
+        effect.outputNode.disconnect();
+      }
     }
     this._effects.length = 0;
 

--- a/src/ui/ScrollContainer.ts
+++ b/src/ui/ScrollContainer.ts
@@ -1,4 +1,5 @@
 import type { Stage } from '#core/Stage';
+import { Rectangle } from '#math/Rectangle';
 import type { Vector } from '#math/Vector';
 import { Container } from '#rendering/Container';
 
@@ -45,6 +46,8 @@ export class ScrollContainer extends Widget {
   private readonly _direction: ScrollDirection;
   private _scrollX = 0;
   private _scrollY = 0;
+  /** Scratch rect reused by {@link ScrollContainer.updateBounds} — avoids an allocation on every bounds rebuild. */
+  private readonly _viewportRect = new Rectangle();
 
   private readonly _onWheel = (delta: Vector): void => {
     const pos = this._stage?.app?.input.getPrimaryPointerPosition();
@@ -116,6 +119,37 @@ export class ScrollContainer extends Widget {
   protected override _relayout(): void {
     // Re-clamp scroll in case the widget was resized.
     this.scrollTo(this._scrollX, this._scrollY);
+    // uiWidth/uiHeight just changed — the viewport rect `updateBounds` builds
+    // from them is now stale.
+    this._invalidateBoundsCascade();
+  }
+
+  /**
+   * Bounds this widget to its declared viewport — `(0, 0, uiWidth, uiHeight)`
+   * in world space — instead of {@link Container.updateBounds}'s default
+   * union of `content`'s (scrolled, often far larger) child extent.
+   *
+   * This is what {@link ScrollContainer.clip} clips descendants to (a `null`
+   * `clipShape` clips to `getBounds()`) and what mouse-wheel routing gates
+   * on, so both now agree with what is actually visible instead of the full,
+   * unclipped content extent.
+   */
+  public override updateBounds(): this {
+    this._viewportRect.set(0, 0, this._uiWidth, this._uiHeight);
+    this._bounds.reset().addRect(this._viewportRect, this.getGlobalTransform());
+
+    return this;
+  }
+
+  /**
+   * A point only hits this widget when it both falls within the viewport
+   * AND lands on a visible child ({@link Container.contains}'s child-union
+   * check) — a scrolled-out child's own geometry no longer makes the
+   * `ScrollContainer` itself claim a point far outside what is actually
+   * rendered.
+   */
+  public override contains(x: number, y: number): boolean {
+    return this.getBounds().contains(x, y) && super.contains(x, y);
   }
 
   /** @internal — subscribe to the app's wheel signal when entering the scene tree. */
@@ -133,6 +167,7 @@ export class ScrollContainer extends Widget {
 
   public override destroy(): void {
     this._stage?.app?.input.onMouseWheel.remove(this._onWheel);
+    this._viewportRect.destroy();
     super.destroy();
   }
 }

--- a/src/ui/Tooltip.ts
+++ b/src/ui/Tooltip.ts
@@ -1,4 +1,6 @@
+import type { Application } from '#core/Application';
 import { Color } from '#core/Color';
+import type { Time } from '#core/Time';
 import type { InteractionEvent } from '#input/InteractionEvent';
 import { Container } from '#rendering/Container';
 import { Graphics } from '#rendering/primitives/Graphics';
@@ -36,6 +38,10 @@ export interface TooltipOptions {
  * `target`, so it always renders in screen space above other content.
  *
  * The target must have `interactive = true` for the hover signals to fire.
+ * The show delay is driven by the target's app's {@link Application.onFrame}
+ * rather than a wall-clock timer, so it freezes while `app.scenes.pause()`
+ * is active instead of finishing in the background — and only starts
+ * counting once the target is attached to a live app.
  *
  * @example
  * ```ts
@@ -49,7 +55,7 @@ export class Tooltip {
   private readonly _target: RenderNode;
   private readonly _offsetX: number;
   private readonly _offsetY: number;
-  private readonly _delayMs: number;
+  private readonly _delaySeconds: number;
   private readonly _background: number;
   private readonly _textColor: number;
   private readonly _padding: number;
@@ -57,16 +63,42 @@ export class Tooltip {
   private readonly _text: string;
 
   private _node: Container | null = null;
-  private _timer: ReturnType<typeof setTimeout> | null = null;
+  /** The app whose {@link Application.onFrame} is currently driving the pending show delay, or `null` while idle. */
+  private _scheduledApp: Application | null = null;
+  private _elapsedSeconds = 0;
+  private _pendingX = 0;
+  private _pendingY = 0;
+
+  /**
+   * Advances the pending show delay by real elapsed time, but only while the
+   * target's current scene is not paused — so `app.scenes.pause()` freezes a
+   * tooltip about to appear exactly like it freezes everything else, instead
+   * of the delay quietly finishing in the background.
+   */
+  private readonly _onFrame = (time: Time): void => {
+    if (this._scheduledApp?.scenes.currentScene?.paused === true) {
+      return;
+    }
+
+    this._elapsedSeconds += time.seconds;
+
+    if (this._elapsedSeconds >= this._delaySeconds) {
+      const x = this._pendingX;
+      const y = this._pendingY;
+
+      this._cancelTimer();
+      this._show(x, y);
+    }
+  };
 
   private readonly _onPointerOver = (event: InteractionEvent): void => {
-    // `event.x`/`event.y` are in `target`'s own layer space (see
-    // InteractionEvent.x's doc) — this tooltip node is always parented to the
-    // UI layer (screen space), so positioning it directly from a WORLD-tree
-    // target's coordinates drifts once the camera pans, zooms, or rotates.
-    // Correct for a plain screen-fixed UI target; a follow-up is needed to
-    // route a world target's coordinates through `view.worldToScreen` first.
-    this._scheduleShow(event.x, event.y);
+    // `Pointer.x`/`Pointer.y` are raw design-pixel screen coordinates,
+    // independent of camera pan/zoom/rotate (see InteractionEvent.x's doc,
+    // which contrasts the two) — the same space this tooltip's node is
+    // positioned in, since it is always parented to the screen-space UI
+    // layer. `event.x`/`event.y` read in `target`'s own layer space instead,
+    // which for a world-tree target would drift under a moved camera.
+    this._scheduleShow(event.pointer.x, event.pointer.y);
   };
 
   private readonly _onPointerOut = (): void => {
@@ -78,7 +110,7 @@ export class Tooltip {
     this._text = options.text;
     this._offsetX = options.offsetX ?? 12;
     this._offsetY = options.offsetY ?? -28;
-    this._delayMs = (options.delay ?? 0.3) * 1000;
+    this._delaySeconds = options.delay ?? 0.3;
     this._background = options.background ?? 0x222222;
     this._textColor = options.textColor ?? 0xffffff;
     this._padding = options.padding ?? 6;
@@ -97,9 +129,20 @@ export class Tooltip {
 
   private _scheduleShow(x: number, y: number): void {
     this._cancelTimer();
-    this._timer = setTimeout(() => {
-      this._show(x, y);
-    }, this._delayMs);
+
+    // Not attached to a live app — nothing to drive the delay (and, per
+    // `_findUIRoot`, nothing that could show a tooltip either way).
+    const app = this._target._getStage()?.app;
+
+    if (app === undefined) {
+      return;
+    }
+
+    this._pendingX = x;
+    this._pendingY = y;
+    this._elapsedSeconds = 0;
+    this._scheduledApp = app;
+    app.onFrame.add(this._onFrame);
   }
 
   private _show(x: number, y: number): void {
@@ -147,12 +190,17 @@ export class Tooltip {
     this._removeNode();
   }
 
+  /**
+   * Destroys (not just detaches) the current tooltip node — `destroy()`
+   * unlinks it from its parent itself (see `SceneNode.destroy`'s doc) and
+   * recursively tears down its `Graphics`/`Text` children, so a hidden
+   * tooltip's GPU-backed resources and signal listeners don't leak. Safe to
+   * call when the node was already detached (or destroyed) externally.
+   */
   private _removeNode(): void {
     if (this._node !== null) {
-      const p = this._node.parent;
-
-      if (p !== null) {
-        p.removeChild(this._node);
+      if (!this._node.destroyed) {
+        this._node.destroy();
       }
 
       this._node = null;
@@ -160,9 +208,9 @@ export class Tooltip {
   }
 
   private _cancelTimer(): void {
-    if (this._timer !== null) {
-      clearTimeout(this._timer);
-      this._timer = null;
+    if (this._scheduledApp !== null) {
+      this._scheduledApp.onFrame.remove(this._onFrame);
+      this._scheduledApp = null;
     }
   }
 

--- a/test/animation/tween-manager.test.ts
+++ b/test/animation/tween-manager.test.ts
@@ -180,6 +180,50 @@ describe('TweenManager', () => {
     expect(onComplete).not.toHaveBeenCalled();
   });
 
+  // ---- clear()/destroy() must not leave an evicted tween's state lying about Active (NEU-E4) ----
+
+  test('clear() transitions every evicted tween to Stopped — state no longer claims Active', () => {
+    const manager = new TweenManager();
+    const active = manager.create(makeTarget()).to({ x: 100 }, 1.0).start();
+    const paused = manager.create(makeTarget()).to({ x: 100 }, 1.0).start().pause();
+
+    manager.clear();
+
+    expect(active.state).toBe(TweenState.Stopped);
+    expect(paused.state).toBe(TweenState.Stopped);
+  });
+
+  test('clear() leaves the manager binding intact — a later start() re-enters the tween', () => {
+    const manager = new TweenManager();
+    const target = makeTarget();
+    const tween = manager.create(target).to({ x: 100 }, 1.0).start();
+
+    manager.clear();
+    expect(trackedCount(manager)).toBe(0);
+
+    tween.start();
+    expect(tween.state).toBe(TweenState.Active);
+    expect(trackedCount(manager)).toBe(1);
+
+    manager.preUpdate(sec(0.5));
+    expect(target.x).toBeCloseTo(50, 5);
+  });
+
+  test('resume() on a tween orphaned by clear() stays inert — resume() alone does not re-track it', () => {
+    const manager = new TweenManager();
+    const target = makeTarget();
+    const tween = manager.create(target).to({ x: 100 }, 1.0).start().pause();
+
+    manager.clear();
+    tween.resume(); // Stopped — resume() only acts on Paused, so this is a no-op.
+
+    expect(tween.state).toBe(TweenState.Stopped);
+    expect(trackedCount(manager)).toBe(0);
+
+    manager.preUpdate(sec(1.0));
+    expect(target.x).toBe(0); // never advanced — genuinely not running
+  });
+
   test('destroy() makes subsequent update() calls no-ops', () => {
     const manager = new TweenManager();
     const target = makeTarget();
@@ -188,6 +232,15 @@ describe('TweenManager', () => {
     manager.destroy();
     manager.preUpdate(sec(1.0));
     expect(target.x).toBe(0); // never advanced
+  });
+
+  test('destroy() transitions every tracked tween to Stopped', () => {
+    const manager = new TweenManager();
+    const tween = manager.create(makeTarget()).to({ x: 100 }, 1.0).start();
+
+    manager.destroy();
+
+    expect(tween.state).toBe(TweenState.Stopped);
   });
 
   test('iteration snapshot: onComplete callback may add new tweens without crashing', () => {

--- a/test/audio/audio-bus.test.ts
+++ b/test/audio/audio-bus.test.ts
@@ -517,6 +517,33 @@ describe('AudioBus', () => {
     expect(() => bus.destroy()).not.toThrow();
   });
 
+  // ---- addEffect() after destroy() must not leak onto a dead bus (NEU-E2) ----
+
+  test('addEffect() after destroy() is a no-op — the effect list does not grow on a dead bus', () => {
+    const spy = spyOnBusCreation();
+    const bus = new AudioBus('add-effect-after-destroy');
+
+    bus.destroy();
+    bus.addEffect(new StubFilter());
+    bus.addEffect(new StubFilter());
+
+    expect((bus as unknown as { _effects: AudioEffect[] })._effects.length).toBe(0);
+
+    spy.restore();
+  });
+
+  test('addEffect() after destroy() returns the bus for chaining without throwing', () => {
+    const spy = spyOnBusCreation();
+    const bus = new AudioBus('add-effect-after-destroy-chain');
+
+    bus.destroy();
+
+    expect(() => bus.addEffect(new StubFilter())).not.toThrow();
+    expect(bus.addEffect(new StubFilter())).toBe(bus);
+
+    spy.restore();
+  });
+
   test('fadeIn schedules a ramp to 0 (not the raw volume) when the bus is muted', () => {
     const spy = spyOnBusCreation();
     const ctx = getAudioContext();

--- a/test/audio/voice-effects.test.ts
+++ b/test/audio/voice-effects.test.ts
@@ -14,6 +14,19 @@ const makeStubEffect = (): AudioEffect => {
   return { inputNode, outputNode, destroy: vi.fn(), ready: Promise.resolve() } as unknown as AudioEffect;
 };
 
+/** An effect whose own node setup has not finished yet — `inputNode`/`outputNode` throw, as every built-in effect does pre-setup. */
+const makeUnreadyEffect = (): AudioEffect =>
+  ({
+    get inputNode(): AudioNode {
+      throw new Error('not yet initialized');
+    },
+    get outputNode(): AudioNode {
+      throw new Error('not yet initialized');
+    },
+    ready: Promise.resolve(),
+    destroy: vi.fn(),
+  }) as unknown as AudioEffect;
+
 interface CapturedGain {
   connect: MockInstance;
   disconnect: MockInstance;
@@ -118,6 +131,42 @@ describe('Voice — per-voice effects', () => {
 
     sound.destroy();
     fx.destroy();
+  });
+
+  // ---- an effect still mid-setup must not make detaching throw (NEU-E3) ----
+  //
+  // `AudioBus.removeEffect`/`destroy` probe `outputNode` readiness before
+  // touching it (a built-in effect throws when accessed pre-setup); these
+  // exercise the same guard on `BaseVoice.removeEffect`/`_finish`. The effect
+  // is spliced straight into the internal list (rather than via `addEffect`,
+  // which would itself throw synchronously touching the same unready node)
+  // to isolate the detach-path guard under test.
+
+  test('removeEffect() tolerates an effect whose nodes are not ready yet', () => {
+    const manager = new AudioManager();
+    const sound = new Sound(makeBufferStub());
+    const voice = manager.play(sound);
+    const unready = makeUnreadyEffect();
+
+    (voice as unknown as { _effects: AudioEffect[] })._effects.push(unready);
+
+    expect(() => voice.removeEffect(unready)).not.toThrow();
+
+    sound.destroy();
+  });
+
+  test('stopping the voice tolerates an effect whose nodes are not ready yet', () => {
+    const manager = new AudioManager();
+    const sound = new Sound(makeBufferStub());
+    const voice = manager.play(sound);
+    const unready = makeUnreadyEffect();
+
+    (voice as unknown as { _effects: AudioEffect[] })._effects.push(unready);
+
+    expect(() => voice.stop()).not.toThrow();
+    expect(voice.ended).toBe(true);
+
+    sound.destroy();
   });
 
   test('stopping the voice detaches its effects', () => {

--- a/test/ui/scroll-container.test.ts
+++ b/test/ui/scroll-container.test.ts
@@ -46,9 +46,14 @@ const makeStage = (pointerPos: { x: number; y: number } | null | undefined = nul
   return { stage: { interaction, focus, app }, onMouseWheel };
 };
 
-/** Stub both the widget's own bounds and its content bounds for deterministic wheel-routing tests. */
-const stubBounds = (scroll: ScrollContainer, ownBounds: Rectangle, contentBounds: Rectangle): void => {
-  vi.spyOn(scroll, 'getBounds').mockReturnValue(ownBounds);
+/**
+ * Stub `content`'s bounds for deterministic wheel-routing tests. The widget's
+ * OWN bounds are deliberately left real (not stubbed) — they now derive from
+ * `uiWidth`/`uiHeight` (see ME-58), and a wheel-routing test that stubs them
+ * back to an arbitrary rect would mask exactly the viewport-vs-content bug
+ * these tests guard against.
+ */
+const stubContentBounds = (scroll: ScrollContainer, contentBounds: Rectangle): void => {
   vi.spyOn(scroll.content, 'getBounds').mockReturnValue(contentBounds);
 };
 
@@ -153,7 +158,7 @@ describe('ScrollContainer mouse-wheel routing', () => {
     const { stage, onMouseWheel } = makeStage(null);
     const scroll = new ScrollContainer({ width: 100, height: 100 });
 
-    stubBounds(scroll, new Rectangle(0, 0, 100, 100), new Rectangle(0, 0, 500, 500));
+    stubContentBounds(scroll, new Rectangle(0, 0, 500, 500));
     scroll._setStage(stage);
 
     onMouseWheel.dispatch(new Vector(0, 50));
@@ -165,7 +170,7 @@ describe('ScrollContainer mouse-wheel routing', () => {
     const { stage, onMouseWheel } = makeStage({ x: 500, y: 500 });
     const scroll = new ScrollContainer({ width: 100, height: 100 });
 
-    stubBounds(scroll, new Rectangle(0, 0, 100, 100), new Rectangle(0, 0, 500, 500));
+    stubContentBounds(scroll, new Rectangle(0, 0, 500, 500));
     scroll._setStage(stage);
 
     onMouseWheel.dispatch(new Vector(0, 50));
@@ -177,7 +182,7 @@ describe('ScrollContainer mouse-wheel routing', () => {
     const { stage, onMouseWheel } = makeStage({ x: 50, y: 50 });
     const scroll = new ScrollContainer({ width: 100, height: 100 });
 
-    stubBounds(scroll, new Rectangle(0, 0, 100, 100), new Rectangle(0, 0, 500, 500));
+    stubContentBounds(scroll, new Rectangle(0, 0, 500, 500));
     scroll._setStage(stage);
 
     onMouseWheel.dispatch(new Vector(30, 20));
@@ -190,7 +195,7 @@ describe('ScrollContainer mouse-wheel routing', () => {
     const { stage, onMouseWheel } = makeStage({ x: 50, y: 50 });
     const scroll = new ScrollContainer({ width: 100, height: 100, direction: 'horizontal' });
 
-    stubBounds(scroll, new Rectangle(0, 0, 100, 100), new Rectangle(0, 0, 500, 500));
+    stubContentBounds(scroll, new Rectangle(0, 0, 500, 500));
     scroll._setStage(stage);
 
     onMouseWheel.dispatch(new Vector(30, 20));
@@ -203,13 +208,75 @@ describe('ScrollContainer mouse-wheel routing', () => {
     const { stage, onMouseWheel } = makeStage({ x: 50, y: 50 });
     const scroll = new ScrollContainer({ width: 100, height: 100, direction: 'both' });
 
-    stubBounds(scroll, new Rectangle(0, 0, 100, 100), new Rectangle(0, 0, 500, 500));
+    stubContentBounds(scroll, new Rectangle(0, 0, 500, 500));
     scroll._setStage(stage);
 
     onMouseWheel.dispatch(new Vector(30, 20));
 
     expect(scroll.scrollX).toBe(30);
     expect(scroll.scrollY).toBe(20);
+  });
+});
+
+describe('ScrollContainer viewport bounds (ME-58)', () => {
+  test('getBounds() reflects the declared viewport, not the (possibly much larger) content extent', () => {
+    const scroll = new ScrollContainer({ width: 100, height: 100 });
+
+    stubContentBounds(scroll, new Rectangle(0, 0, 5000, 5000));
+
+    const bounds = scroll.getBounds();
+
+    expect(bounds.width).toBe(100);
+    expect(bounds.height).toBe(100);
+  });
+
+  test('getBounds() tracks setSize() — a resized viewport is reflected without a stale cache', () => {
+    const scroll = new ScrollContainer({ width: 100, height: 100 });
+
+    expect(scroll.getBounds().width).toBe(100);
+
+    scroll.setSize(250, 180);
+
+    expect(scroll.getBounds().width).toBe(250);
+    expect(scroll.getBounds().height).toBe(180);
+  });
+
+  test('a wheel event over content that scrolled past the viewport is ignored — content bounds no longer widen the hit area', () => {
+    const { stage, onMouseWheel } = makeStage({ x: 150, y: 150 });
+    const scroll = new ScrollContainer({ width: 100, height: 100 });
+
+    // The content is far bigger than the 100x100 viewport; before ME-58,
+    // wheel routing gated on this union instead of the viewport, so a point
+    // at (150, 150) — inside the content extent, outside the viewport —
+    // would have wrongly been accepted.
+    stubContentBounds(scroll, new Rectangle(0, 0, 5000, 5000));
+    scroll._setStage(stage);
+
+    onMouseWheel.dispatch(new Vector(0, 50));
+
+    expect(scroll.scrollY).toBe(0);
+  });
+
+  test('contains() rejects a point outside the viewport even when a scrolled child would otherwise claim it', () => {
+    const scroll = new ScrollContainer({ width: 100, height: 100 });
+    const child = new Container();
+
+    scroll.content.addChild(child);
+    // Simulate a child whose own geometry claims every point — isolates the
+    // viewport gate under test from needing real drawn geometry.
+    vi.spyOn(child, 'contains').mockReturnValue(true);
+
+    // Outside the 100x100 viewport — must be rejected regardless of the child.
+    expect(scroll.contains(500, 500)).toBe(false);
+    // Inside the viewport, with a child that claims the point — accepted.
+    expect(scroll.contains(50, 50)).toBe(true);
+  });
+
+  test('contains() still requires an actual child hit inside the viewport (delegation semantics unchanged)', () => {
+    const scroll = new ScrollContainer({ width: 100, height: 100 });
+
+    // No children at all — nothing to hit, even squarely inside the viewport.
+    expect(scroll.contains(50, 50)).toBe(false);
   });
 });
 

--- a/test/ui/tooltip.test.ts
+++ b/test/ui/tooltip.test.ts
@@ -1,8 +1,14 @@
 /**
- * Tooltip tests — delayed show/hide scheduling, UIRoot-ancestor lookup,
- * default vs. custom option decoding, and destroy() cleanup.
+ * Tooltip tests — delayed show/hide scheduling (driven by Application.onFrame,
+ * frozen while the scene is paused), UIRoot-ancestor lookup, screen-space
+ * pointer coordinates, node teardown on hide, default vs. custom option
+ * decoding, and destroy() cleanup.
  */
 
+import type { Application } from '#core/Application';
+import { Signal } from '#core/Signal';
+import type { Stage } from '#core/Stage';
+import { Time } from '#core/Time';
 import { InteractionEvent } from '#input/InteractionEvent';
 import type { Pointer } from '#input/Pointer';
 import { Container } from '#rendering/Container';
@@ -37,19 +43,67 @@ const fakePool = { getAtlas: vi.fn(() => fakeAtlas) };
 
 beforeEach(() => {
   resetDefaultGlyphAtlasPool(fakePool as unknown as GlyphAtlasPool);
-  vi.useFakeTimers();
 });
 afterEach(() => {
   resetDefaultGlyphAtlasPool();
-  vi.useRealTimers();
 });
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-const dispatchOver = (target: Container, x = 0, y = 0): void => {
-  target.onPointerOver.dispatch(new InteractionEvent('pointerover', target, {} as unknown as Pointer, x, y));
+/** A minimal fake app carrying a real onFrame Signal and a mutable scene.paused flag. */
+interface FakeApp {
+  app: Application;
+  onFrame: Signal<[Time]>;
+  scene: { paused: boolean };
+}
+
+const makeApp = (): FakeApp => {
+  const onFrame = new Signal<[Time]>();
+  const scene = { paused: false };
+  const app = {
+    onFrame,
+    scenes: { currentScene: scene },
+  } as unknown as Application;
+
+  return { app, onFrame, scene };
+};
+
+/** Attach `app` to `root` via a minimal Stage — cascades to every current and future descendant. */
+const attachStage = (root: UIRoot, app: Application): void => {
+  const interaction: Stage['interaction'] = {
+    _notifyNodeAdded: vi.fn(),
+    _notifyNodeRemoved: vi.fn(),
+    _notifyInteractiveChanged: vi.fn(),
+    _notifyBoundsInvalidated: vi.fn(),
+    _notifyTransformGroupMoved: vi.fn(),
+  };
+  const focus: Stage['focus'] = {
+    focused: null,
+    focus: vi.fn(),
+    blur: vi.fn(),
+    _notifyNodeRemoved: vi.fn(),
+  };
+
+  root._setStage({ interaction, focus, app });
+};
+
+/** Advance the fake app's frame clock by `seconds`. */
+const tick = (onFrame: Signal<[Time]>, seconds: number): void => {
+  onFrame.dispatch(new Time(seconds, Time.seconds));
+};
+
+/**
+ * Dispatch a pointerover. `(x, y)` is the InteractionEvent's own layer-space
+ * position; `(pointerX, pointerY)` — defaulting to the same values — is the
+ * separate screen-space `Pointer` position Tooltip now actually positions
+ * from. Pass them apart to simulate a world-tree target under a moved camera.
+ */
+const dispatchOver = (target: Container, x = 0, y = 0, pointerX = x, pointerY = y): void => {
+  const pointer = { x: pointerX, y: pointerY } as unknown as Pointer;
+
+  target.onPointerOver.dispatch(new InteractionEvent('pointerover', target, pointer, x, y));
 };
 
 const dispatchOut = (target: Container): void => {
@@ -82,7 +136,6 @@ describe('Tooltip._findUIRoot', () => {
     const tip = new Tooltip(target, { text: 'Hi', delay: 0.1 });
 
     dispatchOver(target, 10, 20);
-    vi.advanceTimersByTime(200);
 
     expect(target.parent).toBeNull();
 
@@ -97,15 +150,19 @@ describe('Tooltip._findUIRoot', () => {
     root.addChild(wrapper);
     wrapper.addChild(target);
 
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
     const tip = new Tooltip(target, { text: 'Hello', delay: 0.2, offsetX: 5, offsetY: -10 });
 
     expect(root.children.length).toBe(1); // only wrapper so far
 
     dispatchOver(target, 100, 200);
-    vi.advanceTimersByTime(199);
+    tick(onFrame, 0.199);
     expect(root.children.length).toBe(1); // not yet shown
 
-    vi.advanceTimersByTime(1);
+    tick(onFrame, 0.001);
     expect(root.children.length).toBe(2); // tooltip node appended
 
     const node = root.children[1] as Container;
@@ -124,12 +181,16 @@ describe('Tooltip show/hide scheduling', () => {
 
     root.addChild(target);
 
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
     const tip = new Tooltip(target, { text: 'Hello', delay: 0.3 });
 
     dispatchOver(target);
-    vi.advanceTimersByTime(100);
+    tick(onFrame, 0.1);
     dispatchOut(target);
-    vi.advanceTimersByTime(1000);
+    tick(onFrame, 1.0);
 
     expect(root.children.length).toBe(1); // only target — tooltip node never appeared
 
@@ -142,10 +203,14 @@ describe('Tooltip show/hide scheduling', () => {
 
     root.addChild(target);
 
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
     const tip = new Tooltip(target, { text: 'Hello', delay: 0.1 });
 
     dispatchOver(target);
-    vi.advanceTimersByTime(100);
+    tick(onFrame, 0.1);
     expect(root.children.length).toBe(2);
 
     dispatchOut(target);
@@ -154,18 +219,24 @@ describe('Tooltip show/hide scheduling', () => {
     tip.destroy();
   });
 
-  test('a second pointer-over before the delay elapses cancels the first scheduled timer', () => {
+  test('a second pointer-over before the delay elapses cancels the first scheduled subscription', () => {
     const root = new UIRoot();
     const target = new Container();
 
     root.addChild(target);
+
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
 
     const tip = new Tooltip(target, { text: 'Hello', delay: 0.2 });
 
     dispatchOver(target);
     dispatchOver(target);
 
-    expect(vi.getTimerCount()).toBe(1);
+    // _scheduleShow() cancels its own prior subscription before re-adding —
+    // two overs in a row must still leave exactly one onFrame listener, not two.
+    expect(onFrame.count).toBe(1);
 
     tip.destroy();
   });
@@ -176,18 +247,106 @@ describe('Tooltip show/hide scheduling', () => {
 
     root.addChild(target);
 
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
     const tip = new Tooltip(target, { text: 'Hello', delay: 0.05 });
 
     dispatchOver(target);
-    vi.advanceTimersByTime(50);
+    tick(onFrame, 0.05);
     expect(root.children.length).toBe(2);
 
     dispatchOut(target);
     expect(root.children.length).toBe(1);
 
     dispatchOver(target);
-    vi.advanceTimersByTime(50);
+    tick(onFrame, 0.05);
     expect(root.children.length).toBe(2);
+
+    tip.destroy();
+  });
+});
+
+describe('Tooltip pause-aware scheduling (ME-59: time base)', () => {
+  test('the show delay does not advance while the scene is paused', () => {
+    const root = new UIRoot();
+    const target = new Container();
+
+    root.addChild(target);
+
+    const { app, onFrame, scene } = makeApp();
+
+    attachStage(root, app);
+
+    const tip = new Tooltip(target, { text: 'Hello', delay: 0.2 });
+
+    dispatchOver(target);
+    tick(onFrame, 0.1); // half the delay elapsed
+
+    scene.paused = true;
+    tick(onFrame, 5.0); // would easily clear the delay if it were still counting
+
+    expect(root.children.length).toBe(1); // still not shown — frozen while paused
+
+    scene.paused = false;
+    tick(onFrame, 0.1); // the remaining half
+
+    expect(root.children.length).toBe(2); // resumes from where it left off
+
+    tip.destroy();
+  });
+
+  test('a delay that would elapse mid-pause instead fires right after resume, not during it', () => {
+    const root = new UIRoot();
+    const target = new Container();
+
+    root.addChild(target);
+
+    const { app, onFrame, scene } = makeApp();
+
+    attachStage(root, app);
+
+    const tip = new Tooltip(target, { text: 'Hello', delay: 0.1 });
+
+    dispatchOver(target);
+    scene.paused = true;
+    tick(onFrame, 1.0); // far past the delay, but paused throughout
+
+    expect(root.children.length).toBe(1);
+
+    scene.paused = false;
+    tick(onFrame, 0.1);
+
+    expect(root.children.length).toBe(2);
+
+    tip.destroy();
+  });
+});
+
+describe('Tooltip pointer coordinate basis (ME-59: coordinate base)', () => {
+  test('positions from the screen-space Pointer, not the target-layer-space InteractionEvent x/y', () => {
+    const root = new UIRoot();
+    const target = new Container();
+
+    root.addChild(target);
+
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
+    const tip = new Tooltip(target, { text: 'Hello', delay: 0.1, offsetX: 0, offsetY: 0 });
+
+    // Simulate a world-tree target under a panned camera: InteractionEvent's
+    // own x/y (target-layer space) reads far from the pointer's actual
+    // screen-space position.
+    dispatchOver(target, /* event x/y */ 900, 900, /* pointer x/y */ 40, 60);
+    tick(onFrame, 0.1);
+
+    const node = root.children[1] as Container;
+
+    expect(node.position.x).toBe(40);
+    expect(node.position.y).toBe(60);
 
     tip.destroy();
   });
@@ -200,10 +359,14 @@ describe('Tooltip._removeNode defensive guard', () => {
 
     root.addChild(target);
 
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
     const tip = new Tooltip(target, { text: 'Hello', delay: 0.05 });
 
     dispatchOver(target);
-    vi.advanceTimersByTime(50);
+    tick(onFrame, 0.05);
 
     const node = root.children[1] as Container;
 
@@ -217,6 +380,84 @@ describe('Tooltip._removeNode defensive guard', () => {
   });
 });
 
+describe('Tooltip node teardown (ME-59: leak)', () => {
+  test('hiding a shown tooltip destroys its node instead of merely detaching it', () => {
+    const root = new UIRoot();
+    const target = new Container();
+
+    root.addChild(target);
+
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
+    const tip = new Tooltip(target, { text: 'Hello', delay: 0.05 });
+
+    dispatchOver(target);
+    tick(onFrame, 0.05);
+
+    const node = root.children[1] as Container;
+    const bg = node.children[0] as Graphics;
+    const label = node.children[1] as Text;
+
+    dispatchOut(target);
+
+    expect(node.destroyed).toBe(true);
+    expect(bg.destroyed).toBe(true);
+    expect(label.destroyed).toBe(true);
+
+    tip.destroy();
+  });
+
+  test('replacing a shown tooltip (re-hover without an intervening hide) destroys the previous node', () => {
+    const root = new UIRoot();
+    const target = new Container();
+
+    root.addChild(target);
+
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
+    const tip = new Tooltip(target, { text: 'Hello', delay: 0.05 });
+
+    dispatchOver(target);
+    tick(onFrame, 0.05);
+    const firstNode = root.children[1] as Container;
+
+    // _show() is re-entered (e.g. a second show while already visible) via a
+    // fresh over/delay cycle — the first node must not survive as a leak.
+    dispatchOut(target);
+    dispatchOver(target);
+    tick(onFrame, 0.05);
+
+    expect(firstNode.destroyed).toBe(true);
+
+    tip.destroy();
+  });
+
+  test('destroy() while a tooltip is visible destroys its node', () => {
+    const root = new UIRoot();
+    const target = new Container();
+
+    root.addChild(target);
+
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
+    const tip = new Tooltip(target, { text: 'Hello', delay: 0.05 });
+
+    dispatchOver(target);
+    tick(onFrame, 0.05);
+    const node = root.children[1] as Container;
+
+    tip.destroy();
+
+    expect(node.destroyed).toBe(true);
+  });
+});
+
 describe('Tooltip.destroy()', () => {
   test('hides any visible tooltip and unsubscribes the listeners', () => {
     const root = new UIRoot();
@@ -224,10 +465,14 @@ describe('Tooltip.destroy()', () => {
 
     root.addChild(target);
 
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
     const tip = new Tooltip(target, { text: 'Hello', delay: 0.05 });
 
     dispatchOver(target);
-    vi.advanceTimersByTime(50);
+    tick(onFrame, 0.05);
     expect(root.children.length).toBe(2);
 
     tip.destroy();
@@ -237,7 +482,7 @@ describe('Tooltip.destroy()', () => {
 
     // Further hover after destroy is inert — the listener was removed.
     dispatchOver(target);
-    vi.advanceTimersByTime(1000);
+    tick(onFrame, 1.0);
     expect(root.children.length).toBe(1);
   });
 
@@ -248,6 +493,25 @@ describe('Tooltip.destroy()', () => {
     expect(() => tip.destroy()).not.toThrow();
     expect(() => tip.destroy()).not.toThrow();
   });
+
+  test('unsubscribes from onFrame — destroy() while a delay is pending leaves no listener behind', () => {
+    const root = new UIRoot();
+    const target = new Container();
+
+    root.addChild(target);
+
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
+    const tip = new Tooltip(target, { text: 'Hello', delay: 0.2 });
+
+    dispatchOver(target);
+    expect(onFrame.count).toBe(1);
+
+    tip.destroy();
+    expect(onFrame.count).toBe(0);
+  });
 });
 
 describe('Tooltip option decoding', () => {
@@ -257,10 +521,14 @@ describe('Tooltip option decoding', () => {
 
     root.addChild(target);
 
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
     const tip = new Tooltip(target, { text: 'Hello' });
 
     dispatchOver(target, 100, 100);
-    vi.advanceTimersByTime(300); // default delay is 300ms
+    tick(onFrame, 0.3); // default delay is 0.3s
 
     const node = root.children[1] as Container;
 
@@ -288,6 +556,10 @@ describe('Tooltip option decoding', () => {
 
     root.addChild(target);
 
+    const { app, onFrame } = makeApp();
+
+    attachStage(root, app);
+
     const tip = new Tooltip(target, {
       text: 'Hello',
       delay: 0.1,
@@ -298,7 +570,7 @@ describe('Tooltip option decoding', () => {
     });
 
     dispatchOver(target);
-    vi.advanceTimersByTime(100);
+    tick(onFrame, 0.1);
 
     const node = root.children[1] as Container;
     const bg = node.children[0] as Graphics;


### PR DESCRIPTION
The remaining Batch G points plus the open audio/tween follow-ups: ME-58, ME-59, NEU-E2, NEU-E3, NEU-E4. All five verified against current code; none was already fixed. Each has tests confirmed red without the fix.

**ME-58 — ScrollContainer accepted input far outside its visible area.** `getBounds()` inherited Container's default (union of all child bounds) instead of the declared viewport. That affected both the manual wheel gate and — more importantly — InteractionManager's general clip hit-test path, which falls back to `getBounds()` when `clipShape === null`. `updateBounds()` is now overridden to derive from `uiWidth`/`uiHeight` and is invalidated in `_relayout()`; `contains()` additionally gates on the viewport before delegating. Serialization is untouched: it reads `uiWidth`/`uiHeight`, not `getBounds()`.

**ME-59 — three separate bugs in one finding, fixed and tested separately.**
- *Leak*: `_removeNode()` called `removeChild()` but never `destroy()`.
- *Time base*: the delay ran on `setTimeout`, i.e. wall clock, ignoring `app.scenes.pause()`. Now driven by `Application.onFrame` with a pause check.
- *Coordinate base*: it used `event.x/y` (layer space — the code itself flagged this as wrong for world-space targets) instead of the camera-independent `event.pointer.x/y` (screen space), which is the space the tooltip node actually lives in.

The existing suite had to be rewritten because its `vi.useFakeTimers()` setup masked exactly the time-base bug under test. Coverage went up, not down: 12 tests before, 19 after.

**NEU-E2 — `AudioBus.addEffect()` kept growing a dead bus.** `destroy()` set no `_destroyed` flag, so post-teardown `addEffect()` pushed into `_effects` while `_rebuildEffectChain` quietly bailed out. Flag plus guard.

**NEU-E3 — voice effect detach could throw.** `BaseVoice.removeEffect`/`_finish` disconnected without the `_isEffectReady` probing `AudioBus` already used, so an effect with pending setup threw. `isEffectReady` moved to `AudioEffect.ts` as a shared helper — module-internal only, not exported from the audio barrel or the root, so the public surface is unchanged (the export snapshots confirm this).

**NEU-E4 — `TweenManager.clear()`/`destroy()` left tweens claiming to run.** The list was emptied but the tweens stayed `Active`/`Paused`, so `tween.state` lied and `resume()` never re-registered. `clear()` now stops each tracked tween, iterating a snapshot because `stop()` re-enters through `remove()`.

Generated API docs regenerated and committed for every touched public JSDoc; `docs:api:check`, `typecheck`, `format:check` and the affected suites (ui/audio/animation/input/serialization, 1437 tests) green.