### PR TITLE
fix(ldtk): parse and pass through layer parallax factors

### DIFF
--- a/packages/exojs-ldtk/src/LdtkData.ts
+++ b/packages/exojs-ldtk/src/LdtkData.ts
@@ -289,6 +289,26 @@ export interface LdtkLayerDef {
   readonly tilesetDefUid?: number | null;
   readonly gridSize: number;
   readonly intGridValues?: readonly LdtkIntGridValueDef[];
+  /**
+   * Parallax horizontal factor, in `[-1, 1]`. `0` (the default) means "no
+   * parallax" — the layer scrolls at normal camera speed, same as every
+   * other layer. See {@link import('./ldtkToTileMap').ldtkToTileMap} for how
+   * this is carried onto the runtime layer's `parallaxX`.
+   */
+  readonly parallaxFactorX?: number;
+  /** Parallax vertical factor, in `[-1, 1]`. `0` (the default) means "no parallax". */
+  readonly parallaxFactorY?: number;
+  /**
+   * Whether a non-zero parallax factor also scales this layer up/down to
+   * simulate depth. Defaults to `true` (LDtk's own default) when absent.
+   *
+   * Parsed and validated for round-trip fidelity, but not currently carried
+   * onto any runtime layer — the runtime tilemap model has no field for a
+   * parallax-driven scale multiplier (unlike `parallaxX`/`parallaxY`, which
+   * map onto the existing `TileLayer`/`ObjectLayer` fields also used by the
+   * Tiled adapter), and whether/how to add one is an open decision.
+   */
+  readonly parallaxScaling?: boolean;
 }
 
 /** Top-level definitions block (`defs`). */

--- a/packages/exojs-ldtk/src/ldtkParallax.ts
+++ b/packages/exojs-ldtk/src/ldtkParallax.ts
@@ -1,0 +1,44 @@
+// LDtk → runtime parallax conversion.
+//
+// LDtk's `parallaxFactorX`/`parallaxFactorY` (declared on `defs.layers[]`,
+// range `[-1, 1]`) describe "how much slower this layer scrolls relative to
+// the camera", with `0` — the LDtk default — meaning "no parallax, scrolls at
+// normal camera speed". LDtk itself does not mandate a rendering formula for
+// this value: its own reference implementation (`ldtk-haxe-api`) only carries
+// the raw field through and leaves interpretation to the consuming game.
+//
+// The runtime `TileLayer`/`ObjectLayer` model (shared with the Tiled adapter)
+// instead uses `parallaxX`/`parallaxY` with the opposite convention: `1` (the
+// default) means "no parallax, normal camera speed", and render code derives
+// the on-screen shift as `camCenter * (1 - parallaxX)` — see
+// `ChunkStreamer.ts` / `TileLayerNode.ts` / `ImageLayerNode.ts` in
+// `@codexo/exojs-tilemap`. The two conventions share the same "no parallax"
+// origin (LDtk `0` ↔ runtime `1`), so `runtimeFactor = 1 - ldtkFactor` is the
+// direct, order-preserving conversion between them: a layer with a larger
+// LDtk factor lags the camera more, which is exactly a smaller runtime
+// `parallaxX`/`parallaxY`.
+
+import type { LdtkData } from './LdtkData';
+
+/** Resolved runtime parallax factors for one LDtk layer instance. */
+export interface LdtkLayerParallax {
+  readonly parallaxX: number;
+  readonly parallaxY: number;
+}
+
+/**
+ * Resolve the runtime `parallaxX`/`parallaxY` for the layer definition
+ * identified by `layerDefUid`, converting from LDtk's `parallaxFactorX`/
+ * `parallaxFactorY` convention to the runtime `TileLayer`/`ObjectLayer`
+ * convention — see the module doc comment for the formula and why it exists.
+ *
+ * Falls back to `{ parallaxX: 1, parallaxY: 1 }` (no parallax) when the layer
+ * definition cannot be found or declares no parallax factors, matching
+ * LDtk's own default.
+ */
+export function resolveLdtkLayerParallax(data: LdtkData, layerDefUid: number): LdtkLayerParallax {
+  const layerDef = data.defs.layers.find(def => def.uid === layerDefUid);
+  const factorX = layerDef?.parallaxFactorX ?? 0;
+  const factorY = layerDef?.parallaxFactorY ?? 0;
+  return { parallaxX: 1 - factorX, parallaxY: 1 - factorY };
+}

