### PR TITLE
fix(rendering)!: run the vertical text gradient from the first stop down

### DIFF
--- a/site/src/content/api/abstract-text.json
+++ b/site/src/content/api/abstract-text.json
@@ -2417,7 +2417,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Flow-control options — maxWidth, letterSpacing, whiteSpace etc. Handed out read-only: the node holds its own copy, so mutating the object would change nothing. Assign a new one to re-flow."
+          "description": "Flow-control options — maxWidth, letterSpacing, whiteSpace etc. Handed out read-only: the node holds its own copy, so mutating the object would change nothing. Assign a new one to re-flow. Carries layout keys only. A subclass whose options bag merges style and layout into one flat object (as TextOptions does) still reports just the layout half here."
         },
         {
           "name": "mask",

--- a/site/src/content/api/bitmap-text-options.json
+++ b/site/src/content/api/bitmap-text-options.json
@@ -283,7 +283,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Two-stop fill gradient [top, bottom]. When set, overrides fillColor for the glyph interior. null disables the gradient."
+          "description": "Two-stop fill gradient. When set, overrides fillColor for the glyph interior. null disables the gradient. The first colour is the START of the ramp and the second its END, read along gradientAxis: [top, bottom] for 'vertical', [left, right] for 'horizontal'."
         },
         {
           "name": "layout",

--- a/site/src/content/api/bitmap-text.json
+++ b/site/src/content/api/bitmap-text.json
@@ -2580,7 +2580,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Flow-control options — maxWidth, letterSpacing, whiteSpace etc. Handed out read-only: the node holds its own copy, so mutating the object would change nothing. Assign a new one to re-flow."
+          "description": "Flow-control options — maxWidth, letterSpacing, whiteSpace etc. Handed out read-only: the node holds its own copy, so mutating the object would change nothing. Assign a new one to re-flow. Carries layout keys only. A subclass whose options bag merges style and layout into one flat object (as TextOptions does) still reports just the layout half here."
         },
         {
           "name": "mask",

--- a/site/src/content/api/text-options.json
+++ b/site/src/content/api/text-options.json
@@ -367,7 +367,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Two-stop fill gradient [top, bottom]. When set, overrides fillColor for the glyph interior. null disables the gradient."
+          "description": "Two-stop fill gradient. When set, overrides fillColor for the glyph interior. null disables the gradient. The first colour is the START of the ramp and the second its END, read along gradientAxis: [top, bottom] for 'vertical', [left, right] for 'horizontal'."
         },
         {
           "name": "leading",

--- a/site/src/content/api/text-style-options.json
+++ b/site/src/content/api/text-style-options.json
@@ -283,7 +283,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Two-stop fill gradient [top, bottom]. When set, overrides fillColor for the glyph interior. null disables the gradient."
+          "description": "Two-stop fill gradient. When set, overrides fillColor for the glyph interior. null disables the gradient. The first colour is the START of the ramp and the second its END, read along gradientAxis: [top, bottom] for 'vertical', [left, right] for 'horizontal'."
         },
         {
           "name": "leading",

--- a/site/src/content/api/text-style.json
+++ b/site/src/content/api/text-style.json
@@ -427,7 +427,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Two-stop fill gradient [top, bottom]. When set, overrides fillColor for the glyph interior. Assign null to disable."
+          "description": "Two-stop fill gradient. When set, overrides fillColor for the glyph interior. Assign null to disable. The first colour is the START of the ramp and the second its END, read along gradientAxis: [top, bottom] for 'vertical', [left, right] for 'horizontal'."
         },
         {
           "name": "leading",

--- a/site/src/content/api/text.json
+++ b/site/src/content/api/text.json
@@ -2539,7 +2539,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Flow-control options — maxWidth, letterSpacing, whiteSpace etc. Handed out read-only: the node holds its own copy, so mutating the object would change nothing. Assign a new one to re-flow."
+          "description": "Flow-control options — maxWidth, letterSpacing, whiteSpace etc. Handed out read-only: the node holds its own copy, so mutating the object would change nothing. Assign a new one to re-flow. Carries layout keys only. A subclass whose options bag merges style and layout into one flat object (as TextOptions does) still reports just the layout half here."
         },
         {
           "name": "mask",

--- a/site/src/content/guide/rendering/text.mdx
+++ b/site/src/content/guide/rendering/text.mdx
@@ -88,8 +88,19 @@ The visual appearance comes from [`TextStyleOptions`](/ExoJS/en/api/text-style-o
 | `shadowOffsetY` | `number` | `0` | Vertical shadow offset in pixels |
 | `shadowAlpha` | `number` | `0` | Shadow opacity (`0`–`1`); `0` disables the shadow |
 | `shadowBlur` | `number` | `0` | Shadow blur softness (`0`–`1`) |
-| `gradientColors` | `[Color, Color] \| null` | `null` | Two-stop fill gradient `[top, bottom]`; overrides `fillColor` |
+| `gradientColors` | `[Color, Color] \| null` | `null` | Two-stop fill gradient; overrides `fillColor`. First colour starts the ramp, second ends it |
 | `gradientAxis` | `'vertical' \| 'horizontal'` | `'vertical'` | Gradient orientation |
+
+`gradientColors` is ordered along `gradientAxis` and always runs start → end: `[top, bottom]` for the default `'vertical'` axis, `[left, right]` for `'horizontal'`. The ramp spans the ink extent (`getLocalBounds()`), not the advance.
+
+```ts
+import { Color, Text } from '@codexo/exojs';
+
+const banner = new Text('Level Up', {
+    fontSize: 48,
+    gradientColors: [Color.white, Color.tomato], // white on top, tomato at the bottom
+});
+```
 
 Text flow and overflow come from [`LayoutOptions`](/ExoJS/en/api/layout-options/), merged into the same options object:
 

--- a/src/core/serialization/serializerHelpers.ts
+++ b/src/core/serialization/serializerHelpers.ts
@@ -145,6 +145,29 @@ const DIRECTIONS = ['ltr', 'rtl'] as const satisfies ReadonlyArray<NonNullable<L
 const WHITE_SPACES = ['normal', 'pre', 'pre-line'] as const satisfies ReadonlyArray<NonNullable<LayoutOptions['whiteSpace']>>;
 
 /**
+ * Every {@link LayoutOptions} key, paired with the validating reader that
+ * rebuilds it from untrusted JSON.
+ *
+ * This map is the single definition of what counts as a layout option:
+ * {@link readLayoutOptions} runs the readers, {@link pickLayoutOptions} uses
+ * only the keys. The mapped type makes a missing or misspelled entry a compile
+ * error, so the two cannot drift apart or fall behind the interface.
+ */
+const LAYOUT_READERS: {
+  [K in keyof Required<LayoutOptions>]: (source: Record<string, unknown>, key: K) => LayoutOptions[K];
+} = {
+  maxWidth: readNumber,
+  maxHeight: readNumber,
+  overflow: (source, key) => readEnum(source, key, OVERFLOWS),
+  letterSpacing: readNumber,
+  direction: (source, key) => readEnum(source, key, DIRECTIONS),
+  breakWords: readBoolean,
+  whiteSpace: (source, key) => readEnum(source, key, WHITE_SPACES),
+};
+
+const LAYOUT_KEYS = Object.keys(LAYOUT_READERS) as ReadonlyArray<keyof LayoutOptions>;
+
+/**
  * Rebuild {@link LayoutOptions} from a serialized layout object, dropping
  * unknown or mistyped fields. Returns `undefined` when nothing valid remains,
  * so a corrupt `layout` value degrades to the node's constructor defaults.
@@ -155,28 +178,39 @@ export function readLayoutOptions(value: unknown): LayoutOptions | undefined {
   }
 
   const source = value as Record<string, unknown>;
-  const out: LayoutOptions = {};
+  const out: Record<string, unknown> = {};
 
-  const maxWidth = readNumber(source, 'maxWidth');
-  if (maxWidth !== undefined) out.maxWidth = maxWidth;
+  for (const key of LAYOUT_KEYS) {
+    const read = LAYOUT_READERS[key] as (source: Record<string, unknown>, key: string) => unknown;
+    const parsed = read(source, key);
 
-  const maxHeight = readNumber(source, 'maxHeight');
-  if (maxHeight !== undefined) out.maxHeight = maxHeight;
-
-  const overflow = readEnum(source, 'overflow', OVERFLOWS);
-  if (overflow !== undefined) out.overflow = overflow;
-
-  const letterSpacing = readNumber(source, 'letterSpacing');
-  if (letterSpacing !== undefined) out.letterSpacing = letterSpacing;
-
-  const direction = readEnum(source, 'direction', DIRECTIONS);
-  if (direction !== undefined) out.direction = direction;
-
-  const breakWords = readBoolean(source, 'breakWords');
-  if (breakWords !== undefined) out.breakWords = breakWords;
-
-  const whiteSpace = readEnum(source, 'whiteSpace', WHITE_SPACES);
-  if (whiteSpace !== undefined) out.whiteSpace = whiteSpace;
+    if (parsed !== undefined) out[key] = parsed;
+  }
 
   return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Copy only the layout keys out of an options bag, dropping everything else.
+ *
+ * `TextOptions` is a flat merge of style and layout options, so a text node
+ * handed that bag verbatim would keep the style keys in its layout copy and
+ * then hand them back out through `node.layout` — and through every serialized
+ * document written from it.
+ *
+ * Unlike {@link readLayoutOptions} this trusts its input's static type: it
+ * filters keys, it does not validate values. `undefined`-valued keys are
+ * omitted so the result stays a faithful "which options were actually set".
+ */
+export function pickLayoutOptions(source: Readonly<LayoutOptions>): LayoutOptions {
+  const bag = source as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+
+  for (const key of LAYOUT_KEYS) {
+    const value = bag[key];
+
+    if (value !== undefined) out[key] = value;
+  }
+
+  return out;
 }

--- a/src/rendering/text/AbstractText.ts
+++ b/src/rendering/text/AbstractText.ts
@@ -1,3 +1,4 @@
+import { pickLayoutOptions } from '#core/serialization/serializerHelpers';
 import type { ReadonlyRectangle } from '#math/Rectangle';
 import { Drawable } from '#rendering/Drawable';
 
@@ -51,7 +52,9 @@ export abstract class AbstractText extends Drawable {
     this._style.onChange.add(this._onStyleChange);
     // Copied, not aliased: the caller keeps its own options object and may
     // well go on mutating it, which must not silently re-flow this node.
-    this._layout = { ...layout };
+    // Narrowed to the layout keys too — `TextOptions` is a flat merge of style
+    // and layout, and `Text` hands that whole bag down.
+    this._layout = pickLayoutOptions(layout);
   }
 
   /** The string currently displayed by this node. */
@@ -70,13 +73,17 @@ export abstract class AbstractText extends Drawable {
    *
    * Handed out read-only: the node holds its own copy, so mutating the object
    * would change nothing. Assign a new one to re-flow.
+   *
+   * Carries layout keys only. A subclass whose options bag merges style and
+   * layout into one flat object (as `TextOptions` does) still reports just the
+   * layout half here.
    */
   public get layout(): Readonly<LayoutOptions> {
     return this._layout;
   }
 
   public set layout(v: LayoutOptions) {
-    this._layout = { ...v };
+    this._layout = pickLayoutOptions(v);
     this._markDirty('layout');
   }
 

--- a/src/rendering/text/TextStyle.ts
+++ b/src/rendering/text/TextStyle.ts
@@ -104,8 +104,12 @@ export interface TextStyleOptions {
 
   // ── Gradient ──────────────────────────────────────────────────────────────
   /**
-   * Two-stop fill gradient `[top, bottom]`. When set, overrides `fillColor`
-   * for the glyph interior. `null` disables the gradient.
+   * Two-stop fill gradient. When set, overrides `fillColor` for the glyph
+   * interior. `null` disables the gradient.
+   *
+   * The first colour is the START of the ramp and the second its END, read
+   * along `gradientAxis`: `[top, bottom]` for `'vertical'`, `[left, right]`
+   * for `'horizontal'`.
    */
   gradientColors?: [Color, Color] | null;
   /** Gradient orientation. Defaults to `'vertical'`. */
@@ -371,8 +375,12 @@ export class TextStyle {
   // ── Gradient properties (hint: 'tint') ──────────────────────────────────
 
   /**
-   * Two-stop fill gradient `[top, bottom]`. When set, overrides `fillColor`
-   * for the glyph interior. Assign `null` to disable.
+   * Two-stop fill gradient. When set, overrides `fillColor` for the glyph
+   * interior. Assign `null` to disable.
+   *
+   * The first colour is the START of the ramp and the second its END, read
+   * along `gradientAxis`: `[top, bottom]` for `'vertical'`, `[left, right]`
+   * for `'horizontal'`.
    */
   public get gradientColors(): [Color, Color] | null {
     return this._gradientColors;

--- a/src/rendering/webgl2/glsl/text-msdf.frag
+++ b/src/rendering/webgl2/glsl/text-msdf.frag
@@ -49,8 +49,10 @@ void main(void) {
 
   vec4 fillColor;
   if (gradEnabled > 0.5) {
+    // v_gradUV is 0 at the top/left edge of the ink box and 1 at the
+    // bottom/right, so texel 7 (gradientColors[0]) belongs at t = 0.
     float t = gradVertical > 0.5 ? v_gradUV.y : v_gradUV.x;
-    fillColor = mix(tGradBot, tGradTop, t);
+    fillColor = mix(tGradTop, tGradBot, t);
   } else {
     fillColor = tFill;
   }

--- a/src/rendering/webgl2/glsl/text-sdf.frag
+++ b/src/rendering/webgl2/glsl/text-sdf.frag
@@ -50,8 +50,10 @@ void main(void) {
 
   vec4 fillColor;
   if (gradEnabled > 0.5) {
+    // v_gradUV is 0 at the top/left edge of the ink box and 1 at the
+    // bottom/right, so texel 7 (gradientColors[0]) belongs at t = 0.
     float t = gradVertical > 0.5 ? v_gradUV.y : v_gradUV.x;
-    fillColor = mix(tGradBot, tGradTop, t);
+    fillColor = mix(tGradTop, tGradBot, t);
   } else {
     fillColor = tFill;
   }

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -262,8 +262,10 @@ fn fragmentSdf(in: VertexOutput) -> @location(0) vec4<f32> {
 
     var fillColor : vec4<f32>;
     if (gradEnabled > 0.5) {
+        // gradUV is 0 at the top/left edge of the ink box and 1 at the
+        // bottom/right, so texel 7 (gradientColors[0]) belongs at t = 0.
         let t = select(in.gradUV.x, in.gradUV.y, gradVertical > 0.5);
-        fillColor = mix(tGradBot, tGradTop, t);
+        fillColor = mix(tGradTop, tGradBot, t);
     } else {
         fillColor = tFill;
     }
@@ -314,8 +316,10 @@ fn fragmentMsdf(in: VertexOutput) -> @location(0) vec4<f32> {
 
     var fillColor : vec4<f32>;
     if (gradEnabled > 0.5) {
+        // gradUV is 0 at the top/left edge of the ink box and 1 at the
+        // bottom/right, so texel 7 (gradientColors[0]) belongs at t = 0.
         let t = select(in.gradUV.x, in.gradUV.y, gradVertical > 0.5);
-        fillColor = mix(tGradBot, tGradTop, t);
+        fillColor = mix(tGradTop, tGradBot, t);
     } else {
         fillColor = tFill;
     }

--- a/test/core/serialization.test.ts
+++ b/test/core/serialization.test.ts
@@ -266,6 +266,41 @@ describe('serialization — Text', () => {
     expect(restored.style.fontFamily).toBe('Roboto');
     expect(restored.style.fillColor.r).toBe(10);
   });
+
+  // `TextOptions` is a flat merge of style and layout options, so the node has
+  // to split them itself — otherwise `fontSize` and a live `Color` end up
+  // inside a `layout` block that claims a structure the type does not have.
+  it('writes a layout block holding layout keys only, never style keys', () => {
+    const text = new Text('Wrapped', {
+      fontSize: 24,
+      fillColor: new Color(10, 20, 30, 1),
+      outlineWidth: 2,
+      maxWidth: 120,
+      letterSpacing: 3,
+      whiteSpace: 'pre',
+    });
+
+    expect(Object.keys(text.layout).sort()).toEqual(['letterSpacing', 'maxWidth', 'whiteSpace']);
+
+    const data = serializeTree(text);
+
+    expect(data.layout).toEqual({ maxWidth: 120, letterSpacing: 3, whiteSpace: 'pre' });
+
+    // The style half is not lost — it is written where it belongs.
+    expect(data.style).toMatchObject({ fontSize: 24, outlineWidth: 2 });
+
+    const restored = deserializeTree(data) as Text;
+
+    expect(restored.layout).toEqual({ maxWidth: 120, letterSpacing: 3, whiteSpace: 'pre' });
+    expect(restored.style.fontSize).toBe(24);
+    expect(restored.style.outlineWidth).toBe(2);
+  });
+
+  it('omits the layout block entirely when only style options are given', () => {
+    const data = serializeTree(new Text('Plain', { fontSize: 24, fillColor: new Color(1, 2, 3, 1) }));
+
+    expect(data.layout).toBeUndefined();
+  });
 });
 
 describe('serialization — custom serializer', () => {

--- a/test/rendering/browser/webgl2-text-gradient.test.ts
+++ b/test/rendering/browser/webgl2-text-gradient.test.ts
@@ -9,10 +9,13 @@
  * samples the ramp at the wrong place and the clamp eats the overhang.
  *
  * The check does not depend on the shape of the glyph. With a pure red/blue
- * vertical ramp, `r / (r + b)` at any covered pixel IS the ramp fraction, and
- * the ramp fraction is a closed form of the uploaded box — so each ink row can
+ * vertical ramp, `r / (r + b)` at any covered pixel IS the red stop's weight,
+ * and that weight is a closed form of the uploaded box — so each ink row can
  * be predicted from `text.getLocalBounds()` and compared. Partial coverage
  * scales both channels equally and cancels out of the ratio.
+ *
+ * It also pins the ORIENTATION: `gradientColors` reads `[top, bottom]`, so the
+ * first colour must dominate the top rows and fade out towards the bottom.
  *
  * Run via:  pnpm test:browser:webgl
  */
@@ -111,7 +114,8 @@ describe('WebGL2: the text gradient ramp spans the ink extent', () => {
     const backend = await createBackend();
     const root = new Container();
     // 'M' is wide and solid, so most rows carry a strong, unambiguous sample.
-    // gradientColors[0] feeds the shader's ramp-1.0 end, [1] its ramp-0.0 end.
+    // gradientColors[0] is the TOP stop — it feeds the shader's ramp-0.0 end,
+    // [1] its ramp-1.0 end.
     const text = new Text('M', {
       fontSize: 56,
       fillColor: Color.white,
@@ -140,12 +144,27 @@ describe('WebGL2: the text gradient ramp spans the ink extent', () => {
       for (const { y, share } of rows) {
         // The shader interpolates at the pixel centre.
         const localY = y + 0.5 - textY;
-        const expected = Math.min(1, Math.max(0, (localY - ink.y) / ink.height));
+        const t = Math.min(1, Math.max(0, (localY - ink.y) / ink.height));
+        // Red is gradientColors[0] — the TOP stop — so its share is 1 at the
+        // top of the ink box and falls to 0 at the bottom.
+        const expected = 1 - t;
 
         // Measured agreement is within 0.001 on every ink row; the slack
         // covers adapter rounding, not a difference of interpretation.
         expect(Math.abs(share - expected), `row ${y}: red share ${share.toFixed(3)}, expected ${expected.toFixed(3)}`).toBeLessThan(0.02);
       }
+
+      // Orientation, stated without the closed form: the highest sampled ink
+      // row must be materially redder than the lowest. Glyph coverage never
+      // reaches the padded edges of the ink box, so this compares the rows that
+      // actually carry signal rather than the ramp's endpoints.
+      const first = rows[0]!;
+      const last = rows[rows.length - 1]!;
+
+      expect(
+        first.share - last.share,
+        `red must fall from row ${first.y} (${first.share.toFixed(3)}) to row ${last.y} (${last.share.toFixed(3)})`,
+      ).toBeGreaterThan(0.2);
     } finally {
       root.destroy();
       backend.destroy();

--- a/test/rendering/browser/webgpu-text-gradient.test.ts
+++ b/test/rendering/browser/webgpu-text-gradient.test.ts
@@ -1,0 +1,110 @@
+/**
+ * WebGPU counterpart to `webgl2-text-gradient.test.ts` — the ORIENTATION of the
+ * two-stop text gradient.
+ *
+ * Both backends upload `gradientColors[0]` into node texel 7 and `[1]` into
+ * texel 8, and both derive the ramp fraction from a `gradUV` that is 0 at the
+ * top/left edge of the ink box. The two fragment stages therefore have to mix
+ * in the same direction; they are separate sources (GLSL files vs inline WGSL),
+ * so nothing but a test per backend keeps them from drifting apart. The
+ * cross-backend parity suite renders plain white text and would not notice.
+ *
+ * The measurement is the WebGL2 one: with a pure red/blue ramp, `r / (r + b)`
+ * at any covered pixel is the weight of the red (first) stop, and partial
+ * glyph coverage scales both channels equally so it cancels out of the ratio.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+
+import { createWebGpuTestBackend, readWebGpuFrame, renderWebGpuOnce } from './_backendSetup';
+
+const canvasSize = 96;
+const textY = 8;
+
+/**
+ * Per row, the red share of the strongest covered pixel. Rows whose strongest
+ * pixel is too faint carry too little signal to read a ratio out of.
+ */
+const rowRedShares = (frame: ArrayLike<number>): ReadonlyArray<{ y: number; share: number }> => {
+  const rows: Array<{ y: number; share: number }> = [];
+
+  for (let y = 0; y < canvasSize; y++) {
+    let bestTotal = 0;
+    let bestShare = 0;
+
+    for (let x = 0; x < canvasSize; x++) {
+      const i = (y * canvasSize + x) * 4;
+      const total = frame[i]! + frame[i + 2]!;
+
+      if (total > bestTotal) {
+        bestTotal = total;
+        bestShare = frame[i]! / total;
+      }
+    }
+
+    if (bestTotal >= 160) rows.push({ y, share: bestShare });
+  }
+
+  return rows;
+};
+
+describe('WebGPU: the text gradient runs from gradientColors[0] at the top', () => {
+  beforeEach(() => resetDefaultGlyphAtlasPool());
+  afterEach(() => resetDefaultGlyphAtlasPool());
+
+  test('the first stop dominates the top of the ink box and fades out towards the bottom', async ctx => {
+    const backend = await createWebGpuTestBackend(canvasSize);
+    const root = new Container();
+    // 'M' is wide and solid, so most rows carry a strong, unambiguous sample.
+    const text = new Text('M', {
+      fontSize: 56,
+      fillColor: Color.white,
+      gradientColors: [Color.red, Color.blue],
+      gradientAxis: 'vertical',
+    });
+
+    text.setPosition(8, textY);
+    root.addChild(text);
+
+    try {
+      if (!(await renderWebGpuOnce(ctx, backend, root))) return;
+
+      const rows = rowRedShares(readWebGpuFrame(backend, canvasSize));
+      const ink = text.getLocalBounds();
+
+      // Enough rows to make the per-row claim below more than a spot check.
+      expect(rows.length).toBeGreaterThan(20);
+
+      for (const { y, share } of rows) {
+        // The shader interpolates at the pixel centre.
+        const t = Math.min(1, Math.max(0, (y + 0.5 - textY - ink.y) / ink.height));
+        // Red is gradientColors[0] — the TOP stop — so its share is 1 at the
+        // top of the ink box and falls to 0 at the bottom. A flipped mix would
+        // produce `t` here instead, missing by |2t - 1| on every row but the
+        // midpoint.
+        const expected = 1 - t;
+
+        expect(Math.abs(share - expected), `row ${y}: red share ${share.toFixed(3)}, expected ${expected.toFixed(3)}`).toBeLessThan(0.04);
+      }
+
+      // Orientation stated without the closed form. Glyph coverage never
+      // reaches the padded edges of the ink box, so this compares the rows that
+      // actually carry signal rather than the ramp's endpoints.
+      const first = rows[0]!;
+      const last = rows[rows.length - 1]!;
+
+      expect(
+        first.share - last.share,
+        `red must fall from row ${first.y} (${first.share.toFixed(3)}) to row ${last.y} (${last.share.toFixed(3)})`,
+      ).toBeGreaterThan(0.2);
+    } finally {
+      root.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/text/text.test.ts
+++ b/test/rendering/text/text.test.ts
@@ -10,6 +10,7 @@
  * Text now extends Drawable (via AbstractText) rather than Container.
  * It stores geometry internally as TextPageQuads instead of Mesh children.
  */
+import { Color } from '#core/Color';
 import { Drawable } from '#rendering/Drawable';
 import type { GlyphAtlas } from '#rendering/text/GlyphAtlas';
 import type { GlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
@@ -412,6 +413,23 @@ describe('Text', () => {
     assigned.letterSpacing = 40;
 
     expect(text.textBounds.width).toBe(widthBefore);
+  });
+
+  test('layout reports only layout keys, not the style half of the flat options bag', () => {
+    const text = new Text('Hi', { fontSize: 16, fillColor: Color.red, maxWidth: 80, breakWords: true });
+
+    expect(text.layout).toEqual({ maxWidth: 80, breakWords: true });
+  });
+
+  test('the layout setter filters style keys out too', () => {
+    const text = new Text('Hi');
+
+    // A caller re-using the constructor's flat options bag is the realistic
+    // way a style key reaches this setter.
+    text.layout = { letterSpacing: 4, fontSize: 99, fillColor: Color.red } as typeof text.layout;
+
+    expect(text.layout).toEqual({ letterSpacing: 4 });
+    expect(text.style.fontSize).not.toBe(99);
   });
 
   test('colorGlyphs flag is accessible', () => {


### PR DESCRIPTION
## NEU-L2 — gradient orientation (BREAKING)

`gradientColors[0]` is uploaded into texel 7, which the shader calls `gradientTop`, but all fragment stages mixed `mix(tGradBot, tGradTop, t)` while `gradUV` is **0 at the top edge** of the ink box. At `t = 0` the "bottom" colour won, so the colour named and documented as "top" rendered at the bottom.

The guide already documented `[top, bottom]` (`text.mdx`), so this was a plain contradiction between docs and code rather than an open convention question.

- Flipped to `mix(tGradTop, tGradBot, t)` in **all four** stages — `text-sdf.frag`, `text-msdf.frag`, and both `fragmentSdf`/`fragmentMsdf` in `WebGpuTextRenderer`. The shader was flipped rather than the upload order, so texel 7 keeps the meaning its name claims.
- The horizontal axis was mirrored the same way (both axes run through the same `mix`), so `gradientColors[0]` landed on the right for `horizontal`. Fixed with it.
- `TextStyle.gradientColors` now documents "first colour = start of the ramp", including `[left, right]` for `horizontal`.
- WebGPU had **no** gradient test at all, so the WGSL flip would have shipped untested — added `webgpu-text-gradient.test.ts`. Both backends now report identical measurements, which is incidental proof they sample the same way.

BREAKING CHANGE: `gradientColors` now runs from the first stop to the second along the gradient axis — `[top, bottom]` for `vertical` and `[left, right]` for `horizontal`. Code that picked the order empirically renders mirrored and must swap its two stops.

## NEU-L4 — style keys in the serialized `layout` block

`TextOptions` is a flat merge of `TextStyleOptions` and `LayoutOptions`, and `Text` stored that whole object as its `_layout`, so `fontSize`, `fillColor` and every other style option ended up inside the serialized `layout` block. Harmless on read (`readLayoutOptions` filters) but the output claimed a structure that does not exist.

Filtered at the source instead of at the serializer: `AbstractText` uses a new `pickLayoutOptions` in both the constructor and the `layout` setter, so neither serializer needed a change. The whitelist lives exactly once as a `LAYOUT_READERS` mapped type next to `readLayoutOptions` — a missing entry is a compile error, not silent drift.