### PR TITLE
feat(rendering): measure text without building a node

### DIFF
--- a/site/src/content/api/bitmap-text.json
+++ b/site/src/content/api/bitmap-text.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 99,
+  "memberCount": 100,
   "counts": {
     "constructors": 1,
-    "methods": 42,
+    "methods": 43,
     "properties": 42,
     "events": 14
   },
@@ -1903,6 +1903,95 @@
           "params": [],
           "returnType": "this",
           "description": ""
+        },
+        {
+          "name": "measure",
+          "signature": "measure(text: string, font: BmFont, options: BitmapTextOptions): TextSize",
+          "signatureTokens": [
+            {
+              "text": "measure",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "text",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "font",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "BmFont",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "options",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "BitmapTextOptions",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextSize",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "text",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "font",
+              "type": "BmFont",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "BitmapTextOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "TextSize",
+          "description": "Advance extent text would occupy in font under options, without constructing a node. Takes the same arguments as the constructor and gives the same answer as the resulting node's textBounds — it runs the identical layout pass against an adapter built the same way, so the two cannot drift. Unlike Text.measure this costs nothing beyond the layout itself: a BMFont atlas is pre-built, so there is no glyph to rasterize."
         },
         {
           "name": "setInternalSpriteFactory",

--- a/site/src/content/api/text.json
+++ b/site/src/content/api/text.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 98,
+  "memberCount": 99,
   "counts": {
     "constructors": 1,
-    "methods": 41,
+    "methods": 42,
     "properties": 42,
     "events": 14
   },
@@ -1854,6 +1854,74 @@
           "params": [],
           "returnType": "this",
           "description": ""
+        },
+        {
+          "name": "measure",
+          "signature": "measure(text: string, options: TextOptions): TextSize",
+          "signatureTokens": [
+            {
+              "text": "measure",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "text",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "options",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextOptions",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextSize",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "text",
+              "type": "string",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "TextOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "TextSize",
+          "description": "Advance extent text would occupy under options, without constructing a node. Takes the same options as the constructor and gives the same answer as the resulting node's textBounds — it runs the identical layout pass against the identical shared atlas, so the two cannot drift. Rasterizes any glyph not yet in that atlas: measuring an unseen string is not free, and it does claim atlas space. ts const { width } = Text.measure('Continue', { fontSize: 24 }); button.width = width + 32; "
         },
         {
           "name": "setInternalSpriteFactory",

--- a/site/src/content/guide/rendering/text.mdx
+++ b/site/src/content/guide/rendering/text.mdx
@@ -103,7 +103,7 @@ Text flow and overflow come from [`LayoutOptions`](/ExoJS/en/api/layout-options/
 | `breakWords` | `boolean` | `false` | Break words wider than `maxWidth` at character boundaries |
 | `whiteSpace` | `'normal' \| 'pre' \| 'pre-line'` | `'pre-line'` | Whitespace handling |
 
-Layout options stay reachable as `text.layout`. Unlike `style`, this is a plain options object with no change tracking: assigning a new one rebuilds the geometry, mutating the existing one in place does not.
+Layout options stay reachable as `text.layout`. Unlike `style`, this is a plain options object with no change tracking, and the node holds its own copy of it: assign a new one to re-flow the text — mutating the object you passed in, or the one the getter hands back, changes nothing.
 
 Glyphs are rasterized white into the shared SDF atlas and coloured at draw time, so `fillColor`, `outlineColor`, the shadow, and the gradient are shader work only — changing them never touches the atlas.
 
@@ -190,6 +190,19 @@ this.backdrop = new Panel({
 ```
 
 Both reads resolve a pending layout pass first, so the number you get always reflects the changes you have made — including a style mutation on the line above.
+
+To measure without a node at all — sizing a button before you have anything to put in it, deciding whether a caption fits — use the static counterpart. It takes the same options as the constructor and runs the same layout pass against the same shared atlas, so it answers exactly what the node's `textBounds` would:
+
+```ts
+import { BitmapText, Text, type BmFont } from '@codexo/exojs';
+
+declare const font: BmFont;
+
+const { width } = Text.measure('Continue', { fontSize: 24 });
+const { height } = BitmapText.measure('Continue', font, { scale: 2 });
+```
+
+`Text.measure` rasterizes any glyph the shared atlas has not seen yet, so measuring an unfamiliar string is not free and does claim atlas space. `BitmapText.measure` reads a pre-built atlas and costs nothing beyond the layout.
 
 ## Text constraints
 

--- a/src/rendering/text/BitmapText.ts
+++ b/src/rendering/text/BitmapText.ts
@@ -9,7 +9,7 @@ import type { LayoutOptions } from './LayoutOptions';
 import { emptyTextLayout, layoutText } from './TextLayout';
 import type { TextStyleOptions } from './TextStyle';
 import { TextStyle } from './TextStyle';
-import type { GlyphInfo, GlyphProvider, TextLayoutResult, TextLayoutStyle } from './types';
+import type { GlyphInfo, GlyphProvider, TextLayoutResult, TextLayoutStyle, TextSize } from './types';
 
 export type { BmFontChar, BmFontData } from './BmFont';
 
@@ -166,6 +166,44 @@ export class BitmapText extends AbstractText {
     this._adapter = new BmFontAdapter(font.fontData, font.textures, this._fontScale);
   }
 
+  /**
+   * Advance extent `text` would occupy in `font` under `options`, without
+   * constructing a node. Takes the same arguments as the constructor and gives
+   * the same answer as the resulting node's `textBounds` — it runs the
+   * identical layout pass against an adapter built the same way, so the two
+   * cannot drift.
+   *
+   * Unlike {@link Text.measure} this costs nothing beyond the layout itself:
+   * a BMFont atlas is pre-built, so there is no glyph to rasterize.
+   * @stable
+   */
+  public static measure(text: string, font: BmFont, options: BitmapTextOptions = {}): TextSize {
+    if (text.length === 0) return { width: 0, height: 0 };
+
+    const scale = options.scale ?? 1;
+    const style = new TextStyle(options);
+    const adapter = new BmFontAdapter(font.fontData, font.textures, scale);
+
+    return layoutText(text, BitmapText._layoutStyle(font, scale, style), options.layout ?? {}, adapter).advance;
+  }
+
+  /**
+   * The BMFont descriptor rendered as a {@link TextLayoutStyle}.
+   *
+   * Setting `fontSize` to `lineHeight * scale` makes the layout engine's
+   * computed line height equal the font's native one multiplied by
+   * `style.lineHeight`. Shared with {@link measure} so a measurement cannot
+   * derive it differently from a node.
+   */
+  private static _layoutStyle(font: BmFont, scale: number, style: TextStyle): TextLayoutStyle {
+    return {
+      fontSize: font.fontData.lineHeight * scale,
+      lineHeight: style.lineHeight,
+      leading: style.leading,
+      align: style.align,
+    };
+  }
+
   // ── Style ─────────────────────────────────────────────────────────────────
 
   /** Visual style — `align`, `leading`, `fillColor`, `outlineColor` etc. */
@@ -220,16 +258,6 @@ export class BitmapText extends AbstractText {
   protected override _runLayout(): TextLayoutResult {
     if (this._text.length === 0) return emptyTextLayout();
 
-    // Derive a TextLayoutStyle from the BMFont descriptor + scale.
-    // Setting fontSize = fontData.lineHeight * scale makes computedLineHeight
-    // equal to the BMFont's native line height multiplied by style.lineHeight.
-    const layoutStyle: TextLayoutStyle = {
-      fontSize: this._font.fontData.lineHeight * this._fontScale,
-      lineHeight: this._style.lineHeight,
-      leading: this._style.leading,
-      align: this._style.align,
-    };
-
-    return layoutText(this._text, layoutStyle, this._layout, this._adapter);
+    return layoutText(this._text, BitmapText._layoutStyle(this._font, this._fontScale, this._style), this._layout, this._adapter);
   }
 }

--- a/src/rendering/text/Text.ts
+++ b/src/rendering/text/Text.ts
@@ -7,7 +7,7 @@ import type { LayoutOptions } from './LayoutOptions';
 import { emptyTextLayout, layoutText } from './TextLayout';
 import type { StyleChangeHint, TextStyleOptions } from './TextStyle';
 import { TextStyle } from './TextStyle';
-import type { TextLayoutResult, TextPageQuads } from './types';
+import type { TextLayoutResult, TextPageQuads, TextSize } from './types';
 
 export type { TextPageQuads };
 
@@ -74,6 +74,34 @@ export class Text extends AbstractText {
 
     const face = this._extractFace(options);
     if (face !== null) void this._loadFace(face);
+  }
+
+  /**
+   * Advance extent `text` would occupy under `options`, without constructing
+   * a node. Takes the same options as the constructor and gives the same
+   * answer as the resulting node's `textBounds` — it runs the identical
+   * layout pass against the identical shared atlas, so the two cannot drift.
+   *
+   * Rasterizes any glyph not yet in that atlas: measuring an unseen string is
+   * not free, and it does claim atlas space.
+   *
+   * ```ts
+   * const { width } = Text.measure('Continue', { fontSize: 24 });
+   * button.width = width + 32;
+   * ```
+   * @stable
+   */
+  public static measure(text: string, options: TextOptions = {}): TextSize {
+    if (text.length === 0) return { width: 0, height: 0 };
+
+    const style = new TextStyle(options);
+
+    return layoutText(text, style, options, Text._acquireAtlas(style, options.colorGlyphs ?? false, options.sdfRadius ?? SDF_RADIUS)).advance;
+  }
+
+  /** The one place a Text resolves its atlas, so a measurement cannot pick a different one. */
+  private static _acquireAtlas(style: TextStyle, colorGlyphs: boolean, sdfRadius: number): GlyphAtlas {
+    return getDefaultGlyphAtlasPool().getAtlas(style.fontFamily, style.fontStyle, style.fontWeight, colorGlyphs ? 'color' : 'sdf', sdfRadius);
   }
 
   public get style(): TextStyle {
@@ -160,8 +188,7 @@ export class Text extends AbstractText {
 
     if (this._destroyed || version !== this._faceLoadVersion) return;
 
-    const pool = getDefaultGlyphAtlasPool();
-    pool.getAtlas(this._style.fontFamily, this._style.fontStyle, this._style.fontWeight, this.atlasMode, this._sdfRadius).clear();
+    Text._acquireAtlas(this._style, this._colorGlyphs, this._sdfRadius).clear();
     this._markDirty('font');
   }
 
@@ -172,10 +199,7 @@ export class Text extends AbstractText {
 
     // Only a 'font' change can invalidate which atlas this node draws from;
     // a re-flow reuses the one already resolved.
-    const atlas =
-      hint === 'font' || this._atlas === null
-        ? getDefaultGlyphAtlasPool().getAtlas(this._style.fontFamily, this._style.fontStyle, this._style.fontWeight, this.atlasMode, this._sdfRadius)
-        : this._atlas;
+    const atlas = hint === 'font' || this._atlas === null ? Text._acquireAtlas(this._style, this._colorGlyphs, this._sdfRadius) : this._atlas;
 
     this._atlas = atlas;
 

--- a/test/rendering/text/bitmap-text.test.ts
+++ b/test/rendering/text/bitmap-text.test.ts
@@ -332,6 +332,41 @@ describe('BitmapText', () => {
 });
 
 // ---------------------------------------------------------------------------
+// BitmapText.measure()
+// ---------------------------------------------------------------------------
+
+describe('BitmapText.measure', () => {
+  test.each([
+    ['single line', 'AB', {}],
+    ['multi line', 'AB\nA\nBA', {}],
+    ['wrapped', 'A B A', { layout: { maxWidth: 12 } }],
+    ['letterSpacing', 'AB', { layout: { letterSpacing: 3 } }],
+    ['scaled and led', 'AB\nA', { scale: 2, leading: 4, lineHeight: 1.5 }],
+  ])('agrees with a node built the same way — %s', (_label, value, options) => {
+    const font = makeFont();
+    const node = new BitmapText(value, font, options);
+
+    expect(BitmapText.measure(value, font, options)).toEqual(node.textBounds);
+  });
+
+  test('letterSpacing and maxWidth reach the measurement', () => {
+    const font = makeFont();
+    const plain = BitmapText.measure('AB', font);
+    const spaced = BitmapText.measure('AB', font, { layout: { letterSpacing: 4 } });
+
+    expect(spaced.width).toBe(plain.width + 4);
+
+    const wrapped = BitmapText.measure('A B', font, { layout: { maxWidth: 12 } });
+
+    expect(wrapped.height).toBeGreaterThan(plain.height);
+  });
+
+  test('an empty string measures to nothing', () => {
+    expect(BitmapText.measure('', makeFont())).toEqual({ width: 0, height: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Dev assertions — BmFont and BmFontAdapter
 // ---------------------------------------------------------------------------
 

--- a/test/rendering/text/text.test.ts
+++ b/test/rendering/text/text.test.ts
@@ -426,6 +426,59 @@ describe('Text', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Text.measure()
+// ---------------------------------------------------------------------------
+
+describe('Text.measure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // This is the claim the whole construction rests on: the static measurement
+  // and a node's own advance come out of the same layout pass against the same
+  // shared atlas, so they cannot drift apart.
+  test.each([
+    ['single line', 'Hello', {}],
+    ['multi line', 'Hello\nthere\nyou', {}],
+    ['wrapped', 'Hello there you', { maxWidth: 25 }],
+    ['letterSpacing', 'Hello', { letterSpacing: 3 }],
+    ['aligned and led', 'Hi\nthere', { align: 'center' as const, leading: 4, lineHeight: 1.5 }],
+  ])('agrees with a node built the same way — %s', (_label, value, options) => {
+    const node = new Text(value, { fontSize: 16, ...options });
+
+    expect(Text.measure(value, { fontSize: 16, ...options })).toEqual(node.textBounds);
+  });
+
+  test('letterSpacing and maxWidth actually reach the measurement', () => {
+    // The deleted `measureText` ignored both, which is why it disagreed with
+    // what a node of the same configuration reported.
+    const plain = Text.measure('Hello', { fontSize: 16 });
+    const spaced = Text.measure('Hello', { fontSize: 16, letterSpacing: 4 });
+
+    expect(spaced.width).toBe(plain.width + 4 * 4);
+
+    const wrapped = Text.measure('Hello there', { fontSize: 16, maxWidth: 25 });
+
+    expect(wrapped.height).toBeGreaterThan(plain.height);
+    expect(wrapped.width).toBeLessThan(Text.measure('Hello there', { fontSize: 16 }).width);
+  });
+
+  test('an empty string measures to nothing and touches no atlas', () => {
+    expect(Text.measure('', { fontSize: 16 })).toEqual({ width: 0, height: 0 });
+    expect(mockPool.getAtlas).not.toHaveBeenCalled();
+  });
+
+  test('measuring does not construct a node', () => {
+    const passesBefore = layoutPasses();
+
+    Text.measure('Hello', { fontSize: 16 });
+
+    // Exactly one pass: the measurement itself, with no node behind it.
+    expect(layoutPasses()).toBe(passesBefore + 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // FontFace-first tests
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
`Text.measure(text, options)` and `BitmapText.measure(text, font, options)` answer what a node built the same way would report as its `textBounds`, without constructing one — for sizing a button before its label exists, or deciding whether a caption fits.

```ts
const { width } = Text.measure('Continue', { fontSize: 24 });
button.width = width + 32;
```

They take the constructor's own arguments and run the constructor's own layout pass: `Text` resolves the atlas through the same private helper `_runLayout()` uses, `BitmapText` derives its layout style through the same one. There is no second measuring path to drift — which is exactly what went wrong with the `measureText` these replace (removed in #515): it ignored `letterSpacing`, kerning and wrap, and so disagreed with the node it was meant to describe.

Measuring through `Text` rasterizes any glyph the shared atlas has not seen, so it costs real work and claims atlas space; the `BitmapText` path reads a pre-built atlas and costs only the layout. Both say so in their docs, and the guide's measuring section now covers the static form alongside the two node measures.

## Tests

Five equivalence cases per class — single line, multi line, wrapped, `letterSpacing`, and aligned/led/scaled — each asserting `X.measure(…)` equals `new X(…).textBounds` exactly. Plus: `letterSpacing` and `maxWidth` demonstrably reach the measurement, an empty string measures to nothing and touches no atlas, and measuring runs exactly one layout pass with no node behind it.

Mutant probe: making `measure` drop its layout options turns the wrapped case, the letterSpacing case and the direct assertion red.

Node lane 6493 green, `verify:quick` 11/11.

Closes `ME-N16` from the review master; completes the text track.