--- a/packages/exojs-ldtk/src/ldtkToTileMap.ts
+++ b/packages/exojs-ldtk/src/ldtkToTileMap.ts
@@ -13,6 +13,8 @@ import type {
 import { LDTK_FLIP_X, LDTK_FLIP_Y } from './LdtkData';
 import { getLdtkLevelEntries } from './ldtkLevelEntries';
 import { LdtkMap } from './LdtkMap';
+import type { LdtkLayerParallax } from './ldtkParallax';
+import { resolveLdtkLayerParallax } from './ldtkParallax';
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
@@ -93,19 +95,20 @@ function convertLevel(
     // Layer IDs must be unique within a TileMap (= one level).
     // Use layerDefUid directly — it is unique per layer definition in the file.
     const layerId = layerInst.layerDefUid;
+    const parallax = resolveLdtkLayerParallax(data, layerInst.layerDefUid);
 
     switch (layerInst.__type) {
       case 'Tiles':
       case 'AutoLayer':
-        runtimeLayers.push(convertTilesOrAutoLayer(layerInst, layerId, runtimeTilesets, tilesets));
+        runtimeLayers.push(convertTilesOrAutoLayer(layerInst, layerId, runtimeTilesets, tilesets, parallax));
         break;
 
       case 'IntGrid':
-        runtimeLayers.push(convertIntGridLayer(layerInst, layerId, runtimeTilesets, tilesets, data));
+        runtimeLayers.push(convertIntGridLayer(layerInst, layerId, runtimeTilesets, tilesets, data, parallax));
         break;
 
       case 'Entities':
-        runtimeObjectLayers.push(convertEntitiesLayer(layerInst, layerId, levelIndex, entityCounter));
+        runtimeObjectLayers.push(convertEntitiesLayer(layerInst, layerId, levelIndex, entityCounter, parallax));
         entityCounter += layerInst.entityInstances?.length ?? 0;
         break;
     }
@@ -144,8 +147,9 @@ function convertTilesOrAutoLayer(
   layerId: number,
   runtimeTilesets: readonly TileSet[],
   tilesets: ReadonlyMap<number, TileSet>,
+  parallax: LdtkLayerParallax,
 ): TileLayer {
-  const rLayer = makeTileLayer(layerInst, layerId, runtimeTilesets);
+  const rLayer = makeTileLayer(layerInst, layerId, runtimeTilesets, parallax);
   const tiles =
     layerInst.__type === 'Tiles' ? (layerInst.gridTiles ?? []) : (layerInst.autoLayerTiles ?? []);
   const tsUid = layerInst.__tilesetDefUid;
@@ -163,9 +167,10 @@ function convertIntGridLayer(
   runtimeTilesets: readonly TileSet[],
   tilesets: ReadonlyMap<number, TileSet>,
   data: LdtkData,
+  parallax: LdtkLayerParallax,
 ): TileLayer {
   const intGridProperties = buildIntGridProperties(layerInst, data);
-  const rLayer = makeTileLayer(layerInst, layerId, runtimeTilesets, intGridProperties);
+  const rLayer = makeTileLayer(layerInst, layerId, runtimeTilesets, parallax, intGridProperties);
   // IntGrid layers may carry auto-tiles when "Auto-layer" rules are
   // configured. Use those for rendering; raw intGridCsv is exposed as
   // data-only layer properties (see buildIntGridProperties).
@@ -184,6 +189,7 @@ function convertEntitiesLayer(
   layerId: number,
   levelIndex: number,
   entityCounter: number,
+  parallax: LdtkLayerParallax,
 ): ObjectLayer {
   const objects = convertEntityLayer(layerInst, layerInst.__gridSize, levelIndex, entityCounter);
   return new ObjectLayer({
@@ -193,6 +199,8 @@ function convertEntitiesLayer(
     opacity: layerInst.opacity ?? 1,
     offsetX: layerInst.pxOffsetX ?? 0,
     offsetY: layerInst.pxOffsetY ?? 0,
+    parallaxX: parallax.parallaxX,
+    parallaxY: parallax.parallaxY,
     objects,
   });
 }
@@ -203,6 +211,7 @@ function makeTileLayer(
   layerInst: LdtkLayerInstance,
   layerId: number,
   tilesets: readonly TileSet[],
+  parallax: LdtkLayerParallax,
   properties?: TileProperties,
 ): TileLayer {
   return new TileLayer({
@@ -217,6 +226,8 @@ function makeTileLayer(
     opacity: layerInst.opacity ?? 1,
     offsetX: layerInst.pxOffsetX ?? 0,
     offsetY: layerInst.pxOffsetY ?? 0,
+    parallaxX: parallax.parallaxX,
+    parallaxY: parallax.parallaxY,
     ...(properties && { properties }),
   });
 }

--- a/packages/exojs-ldtk/src/validate.ts
+++ b/packages/exojs-ldtk/src/validate.ts
@@ -130,6 +130,10 @@ function optionalString(obj: Record<string, unknown>, key: string, source: strin
   if (obj[key] !== undefined) expectString(obj[key], source, joinPath(path, key));
 }
 
+function optionalBoolean(obj: Record<string, unknown>, key: string, source: string, path: string): void {
+  if (obj[key] !== undefined) expectBoolean(obj[key], source, joinPath(path, key));
+}
+
 function eachEntry(
   value: unknown,
   source: string,
@@ -190,6 +194,9 @@ function validateLayerDef(raw: unknown, source: string, path: string): void {
   expectString(def.identifier, source, joinPath(path, 'identifier'));
   validateLayerType(def.type, source, joinPath(path, 'type'));
   expectNonNegativeInteger(def.gridSize, source, joinPath(path, 'gridSize'));
+  optionalNumber(def, 'parallaxFactorX', source, path);
+  optionalNumber(def, 'parallaxFactorY', source, path);
+  optionalBoolean(def, 'parallaxScaling', source, path);
 
   if (def.intGridValues !== undefined) {
     eachEntry(def.intGridValues, source, joinPath(path, 'intGridValues'), (item, itemPath) =>

--- a/packages/exojs-ldtk/test/ldtkToTileMap.test.ts
+++ b/packages/exojs-ldtk/test/ldtkToTileMap.test.ts
@@ -362,6 +362,44 @@ describe('ldtkToTileMap', () => {
     });
   });
 
+  describe('layer conversion: parallax', () => {
+    /** Same layout as `layeredData` but the `Tiles` and `Entities` layer defs carry parallax factors. */
+    const parallaxData: LdtkData = {
+      ...layeredData,
+      defs: {
+        tilesets: layeredData.defs.tilesets,
+        layers: layeredData.defs.layers.map(def =>
+          def.uid === 101
+            ? { ...def, parallaxFactorX: 0.5, parallaxFactorY: -0.25 }
+            : def.uid === 103
+              ? { ...def, parallaxFactorX: 1, parallaxFactorY: 0 }
+              : def,
+        ),
+      },
+    };
+
+    it('converts a layer def parallax factor into the runtime TileLayer parallaxX/Y (1 - factor)', () => {
+      const result = ldtkToTileMap(parallaxData);
+      const tilesLayer = result.levels[0]?.layers.find(l => l.name === 'Tiles');
+      expect(tilesLayer?.parallaxX).toBeCloseTo(0.5);
+      expect(tilesLayer?.parallaxY).toBeCloseTo(1.25);
+    });
+
+    it('defaults a TileLayer to parallaxX/Y = 1 (no parallax) when the layer def has no factors', () => {
+      const result = ldtkToTileMap(parallaxData);
+      const groundLayer = result.levels[0]?.layers.find(l => l.name === 'Ground');
+      expect(groundLayer?.parallaxX).toBe(1);
+      expect(groundLayer?.parallaxY).toBe(1);
+    });
+
+    it('converts a layer def parallax factor into the runtime ObjectLayer parallaxX/Y', () => {
+      const result = ldtkToTileMap(parallaxData);
+      const entitiesLayer = result.levels[0]?.objectLayers[0];
+      expect(entitiesLayer?.parallaxX).toBe(0);
+      expect(entitiesLayer?.parallaxY).toBe(1);
+    });
+  });
+
   describe('destroy', () => {
     it('destroys all owned levels', () => {
       const result = ldtkToTileMap(minimalData);

--- a/packages/exojs-ldtk/test/validate.test.ts
+++ b/packages/exojs-ldtk/test/validate.test.ts
@@ -96,6 +96,14 @@ describe('validateLdtkData — accepts well-formed documents', () => {
       root.levels = [];
     }), SOURCE)).not.toThrow();
   });
+
+  it('accepts a layer definition with parallax factors and parallaxScaling', () => {
+    expect(() => validateLdtkData(withRoot(root => {
+      root.defs.layers[0].parallaxFactorX = 0.5;
+      root.defs.layers[0].parallaxFactorY = -0.25;
+      root.defs.layers[0].parallaxScaling = false;
+    }), SOURCE)).not.toThrow();
+  });
 });
 
 describe('validateLdtkData — rejects malformed documents', () => {
@@ -185,6 +193,18 @@ describe('validateLdtkData — rejects malformed documents', () => {
     expect(() => validateLdtkData(withRoot(root => {
       root.levels[0].fieldInstances = [{ __type: 'String', __value: 'x' }];
     }), SOURCE)).toThrow(/fieldInstances\[0\]\.__identifier/);
+  });
+
+  it('rejects a non-numeric parallaxFactorX on a layer definition', () => {
+    expect(() => validateLdtkData(withRoot(root => {
+      root.defs.layers[0].parallaxFactorX = 'fast';
+    }), SOURCE)).toThrow(/defs\.layers\[0\]\.parallaxFactorX/);
+  });
+
+  it('rejects a non-boolean parallaxScaling on a layer definition', () => {
+    expect(() => validateLdtkData(withRoot(root => {
+      root.defs.layers[0].parallaxScaling = 'yes';
+    }), SOURCE)).toThrow(/defs\.layers\[0\]\.parallaxScaling/);
   });
 });
 

--- a/site/src/content/api/ldtk-layer-def.json
+++ b/site/src/content/api/ldtk-layer-def.json
@@ -6,11 +6,11 @@
   "subsystem": "ldtk",
   "importPath": "@codexo/exojs-ldtk",
   "tier": "stable",
-  "memberCount": 6,
+  "memberCount": 9,
   "counts": {
     "constructors": 0,
     "methods": 0,
-    "properties": 6,
+    "properties": 9,
     "events": 0
   },
   "sections": [
@@ -106,6 +106,81 @@
           "params": [],
           "returnType": null,
           "description": ""
+        },
+        {
+          "name": "parallaxFactorX",
+          "signature": "parallaxFactorX?: number",
+          "signatureTokens": [
+            {
+              "text": "parallaxFactorX",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Parallax horizontal factor, in [-1, 1]. 0 (the default) means \"no parallax\" — the layer scrolls at normal camera speed, same as every other layer. See import('./ldtkToTileMap').ldtkToTileMap for how this is carried onto the runtime layer's parallaxX."
+        },
+        {
+          "name": "parallaxFactorY",
+          "signature": "parallaxFactorY?: number",
+          "signatureTokens": [
+            {
+              "text": "parallaxFactorY",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Parallax vertical factor, in [-1, 1]. 0 (the default) means \"no parallax\"."
+        },
+        {
+          "name": "parallaxScaling",
+          "signature": "parallaxScaling?: boolean",
+          "signatureTokens": [
+            {
+              "text": "parallaxScaling",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Whether a non-zero parallax factor also scales this layer up/down to simulate depth. Defaults to true (LDtk's own default) when absent. Parsed and validated for round-trip fidelity, but not currently carried onto any runtime layer — the runtime tilemap model has no field for a parallax-driven scale multiplier (unlike parallaxX/parallaxY, which map onto the existing TileLayer/ObjectLayer fields also used by the Tiled adapter), and whether/how to add one is an open decision."
         },
         {
           "name": "tilesetDefUid",


### PR DESCRIPTION
LDtk layer parallax was never read in: `LdtkLayerDef` modelled neither `parallaxFactorX`/`parallaxFactorY` nor `parallaxScaling`, so every LDtk map rendered flat with no indication.

- Fields added to `LdtkLayerDef`, validated leanly in `validate.ts` (`LdtkFormatError` with a property path), passed onto all four layer conversion paths in `ldtkToTileMap.ts`.
- The two conventions are **inverted** — LDtk `0` means "no parallax", the runtime `TileLayer`/`ObjectLayer` model uses `1` — so `resolveLdtkLayerParallax()` converts with `parallaxX = 1 - parallaxFactorX`. Derivation is in the module comment of the new `ldtkParallax.ts`.
- Typed as optional although the schema marks them required: files written by LDtk versions predating parallax do not carry them.

Two corrections to the original finding, both checked against the official LDtk JSON schema:

- **LDtk has no layer tint.** Neither `LayerDef` nor `LayerInstance` carries one; the only colour field is `uiColor`, an editor-only display colour. There was nothing to parse, so the scope is parallax alone.
- **`parallaxScaling` defaults to `true`**, so LDtk scales parallax layers by default. The runtime model has no such factor and the three renderers only compute a positional shift, so a parallax map still renders differently from the editor. The field is parsed and validated but deliberately not carried through — LDtk specifies no scaling formula, and `ldtk-haxe-api` and `bevy_ecs_ldtk` both pass the raw field through without rendering logic. Tracked separately.