### PR TITLE
refactor(rendering)!: one dirty model for text, two honest measures

### DIFF
--- a/site/src/content/api/abstract-text.json
+++ b/site/src/content/api/abstract-text.json
@@ -1,16 +1,16 @@
 {
   "title": "AbstractText",
-  "description": "Base class for all text rendering nodes. Provides the common `text` property and the on-demand dirty protocol used by the renderer. Subclasses: - Text — runtime Canvas 2D / SDF rasterization - BitmapText — offline pre-built atlas (BMFont / MSDF)",
+  "description": "Base class for all text rendering nodes. Owns the string, the style and layout references, the on-demand dirty protocol, and the two extents a laid-out string has. A mutation never lays text out. It marks the node dirty; the pass runs on the next read — `getLocalBounds()`, `textBounds`, or the renderer's collect phase, whichever comes first — and runs exactly once per actual change no matter how many properties were touched in between. Subclasses: - Text — runtime Canvas 2D / SDF rasterization - BitmapText — offline pre-built atlas (BMFont / MSDF)",
   "symbol": "AbstractText",
   "kind": "class",
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 87,
+  "memberCount": 93,
   "counts": {
     "constructors": 1,
-    "methods": 37,
-    "properties": 35,
+    "methods": 41,
+    "properties": 37,
     "events": 14
   },
   "sections": [
@@ -19,7 +19,8 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Base class for all text rendering nodes. Provides the common `text` property and the on-demand dirty protocol used by the renderer.",
+        "Base class for all text rendering nodes. Owns the string, the style and layout references, the on-demand dirty protocol, and the two extents a laid-out string has.",
+        "A mutation never lays text out. It marks the node dirty; the pass runs on the next read — `getLocalBounds()`, `textBounds`, or the renderer's collect phase, whichever comes first — and runs exactly once per actual change no matter how many properties were touched in between.",
         "Subclasses: - Text — runtime Canvas 2D / SDF rasterization - BitmapText — offline pre-built atlas (BMFont / MSDF)"
       ],
       "importLine": "import { AbstractText } from '@codexo/exojs'",
@@ -31,7 +32,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(text: string): AbstractText",
+          "signature": "new(text: string, style: TextStyle, layout: LayoutOptions): AbstractText",
           "signatureTokens": [
             {
               "text": "new",
@@ -54,6 +55,38 @@
               "kind": "keyword"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "style",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextStyle",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "layout",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "LayoutOptions",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -71,6 +104,16 @@
               "name": "text",
               "type": "string",
               "optional": false
+            },
+            {
+              "name": "style",
+              "type": "TextStyle",
+              "optional": false
+            },
+            {
+              "name": "layout",
+              "type": "LayoutOptions",
+              "optional": false
             }
           ],
           "returnType": "AbstractText",
@@ -85,6 +128,184 @@
       "id": "methods",
       "title": "Methods",
       "members": [
+        {
+          "name": "_consumePendingHint",
+          "signature": "_consumePendingHint(): StyleChangeHint | null",
+          "signatureTokens": [
+            {
+              "text": "_consumePendingHint",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "StyleChangeHint",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "StyleChangeHint | null",
+          "description": "Take the heaviest pending hint and settle the node, folding in whatever the attached TextStyle has latched since the last pass. A style carries its own dirty flag because it is mutated in place rather than assigned, so polling it here is what makes label.style.align = … land."
+        },
+        {
+          "name": "_markDirty",
+          "signature": "_markDirty(hint: StyleChangeHint): void",
+          "signatureTokens": [
+            {
+              "text": "_markDirty",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "hint",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "StyleChangeHint",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "hint",
+              "type": "StyleChangeHint",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Mark the laid-out geometry stale without laying anything out. Subclasses call this from every setter that affects the glyph run. The content stamp is not deferred with the pass — see _onStyleChange for why a retained subtree has to learn about the change immediately even though the geometry can wait."
+        },
+        {
+          "name": "_replaceStyle",
+          "signature": "_replaceStyle(style: TextStyle): void",
+          "signatureTokens": [
+            {
+              "text": "_replaceStyle",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "style",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextStyle",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "style",
+              "type": "TextStyle",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Swap the attached style, moving the in-place-mutation subscription with it so the replaced style stops driving this node."
+        },
+        {
+          "name": "_runLayout",
+          "signature": "_runLayout(hint: StyleChangeHint): TextLayoutResult",
+          "signatureTokens": [
+            {
+              "text": "_runLayout",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "hint",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "StyleChangeHint",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextLayoutResult",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "hint",
+              "type": "StyleChangeHint",
+              "optional": false
+            }
+          ],
+          "returnType": "TextLayoutResult",
+          "description": "Run one layout pass. Subclasses supply the glyph provider and style. hint is the heaviest change this pass has to account for: only 'font' invalidates the glyph source, so a subclass that pays to acquire one can reuse its cached provider for a plain 'layout' pass."
+        },
         {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",
@@ -112,7 +333,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": "Re-derive origin from the fractional anchor and the CURRENT local bounds. Uses local (untransformed) bounds on purpose: the transform multiplies the origin by scale itself, so deriving from world bounds would double-apply scale whenever the anchor is set after scaling. Subclasses whose local bounds change after construction (e.g. a sprite switching to a texture sub-frame) must call this to keep an anchored node anchored. The origin includes the bounds ORIGIN, not just its extent: a node whose local rectangle does not start at (0, 0) — a mesh built around its own centre, an Aseprite frame carrying an offset — still rotates and scales about its own middle at anchor = (0.5, 0.5)."
+          "description": "Anchor against the ADVANCE box, not against the local (ink) bounds. The base implementation derives the origin from getLocalBounds(), which is right for every node whose extent is its content. Text is the exception: its ink carries SDF padding that reaches past the glyphs on all four sides, by a different amount on each. Anchoring against it would centre the padded tile rather than the text, and would push an UNanchored label off its own position by the left/top padding. The typographic box is what a caller means by \"centre this caption\"."
         },
         {
           "name": "addFilter",
@@ -485,7 +706,7 @@
           ],
           "params": [],
           "returnType": "ReadonlyRectangle",
-          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
+          "description": "Local ink extent — the union of the glyph quads, resolving a pending layout pass first. The resolve is not optional. Culling reads the local bounds BEFORE the renderer's collect phase gets a chance to call syncDirty, so a node that deferred its pass would be culled against the previous string's extent — and a label going from empty to non-empty would never appear at all. Reading is still cheap: with nothing pending this returns straight away, so no per-frame invalidation is introduced and a static subtree stays skippable."
         },
         {
           "name": "getNormals",
@@ -1515,7 +1736,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": "Consume any pending style mutations and apply them synchronously. The renderer calls this automatically before each draw, so manual calls are only needed when you require up-to-date geometry outside of a render pass (e.g. to measure bounds right after a style change)."
+          "description": "Resolve a pending layout pass, if any, and apply it synchronously. The renderer calls this before each draw and every extent read resolves on its own, so manual calls are rarely needed."
         },
         {
           "name": "update",
@@ -2166,6 +2387,39 @@
           "description": ""
         },
         {
+          "name": "layout",
+          "signature": "layout: Readonly<LayoutOptions>",
+          "signatureTokens": [
+            {
+              "text": "layout",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Readonly",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "LayoutOptions",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Flow-control options — maxWidth, letterSpacing, whiteSpace etc. Handed out read-only: the node holds its own copy, so mutating the object would change nothing. Assign a new one to re-flow."
+        },
+        {
           "name": "mask",
           "signature": "mask: MaskSource",
           "signatureTokens": [
@@ -2206,6 +2460,39 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "pageQuads",
+          "signature": "pageQuads: readonly TextPageQuads[]",
+          "signatureTokens": [
+            {
+              "text": "pageQuads",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextPageQuads",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Per-page quad data consumed by the text renderer. Resolves a pending layout pass first, so a reader never sees the previous string's geometry."
         },
         {
           "name": "parent",
@@ -2423,7 +2710,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Pixel dimensions of the laid-out text block in local space. Used by the renderer to compute normalized gradient UVs."
+          "description": "Advance extent of the laid-out text — where the cursor ends up, which is the number to size a panel or place a caret against. This is NOT the rectangle the glyphs cover: SDF padding, outlines and shadows all reach past it, and in SDF mode the ink even starts at a negative coordinate. getLocalBounds returns that ink extent, and it is what culling, hit-testing and the gradient box use. Resolves a pending layout pass before answering."
         },
         {
           "name": "tint",

--- a/site/src/content/api/bitmap-text.json
+++ b/site/src/content/api/bitmap-text.json
@@ -1,15 +1,15 @@
 {
   "title": "BitmapText",
-  "description": "Text node that renders from an offline-generated atlas — either a BMFont (AngelCode .fnt + .png) or an MSDF atlas (msdf-atlas-gen + .json). The atlas is pre-built so there is no runtime Canvas 2D rasterisation. All layout features (alignment, word-wrap, justify, leading, breakWords, whiteSpace, letterSpacing) and kerning pairs from the descriptor are fully supported. Outline effects are handled as shader uniforms — no extra draw calls, no atlas rebuilds. ## Usage ```ts const font = await loader.load(Asset.type('bmFont', 'fonts/ui.fnt')); // BmFont, no setup needed const label = new BitmapText('Score: 0', font, { msdf: true }); scene.addChild(label); label.text = 'Score: 42'; // instant geometry rebuild label.style.align = 'center'; // immediate rebuild ```",
+  "description": "Text node that renders from an offline-generated atlas — either a BMFont (AngelCode .fnt + .png) or an MSDF atlas (msdf-atlas-gen + .json). The atlas is pre-built so there is no runtime Canvas 2D rasterisation. All layout features (alignment, word-wrap, justify, leading, breakWords, whiteSpace, letterSpacing) and kerning pairs from the descriptor are fully supported. Outline effects are handled as shader uniforms — no extra draw calls, no atlas rebuilds. ## Usage ```ts const font = await loader.load(Asset.type('bmFont', 'fonts/ui.fnt')); // BmFont, no setup needed const label = new BitmapText('Score: 0', font, { msdf: true }); scene.addChild(label); label.text = 'Score: 42'; // cheap — marks the geometry stale label.style.align = 'center'; // cheap — same pending pass ``` Mutating any number of properties in the same frame is cheap; the geometry is rebuilt at most once, on demand.",
   "symbol": "BitmapText",
   "kind": "class",
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 95,
+  "memberCount": 99,
   "counts": {
     "constructors": 1,
-    "methods": 38,
+    "methods": 42,
     "properties": 42,
     "events": 14
   },
@@ -23,7 +23,8 @@
         "The atlas is pre-built so there is no runtime Canvas 2D rasterisation. All layout features (alignment, word-wrap, justify, leading, breakWords, whiteSpace, letterSpacing) and kerning pairs from the descriptor are fully supported. Outline effects are handled as shader uniforms — no extra draw calls, no atlas rebuilds.",
         "## Usage",
         "```ts const font = await loader.load(Asset.type('bmFont', 'fonts/ui.fnt')); // BmFont, no setup needed const label = new BitmapText('Score: 0', font, { msdf: true }); scene.addChild(label);",
-        "label.text = 'Score: 42'; // instant geometry rebuild label.style.align = 'center'; // immediate rebuild ```"
+        "label.text = 'Score: 42'; // cheap — marks the geometry stale label.style.align = 'center'; // cheap — same pending pass ```",
+        "Mutating any number of properties in the same frame is cheap; the geometry is rebuilt at most once, on demand."
       ],
       "importLine": "import { BitmapText } from '@codexo/exojs'",
       "sourceLink": null
@@ -131,6 +132,166 @@
       "title": "Methods",
       "members": [
         {
+          "name": "_consumePendingHint",
+          "signature": "_consumePendingHint(): StyleChangeHint | null",
+          "signatureTokens": [
+            {
+              "text": "_consumePendingHint",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "StyleChangeHint",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "StyleChangeHint | null",
+          "description": "Take the heaviest pending hint and settle the node, folding in whatever the attached TextStyle has latched since the last pass. A style carries its own dirty flag because it is mutated in place rather than assigned, so polling it here is what makes label.style.align = … land."
+        },
+        {
+          "name": "_markDirty",
+          "signature": "_markDirty(hint: StyleChangeHint): void",
+          "signatureTokens": [
+            {
+              "text": "_markDirty",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "hint",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "StyleChangeHint",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "hint",
+              "type": "StyleChangeHint",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Mark the laid-out geometry stale without laying anything out. Subclasses call this from every setter that affects the glyph run. The content stamp is not deferred with the pass — see _onStyleChange for why a retained subtree has to learn about the change immediately even though the geometry can wait."
+        },
+        {
+          "name": "_replaceStyle",
+          "signature": "_replaceStyle(style: TextStyle): void",
+          "signatureTokens": [
+            {
+              "text": "_replaceStyle",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "style",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextStyle",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "style",
+              "type": "TextStyle",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Swap the attached style, moving the in-place-mutation subscription with it so the replaced style stops driving this node."
+        },
+        {
+          "name": "_runLayout",
+          "signature": "_runLayout(): TextLayoutResult",
+          "signatureTokens": [
+            {
+              "text": "_runLayout",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextLayoutResult",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": "TextLayoutResult",
+          "description": "Run one layout pass. Subclasses supply the glyph provider and style. hint is the heaviest change this pass has to account for: only 'font' invalidates the glyph source, so a subclass that pays to acquire one can reuse its cached provider for a plain 'layout' pass."
+        },
+        {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",
           "signatureTokens": [
@@ -157,7 +318,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": "Re-derive origin from the fractional anchor and the CURRENT local bounds. Uses local (untransformed) bounds on purpose: the transform multiplies the origin by scale itself, so deriving from world bounds would double-apply scale whenever the anchor is set after scaling. Subclasses whose local bounds change after construction (e.g. a sprite switching to a texture sub-frame) must call this to keep an anchored node anchored. The origin includes the bounds ORIGIN, not just its extent: a node whose local rectangle does not start at (0, 0) — a mesh built around its own centre, an Aseprite frame carrying an offset — still rotates and scales about its own middle at anchor = (0.5, 0.5)."
+          "description": "Anchor against the ADVANCE box, not against the local (ink) bounds. The base implementation derives the origin from getLocalBounds(), which is right for every node whose extent is its content. Text is the exception: its ink carries SDF padding that reaches past the glyphs on all four sides, by a different amount on each. Anchoring against it would centre the padded tile rather than the text, and would push an UNanchored label off its own position by the left/top padding. The typographic box is what a caller means by \"centre this caption\"."
         },
         {
           "name": "addFilter",
@@ -530,7 +691,7 @@
           ],
           "params": [],
           "returnType": "ReadonlyRectangle",
-          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
+          "description": "Local ink extent — the union of the glyph quads, resolving a pending layout pass first. The resolve is not optional. Culling reads the local bounds BEFORE the renderer's collect phase gets a chance to call syncDirty, so a node that deferred its pass would be culled against the previous string's extent — and a label going from empty to non-empty would never appear at all. Reading is still cheap: with nothing pending this returns straight away, so no per-frame invalidation is introduced and a static subtree stays skippable."
         },
         {
           "name": "getNormals",
@@ -1212,7 +1373,7 @@
             }
           ],
           "returnType": "void",
-          "description": "Replace the font and rebuild the geometry."
+          "description": "Replace the font and mark the geometry stale."
         },
         {
           "name": "setOrigin",
@@ -1607,7 +1768,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": "Consume any pending style mutations and apply them synchronously. The renderer calls this automatically before each draw, so manual calls are only needed when you require up-to-date geometry outside of a render pass (e.g. to measure bounds right after a style change)."
+          "description": "Resolve a pending layout pass, if any, and apply it synchronously. The renderer calls this before each draw and every extent read resolves on its own, so manual calls are rarely needed."
         },
         {
           "name": "update",
@@ -2301,7 +2462,7 @@
         },
         {
           "name": "layout",
-          "signature": "layout: LayoutOptions",
+          "signature": "layout: Readonly<LayoutOptions>",
           "signatureTokens": [
             {
               "text": "layout",
@@ -2312,13 +2473,25 @@
               "kind": "punctuation"
             },
             {
+              "text": "Readonly",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
               "text": "LayoutOptions",
               "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             }
           ],
           "params": [],
           "returnType": null,
-          "description": "Flow-control options — maxWidth, letterSpacing, whiteSpace etc."
+          "description": "Flow-control options — maxWidth, letterSpacing, whiteSpace etc. Handed out read-only: the node holds its own copy, so mutating the object would change nothing. Assign a new one to re-flow."
         },
         {
           "name": "mask",
@@ -2414,7 +2587,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Per-page quad data consumed by the text renderer."
+          "description": "Per-page quad data consumed by the text renderer. Resolves a pending layout pass first, so a reader never sees the previous string's geometry."
         },
         {
           "name": "parent",
@@ -2653,7 +2826,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Pixel dimensions of the laid-out text block in local space. Used by the renderer to compute normalized gradient UVs."
+          "description": "Advance extent of the laid-out text — where the cursor ends up, which is the number to size a panel or place a caret against. This is NOT the rectangle the glyphs cover: SDF padding, outlines and shadows all reach past it, and in SDF mode the ink even starts at a negative coordinate. getLocalBounds returns that ink extent, and it is what culling, hit-testing and the gradient box use. Resolves a pending layout pass before answering."
         },
         {
           "name": "textures",

--- a/site/src/content/api/text-layout-result.json
+++ b/site/src/content/api/text-layout-result.json
@@ -1,0 +1,190 @@
+{
+  "title": "TextLayoutResult",
+  "description": "Result of a full text layout pass: quad placements plus both extents. Text has two honest sizes and they are not interchangeable. The advance is what a layout wants — it answers \"how much room does this string take up in the flow\". The ink is what the GPU wants — it answers \"which rectangle do these glyphs actually cover\", padding, outline reach and all.",
+  "symbol": "TextLayoutResult",
+  "kind": "interface",
+  "subsystem": "rendering",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 3,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 3,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Result of a full text layout pass: quad placements plus both extents.",
+        "Text has two honest sizes and they are not interchangeable. The advance is what a layout wants — it answers \"how much room does this string take up in the flow\". The ink is what the GPU wants — it answers \"which rectangle do these glyphs actually cover\", padding, outline reach and all."
+      ],
+      "importLine": "import { TextLayoutResult } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "advance",
+          "signature": "advance: TextSize",
+          "signatureTokens": [
+            {
+              "text": "advance",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextSize",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Advance extent — where the cursor ends up. Width is the widest line's advance (letterSpacing and kerning included, no trailing gap), height is lineCount * (fontSize * lineHeight + leading). This is the measure a caller wants for layout, panel sizing and caret placement."
+        },
+        {
+          "name": "ink",
+          "signature": "ink: { height: number; width: number; x: number; y: number }",
+          "signatureTokens": [
+            {
+              "text": "ink",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "{ ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "height",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "; ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "width",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "; ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "x",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "; ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "y",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": " }",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Ink extent — the union of the glyph quads, in the same local space as placements. Carries SDF padding and therefore outline/shadow reach, and its minimum is not necessarily zero. This is the node's local bounds."
+        },
+        {
+          "name": "placements",
+          "signature": "placements: readonly GlyphPlacement[]",
+          "signatureTokens": [
+            {
+              "text": "placements",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GlyphPlacement",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Per-glyph quad placements in local text space."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/rendering/text/types.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/types.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/rendering/text/types.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/text/types.ts"
+}

--- a/site/src/content/api/text-layout-style.json
+++ b/site/src/content/api/text-layout-style.json
@@ -1,6 +1,6 @@
 {
   "title": "TextLayoutStyle",
-  "description": "Minimal interface consumed by layoutText and measureText. Both TextStyle and the BMFont adapter satisfy this structurally.",
+  "description": "Minimal interface consumed by layoutText. Both TextStyle and the BMFont adapter satisfy this structurally.",
   "symbol": "TextLayoutStyle",
   "kind": "interface",
   "subsystem": "rendering",
@@ -19,7 +19,7 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Minimal interface consumed by layoutText and measureText. Both TextStyle and the BMFont adapter satisfy this structurally."
+        "Minimal interface consumed by layoutText. Both TextStyle and the BMFont adapter satisfy this structurally."
       ],
       "importLine": "import { TextLayoutStyle } from '@codexo/exojs'",
       "sourceLink": null

--- a/site/src/content/api/text-size.json
+++ b/site/src/content/api/text-size.json
@@ -1,6 +1,6 @@
 {
   "title": "TextSize",
-  "description": "Pixel dimensions of a laid-out text string returned by measureText.",
+  "description": "Advance extent of a laid-out text string in pixels — where the cursor ends up, not how far the glyphs reach. See TextLayoutResult for the difference between the two measures.",
   "symbol": "TextSize",
   "kind": "interface",
   "subsystem": "rendering",
@@ -19,7 +19,7 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Pixel dimensions of a laid-out text string returned by measureText."
+        "Advance extent of a laid-out text string in pixels — where the cursor ends up, not how far the glyphs reach. See TextLayoutResult for the difference between the two measures."
       ],
       "importLine": "import { TextSize } from '@codexo/exojs'",
       "sourceLink": null

--- a/site/src/content/api/text.json
+++ b/site/src/content/api/text.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 94,
+  "memberCount": 98,
   "counts": {
     "constructors": 1,
-    "methods": 37,
+    "methods": 41,
     "properties": 42,
     "events": 14
   },
@@ -112,6 +112,184 @@
       "title": "Methods",
       "members": [
         {
+          "name": "_consumePendingHint",
+          "signature": "_consumePendingHint(): StyleChangeHint | null",
+          "signatureTokens": [
+            {
+              "text": "_consumePendingHint",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "StyleChangeHint",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "StyleChangeHint | null",
+          "description": "Take the heaviest pending hint and settle the node, folding in whatever the attached TextStyle has latched since the last pass. A style carries its own dirty flag because it is mutated in place rather than assigned, so polling it here is what makes label.style.align = … land."
+        },
+        {
+          "name": "_markDirty",
+          "signature": "_markDirty(hint: StyleChangeHint): void",
+          "signatureTokens": [
+            {
+              "text": "_markDirty",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "hint",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "StyleChangeHint",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "hint",
+              "type": "StyleChangeHint",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Mark the laid-out geometry stale without laying anything out. Subclasses call this from every setter that affects the glyph run. The content stamp is not deferred with the pass — see _onStyleChange for why a retained subtree has to learn about the change immediately even though the geometry can wait."
+        },
+        {
+          "name": "_replaceStyle",
+          "signature": "_replaceStyle(style: TextStyle): void",
+          "signatureTokens": [
+            {
+              "text": "_replaceStyle",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "style",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextStyle",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "style",
+              "type": "TextStyle",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Swap the attached style, moving the in-place-mutation subscription with it so the replaced style stops driving this node."
+        },
+        {
+          "name": "_runLayout",
+          "signature": "_runLayout(hint: StyleChangeHint): TextLayoutResult",
+          "signatureTokens": [
+            {
+              "text": "_runLayout",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "hint",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "StyleChangeHint",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextLayoutResult",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "hint",
+              "type": "StyleChangeHint",
+              "optional": false
+            }
+          ],
+          "returnType": "TextLayoutResult",
+          "description": "Run one layout pass. Subclasses supply the glyph provider and style. hint is the heaviest change this pass has to account for: only 'font' invalidates the glyph source, so a subclass that pays to acquire one can reuse its cached provider for a plain 'layout' pass."
+        },
+        {
           "name": "_updateOrigin",
           "signature": "_updateOrigin(): void",
           "signatureTokens": [
@@ -138,7 +316,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": "Re-derive origin from the fractional anchor and the CURRENT local bounds. Uses local (untransformed) bounds on purpose: the transform multiplies the origin by scale itself, so deriving from world bounds would double-apply scale whenever the anchor is set after scaling. Subclasses whose local bounds change after construction (e.g. a sprite switching to a texture sub-frame) must call this to keep an anchored node anchored. The origin includes the bounds ORIGIN, not just its extent: a node whose local rectangle does not start at (0, 0) — a mesh built around its own centre, an Aseprite frame carrying an offset — still rotates and scales about its own middle at anchor = (0.5, 0.5)."
+          "description": "Anchor against the ADVANCE box, not against the local (ink) bounds. The base implementation derives the origin from getLocalBounds(), which is right for every node whose extent is its content. Text is the exception: its ink carries SDF padding that reaches past the glyphs on all four sides, by a different amount on each. Anchoring against it would centre the padded tile rather than the text, and would push an UNanchored label off its own position by the left/top padding. The typographic box is what a caller means by \"centre this caption\"."
         },
         {
           "name": "addFilter",
@@ -511,7 +689,7 @@
           ],
           "params": [],
           "returnType": "ReadonlyRectangle",
-          "description": "This node's untransformed extent in its own local coordinate space. Returns the LIVE internal rectangle, not a copy: it is read on hot paths (updateBounds re-reads it on every transform-dirty recompute, i.e. potentially every frame for a moving node), so copying it here would add a per-frame allocation. It is therefore typed as a ReadonlyRectangle — reads are unchanged, writes are rejected at compile time. Writing to it directly would skip the bounds/content invalidation the engine needs, leaving culling, hit-testing and retained render fragments on a stale extent. A custom Drawable that owns its own size sets it through _setLocalBounds, which writes and invalidates in one step."
+          "description": "Local ink extent — the union of the glyph quads, resolving a pending layout pass first. The resolve is not optional. Culling reads the local bounds BEFORE the renderer's collect phase gets a chance to call syncDirty, so a node that deferred its pass would be culled against the previous string's extent — and a label going from empty to non-empty would never appear at all. Reading is still cheap: with nothing pending this returns straight away, so no per-frame invalidation is introduced and a static subtree stays skippable."
         },
         {
           "name": "getNormals",
@@ -1541,7 +1719,7 @@
           ],
           "params": [],
           "returnType": "void",
-          "description": "Consume any pending style mutations and apply them synchronously. The renderer calls this automatically before each draw, so manual calls are only needed when you require up-to-date geometry outside of a render pass (e.g. to measure bounds right after a style change)."
+          "description": "Resolve a pending layout pass, if any, and apply it synchronously. The renderer calls this before each draw and every extent read resolves on its own, so manual calls are rarely needed."
         },
         {
           "name": "update",
@@ -2264,7 +2442,7 @@
         },
         {
           "name": "layout",
-          "signature": "layout: LayoutOptions",
+          "signature": "layout: Readonly<LayoutOptions>",
           "signatureTokens": [
             {
               "text": "layout",
@@ -2275,13 +2453,25 @@
               "kind": "punctuation"
             },
             {
+              "text": "Readonly",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
               "text": "LayoutOptions",
               "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
             }
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Flow-control options — maxWidth, letterSpacing, whiteSpace etc. Handed out read-only: the node holds its own copy, so mutating the object would change nothing. Assign a new one to re-flow."
         },
         {
           "name": "mask",
@@ -2356,7 +2546,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Per-page quad data consumed by the text renderer."
+          "description": "Per-page quad data consumed by the text renderer. Resolves a pending layout pass first, so a reader never sees the previous string's geometry."
         },
         {
           "name": "parent",
@@ -2616,7 +2806,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Pixel dimensions of the laid-out text block in local space. Used by the renderer to compute normalized gradient UVs."
+          "description": "Advance extent of the laid-out text — where the cursor ends up, which is the number to size a panel or place a caret against. This is NOT the rectangle the glyphs cover: SDF padding, outlines and shadows all reach past it, and in SDF mode the ink even starts at a negative coordinate. getLocalBounds returns that ink extent, and it is what culling, hit-testing and the gradient box use. Resolves a pending layout pass before answering."
         },
         {
           "name": "tint",

--- a/site/src/content/guide/rendering/text.mdx
+++ b/site/src/content/guide/rendering/text.mdx
@@ -167,15 +167,18 @@ this.hud.addChild(this.scoreLabel);
 this.addChild(this.hud);
 ```
 
-The glyph geometry is not a child node — it lives on the `Text` itself as per-atlas-page quad data the text renderer consumes. Two rebuild paths feed it:
-- Assigning `text.text` (or `text.layout`, or a whole new `text.style`) re-lays out immediately. Assigning the same string is a no-op, so changing the text every frame only costs a rebuild on the frames it actually changes.
-- Mutating `style` fields (e.g. `text.style.fillColor = ...`) only raises a dirty flag. Any number of mutations in one frame coalesce into at most one rebuild, applied automatically before the next draw — no manual call needed. `text.syncDirty()` forces it early, which is what you want before reading bounds right after a style change.
+The glyph geometry is not a child node — it lives on the `Text` itself as per-atlas-page quad data the text renderer consumes. Nothing you assign lays the text out on the spot: assigning `text.text`, `text.layout` or a whole new `text.style`, and mutating `style` fields (e.g. `text.style.fillColor = ...`), all just mark the geometry stale. Any number of changes in one frame coalesce into **at most one layout pass**, which runs the moment something reads the node — its bounds, its measurements, or the renderer's collect phase, whichever comes first. Assigning the same string is a no-op, so changing the text every frame only costs a pass on the frames it actually changes. `text.syncDirty()` forces the pass early, but you rarely need it: every read resolves on its own.
 
 The node's local bounds track the laid-out text, so an anchored label re-derives its origin whenever the string changes width — a centred score readout stays centred as it grows.
 
 ## Measuring text
 
-`text.textBounds` reports the pixel dimensions of the laid-out block in local space as a [`TextSize`](/ExoJS/en/api/text-size/) (`{ width, height }`) — use it to size a panel around a label or to position something next to it:
+A laid-out string has **two honest sizes**, and picking the wrong one is the usual source of a panel that fits badly:
+
+- `text.textBounds` is the **advance** — where the cursor ends up. This is the layout measure: how much room the string takes up in the flow, and where a caret or a following element belongs. It is a [`TextSize`](/ExoJS/en/api/text-size/) (`{ width, height }`).
+- `text.getLocalBounds()` is the **ink** — the rectangle the glyph quads actually cover. It includes the SDF padding, and therefore the reach of any outline or shadow. In SDF mode it starts at a slightly negative `x`/`y` and is a little larger than the advance on both axes. This is what culling, hit-testing and the gradient ramp use.
+
+Use the advance to size a panel around a label or to position something next to it:
 
 ```ts
 this.label = new Text('Ready', { fontSize: 24 });
@@ -186,7 +189,7 @@ this.backdrop = new Panel({
 });
 ```
 
-Reading it right after a style mutation returns the pre-change size, because style changes are only applied on the next draw. Call `this.label.syncDirty()` first to force the pending rebuild.
+Both reads resolve a pending layout pass first, so the number you get always reflects the changes you have made — including a style mutation on the line above.
 
 ## Text constraints
 

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -987,6 +987,23 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   /**
+   * Write the local extent and refresh the bounds flags WITHOUT a revision
+   * stamp — the {@link _setLocalBounds} counterpart for a node that already
+   * stamped itself content-dirty when the change was requested.
+   *
+   * A node that lays its content out lazily has to stamp at mutation time,
+   * because a retained subtree decides whether to replay from the revision
+   * alone and never visits a node it skipped. Stamping a second time when the
+   * deferred pass finally writes the extent would move the goalposts one frame
+   * on and keep the subtree re-capturing instead of recording.
+   * @internal
+   */
+  protected _setLocalBoundsUnstamped(x: number, y: number, width: number, height: number): void {
+    this._localBounds.set(x, y, width, height);
+    this._invalidateBoundsFlags();
+  }
+
+  /**
    * Flag-only bounds invalidation: own BoundsRect + ancestor walk, WITHOUT a
    * revision stamp. Used by transform-group boundaries whose own moves must
    * refresh ancestor world bounds but must NOT invalidate retained fragments.

--- a/src/rendering/public.ts
+++ b/src/rendering/public.ts
@@ -99,7 +99,17 @@ export type { TextOptions } from '#rendering/text/Text';
 export { Text } from '#rendering/text/Text';
 export type { FontFamily, FontRegistry, FontWeight, GradientAxis, StyleChangeHint, TextStyleOptions } from '#rendering/text/TextStyle';
 export { TextStyle } from '#rendering/text/TextStyle';
-export type { GlyphInfo, GlyphKey, GlyphPlacement, GlyphProvider, TextAlignment, TextLayoutStyle, TextPageQuads, TextSize } from '#rendering/text/types';
+export type {
+  GlyphInfo,
+  GlyphKey,
+  GlyphPlacement,
+  GlyphProvider,
+  TextAlignment,
+  TextLayoutResult,
+  TextLayoutStyle,
+  TextPageQuads,
+  TextSize,
+} from '#rendering/text/types';
 export type { DataTextureBuffer, DataTextureDirtyRegion, DataTextureFormat, DataTextureOptions } from '#rendering/texture/DataTexture';
 export { DataTexture } from '#rendering/texture/DataTexture';
 export { RenderTexture } from '#rendering/texture/RenderTexture';

--- a/src/rendering/text/AbstractText.ts
+++ b/src/rendering/text/AbstractText.ts
@@ -1,10 +1,21 @@
+import type { ReadonlyRectangle } from '#math/Rectangle';
 import { Drawable } from '#rendering/Drawable';
 
-import type { TextSize } from './types';
+import type { LayoutOptions } from './LayoutOptions';
+import { buildTextPageQuads } from './TextLayout';
+import type { StyleChangeHint, TextStyle } from './TextStyle';
+import { mergeHint } from './TextStyle';
+import type { TextLayoutResult, TextPageQuads, TextSize } from './types';
 
 /**
- * Base class for all text rendering nodes. Provides the common `text`
- * property and the on-demand dirty protocol used by the renderer.
+ * Base class for all text rendering nodes. Owns the string, the style and
+ * layout references, the on-demand dirty protocol, and the two extents a
+ * laid-out string has.
+ *
+ * A mutation never lays text out. It marks the node dirty; the pass runs on
+ * the next read — `getLocalBounds()`, `textBounds`, or the renderer's collect
+ * phase, whichever comes first — and runs exactly once per actual change no
+ * matter how many properties were touched in between.
  *
  * Subclasses:
  * - {@link Text} — runtime Canvas 2D / SDF rasterization
@@ -12,10 +23,35 @@ import type { TextSize } from './types';
  */
 export abstract class AbstractText extends Drawable {
   protected _text: string;
+  protected _style: TextStyle;
+  protected _layout: LayoutOptions;
 
-  public constructor(text: string) {
+  /** Per-page quad geometry built by the layout pass. */
+  private _pageQuads: TextPageQuads[] = [];
+  private _advance: TextSize = { width: 0, height: 0 };
+  /** Heaviest change awaiting a layout pass, or `null` when settled. */
+  private _pendingHint: StyleChangeHint | null = 'font';
+
+  /**
+   * Stamps the node content-dirty when the attached style is mutated IN PLACE.
+   *
+   * The layout itself waits for the next read, but the stamp cannot: a
+   * retained subtree decides whether to replay its recording from the content
+   * revision alone, and a replayed group never visits the node to notice that
+   * a pass was pending. Bound once so it can be detached again.
+   */
+  private readonly _onStyleChange = (): void => {
+    this._markContentDirty();
+  };
+
+  protected constructor(text: string, style: TextStyle, layout: LayoutOptions) {
     super();
     this._text = text;
+    this._style = style;
+    this._style.onChange.add(this._onStyleChange);
+    // Copied, not aliased: the caller keeps its own options object and may
+    // well go on mutating it, which must not silently re-flow this node.
+    this._layout = { ...layout };
   }
 
   /** The string currently displayed by this node. */
@@ -23,23 +59,100 @@ export abstract class AbstractText extends Drawable {
     return this._text;
   }
 
-  /**
-   * Pixel dimensions of the laid-out text block in local space.
-   * Used by the renderer to compute normalized gradient UVs.
-   */
-  public get textBounds(): TextSize {
-    return { width: 0, height: 0 };
+  public set text(v: string) {
+    if (this._text === v) return;
+    this._text = v;
+    this._markDirty('layout');
   }
 
   /**
-   * Consume any pending style mutations and apply them synchronously.
+   * Flow-control options — `maxWidth`, `letterSpacing`, `whiteSpace` etc.
    *
-   * The renderer calls this automatically before each draw, so manual
-   * calls are only needed when you require up-to-date geometry outside
-   * of a render pass (e.g. to measure bounds right after a style change).
+   * Handed out read-only: the node holds its own copy, so mutating the object
+   * would change nothing. Assign a new one to re-flow.
+   */
+  public get layout(): Readonly<LayoutOptions> {
+    return this._layout;
+  }
+
+  public set layout(v: LayoutOptions) {
+    this._layout = { ...v };
+    this._markDirty('layout');
+  }
+
+  /**
+   * Per-page quad data consumed by the text renderer. Resolves a pending
+   * layout pass first, so a reader never sees the previous string's geometry.
+   */
+  public get pageQuads(): readonly TextPageQuads[] {
+    this.syncDirty();
+
+    return this._pageQuads;
+  }
+
+  /**
+   * Advance extent of the laid-out text — where the cursor ends up, which is
+   * the number to size a panel or place a caret against.
+   *
+   * This is NOT the rectangle the glyphs cover: SDF padding, outlines and
+   * shadows all reach past it, and in SDF mode the ink even starts at a
+   * negative coordinate. {@link getLocalBounds} returns that ink extent, and
+   * it is what culling, hit-testing and the gradient box use.
+   *
+   * Resolves a pending layout pass before answering.
+   */
+  public get textBounds(): TextSize {
+    this.syncDirty();
+
+    return this._advance;
+  }
+
+  /**
+   * Local ink extent — the union of the glyph quads, resolving a pending
+   * layout pass first.
+   *
+   * The resolve is not optional. Culling reads the local bounds BEFORE the
+   * renderer's collect phase gets a chance to call {@link syncDirty}, so a
+   * node that deferred its pass would be culled against the previous string's
+   * extent — and a label going from empty to non-empty would never appear at
+   * all. Reading is still cheap: with nothing pending this returns straight
+   * away, so no per-frame invalidation is introduced and a static subtree
+   * stays skippable.
+   */
+  public override getLocalBounds(): ReadonlyRectangle {
+    this.syncDirty();
+
+    return super.getLocalBounds();
+  }
+
+  /**
+   * Resolve a pending layout pass, if any, and apply it synchronously.
+   *
+   * The renderer calls this before each draw and every extent read resolves on
+   * its own, so manual calls are rarely needed.
    */
   public syncDirty(): void {
-    // Intentional no-op; subclasses override.
+    if (this.destroyed) return;
+
+    // Consumed BEFORE the pass runs, so the re-entrant read inside
+    // `_updateOrigin()` below sees a settled node instead of recursing.
+    const hint = this._consumePendingHint();
+
+    if (hint === null || hint === 'tint') return;
+
+    const result = this._runLayout(hint);
+
+    this._advance = result.advance;
+    this._pageQuads = buildTextPageQuads(result.placements);
+    // Unstamped on purpose: `_markDirty` already stamped when the change came
+    // in, and stamping again here would land a frame later than the consumers
+    // that already reacted to the first one.
+    this._setLocalBoundsUnstamped(result.ink.x, result.ink.y, result.ink.width, result.ink.height);
+
+    // An anchor is a fraction of the bounds, so a node whose text just changed
+    // width has to re-derive its origin — otherwise a centred label drifts
+    // left as it grows. Mirrors what Sprite does when it switches sub-frame.
+    this._updateOrigin();
   }
 
   /**
@@ -51,4 +164,80 @@ export abstract class AbstractText extends Drawable {
   public update(_dt: number): void {
     this.syncDirty();
   }
+
+  public override destroy(): void {
+    this._style.onChange.remove(this._onStyleChange);
+    this._pageQuads = [];
+    super.destroy();
+  }
+
+  // ── Protected ────────────────────────────────────────────────────────────
+
+  /**
+   * Mark the laid-out geometry stale without laying anything out. Subclasses
+   * call this from every setter that affects the glyph run.
+   *
+   * The content stamp is not deferred with the pass — see
+   * {@link _onStyleChange} for why a retained subtree has to learn about the
+   * change immediately even though the geometry can wait.
+   */
+  protected _markDirty(hint: StyleChangeHint): void {
+    this._pendingHint = this._pendingHint === null ? hint : mergeHint(this._pendingHint, hint);
+    this._markContentDirty();
+  }
+
+  /**
+   * Swap the attached style, moving the in-place-mutation subscription with
+   * it so the replaced style stops driving this node.
+   */
+  protected _replaceStyle(style: TextStyle): void {
+    this._style.onChange.remove(this._onStyleChange);
+    this._style = style;
+    this._style.onChange.add(this._onStyleChange);
+    this._markDirty('font');
+  }
+
+  /**
+   * Take the heaviest pending hint and settle the node, folding in whatever
+   * the attached {@link TextStyle} has latched since the last pass. A style
+   * carries its own dirty flag because it is mutated in place rather than
+   * assigned, so polling it here is what makes `label.style.align = …` land.
+   */
+  protected _consumePendingHint(): StyleChangeHint | null {
+    const own = this._pendingHint;
+    const style = this._style.consumeDirty();
+
+    this._pendingHint = null;
+
+    if (own === null) return style;
+    if (style === null) return own;
+
+    return mergeHint(own, style);
+  }
+
+  /**
+   * Anchor against the ADVANCE box, not against the local (ink) bounds.
+   *
+   * The base implementation derives the origin from `getLocalBounds()`, which
+   * is right for every node whose extent is its content. Text is the exception:
+   * its ink carries SDF padding that reaches past the glyphs on all four sides,
+   * by a different amount on each. Anchoring against it would centre the padded
+   * tile rather than the text, and would push an UNanchored label off its own
+   * position by the left/top padding. The typographic box is what a caller
+   * means by "centre this caption".
+   */
+  protected override _updateOrigin(): void {
+    const { x, y } = this.anchor;
+
+    this.setOrigin(this._advance.width * x, this._advance.height * y);
+  }
+
+  /**
+   * Run one layout pass. Subclasses supply the glyph provider and style.
+   *
+   * `hint` is the heaviest change this pass has to account for: only `'font'`
+   * invalidates the glyph source, so a subclass that pays to acquire one can
+   * reuse its cached provider for a plain `'layout'` pass.
+   */
+  protected abstract _runLayout(hint: StyleChangeHint): TextLayoutResult;
 }

--- a/src/rendering/text/BitmapText.ts
+++ b/src/rendering/text/BitmapText.ts
@@ -6,10 +6,10 @@ import { AbstractText } from './AbstractText';
 import type { BmFontData } from './BmFont';
 import { type BmFont } from './BmFont';
 import type { LayoutOptions } from './LayoutOptions';
-import { buildTextPageQuads, layoutText } from './TextLayout';
+import { emptyTextLayout, layoutText } from './TextLayout';
 import type { TextStyleOptions } from './TextStyle';
 import { TextStyle } from './TextStyle';
-import type { GlyphInfo, GlyphProvider, TextLayoutStyle, TextPageQuads, TextSize } from './types';
+import type { GlyphInfo, GlyphProvider, TextLayoutResult, TextLayoutStyle } from './types';
 
 export type { BmFontChar, BmFontData } from './BmFont';
 
@@ -144,61 +144,29 @@ export class BmFontAdapter implements GlyphProvider {
  * const label = new BitmapText('Score: 0', font, { msdf: true });
  * scene.addChild(label);
  *
- * label.text         = 'Score: 42';  // instant geometry rebuild
- * label.style.align  = 'center';     // immediate rebuild
+ * label.text         = 'Score: 42';  // cheap — marks the geometry stale
+ * label.style.align  = 'center';     // cheap — same pending pass
  * ```
+ *
+ * Mutating any number of properties in the same frame is cheap; the geometry
+ * is rebuilt at most once, on demand.
  * @stable
  */
 export class BitmapText extends AbstractText {
   private _font: BmFont;
   private _fontScale: number;
   private _msdf: boolean;
-  private _style: TextStyle;
-  private _layout: LayoutOptions;
-
-  /** Per-page quad geometry consumed by the text renderer. */
-  private _pageQuads: TextPageQuads[] = [];
-  private _textBounds: TextSize = { width: 0, height: 0 };
   private _adapter: BmFontAdapter;
 
-  /**
-   * Rebuilds on any style mutation. Bound once so it can be detached again
-   * when the style is replaced or the node is destroyed.
-   */
-  private readonly _onStyleChange = (): void => {
-    // TextStyle latches its dirty flag until something consumes it, and only
-    // dispatches onChange on the clean-to-dirty edge. Draining it here is what
-    // keeps the second and every later mutation notifying instead of just the
-    // first. BitmapText rebuilds eagerly, so there is no deferred hint to keep.
-    this._style.consumeDirty();
-    this._rebuild();
-  };
-
   public constructor(text: string, font: BmFont, options: BitmapTextOptions = {}) {
-    super(text);
+    super(text, new TextStyle(options), options.layout ?? {});
     this._font = font;
     this._fontScale = options.scale ?? 1;
     this._msdf = options.msdf ?? false;
-    this._style = new TextStyle(options);
-    this._layout = options.layout ?? {};
     this._adapter = new BmFontAdapter(font.fontData, font.textures, this._fontScale);
-    this._attachStyle();
-    this._rebuild();
   }
 
-  // ── Text ──────────────────────────────────────────────────────────────────
-
-  public override get text(): string {
-    return this._text;
-  }
-
-  public override set text(v: string) {
-    if (this._text === v) return;
-    this._text = v;
-    this._rebuild();
-  }
-
-  // ── Style & layout ────────────────────────────────────────────────────────
+  // ── Style ─────────────────────────────────────────────────────────────────
 
   /** Visual style — `align`, `leading`, `fillColor`, `outlineColor` etc. */
   public get style(): TextStyle {
@@ -206,20 +174,7 @@ export class BitmapText extends AbstractText {
   }
 
   public set style(v: TextStyle | TextStyleOptions) {
-    this._style.onChange.remove(this._onStyleChange);
-    this._style = v instanceof TextStyle ? v : new TextStyle(v);
-    this._attachStyle();
-    this._rebuild();
-  }
-
-  /** Flow-control options — `maxWidth`, `letterSpacing`, `whiteSpace` etc. */
-  public get layout(): LayoutOptions {
-    return this._layout;
-  }
-
-  public set layout(v: LayoutOptions) {
-    this._layout = v;
-    this._rebuild();
+    this._replaceStyle(v instanceof TextStyle ? v : new TextStyle(v));
   }
 
   /** Scale factor applied to all glyph metrics from the font descriptor. */
@@ -231,7 +186,7 @@ export class BitmapText extends AbstractText {
     if (this._fontScale === v) return;
     this._fontScale = v;
     this._adapter = new BmFontAdapter(this._font.fontData, this._font.textures, v);
-    this._rebuild();
+    this._markDirty('font');
   }
 
   // ── Read-only state ───────────────────────────────────────────────────────
@@ -246,15 +201,6 @@ export class BitmapText extends AbstractText {
     return this._font;
   }
 
-  /** Per-page quad data consumed by the text renderer. */
-  public get pageQuads(): readonly TextPageQuads[] {
-    return this._pageQuads;
-  }
-
-  public override get textBounds(): TextSize {
-    return this._textBounds;
-  }
-
   /** The page textures this node draws from. */
   public get textures(): readonly Texture[] {
     return this._font.textures;
@@ -262,41 +208,17 @@ export class BitmapText extends AbstractText {
 
   // ── Font replacement ──────────────────────────────────────────────────────
 
-  /** Replace the font and rebuild the geometry. */
+  /** Replace the font and mark the geometry stale. */
   public setFont(font: BmFont): void {
     this._font = font;
     this._adapter = new BmFontAdapter(font.fontData, font.textures, this._fontScale);
-    this._rebuild();
-  }
-
-  public override destroy(): void {
-    this._style.onChange.remove(this._onStyleChange);
-    this._pageQuads = [];
-    super.destroy();
+    this._markDirty('font');
   }
 
   // ── Private ──────────────────────────────────────────────────────────────
 
-  private _attachStyle(): void {
-    // A freshly constructed style starts dirty. The caller rebuilds right
-    // after attaching, so drain that initial flag — otherwise the style never
-    // reaches the clean state its next mutation needs in order to dispatch.
-    this._style.consumeDirty();
-    this._style.onChange.add(this._onStyleChange);
-  }
-
-  private _rebuild(): void {
-    this._pageQuads = [];
-    this._textBounds = { width: 0, height: 0 };
-    if (this._text.length === 0) {
-      // Empty transition: reset the extent and route through the content-dirty
-      // contract like the non-empty path below, so a BitmapText going empty
-      // does not leave a stale local bounds / un-dirtied revision behind for
-      // culling, hit-testing, or an instruction-set cache of prior geometry.
-      this._setLocalBounds(0, 0, 0, 0);
-      this._updateOrigin();
-      return;
-    }
+  protected override _runLayout(): TextLayoutResult {
+    if (this._text.length === 0) return emptyTextLayout();
 
     // Derive a TextLayoutStyle from the BMFont descriptor + scale.
     // Setting fontSize = fontData.lineHeight * scale makes computedLineHeight
@@ -308,24 +230,6 @@ export class BitmapText extends AbstractText {
       align: this._style.align,
     };
 
-    const placements = layoutText(this._text, layoutStyle, this._layout, this._adapter);
-
-    let maxX = 0,
-      maxY = 0;
-    for (const p of placements) {
-      const px = p.x + p.width;
-      const py = p.y + p.height;
-      if (px > maxX) maxX = px;
-      if (py > maxY) maxY = py;
-    }
-    this._textBounds = { width: maxX, height: maxY };
-    this._setLocalBounds(0, 0, maxX, maxY);
-
-    // An anchor is a fraction of the bounds, so a node whose text just changed
-    // width has to re-derive its origin — otherwise a centred label drifts left
-    // as it grows. Mirrors what Sprite does when it switches sub-frame.
-    this._updateOrigin();
-
-    this._pageQuads = buildTextPageQuads(placements);
+    return layoutText(this._text, layoutStyle, this._layout, this._adapter);
   }
 }

--- a/src/rendering/text/Text.ts
+++ b/src/rendering/text/Text.ts
@@ -4,10 +4,10 @@ import type { GlyphAtlas } from './GlyphAtlas';
 import { SDF_RADIUS } from './GlyphAtlas';
 import { getDefaultGlyphAtlasPool } from './GlyphAtlasPool';
 import type { LayoutOptions } from './LayoutOptions';
-import { buildTextPageQuads, layoutText } from './TextLayout';
+import { emptyTextLayout, layoutText } from './TextLayout';
 import type { StyleChangeHint, TextStyleOptions } from './TextStyle';
 import { TextStyle } from './TextStyle';
-import type { TextPageQuads, TextSize } from './types';
+import type { TextLayoutResult, TextPageQuads } from './types';
 
 export type { TextPageQuads };
 
@@ -61,29 +61,19 @@ export interface TextOptions extends TextStyleOptions, LayoutOptions {
  * @stable
  */
 export class Text extends AbstractText {
-  private _style: TextStyle;
-  private _layout: LayoutOptions;
   private _colorGlyphs: boolean;
   private _sdfRadius: number;
   private _atlas: GlyphAtlas | null = null;
   private _destroyed = false;
   private _faceLoadVersion = 0;
 
-  /** Per-page quad geometry built by `_rebuild()`. */
-  private _pageQuads: TextPageQuads[] = [];
-  private _textBounds: TextSize = { width: 0, height: 0 };
-
   public constructor(text: string, options: TextOptions = {}) {
-    super(text);
-    this._style = new TextStyle(options);
-    this._layout = options;
+    super(text, new TextStyle(options), options);
     this._colorGlyphs = options.colorGlyphs ?? false;
     this._sdfRadius = options.sdfRadius ?? SDF_RADIUS;
 
     const face = this._extractFace(options);
     if (face !== null) void this._loadFace(face);
-
-    this._rebuild('font');
   }
 
   public get style(): TextStyle {
@@ -91,31 +81,12 @@ export class Text extends AbstractText {
   }
 
   public set style(v: TextStyle | TextStyleOptions) {
-    this._style = v instanceof TextStyle ? v : new TextStyle(v);
+    this._replaceStyle(v instanceof TextStyle ? v : new TextStyle(v));
+
     if (!(v instanceof TextStyle)) {
       const face = this._extractFace(v);
       if (face !== null) void this._loadFace(face);
     }
-    this._rebuild('font');
-  }
-
-  public override get text(): string {
-    return this._text;
-  }
-
-  public override set text(v: string) {
-    if (this._text === v) return;
-    this._text = v;
-    this._rebuild('layout');
-  }
-
-  public get layout(): LayoutOptions {
-    return this._layout;
-  }
-
-  public set layout(v: LayoutOptions) {
-    this._layout = v;
-    this._rebuild('layout');
   }
 
   /**
@@ -144,31 +115,14 @@ export class Text extends AbstractText {
     return this._colorGlyphs ? 'color' : 'sdf';
   }
 
-  /** Per-page quad data consumed by the text renderer. */
-  public get pageQuads(): readonly TextPageQuads[] {
-    return this._pageQuads;
-  }
-
-  public override get textBounds(): TextSize {
-    return this._textBounds;
-  }
-
   /** The {@link GlyphAtlas} this node currently draws from. */
   public get atlas(): GlyphAtlas | null {
     return this._atlas;
   }
 
-  public override syncDirty(): void {
-    const hint = this._style.consumeDirty();
-    if (hint !== null && hint !== 'tint') {
-      this._rebuild(hint);
-    }
-  }
-
   public override destroy(): void {
     this._destroyed = true;
     this._faceLoadVersion++;
-    this._pageQuads = [];
     this._atlas = null;
     super.destroy();
   }
@@ -208,58 +162,24 @@ export class Text extends AbstractText {
 
     const pool = getDefaultGlyphAtlasPool();
     pool.getAtlas(this._style.fontFamily, this._style.fontStyle, this._style.fontWeight, this.atlasMode, this._sdfRadius).clear();
-    this._rebuild('font');
+    this._markDirty('font');
   }
 
-  private _rebuild(_hint: StyleChangeHint): void {
-    this._pageQuads = [];
-    this._textBounds = { width: 0, height: 0 };
+  protected override _runLayout(hint: StyleChangeHint): TextLayoutResult {
+    // Empty text needs no glyph source at all, and acquiring one would create
+    // an atlas for a variant this node may never actually rasterize.
+    if (this._text.length === 0) return emptyTextLayout();
 
-    if (this._text.length === 0) {
-      // Empty transition: reset the extent and route through the content-dirty
-      // contract, exactly like the non-empty path below. Without this a Text
-      // going empty keeps its old local bounds and bumps no revision, so
-      // culling / hit-testing / the retained group aggregate read a stale
-      // extent, and any instruction-set cache of the prior geometry stays live.
-      this._setLocalBounds(0, 0, 0, 0);
-      this._updateOrigin();
-      this._style.consumeDirty();
-      return;
-    }
+    // Only a 'font' change can invalidate which atlas this node draws from;
+    // a re-flow reuses the one already resolved.
+    const atlas =
+      hint === 'font' || this._atlas === null
+        ? getDefaultGlyphAtlasPool().getAtlas(this._style.fontFamily, this._style.fontStyle, this._style.fontWeight, this.atlasMode, this._sdfRadius)
+        : this._atlas;
 
-    const pool = getDefaultGlyphAtlasPool();
-    const atlas = pool.getAtlas(this._style.fontFamily, this._style.fontStyle, this._style.fontWeight, this.atlasMode, this._sdfRadius);
     this._atlas = atlas;
 
-    const placements = layoutText(this._text, this._style, this._layout, atlas);
-
-    if (placements.length === 0) {
-      // Same empty-transition contract as above: no glyphs placed, so reset the
-      // extent and content-dirty rather than leaving a stale non-empty bounds.
-      this._setLocalBounds(0, 0, 0, 0);
-      this._updateOrigin();
-      this._style.consumeDirty();
-      return;
-    }
-
-    let maxX = 0,
-      maxY = 0;
-    for (const p of placements) {
-      const px = p.x + p.width;
-      const py = p.y + p.height;
-      if (px > maxX) maxX = px;
-      if (py > maxY) maxY = py;
-    }
-    this._textBounds = { width: maxX, height: maxY };
-    this._setLocalBounds(0, 0, maxX, maxY);
-
-    // An anchor is a fraction of the bounds, so a node whose text just changed
-    // width has to re-derive its origin — otherwise a centred label drifts left
-    // as it grows. Mirrors what Sprite does when it switches sub-frame.
-    this._updateOrigin();
-
-    this._pageQuads = buildTextPageQuads(placements);
-    this._style.consumeDirty();
+    return layoutText(this._text, this._style, this._layout, atlas);
   }
 }
 

--- a/src/rendering/text/TextLayout.ts
+++ b/src/rendering/text/TextLayout.ts
@@ -1,5 +1,5 @@
 import type { LayoutOptions } from './LayoutOptions';
-import type { GlyphInfo, GlyphPlacement, GlyphProvider, TextLayoutStyle, TextPageQuads, TextSize } from './types';
+import type { GlyphInfo, GlyphPlacement, GlyphProvider, TextLayoutResult, TextLayoutStyle, TextPageQuads } from './types';
 
 interface LinePlacement {
   placements: Array<{ info: GlyphInfo; x: number; y: number; char: string }>;
@@ -8,26 +8,13 @@ interface LinePlacement {
 }
 
 /**
- * Compute the bounding pixel dimensions of `text` without allocating quad
- * placements. Returns `{ width: 0, height: 0 }` for empty text.
+ * Result for text that places no glyph at all: no quads, no advance, no ink.
+ * Exported so a node can answer for an empty string without having to acquire
+ * a glyph provider it would not use.
+ * @internal
  */
-export function measureText(text: string, style: TextLayoutStyle, provider: GlyphProvider): TextSize {
-  if (text.length === 0) return { width: 0, height: 0 };
-
-  const { fontSize, lineHeight, leading } = style;
-  const computedLineHeight = fontSize * lineHeight + leading;
-  const lines = text.split('\n');
-  let maxLineWidth = 0;
-
-  for (const line of lines) {
-    let lineWidth = 0;
-    for (const char of line) {
-      lineWidth += provider.getGlyph(char, fontSize).advance;
-    }
-    if (lineWidth > maxLineWidth) maxLineWidth = lineWidth;
-  }
-
-  return { width: maxLineWidth, height: lines.length * computedLineHeight };
+export function emptyTextLayout(): TextLayoutResult {
+  return { placements: [], advance: { width: 0, height: 0 }, ink: { x: 0, y: 0, width: 0, height: 0 } };
 }
 
 /**
@@ -44,10 +31,12 @@ export function measureText(text: string, style: TextLayoutStyle, provider: Glyp
  * shaping, and ligature shaping are out of scope; Unicode/diacritics are
  * delegated to the browser's canvas engine.
  *
- * Returns an empty array for empty text.
+ * Returns the placements alongside both extents the callers need — see
+ * {@link TextLayoutResult} for why the advance and the ink are different
+ * numbers. Text that places no glyph yields zeroes for both.
  */
-export function layoutText(text: string, style: TextLayoutStyle, layout: LayoutOptions, provider: GlyphProvider): readonly GlyphPlacement[] {
-  if (text.length === 0) return [];
+export function layoutText(text: string, style: TextLayoutStyle, layout: LayoutOptions, provider: GlyphProvider): TextLayoutResult {
+  if (text.length === 0) return emptyTextLayout();
 
   const { fontSize, lineHeight, leading, align } = style;
   const computedLineHeight = fontSize * lineHeight + leading;
@@ -133,8 +122,26 @@ export function layoutText(text: string, style: TextLayoutStyle, layout: LayoutO
   }
 
   // Pass 2: apply alignment offset and build final GlyphPlacement array.
+  //
+  // The ink extent accumulates here rather than in a follow-up sweep: every
+  // quad is already in hand, and the minimum is genuinely open — in SDF mode
+  // the first glyph starts at a negative x/y because the atlas hands out
+  // bearings that pull the padded tile back around the cursor.
   const result: GlyphPlacement[] = [];
   const lastLineIndex = linePlacements.length - 1;
+  let inkMinX = Infinity;
+  let inkMinY = Infinity;
+  let inkMaxX = -Infinity;
+  let inkMaxY = -Infinity;
+
+  const place = (placement: GlyphPlacement): void => {
+    result.push(placement);
+
+    if (placement.x < inkMinX) inkMinX = placement.x;
+    if (placement.y < inkMinY) inkMinY = placement.y;
+    if (placement.x + placement.width > inkMaxX) inkMaxX = placement.x + placement.width;
+    if (placement.y + placement.height > inkMaxY) inkMaxY = placement.y + placement.height;
+  };
 
   for (let li = 0; li < linePlacements.length; li++) {
     // In-bounds: li < linePlacements.length.
@@ -160,7 +167,7 @@ export function layoutText(text: string, style: TextLayoutStyle, layout: LayoutO
           prevWasSpace = true;
         }
 
-        result.push({
+        place({
           x: entry.x + offsetX + wordIdx * extraPerGap + (entry.info.xBearing ?? 0),
           y: entry.y + (entry.info.yBearing ?? 0),
           width: entry.info.width,
@@ -176,7 +183,7 @@ export function layoutText(text: string, style: TextLayoutStyle, layout: LayoutO
     }
 
     for (const { info, x, y } of line.placements) {
-      result.push({
+      place({
         x: x + offsetX + (info.xBearing ?? 0),
         y: y + (info.yBearing ?? 0),
         width: info.width,
@@ -190,7 +197,13 @@ export function layoutText(text: string, style: TextLayoutStyle, layout: LayoutO
     }
   }
 
-  return result;
+  if (result.length === 0) return emptyTextLayout();
+
+  return {
+    placements: result,
+    advance: { width: maxLineWidth, height: allLines.length * computedLineHeight },
+    ink: { x: inkMinX, y: inkMinY, width: inkMaxX - inkMinX, height: inkMaxY - inkMinY },
+  };
 }
 
 /**

--- a/src/rendering/text/TextStyle.ts
+++ b/src/rendering/text/TextStyle.ts
@@ -13,7 +13,12 @@ export type GradientAxis = 'vertical' | 'horizontal';
  */
 export type StyleChangeHint = 'tint' | 'layout' | 'font';
 
-function mergeHint(a: StyleChangeHint, b: StyleChangeHint): StyleChangeHint {
+/**
+ * Accumulate two hints to the heavier of the two, so a pending rebuild is
+ * never downgraded by a cheaper change arriving after it.
+ * @internal
+ */
+export function mergeHint(a: StyleChangeHint, b: StyleChangeHint): StyleChangeHint {
   if (a === 'font' || b === 'font') return 'font';
   if (a === 'layout' || b === 'layout') return 'layout';
   return 'tint';

--- a/src/rendering/text/types.ts
+++ b/src/rendering/text/types.ts
@@ -2,7 +2,7 @@
 export type TextAlignment = 'left' | 'center' | 'right' | 'justify';
 
 /**
- * Minimal interface consumed by {@link layoutText} and {@link measureText}.
+ * Minimal interface consumed by {@link layoutText}.
  * Both {@link TextStyle} and the BMFont adapter satisfy this structurally.
  */
 export interface TextLayoutStyle {
@@ -89,10 +89,40 @@ export interface GlyphInfo {
   readonly yBearing?: number;
 }
 
-/** Pixel dimensions of a laid-out text string returned by {@link measureText}. */
+/**
+ * Advance extent of a laid-out text string in pixels — where the cursor ends
+ * up, not how far the glyphs reach. See {@link TextLayoutResult} for the
+ * difference between the two measures.
+ */
 export interface TextSize {
   readonly width: number;
   readonly height: number;
+}
+
+/**
+ * Result of a full text layout pass: quad placements plus both extents.
+ *
+ * Text has two honest sizes and they are not interchangeable. The advance is
+ * what a layout wants — it answers "how much room does this string take up in
+ * the flow". The ink is what the GPU wants — it answers "which rectangle do
+ * these glyphs actually cover", padding, outline reach and all.
+ */
+export interface TextLayoutResult {
+  /** Per-glyph quad placements in local text space. */
+  readonly placements: readonly GlyphPlacement[];
+  /**
+   * Advance extent — where the cursor ends up. Width is the widest line's
+   * advance (letterSpacing and kerning included, no trailing gap), height is
+   * `lineCount * (fontSize * lineHeight + leading)`. This is the measure a
+   * caller wants for layout, panel sizing and caret placement.
+   */
+  readonly advance: TextSize;
+  /**
+   * Ink extent — the union of the glyph quads, in the same local space as
+   * `placements`. Carries SDF padding and therefore outline/shadow reach, and
+   * its minimum is not necessarily zero. This is the node's local bounds.
+   */
+  readonly ink: { readonly x: number; readonly y: number; readonly width: number; readonly height: number };
 }
 
 /**

--- a/src/rendering/webgl2/WebGl2TextRenderer.ts
+++ b/src/rendering/webgl2/WebGl2TextRenderer.ts
@@ -407,13 +407,15 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       arr[base + 32] = arr[base + 33] = arr[base + 34] = arr[base + 35] = 0;
     }
 
-    // Text block bounds (texel 9): (minX, minY, width, height)
-    // Vertex shader uses these to compute normalized gradient UV.
-    const bounds = node.textBounds;
-    arr[base + 36] = 0;
-    arr[base + 37] = 0;
-    arr[base + 38] = bounds.width;
-    arr[base + 39] = bounds.height;
+    // Text ink bounds (texel 9): (minX, minY, width, height)
+    // Vertex shader uses these to compute normalized gradient UV, so it needs
+    // the rectangle the glyph quads actually cover — not the advance extent,
+    // whose origin is (0, 0) while the SDF quads start at a negative offset.
+    const ink = node.getLocalBounds();
+    arr[base + 36] = ink.x;
+    arr[base + 37] = ink.y;
+    arr[base + 38] = ink.width;
+    arr[base + 39] = ink.height;
   }
 
   // ── Flush ────────────────────────────────────────────────────────────────

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -868,11 +868,14 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       arr[base + 32] = arr[base + 33] = arr[base + 34] = arr[base + 35] = 0;
     }
 
-    const bounds = node.textBounds;
-    arr[base + 36] = 0;
-    arr[base + 37] = 0;
-    arr[base + 38] = bounds.width;
-    arr[base + 39] = bounds.height;
+    // The gradient UV is normalized against the rectangle the glyph quads
+    // actually cover, not the advance extent — the SDF quads start at a
+    // negative offset, so an origin of (0, 0) would skew the ramp.
+    const ink = node.getLocalBounds();
+    arr[base + 36] = ink.x;
+    arr[base + 37] = ink.y;
+    arr[base + 38] = ink.width;
+    arr[base + 39] = ink.height;
   }
 
   // ── GPU resource helpers ─────────────────────────────────────────────────

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -456,6 +456,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "TextAlignment: type alias",
   "TextAsset: class",
   "TextFactory: class",
+  "TextLayoutResult: interface",
   "TextLayoutStyle: interface",
   "TextOptions: interface",
   "TextPageQuads: interface",

--- a/test/rendering/browser/webgl2-text-gradient.test.ts
+++ b/test/rendering/browser/webgl2-text-gradient.test.ts
@@ -1,0 +1,154 @@
+/**
+ * WebGL2 browser test — the gradient ramp is normalized against the text INK.
+ *
+ * `text.vert` computes `v_gradUV = clamp((a_position - box.xy) / box.zw)` from
+ * the rectangle the renderer uploads, and `text-sdf.frag` mixes the two ramp
+ * colours by that fraction. Uploading the advance extent instead of the ink
+ * runs the ramp against a box the glyph quads do not sit in: its origin is
+ * (0, 0) while the SDF quads start at a negative offset, so every glyph row
+ * samples the ramp at the wrong place and the clamp eats the overhang.
+ *
+ * The check does not depend on the shape of the glyph. With a pure red/blue
+ * vertical ramp, `r / (r + b)` at any covered pixel IS the ramp fraction, and
+ * the ramp fraction is a closed form of the uploaded box — so each ink row can
+ * be predicted from `text.getLocalBounds()` and compared. Partial coverage
+ * scales both channels equally and cancels out of the ratio.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { readWebGl2Frame } from './_backendSetup';
+import { wireCoreRenderers } from './_coreRenderers';
+
+const canvasSize = 96;
+const textY = 8;
+
+const createBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+const render = (backend: WebGl2Backend, node: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+};
+
+/**
+ * Per row, the red share of the strongest covered pixel. Rows whose strongest
+ * pixel is too faint carry too little signal to read a ratio out of and are
+ * dropped.
+ */
+const rowRedShares = (frame: Uint8Array): ReadonlyArray<{ y: number; share: number }> => {
+  const rows: Array<{ y: number; share: number }> = [];
+
+  for (let y = 0; y < canvasSize; y++) {
+    let bestTotal = 0;
+    let bestShare = 0;
+
+    for (let x = 0; x < canvasSize; x++) {
+      const i = (y * canvasSize + x) * 4;
+      const r = frame[i]!;
+      const b = frame[i + 2]!;
+      const total = r + b;
+
+      if (total > bestTotal) {
+        bestTotal = total;
+        bestShare = r / total;
+      }
+    }
+
+    if (bestTotal >= 160) rows.push({ y, share: bestShare });
+  }
+
+  return rows;
+};
+
+describe('WebGL2: the text gradient ramp spans the ink extent', () => {
+  beforeEach(() => resetDefaultGlyphAtlasPool());
+  afterEach(() => resetDefaultGlyphAtlasPool());
+
+  test('every ink row samples the ramp at the fraction its ink position implies', async () => {
+    const backend = await createBackend();
+    const root = new Container();
+    // 'M' is wide and solid, so most rows carry a strong, unambiguous sample.
+    // gradientColors[0] feeds the shader's ramp-1.0 end, [1] its ramp-0.0 end.
+    const text = new Text('M', {
+      fontSize: 56,
+      fillColor: Color.white,
+      gradientColors: [Color.red, Color.blue],
+      gradientAxis: 'vertical',
+    });
+
+    text.setPosition(8, textY);
+    root.addChild(text);
+
+    try {
+      render(backend, root);
+
+      const rows = rowRedShares(readWebGl2Frame(backend, canvasSize));
+      const ink = text.getLocalBounds();
+
+      // Enough rows to make the per-row claim below more than a spot check.
+      expect(rows.length).toBeGreaterThan(20);
+
+      // The ink here is (-8, -8, 59, 79) against an advance of (46.6, 67.2):
+      // both the origin and the span differ, so predicting from one box and
+      // rendering from the other misses by far more than the slack below.
+      expect(ink.y).toBeLessThan(0);
+      expect(ink.height).not.toBe(text.textBounds.height);
+
+      for (const { y, share } of rows) {
+        // The shader interpolates at the pixel centre.
+        const localY = y + 0.5 - textY;
+        const expected = Math.min(1, Math.max(0, (localY - ink.y) / ink.height));
+
+        // Measured agreement is within 0.001 on every ink row; the slack
+        // covers adapter rounding, not a difference of interpretation.
+        expect(Math.abs(share - expected), `row ${y}: red share ${share.toFixed(3)}, expected ${expected.toFixed(3)}`).toBeLessThan(0.02);
+      }
+    } finally {
+      root.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/text-retained-webgpu.test.ts
+++ b/test/rendering/text-retained-webgpu.test.ts
@@ -459,6 +459,82 @@ describe('WebGPU Text retained-batch record/replay', () => {
     }
   });
 
+  // The vertex shader normalizes the gradient ramp against this rectangle
+  // (`v_gradUV = clamp((a_position - box.xy) / box.zw)`), so uploading the
+  // advance extent instead of the ink runs the ramp against a box the glyph
+  // quads do not sit in: its origin is (0, 0) while the SDF quads start at a
+  // negative offset, and the clamp eats the overhang.
+  test('the gradient box uploaded per node is the ink extent, not the advance', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createBackend(environment);
+      const root = new Container();
+      const group = new RetainedContainer();
+      const text = new Text('Hi', { fontSize: 16, gradientColors: [Color.red, Color.blue] });
+
+      group.addChild(text);
+      root.addChild(group);
+
+      renderFrame(backend, root); // F1: capture
+      renderFrame(backend, root); // F2: record
+      renderFrame(backend, root); // F3: replay — uploads the node-data rows
+
+      const upload = environment
+        .writes()
+        .filter(write => write.label === nodeDataLabel)
+        .at(-1);
+
+      expect(upload).toBeDefined();
+
+      const row = new Float32Array(upload!.bytes.slice().buffer);
+      const ink = text.getLocalBounds();
+
+      expect([row[36], row[37], row[38], row[39]]).toEqual([ink.x, ink.y, ink.width, ink.height]);
+
+      // The two measures have to actually differ here, or the assertion above
+      // would hold for the advance box too and prove nothing.
+      expect(ink.x).toBeLessThan(0);
+      expect(ink.width).not.toBe(text.textBounds.width);
+
+      root.destroy();
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('an in-place style mutation forces a full re-record', async () => {
+    // The layout pass itself is deferred to the next read, but a replaying
+    // group never reads the node — so the content stamp has to land when the
+    // style is mutated, not when the pass eventually runs.
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createBackend(environment);
+      const { root, group, text } = buildTextGroup();
+
+      renderFrame(backend, root); // F1: capture
+      renderFrame(backend, root); // F2: record
+
+      expect(fragmentOf(group).instructions?.hasRecording).toBe(true);
+
+      text.style.fontSize = 32;
+      renderFrame(backend, root); // F3: content-dirty — drops the recording
+
+      expect(fragmentOf(group).instructions?.hasRecording).not.toBe(true);
+
+      renderFrame(backend, root); // F4: re-record against the new content
+
+      expect(fragmentOf(group).instructions?.hasRecording).toBe(true);
+
+      root.destroy();
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
   test('a flush producing more than one (shaderType, atlasTexture) batch poisons the capture instead of recording it', async () => {
     const environment = createMockWebGpuEnvironment();
     // Force the multi-batch branch deterministically (getting real content to

--- a/test/rendering/text/bitmap-text.test.ts
+++ b/test/rendering/text/bitmap-text.test.ts
@@ -10,6 +10,28 @@ import { BmFont } from '#rendering/text/BmFont';
 import type { Texture } from '#rendering/texture/Texture';
 
 // ---------------------------------------------------------------------------
+// Layout-pass counter — "at most one pass per change" is only observable by
+// counting; comparing geometry cannot tell one pass from three.
+// ---------------------------------------------------------------------------
+
+const layoutCounter = vi.hoisted(() => ({ passes: 0 }));
+
+vi.mock('#rendering/text/TextLayout', async importOriginal => {
+  const actual = await importOriginal<typeof import('#rendering/text/TextLayout')>();
+
+  return {
+    ...actual,
+    layoutText: (...args: Parameters<typeof actual.layoutText>) => {
+      layoutCounter.passes++;
+
+      return actual.layoutText(...args);
+    },
+  };
+});
+
+const layoutPasses = (): number => layoutCounter.passes;
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -138,10 +160,10 @@ describe('BitmapText', () => {
     expect(text.pageQuads[0]).not.toBe(first);
   });
 
-  test('mutating a style property in place triggers an immediate rebuild', () => {
+  test('mutating a style property in place reaches the next layout pass', () => {
     // Line 0 ("A") is narrower than line 1 ("AB"), so right-alignment has to
-    // shift line 0's glyph to the right — a rebuild that skipped would leave
-    // it at x = 0.
+    // shift line 0's glyph to the right — a pass that skipped would leave it
+    // at x = 0.
     const text = new BitmapText('A\nAB', makeFont());
     const first = text.pageQuads[0];
     const firstX = first.vertices[0];
@@ -152,9 +174,9 @@ describe('BitmapText', () => {
     expect(text.pageQuads[0].vertices[0]).toBeGreaterThan(firstX);
   });
 
-  test('consecutive in-place style mutations each trigger a rebuild', () => {
+  test('consecutive in-place style mutations each reach a layout pass', () => {
     // Guards the dirty-latch failure mode: a style that stays dirty after the
-    // first notification would silently swallow every later mutation.
+    // first read would silently swallow every later mutation.
     const text = new BitmapText('AB', makeFont());
 
     text.style.leading = 4;
@@ -162,6 +184,72 @@ describe('BitmapText', () => {
     text.style.leading = 8;
 
     expect(text.pageQuads[0]).not.toBe(afterFirst);
+  });
+
+  // NEU-K3 / ME-60: BitmapText used to lay text out inside every setter and in
+  // its style-change signal handler, so a burst of edits paid for a full pass
+  // each. It now shares the deferred model with Text.
+  test('a run of mutations costs exactly one layout pass', () => {
+    const text = new BitmapText('AB', makeFont());
+
+    text.syncDirty();
+    const passesBefore = layoutPasses();
+
+    text.text = 'A';
+    text.text = 'B';
+    text.style.align = 'center';
+    text.style.leading = 6;
+    text.layout = { letterSpacing: 2 };
+    text.fontScale = 2;
+
+    expect(layoutPasses()).toBe(passesBefore);
+
+    expect(text.pageQuads.length).toBeGreaterThan(0);
+
+    expect(layoutPasses()).toBe(passesBefore + 1);
+  });
+
+  test('an in-place style mutation defers its pass until the node is read', () => {
+    const text = new BitmapText('AB', makeFont());
+
+    text.syncDirty();
+    const passesBefore = layoutPasses();
+
+    text.style.align = 'right';
+
+    expect(layoutPasses()).toBe(passesBefore);
+
+    text.syncDirty();
+
+    expect(layoutPasses()).toBe(passesBefore + 1);
+  });
+
+  test('getLocalBounds() resolves a pending layout without an explicit sync', () => {
+    const text = new BitmapText('A', makeFont());
+    const shortWidth = text.getLocalBounds().width;
+
+    text.text = 'AAAAA';
+
+    expect(text.getLocalBounds().width).toBeGreaterThan(shortWidth);
+  });
+
+  test('textBounds is the advance, getLocalBounds() the glyph ink', () => {
+    // 'A' and 'B' advance 10 each; the glyph quads are 8 wide, so the ink
+    // stops short of the cursor while the advance does not.
+    const text = new BitmapText('AB', makeFont());
+
+    expect(text.textBounds.width).toBe(19); // 10 + 10, less the 1px A→B kerning
+    expect(text.getLocalBounds().width).toBe(17); // last quad ends 8 past its x
+  });
+
+  test('mutating the layout object after construction does not re-flow the node', () => {
+    const layout = { letterSpacing: 0 };
+    const text = new BitmapText('AB', makeFont(), { layout });
+    const widthBefore = text.textBounds.width;
+
+    layout.letterSpacing = 40;
+
+    expect(text.textBounds.width).toBe(widthBefore);
   });
 
   test('replacing the style detaches the previous one from rebuilds', () => {
@@ -332,13 +420,14 @@ describe('BmFontAdapter missing-glyph warnings', () => {
     spy.mockRestore();
   });
 
-  test('BitmapText rebuild does not re-trigger warning for already-seen missing glyph', () => {
+  test('a second layout pass does not re-warn about an already-seen missing glyph', () => {
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const font = makeFont(); // font has A, B, space — not Z
     const text = new BitmapText('AZB', font);
 
-    // Force a rebuild by changing the text (triggers _rebuild internally)
-    text.text = 'AZB';
+    text.syncDirty();
+    text.text = 'BZA'; // a different string still missing the same glyph
+    text.syncDirty();
 
     expect(spy).toHaveBeenCalledTimes(1); // Z warned exactly once across both layouts
     spy.mockRestore();

--- a/test/rendering/text/text-layout.test.ts
+++ b/test/rendering/text/text-layout.test.ts
@@ -1,15 +1,13 @@
 ﻿/**
- * Tests for the TextLayout module: layoutText(), measureText(), and
- * buildTextPageQuads().
+ * Tests for the TextLayout module: layoutText() and buildTextPageQuads().
  *
- * We use a minimal mock GlyphAtlas (for layoutText) and a bare-bones fake
- * GlyphProvider with a fixed advance per char (for measureText) so we can
- * assert exact placement/measurement math without depending on a real
- * canvas 2D context.
+ * We use a minimal mock GlyphAtlas and a bare-bones fake GlyphProvider with a
+ * fixed advance per char so we can assert exact placement/measurement math
+ * without depending on a real canvas 2D context.
  */
 
 import type { GlyphAtlas } from '#rendering/text/GlyphAtlas';
-import { buildTextPageQuads, layoutText, measureText } from '#rendering/text/TextLayout';
+import { buildTextPageQuads, layoutText } from '#rendering/text/TextLayout';
 import { TextStyle } from '#rendering/text/TextStyle';
 import type { GlyphInfo, GlyphPlacement, GlyphProvider } from '#rendering/text/types';
 
@@ -65,11 +63,11 @@ function makeProvider(advance = 10): GlyphProvider {
 // ---------------------------------------------------------------------------
 
 describe('layoutText', () => {
-  test('empty text returns an empty array', () => {
+  test('empty text returns no placements', () => {
     const atlas = makeAtlas();
     const style = new TextStyle({ fontSize: 16, align: 'left' });
 
-    expect(layoutText('', style, {}, atlas)).toEqual([]);
+    expect(layoutText('', style, {}, atlas).placements).toEqual([]);
   });
 
   test('single line "Hello" — 5 placements with increasing x', () => {
@@ -77,7 +75,7 @@ describe('layoutText', () => {
     const atlas = makeAtlas(advance);
     const style = new TextStyle({ fontSize: 16, align: 'left' });
 
-    const placements = layoutText('Hello', style, {}, atlas);
+    const placements = layoutText('Hello', style, {}, atlas).placements;
 
     expect(placements).toHaveLength(5);
 
@@ -94,7 +92,7 @@ describe('layoutText', () => {
     const atlas = makeAtlas(advance);
     const style = new TextStyle({ fontSize, lineHeight, align: 'left' });
 
-    const placements = layoutText('Hi\nThere', style, {}, atlas);
+    const placements = layoutText('Hi\nThere', style, {}, atlas).placements;
 
     expect(placements).toHaveLength(7);
 
@@ -112,7 +110,7 @@ describe('layoutText', () => {
     const atlas = makeAtlas(advance);
     const style = new TextStyle({ fontSize: 16, align: 'left' });
 
-    const placements = layoutText('AB\nC', style, {}, atlas);
+    const placements = layoutText('AB\nC', style, {}, atlas).placements;
 
     expect(placements[0].x).toBe(0);
     expect(placements[1].x).toBe(10);
@@ -124,7 +122,7 @@ describe('layoutText', () => {
     const atlas = makeAtlas(advance);
     const style = new TextStyle({ fontSize: 16, align: 'right' });
 
-    const placements = layoutText('AB\nC', style, {}, atlas);
+    const placements = layoutText('AB\nC', style, {}, atlas).placements;
 
     expect(placements).toHaveLength(3);
     expect(placements[0].x).toBe(0);
@@ -137,7 +135,7 @@ describe('layoutText', () => {
     const atlas = makeAtlas(advance);
     const style = new TextStyle({ fontSize: 16, align: 'center' });
 
-    const placements = layoutText('AB\nC', style, {}, atlas);
+    const placements = layoutText('AB\nC', style, {}, atlas).placements;
 
     expect(placements).toHaveLength(3);
     expect(placements[2].x).toBeCloseTo(5);
@@ -147,7 +145,7 @@ describe('layoutText', () => {
     const atlas = makeAtlas(5);
     const style = new TextStyle({ fontSize: 16, align: 'left' });
 
-    const placements = layoutText(' ', style, {}, atlas);
+    const placements = layoutText(' ', style, {}, atlas).placements;
 
     expect(placements).toHaveLength(1);
     expect(placements[0].x).toBe(0);
@@ -174,7 +172,7 @@ describe('layoutText', () => {
     } as unknown as GlyphAtlas;
 
     const style = new TextStyle({ fontSize: 16, align: 'left' });
-    const placements = layoutText('X', style, {}, atlas);
+    const placements = layoutText('X', style, {}, atlas).placements;
 
     expect(placements[0].uvLeft).toBe(glyphInfo.uvLeft);
     expect(placements[0].uvTop).toBe(glyphInfo.uvTop);
@@ -190,7 +188,7 @@ describe('layoutText', () => {
     const atlas = makeAtlas(advance);
     const style = new TextStyle({ fontSize: 16 });
 
-    const placements = layoutText('ABC', style, { letterSpacing: 5 }, atlas);
+    const placements = layoutText('ABC', style, { letterSpacing: 5 }, atlas).placements;
 
     expect(placements).toHaveLength(3);
     expect(placements[0].x).toBe(0);
@@ -206,7 +204,7 @@ describe('layoutText', () => {
     // "Hello World" with advance=10 per char, space width=10
     // "Hello" = 50px, "World" = 50px, with space = 110px total
     // maxWidth = 60 → wrap before "World"
-    const placements = layoutText('Hello World', style, { maxWidth: 60 }, atlas);
+    const placements = layoutText('Hello World', style, { maxWidth: 60 }, atlas).placements;
 
     // "Hello" on line 0 at y=0, "World" on line 1 at y=lineHeight
     expect(placements.length).toBe(10); // 5 + 5 chars
@@ -220,7 +218,7 @@ describe('layoutText', () => {
     const atlas = makeAtlas(advance);
     const style = new TextStyle({ fontSize: 16, align: 'left' });
 
-    const placements = layoutText('the quick brown fox', style, {}, atlas);
+    const placements = layoutText('the quick brown fox', style, {}, atlas).placements;
 
     // Without a wrap width every glyph stays on line 0 and x increases
     // monotonically — the canonical "no wrap" behaviour.
@@ -238,7 +236,7 @@ describe('layoutText', () => {
     const style = new TextStyle({ fontSize: 16, align: 'left' });
 
     // 12-char token at advance 10 → 120px; maxWidth 50 → ~5 chars per line.
-    const placements = layoutText('ABCDEFGHIJKL', style, { maxWidth: 50, breakWords: true }, atlas);
+    const placements = layoutText('ABCDEFGHIJKL', style, { maxWidth: 50, breakWords: true }, atlas).placements;
 
     const lineYs = [...new Set(placements.map(placement => placement.y))];
     expect(lineYs.length).toBeGreaterThanOrEqual(2); // wrapped onto multiple lines
@@ -251,7 +249,7 @@ describe('layoutText', () => {
     const style = new TextStyle({ fontSize: 16, align: 'left' });
 
     // No spaces to break on and breakWords off → a single overflowing line.
-    const placements = layoutText('ABCDEFGHIJKL', style, { maxWidth: 50 }, atlas);
+    const placements = layoutText('ABCDEFGHIJKL', style, { maxWidth: 50 }, atlas).placements;
 
     const lineYs = [...new Set(placements.map(placement => placement.y))];
     expect(lineYs).toEqual([0]);
@@ -263,7 +261,7 @@ describe('layoutText', () => {
     const style = new TextStyle({ fontSize: 16, align: 'left' });
 
     // "A B" = 10 + 10(space) + 10 = 30px. maxWidth = 100 → both words fit on line 0.
-    const placements = layoutText('A B', style, { maxWidth: 100 }, atlas);
+    const placements = layoutText('A B', style, { maxWidth: 100 }, atlas).placements;
 
     const lineYs = [...new Set(placements.map(placement => placement.y))];
     expect(lineYs).toEqual([0]);
@@ -277,7 +275,7 @@ describe('layoutText', () => {
 
     // "Hi" (20px) fits on line 0 first; the following 12-char token (120px)
     // cannot join it and must be flushed + char-split across further lines.
-    const placements = layoutText('Hi ABCDEFGHIJKL', style, { maxWidth: 50, breakWords: true }, atlas);
+    const placements = layoutText('Hi ABCDEFGHIJKL', style, { maxWidth: 50, breakWords: true }, atlas).placements;
 
     const lineYs = [...new Set(placements.map(placement => placement.y))];
     expect(lineYs.length).toBeGreaterThanOrEqual(3); // "Hi" line + at least 2 char-split lines
@@ -307,7 +305,7 @@ describe('layoutText', () => {
     // _wrapLine (maxWidth 30): "A B" (25px) fits on line 0; "CCCCC" (50px,
     // over budget but unbreakable without breakWords) becomes line 1 — the
     // widest realized line, so line 0 has slack to distribute.
-    const placements = layoutText('A B CCCCC', style, { maxWidth: 30 }, atlas);
+    const placements = layoutText('A B CCCCC', style, { maxWidth: 30 }, atlas).placements;
 
     const lineYs = [...new Set(placements.map(p => p.y))];
     expect(lineYs).toHaveLength(2);
@@ -331,7 +329,7 @@ describe('layoutText', () => {
     // _wrapLine (maxWidth 30): "A B" (30px) fits on line 0; "CCCCC" (50px,
     // over budget but unbreakable without breakWords) becomes line 1 — the
     // widest realized line, so line 0 has slack to distribute.
-    const placements = layoutText('A B CCCCC', style, { maxWidth: 30 }, atlas);
+    const placements = layoutText('A B CCCCC', style, { maxWidth: 30 }, atlas).placements;
 
     const lineYs = [...new Set(placements.map(p => p.y))];
     expect(lineYs).toHaveLength(2);
@@ -351,7 +349,7 @@ describe('layoutText', () => {
 
     // Single line (no wrap) — justify must behave like left-align since this
     // is simultaneously the first and last line.
-    const placements = layoutText('A B', style, {}, atlas);
+    const placements = layoutText('A B', style, {}, atlas).placements;
 
     expect(placements[0]?.x).toBe(0);
     expect(placements[2]?.x).toBe(2 * advance);
@@ -362,8 +360,8 @@ describe('layoutText', () => {
     const atlas = makeAtlas(advance);
     const style = new TextStyle({ fontSize: 16, align: 'left' });
 
-    const normalized = layoutText('A\nB   C', style, { whiteSpace: 'normal' }, atlas);
-    const preLine = layoutText('A\nB   C', style, { whiteSpace: 'pre-line' }, atlas);
+    const normalized = layoutText('A\nB   C', style, { whiteSpace: 'normal' }, atlas).placements;
+    const preLine = layoutText('A\nB   C', style, { whiteSpace: 'pre-line' }, atlas).placements;
 
     // 'normal' turns the whole string into one line: "A B C" (5 chars incl. spaces).
     const normalLineYs = [...new Set(normalized.map(p => p.y))];
@@ -380,7 +378,7 @@ describe('layoutText', () => {
     const atlas = makeAtlas(advance);
     const style = new TextStyle({ fontSize: 16, align: 'left' });
 
-    const placements = layoutText('A   B', style, { whiteSpace: 'pre' }, atlas);
+    const placements = layoutText('A   B', style, { whiteSpace: 'pre' }, atlas).placements;
 
     expect(placements).toHaveLength(5); // 'A', ' ', ' ', ' ', 'B' — no collapsing
   });
@@ -399,14 +397,14 @@ describe('layoutText vertical overflow', () => {
   }
 
   test('maxHeight without overflow keeps every line visible', () => {
-    const placements = layoutText('A\nB\nC', overflowStyle(), { maxHeight: twoLineMaxHeight }, makeAtlas());
+    const placements = layoutText('A\nB\nC', overflowStyle(), { maxHeight: twoLineMaxHeight }, makeAtlas()).placements;
 
     expect(placements).toHaveLength(3);
     expect(placements[2].y).toBeCloseTo(38.4);
   });
 
   test('overflow "clip" drops lines that do not fit maxHeight', () => {
-    const placements = layoutText('A\nB\nC', overflowStyle(), { maxHeight: twoLineMaxHeight, overflow: 'clip' }, makeAtlas());
+    const placements = layoutText('A\nB\nC', overflowStyle(), { maxHeight: twoLineMaxHeight, overflow: 'clip' }, makeAtlas()).placements;
 
     expect(placements).toHaveLength(2);
     expect(placements[0].y).toBe(0);
@@ -414,7 +412,7 @@ describe('layoutText vertical overflow', () => {
   });
 
   test('overflow "ellipsis" clips and appends an ellipsis to the last visible line', () => {
-    const placements = layoutText('A\nB\nC', overflowStyle(), { maxHeight: twoLineMaxHeight, overflow: 'ellipsis' }, makeAtlas());
+    const placements = layoutText('A\nB\nC', overflowStyle(), { maxHeight: twoLineMaxHeight, overflow: 'ellipsis' }, makeAtlas()).placements;
 
     // 'A' on line 0, then 'B' + the ellipsis glyph on line 1.
     expect(placements).toHaveLength(3);
@@ -424,13 +422,13 @@ describe('layoutText vertical overflow', () => {
   });
 
   test('overflow without maxHeight leaves the text untouched', () => {
-    const placements = layoutText('A\nB\nC', overflowStyle(), { overflow: 'clip' }, makeAtlas());
+    const placements = layoutText('A\nB\nC', overflowStyle(), { overflow: 'clip' }, makeAtlas()).placements;
 
     expect(placements).toHaveLength(3);
   });
 
   test('maxHeight smaller than a single line clips everything away', () => {
-    const placements = layoutText('A\nB', overflowStyle(), { maxHeight: 5, overflow: 'clip' }, makeAtlas());
+    const placements = layoutText('A\nB', overflowStyle(), { maxHeight: 5, overflow: 'clip' }, makeAtlas()).placements;
 
     expect(placements).toHaveLength(0);
   });
@@ -438,7 +436,7 @@ describe('layoutText vertical overflow', () => {
   test('overflow "ellipsis" drops trailing characters so the line still fits maxWidth', () => {
     // advance 10, maxWidth 30 → three glyph slots. 'ABC' already fills them,
     // so the ellipsis has to displace a character rather than overflow.
-    const placements = layoutText('ABC\nD', overflowStyle(), { maxWidth: 30, maxHeight: 19.2, overflow: 'ellipsis' }, makeAtlas());
+    const placements = layoutText('ABC\nD', overflowStyle(), { maxWidth: 30, maxHeight: 19.2, overflow: 'ellipsis' }, makeAtlas()).placements;
 
     expect(placements).toHaveLength(3);
     for (const p of placements) expect(p.y).toBe(0);
@@ -477,7 +475,7 @@ describe('layoutText direction', () => {
     const provider = makeCharProvider({ A: 10, B: 20 });
     const style = new TextStyle({ fontSize: 16, align: 'left' });
 
-    const placements = layoutText('AB', style, { direction: 'ltr' }, provider);
+    const placements = layoutText('AB', style, { direction: 'ltr' }, provider).placements;
 
     expect(placements[0].width).toBe(10); // 'A' first
     expect(placements[0].x).toBe(0);
@@ -489,7 +487,7 @@ describe('layoutText direction', () => {
     const provider = makeCharProvider({ A: 10, B: 20 });
     const style = new TextStyle({ fontSize: 16, align: 'left' });
 
-    const placements = layoutText('AB', style, { direction: 'rtl' }, provider);
+    const placements = layoutText('AB', style, { direction: 'rtl' }, provider).placements;
 
     expect(placements[0].width).toBe(20); // 'B' now leads visually
     expect(placements[0].x).toBe(0);
@@ -501,7 +499,7 @@ describe('layoutText direction', () => {
     const provider = makeCharProvider({ A: 10, B: 20, C: 30, D: 40 });
     const style = new TextStyle({ fontSize: 16, lineHeight: 1.2, align: 'left' });
 
-    const placements = layoutText('AB\nCD', style, { direction: 'rtl' }, provider);
+    const placements = layoutText('AB\nCD', style, { direction: 'rtl' }, provider).placements;
 
     expect(placements[0].width).toBe(20); // line 0 → 'B', 'A'
     expect(placements[1].width).toBe(10);
@@ -511,15 +509,19 @@ describe('layoutText direction', () => {
 });
 
 // ---------------------------------------------------------------------------
-// measureText()
+// layoutText() — the advance extent
 // ---------------------------------------------------------------------------
 
-describe('measureText', () => {
-  test('empty text returns zero width and height', () => {
+describe('layoutText advance', () => {
+  test('empty text has neither advance nor ink', () => {
     const provider = makeProvider();
     const style = new TextStyle({ fontSize: 16 });
 
-    expect(measureText('', style, provider)).toEqual({ width: 0, height: 0 });
+    expect(layoutText('', style, {}, provider)).toEqual({
+      placements: [],
+      advance: { width: 0, height: 0 },
+      ink: { x: 0, y: 0, width: 0, height: 0 },
+    });
   });
 
   test('single-line width is the sum of glyph advances', () => {
@@ -527,7 +529,7 @@ describe('measureText', () => {
     const provider = makeProvider(advance);
     const style = new TextStyle({ fontSize: 16, lineHeight: 1, leading: 0 });
 
-    const size = measureText('Hello', style, provider);
+    const size = layoutText('Hello', style, {}, provider).advance;
 
     expect(size.width).toBe(5 * advance);
   });
@@ -538,7 +540,7 @@ describe('measureText', () => {
     const lineHeight = 2; // multiplier
     const style = new TextStyle({ fontSize, lineHeight, leading: 0 });
 
-    const size = measureText('X', style, provider);
+    const size = layoutText('X', style, {}, provider).advance;
 
     // computedLineHeight = fontSize * lineHeight + leading = 20 * 2 + 0 = 40
     expect(size.height).toBe(40);
@@ -548,7 +550,7 @@ describe('measureText', () => {
     const provider = makeProvider(10);
     const style = new TextStyle({ fontSize: 10, lineHeight: 1, leading: 4 });
 
-    const size = measureText('X', style, provider);
+    const size = layoutText('X', style, {}, provider).advance;
 
     // computedLineHeight = 10 * 1 + 4 = 14
     expect(size.height).toBe(14);
@@ -561,7 +563,7 @@ describe('measureText', () => {
     const leading = 3;
     const style = new TextStyle({ fontSize, lineHeight, leading });
 
-    const size = measureText('one\ntwo\nthree', style, provider);
+    const size = layoutText('one\ntwo\nthree', style, {}, provider).advance;
 
     const computedLineHeight = fontSize * lineHeight + leading;
     expect(size.height).toBe(3 * computedLineHeight);
@@ -572,7 +574,7 @@ describe('measureText', () => {
     const style = new TextStyle({ fontSize: 16 });
 
     // Line widths: 'Hi' = 20, 'Hello' = 50, 'Yo' = 20 → widest is 50.
-    const size = measureText('Hi\nHello\nYo', style, provider);
+    const size = layoutText('Hi\nHello\nYo', style, {}, provider).advance;
 
     expect(size.width).toBe(50);
   });
@@ -581,10 +583,95 @@ describe('measureText', () => {
     const provider = makeProvider(10);
     const style = new TextStyle({ fontSize: 20, lineHeight: 1, leading: 0 });
 
-    const size = measureText('A\n', style, provider);
+    const size = layoutText('A\n', style, {}, provider).advance;
 
     expect(size.width).toBe(10); // widest line is 'A'
     expect(size.height).toBe(2 * 20); // 2 lines: 'A' and ''
+  });
+
+  test('letterSpacing widens the advance but not by a trailing gap', () => {
+    const provider = makeProvider(10);
+    const style = new TextStyle({ fontSize: 16, lineHeight: 1, leading: 0 });
+
+    const size = layoutText('ABC', style, { letterSpacing: 5 }, provider).advance;
+
+    // 3 advances of 10 plus the 2 INTERIOR gaps — the gap after the last
+    // glyph is not part of the extent.
+    expect(size.width).toBe(3 * 10 + 2 * 5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// layoutText() — the ink extent
+// ---------------------------------------------------------------------------
+
+describe('layoutText ink', () => {
+  /**
+   * Provider standing in for the SDF path, where the atlas pads every glyph
+   * and hands back negative bearings to pull the padded tile back around the
+   * cursor. The ink therefore starts left of and above the layout origin.
+   */
+  function makePaddedProvider(buffer: number, advance = 10, glyph = 8): GlyphProvider {
+    return {
+      getGlyph: (): GlyphInfo => ({
+        x: 0,
+        y: 0,
+        width: glyph + 2 * buffer,
+        height: glyph + 2 * buffer,
+        advance,
+        ascent: glyph,
+        page: 0,
+        uvLeft: 0,
+        uvTop: 0,
+        uvRight: 1,
+        uvBottom: 1,
+        xBearing: -buffer,
+        yBearing: -buffer,
+      }),
+    };
+  }
+
+  test('ink starts in the negative when the provider pads its glyphs', () => {
+    const buffer = 3;
+    const provider = makePaddedProvider(buffer);
+    const style = new TextStyle({ fontSize: 16, lineHeight: 1, leading: 0, align: 'left' });
+
+    const { advance, ink } = layoutText('AB', style, {}, provider);
+
+    // Clamping the ink minimum to zero would report x = 0 here and cut the
+    // outline reach off the left edge of every SDF label.
+    expect(ink.x).toBe(-buffer);
+    expect(ink.y).toBe(-buffer);
+
+    // Two glyphs: quads span from -3 to (advance of 'A' = 10) + 8 + 3 = 21.
+    expect(ink.width).toBe(21 - -buffer);
+    expect(ink.height).toBe(8 + buffer - -buffer);
+
+    // The advance is untouched by the padding.
+    expect(advance.width).toBe(20);
+    expect(advance.height).toBe(16);
+  });
+
+  test('ink is wider and taller than the advance in the padded case', () => {
+    const provider = makePaddedProvider(3);
+    const style = new TextStyle({ fontSize: 16, lineHeight: 1, leading: 0 });
+
+    const { advance, ink } = layoutText('A', style, {}, provider);
+
+    expect(ink.width).toBeGreaterThan(advance.width);
+    expect(ink.x).toBeLessThan(0);
+  });
+
+  test('unpadded glyphs put the ink at the layout origin', () => {
+    const provider = makeProvider(10);
+    const style = new TextStyle({ fontSize: 16, lineHeight: 1, leading: 0 });
+
+    const { ink } = layoutText('AB', style, {}, provider);
+
+    expect(ink.x).toBe(0);
+    expect(ink.y).toBe(0);
+    expect(ink.width).toBe(20);
+    expect(ink.height).toBe(16);
   });
 });
 

--- a/test/rendering/text/text.test.ts
+++ b/test/rendering/text/text.test.ts
@@ -19,14 +19,46 @@ import { TextStyle } from '#rendering/text/TextStyle';
 import type { GlyphInfo } from '#rendering/text/types';
 
 // ---------------------------------------------------------------------------
-// Mock pool
+// Layout-pass counter
+//
+// The dirty model's whole promise is "at most one pass per change", which is
+// only observable by counting the passes — a geometry comparison cannot tell
+// one rebuild from three.
 // ---------------------------------------------------------------------------
+
+const layoutCounter = vi.hoisted(() => ({ passes: 0 }));
+
+vi.mock('#rendering/text/TextLayout', async importOriginal => {
+  const actual = await importOriginal<typeof import('#rendering/text/TextLayout')>();
+
+  return {
+    ...actual,
+    layoutText: (...args: Parameters<typeof actual.layoutText>) => {
+      layoutCounter.passes++;
+
+      return actual.layoutText(...args);
+    },
+  };
+});
+
+const layoutPasses = (): number => layoutCounter.passes;
+
+// ---------------------------------------------------------------------------
+// Mock pool
+//
+// The glyph metrics imitate the SDF path: the atlas tile is bigger than the
+// advance and the bearings are negative, so the ink extent is wider than the
+// advance extent and starts left of / above the layout origin.
+// ---------------------------------------------------------------------------
+
+/** SDF padding baked into the mock glyph, mirroring `GlyphSdf`'s buffer. */
+const PADDING_BEARING = -4;
 
 const fixedGlyphInfo: GlyphInfo = {
   x: 0,
   y: 0,
-  width: 8,
-  height: 16,
+  width: 16,
+  height: 32,
   advance: 10,
   ascent: 13,
   page: 0,
@@ -34,6 +66,8 @@ const fixedGlyphInfo: GlyphInfo = {
   uvTop: 0.0,
   uvRight: 0.01,
   uvBottom: 0.02,
+  xBearing: PADDING_BEARING,
+  yBearing: PADDING_BEARING,
 };
 
 const mockPage = {
@@ -171,13 +205,13 @@ describe('Text', () => {
     const text = new Text('Hi');
     text.setAnchor(0.5, 0.5);
 
-    const shortWidth = text.getLocalBounds().width;
+    const shortWidth = text.textBounds.width;
 
     expect(text.origin.x).toBeCloseTo(shortWidth / 2);
 
     text.text = 'Much longer caption';
 
-    const longWidth = text.getLocalBounds().width;
+    const longWidth = text.textBounds.width;
 
     expect(longWidth).toBeGreaterThan(shortWidth);
     expect(text.origin.x).toBeCloseTo(longWidth / 2);
@@ -250,17 +284,134 @@ describe('Text', () => {
     expect(text.pageQuads[0]).not.toBe(quadsBefore);
   });
 
-  test('style property mutations are deferred to update()', () => {
+  test('style property mutations are deferred until something reads the node', () => {
     const text = new Text('Hi', { fontSize: 16 });
     const style = text.style;
     const quadsBefore = text.pageQuads[0];
+    const passesBefore = layoutPasses();
 
-    style.fontFamily = 'Georgia'; // font hint — must NOT rebuild immediately
+    style.fontFamily = 'Georgia'; // font hint — must NOT lay out immediately
 
-    expect(text.pageQuads[0]).toBe(quadsBefore);
+    expect(layoutPasses()).toBe(passesBefore);
 
     text.update(16);
+
+    expect(layoutPasses()).toBe(passesBefore + 1);
     expect(text.pageQuads[0]).not.toBe(quadsBefore);
+  });
+
+  // ME-60: the class doc promises "rebuilt at most once, on demand". Every
+  // setter used to lay the text out on the spot, so a label updated three
+  // times in a frame paid for three full passes and threw two of them away.
+  test('a run of mutations costs exactly one layout pass', () => {
+    const text = new Text('Hello', { fontSize: 16 });
+
+    // Settle the node so the constructor's own pass is not counted.
+    text.syncDirty();
+
+    const passesBefore = layoutPasses();
+
+    text.text = 'a';
+    text.text = 'b';
+    text.text = 'c';
+    text.style.align = 'center';
+    text.layout = { letterSpacing: 2 };
+
+    expect(layoutPasses()).toBe(passesBefore);
+
+    expect(text.pageQuads.length).toBeGreaterThan(0);
+
+    expect(layoutPasses()).toBe(passesBefore + 1);
+
+    // And a second read with nothing pending costs nothing at all.
+    expect(text.pageQuads.length).toBeGreaterThan(0);
+    expect(layoutPasses()).toBe(passesBefore + 1);
+  });
+
+  // The cull pass reads getLocalBounds() BEFORE the renderer's collect phase
+  // calls syncDirty(). A node that deferred its layout past that read would be
+  // culled against the previous string's extent.
+  test('getLocalBounds() resolves a pending layout without an explicit sync', () => {
+    const text = new Text('Hi');
+    const shortWidth = text.getLocalBounds().width;
+
+    text.text = 'Much longer caption';
+
+    expect(text.getLocalBounds().width).toBeGreaterThan(shortWidth);
+  });
+
+  test('a text going from empty to non-empty has a non-zero extent on the first read', () => {
+    const text = new Text('');
+
+    expect(text.getLocalBounds().width).toBe(0);
+
+    text.text = 'Now visible';
+
+    // Without the resolving getLocalBounds() this stays 0, the node is culled
+    // as empty, and the label never appears at all.
+    expect(text.getLocalBounds().width).toBeGreaterThan(0);
+  });
+
+  // Two measures, two meanings: the advance is where the cursor lands, the ink
+  // is the rectangle the padded SDF quads cover.
+  test('textBounds is the advance while getLocalBounds() is the wider ink', () => {
+    const text = new Text('Hi');
+    const advance = text.textBounds;
+    const ink = text.getLocalBounds();
+
+    expect(advance.width).toBe(2 * fixedGlyphInfo.advance);
+    expect(ink.x).toBe(PADDING_BEARING);
+    expect(ink.y).toBe(PADDING_BEARING);
+    expect(ink.width).toBeGreaterThan(advance.width);
+    expect(ink.height).toBeGreaterThan(advance.height);
+  });
+
+  // The anchor is measured against the typographic box, NOT against the ink:
+  // the SDF padding reaches past the glyphs by a different amount on each
+  // side, so anchoring to the ink would centre the padded tile instead of the
+  // caption — and would push an unanchored label off its own position.
+  test('the anchor is taken against the advance, not the padded ink', () => {
+    const text = new Text('Hi');
+    const advance = text.textBounds;
+    const ink = text.getLocalBounds();
+
+    text.setAnchor(0.5, 0.5);
+
+    expect(text.origin.x).toBeCloseTo(advance.width / 2);
+    expect(text.origin.y).toBeCloseTo(advance.height / 2);
+    expect(text.origin.x).not.toBeCloseTo(ink.x + ink.width / 2);
+  });
+
+  test('a laid-out text at the default anchor keeps its origin at zero', () => {
+    // Regression: deriving the origin from the ink gave an unanchored label an
+    // origin of (-padding, -padding), moving every SDF text on screen.
+    const text = new Text('Hi');
+
+    expect(text.pageQuads.length).toBeGreaterThan(0);
+    expect(text.origin.x).toBe(0);
+    expect(text.origin.y).toBe(0);
+  });
+
+  test('mutating the options object after construction does not re-flow the node', () => {
+    const options = { fontSize: 16, letterSpacing: 0 };
+    const text = new Text('Hi', options);
+    const widthBefore = text.textBounds.width;
+
+    options.letterSpacing = 40;
+
+    expect(text.textBounds.width).toBe(widthBefore);
+  });
+
+  test('layout is handed out as a copy of the assigned object', () => {
+    const text = new Text('Hi');
+    const assigned = { letterSpacing: 4 };
+
+    text.layout = assigned;
+    const widthBefore = text.textBounds.width;
+
+    assigned.letterSpacing = 40;
+
+    expect(text.textBounds.width).toBe(widthBefore);
   });
 
   test('colorGlyphs flag is accessible', () => {


### PR DESCRIPTION
Text had two numbers pretending to be one. `textBounds` reported the union of the glyph quads with its minimum clamped to zero — neither the advance a caller wants for layout nor the ink the GPU needs. `Text` and `BitmapText` derived it in a duplicated block, then handed it to the renderers as the gradient box, where the clamped origin put the ramp somewhere the SDF quads are not.

## What changed

**`layoutText` returns both extents.** It already computed the advance and threw it away; the ink now accumulates in the same pass that builds the quads, with its minimum left where the bearings put it. The node's local bounds are the ink; `textBounds` is the advance; both renderers upload the ink as the gradient box.

**`AbstractText` owns the model.** It grows from a near-empty base into the one place the dirty protocol, the quad build, the bounds write and the origin live. Every setter on both classes only marks the geometry stale; the pass runs on the next read — `getLocalBounds()`, `textBounds`, `pageQuads`, or the renderer's collect phase. Subclasses implement `_runLayout()` and nothing else.

`getLocalBounds()` **has** to resolve: culling reads it before the collect phase, so a deferred node would be culled against its previous string, and a label going from empty to non-empty would never appear.

**Deferring the pass without deferring the notice.** `_markDirty` stamps the node content-dirty immediately, and the pass writes the extent through a new `SceneNode._setLocalBoundsUnstamped()`. A retained subtree decides whether to replay from the revision alone and never visits a node it skipped; stamping again at pass time moves the goalposts one frame on and keeps the group re-capturing instead of recording. Both halves are pinned by tests.

**The anchor is taken against the advance, not the ink.** This is the one place the design spec was wrong, and the WebGL2 lane caught it: with an ink-based origin, a default anchor of `(0,0)` jumped to `(−8, −8)` and moved *every* SDF label by the padding. The SDF padding reaches past the glyphs by a different amount on each side; an anchor means the typographic box.

**Also:** `measureText` is gone — no caller, unreachable from the public surface, and it disagreed with `layoutText` on letterSpacing, kerning and wrap. Its coverage moved onto `layoutText(...).advance`. `layout` options are copied on assignment. The `StyleChangeHint` a rebuild receives is finally read: only `'font'` re-resolves the atlas.

## Tests

- `layoutText`: advance and ink asserted separately, including a padded provider standing in for the SDF path (`ink.x`/`ink.y` negative, advance untouched).
- Lazy model: a run of five mutations costs exactly one layout pass, on both classes; a second read with nothing pending costs none.
- Culling safety: `getLocalBounds()` resolves without an explicit `syncDirty()`, and an empty→non-empty text has a width on the first read.
- Retained: a text change and an in-place style mutation each force a full re-record.
- Gradient box: a node-lane test asserts the uploaded rectangle byte for byte, and a new browser test predicts the ramp fraction of every ink row from the ink box and measures it through the real GL context (agreement < 0.001 over 40 rows). The old code passed the *entire* WebGL2 lane with a broken box — that gap is closed.

Mutant probes: clamping `ink.x` back to zero, removing the resolving `getLocalBounds()`, and replacing `_markDirty` with an eager rebuild each turn the matching tests red.

Node lane 6478 green, both browser lanes green with **no baseline changes**, `verify:quick` 11/11.

## Breaking

- `layoutText` returns a `TextLayoutResult` instead of a bare placement array — read `.placements` for the old value.
- `measureText` is removed (replaced in the follow-up PR by `Text.measure()` / `BitmapText.measure()`).
- `AbstractText.textBounds` reports the advance, which is smaller than the value it used to report.
- `getLocalBounds()` on a text node now starts at a negative origin.

Closes `ME-60`, `NEU-J1`–`NEU-J5`, `NEU-K2`, `NEU-K3` from the review master.