### PR TITLE
fix(examples,tooling): rotate the HUD spinner about its centre, and name the missing build

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -42,6 +42,24 @@ while read local_ref local_sha remote_ref remote_sha; do
     esac
 done
 
+# Both verify:quick and verify:release include `typecheck:site`, which
+# type-checks the site/examples package against the PUBLISHED entry points
+# (package.json `exports` → dist/esm/*.d.ts) rather than against src/. Without
+# a build those declaration files don't exist and tsc reports a wall of
+# ts(2307) "Cannot find module 'exojs'" — a failure mode that reads like a
+# broken import in the pushed change, not like a missing prerequisite. Checking
+# for the root entry point's .d.ts up front turns that into one actionable
+# line. Deliberately not running the build here: it is slow enough that a hook
+# doing it silently would be the thing people bypass.
+if [ "$is_tag_push" = "1" ] || [ "$is_branch_push" = "1" ]; then
+    if [ ! -e dist/esm/index.d.ts ]; then
+        echo "[pre-push] dist/ is missing — 'typecheck:site' would fail with ts(2307) 'Cannot find module exojs'."
+        echo "[pre-push] It type-checks site/examples against the published entry points, which only exist after a build."
+        echo "[pre-push] Run 'pnpm build', then push again."
+        exit 1
+    fi
+fi
+
 if [ "$is_tag_push" = "1" ]; then
     echo "[pre-push] tag push detected — running full release verification"
     npm run verify:release || exit 1

--- a/examples/ui/hud-and-widgets.js
+++ b/examples/ui/hud-and-widgets.js
@@ -17,6 +17,12 @@ class HudScene extends Scene {
         // A bit of "world" content so the UI clearly sits on top of it.
         this.spinner = new Panel({ width: 160, height: 160, color: new Color(60, 130, 235, 1), cornerRadius: 24 });
         this.spinner.setPosition(640, 360);
+        // Rotate around the panel's centre. `origin` is the point a node is
+        // positioned and rotated about, so this also re-centres the panel on
+        // (640, 360) instead of hanging its top-left corner there. A `Panel`
+        // is a `Container` and has no content box of its own, which is why
+        // the normalised `anchor` is not the tool for this.
+        this.spinner.setOrigin(80, 80);
         this.addChild(this.spinner);
         // HUD: score + health anchored to the top-left corner.
         this.scoreLabel = new Label('Score: 0', { fontSize: 26 });

--- a/examples/ui/hud-and-widgets.ts
+++ b/examples/ui/hud-and-widgets.ts
@@ -20,6 +20,12 @@ class HudScene extends Scene {
         // A bit of "world" content so the UI clearly sits on top of it.
         this.spinner = new Panel({ width: 160, height: 160, color: new Color(60, 130, 235, 1), cornerRadius: 24 });
         this.spinner.setPosition(640, 360);
+        // Rotate around the panel's centre. `origin` is the point a node is
+        // positioned and rotated about, so this also re-centres the panel on
+        // (640, 360) instead of hanging its top-left corner there. A `Panel`
+        // is a `Container` and has no content box of its own, which is why
+        // the normalised `anchor` is not the tool for this.
+        this.spinner.setOrigin(80, 80);
         this.addChild(this.spinner);
 
         // HUD: score + health anchored to the top-left corner.


### PR DESCRIPTION
Two unrelated leftovers from the anchor/text sweep, both small.

## NEU-M2 — the HUD spinner rotated about its top-left corner

The `spinner` panel set an anchor and rotated, but a `Panel` is a `Container`
with no content box of its own, so the anchor never reached the origin. #519
removed the dead call; this fills in the intent with `setOrigin(80, 80)`, which
also re-centres the panel on the position it was given.

Verified in a real browser (Playwright, against the built entry points, 1280×720),
because the gates do not catch a silently wrong example:

| | panel centre |
|---|---|
| before | ≈ `(745, 318)`, drifting with the rotation angle |
| after | fixed `(640, 358)` |

Same setup both times, one line of difference — so it doubles as the mutation probe.
No console errors in either run. The generated `.js` was regenerated via
`examples:sync`; `examples:sync:check` passes.

## NEU-M3 — `pre-push` reported a missing build as a broken import

`verify:quick` and `verify:release` both include `typecheck:site`, which checks
`site/` and `examples/` against the **published** entry points (`package.json`
`exports` → `dist/esm/*.d.ts`) rather than `src/`. Without a build, that comes
out as a wall of `ts(2307) Cannot find module 'exojs'` — a failure that reads
like a broken import in the change being pushed, not like a missing prerequisite.

The hook now checks for `dist/esm/index.d.ts` up front and exits with three
lines of plain text. Deliberately no automatic build: it is slow enough that a
hook doing it silently is a hook people bypass. This is the second line of
defence behind the `WorktreeCreate` hook from NEU-C5, which only covers
worktrees it created itself.

Probed rather than assumed: run in a directory without `dist/`, the hook prints
the three lines and exits 1 before `verify:quick` starts; in the repo root with
`dist/` present the condition does not fire.

`pnpm verify:quick` — all 11 gates pass.