### PR TITLE
fix!: the decision sweep — getBounds ownership, gamepad slot 17, immutable signal payloads, Loader.peek

### DIFF
--- a/examples/application-scenes/camera-basic.js
+++ b/examples/application-scenes/camera-basic.js
@@ -25,8 +25,8 @@ class CameraBasicScene extends Scene {
         app.input.onPointerMove.add(p => {
             app.rendering.view.setCenter(p.x, p.y);
         });
-        app.input.onMouseWheel.add(delta => {
-            this.zoom = Math.max(0.2, Math.min(4, this.zoom - delta.y * 0.001));
+        app.input.onMouseWheel.add((_deltaX, deltaY) => {
+            this.zoom = Math.max(0.2, Math.min(4, this.zoom - deltaY * 0.001));
             app.rendering.view.setZoom(this.zoom);
         });
     }

--- a/examples/application-scenes/camera-basic.ts
+++ b/examples/application-scenes/camera-basic.ts
@@ -35,8 +35,8 @@ class CameraBasicScene extends Scene {
             app.rendering.view.setCenter(p.x, p.y);
         });
 
-        app.input.onMouseWheel.add(delta => {
-            this.zoom = Math.max(0.2, Math.min(4, this.zoom - delta.y * 0.001));
+        app.input.onMouseWheel.add((_deltaX, deltaY) => {
+            this.zoom = Math.max(0.2, Math.min(4, this.zoom - deltaY * 0.001));
             app.rendering.view.setZoom(this.zoom);
         });
     }

--- a/examples/debug-layer/asset-browser.js
+++ b/examples/debug-layer/asset-browser.js
@@ -144,7 +144,7 @@ class AssetBrowserScene extends Scene {
         await this.ensureCategory(this.cat);
         app.input.onPointerTap.add(p => this.onTap(p.x, p.y));
         app.input.onPointerMove.add(p => this.onMove(p.x, p.y));
-        app.input.onMouseWheel.add(v => this.onWheel(v.y));
+        app.input.onMouseWheel.add((_deltaX, deltaY) => this.onWheel(deltaY));
         this.selectFirstInCategory();
     }
     /** Load a category's assets (and build its preview objects) exactly once. */

--- a/examples/debug-layer/asset-browser.ts
+++ b/examples/debug-layer/asset-browser.ts
@@ -191,7 +191,7 @@ class AssetBrowserScene extends Scene {
 
         app.input.onPointerTap.add(p => this.onTap(p.x, p.y));
         app.input.onPointerMove.add(p => this.onMove(p.x, p.y));
-        app.input.onMouseWheel.add(v => this.onWheel(v.y));
+        app.input.onMouseWheel.add((_deltaX, deltaY) => this.onWheel(deltaY));
 
         this.selectFirstInCategory();
     }

--- a/examples/input/pointer-to-world.js
+++ b/examples/input/pointer-to-world.js
@@ -44,8 +44,8 @@ class PointerToWorldScene extends Scene {
             this.markerWorld.push({ x: world.x, y: world.y });
         });
         // Scroll to nudge a user-controlled zoom that the automatic breath multiplies.
-        app.input.onMouseWheel.add(offset => {
-            this.userZoom = Math.max(0.4, Math.min(3, this.userZoom + (offset.y < 0 ? 0.1 : -0.1)));
+        app.input.onMouseWheel.add((_deltaX, deltaY) => {
+            this.userZoom = Math.max(0.4, Math.min(3, this.userZoom + (deltaY < 0 ? 0.1 : -0.1)));
         });
         this.hud = mountControls({
             title: 'Pointer to World',

--- a/examples/input/pointer-to-world.ts
+++ b/examples/input/pointer-to-world.ts
@@ -53,8 +53,8 @@ class PointerToWorldScene extends Scene {
         });
 
         // Scroll to nudge a user-controlled zoom that the automatic breath multiplies.
-        app.input.onMouseWheel.add(offset => {
-            this.userZoom = Math.max(0.4, Math.min(3, this.userZoom + (offset.y < 0 ? 0.1 : -0.1)));
+        app.input.onMouseWheel.add((_deltaX, deltaY) => {
+            this.userZoom = Math.max(0.4, Math.min(3, this.userZoom + (deltaY < 0 ? 0.1 : -0.1)));
         });
 
         this.hud = mountControls({

--- a/site/public/preview.html
+++ b/site/public/preview.html
@@ -66,14 +66,10 @@
                 var exoRenderingEntry;
                 var exoRendererSdkEntry;
                 var particlesEntry;
-                var particlesRegisterEntry;
                 var audioFxEntry;
                 var tiledEntry;
-                var tiledRegisterEntry;
                 var tilemapEntry;
-                var tilemapRegisterEntry;
                 var ldtkEntry;
-                var ldtkRegisterEntry;
                 var physicsEntry;
                 var physicsDebugEntry;
                 if (!safeVersion || safeVersion === 'current') {
@@ -83,14 +79,10 @@
                     exoRenderingEntry = './vendor/exojs/esm/rendering.js?no-cache=' + noCache;
                     exoRendererSdkEntry = './vendor/exojs/esm/renderer-sdk.js?no-cache=' + noCache;
                     particlesEntry = './vendor/exojs-particles/esm/index.js?no-cache=' + noCache;
-                    particlesRegisterEntry = './vendor/exojs-particles/esm/register.js?no-cache=' + noCache;
                     audioFxEntry = './vendor/exojs-audio-fx/esm/index.js?no-cache=' + noCache;
                     tiledEntry = './vendor/exojs-tiled/esm/index.js?no-cache=' + noCache;
-                    tiledRegisterEntry = './vendor/exojs-tiled/esm/register.js?no-cache=' + noCache;
                     tilemapEntry = './vendor/exojs-tilemap/esm/index.js?no-cache=' + noCache;
-                    tilemapRegisterEntry = './vendor/exojs-tilemap/esm/register.js?no-cache=' + noCache;
                     ldtkEntry = './vendor/exojs-ldtk/esm/index.js?no-cache=' + noCache;
-                    ldtkRegisterEntry = './vendor/exojs-ldtk/esm/register.js?no-cache=' + noCache;
                     physicsEntry = './vendor/exojs-physics/esm/index.js?no-cache=' + noCache;
                     physicsDebugEntry = './vendor/exojs-physics/esm/debug/index.js?no-cache=' + noCache;
                 } else {
@@ -103,14 +95,10 @@
                     exoRenderingEntry = cdnBase + 'exojs@' + safeVersion + '/dist/esm/rendering.js';
                     exoRendererSdkEntry = cdnBase + 'exojs@' + safeVersion + '/dist/esm/renderer-sdk.js';
                     particlesEntry = cdnBase + 'exojs-particles@' + safeVersion + '/dist/esm/index.js';
-                    particlesRegisterEntry = cdnBase + 'exojs-particles@' + safeVersion + '/dist/esm/register.js';
                     audioFxEntry = cdnBase + 'exojs-audio-fx@' + safeVersion + '/dist/esm/index.js';
                     tiledEntry = cdnBase + 'exojs-tiled@' + safeVersion + '/dist/esm/index.js';
-                    tiledRegisterEntry = cdnBase + 'exojs-tiled@' + safeVersion + '/dist/esm/register.js';
                     tilemapEntry = cdnBase + 'exojs-tilemap@' + safeVersion + '/dist/esm/index.js';
-                    tilemapRegisterEntry = cdnBase + 'exojs-tilemap@' + safeVersion + '/dist/esm/register.js';
                     ldtkEntry = cdnBase + 'exojs-ldtk@' + safeVersion + '/dist/esm/index.js';
-                    ldtkRegisterEntry = cdnBase + 'exojs-ldtk@' + safeVersion + '/dist/esm/register.js';
                     physicsEntry = cdnBase + 'exojs-physics@' + safeVersion + '/dist/esm/index.js';
                     physicsDebugEntry = cdnBase + 'exojs-physics@' + safeVersion + '/dist/esm/debug/index.js';
                 }
@@ -123,14 +111,10 @@
                         '@codexo/exojs/rendering': exoRenderingEntry,
                         '@codexo/exojs/renderer-sdk': exoRendererSdkEntry,
                         '@codexo/exojs-particles': particlesEntry,
-                        '@codexo/exojs-particles/register': particlesRegisterEntry,
                         '@codexo/exojs-audio-fx': audioFxEntry,
                         '@codexo/exojs-tiled': tiledEntry,
-                        '@codexo/exojs-tiled/register': tiledRegisterEntry,
                         '@codexo/exojs-tilemap': tilemapEntry,
-                        '@codexo/exojs-tilemap/register': tilemapRegisterEntry,
                         '@codexo/exojs-ldtk': ldtkEntry,
-                        '@codexo/exojs-ldtk/register': ldtkRegisterEntry,
                         '@codexo/exojs-physics': physicsEntry,
                         '@codexo/exojs-physics/debug': physicsDebugEntry,
                         '@examples/runtime': './examples/shared/runtime.js?no-cache=' + noCache,

--- a/site/scripts/sync-exo-vendor.ts
+++ b/site/scripts/sync-exo-vendor.ts
@@ -388,7 +388,7 @@ const syncVendor = (): void => {
     // core: copy the ESM tree, rewrite '#'-subpath imports to relative paths
     // (Monaco can't resolve '#'), emit an `esm-typings.json` manifest, and emit a
     // `monaco-registry.json` (virtual package.json + subpath shims for e.g.
-    // `/register`, `/debug`). Without this the playground's TypeScript worker
+    // `/debug`). Without this the playground's TypeScript worker
     // can't resolve `@codexo/exojs-particles` & co. and every extension example
     // shows a ts2307 "Cannot find module" error.
     const extensionPackages = ['exojs-particles', 'exojs-audio-fx', 'exojs-tilemap', 'exojs-tiled', 'exojs-ldtk', 'exojs-physics'] as const;

--- a/site/src/content/api/abstract-text.json
+++ b/site/src/content/api/abstract-text.json
@@ -623,7 +623,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -632,6 +632,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -646,9 +662,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/animated-sprite.json
+++ b/site/src/content/api/animated-sprite.json
@@ -545,7 +545,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -554,6 +554,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -568,9 +584,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/bitmap-text.json
+++ b/site/src/content/api/bitmap-text.json
@@ -608,7 +608,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -617,6 +617,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -631,9 +647,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/button.json
+++ b/site/src/content/api/button.json
@@ -786,7 +786,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -795,6 +795,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -809,9 +825,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/circle.json
+++ b/site/src/content/api/circle.json
@@ -417,7 +417,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -426,6 +426,18 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -440,9 +452,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": false
+            }
+          ],
           "returnType": "Rectangle",
-          "description": ""
+          "description": "The axis-aligned bounding box of this object. Pass out to write into a rectangle you own — every implementer honours it, so this form is always safe to retain and never allocates. Without out, the ShapeLike shapes return a **fresh** rectangle, while a node or view that maintains a cached box (see SceneNode.getBounds) returns that cached instance, which the next invalidation overwrites."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/container.json
+++ b/site/src/content/api/container.json
@@ -517,7 +517,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -526,6 +526,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -540,9 +556,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/drawable.json
+++ b/site/src/content/api/drawable.json
@@ -385,7 +385,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -394,6 +394,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -408,9 +424,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/ellipse.json
+++ b/site/src/content/api/ellipse.json
@@ -437,7 +437,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -446,6 +446,18 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -460,9 +472,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": false
+            }
+          ],
           "returnType": "Rectangle",
-          "description": ""
+          "description": "The axis-aligned bounding box of this object. Pass out to write into a rectangle you own — every implementer honours it, so this form is always safe to retain and never allocates. Without out, the ShapeLike shapes return a **fresh** rectangle, while a node or view that maintains a cached box (see SceneNode.getBounds) returns that cached instance, which the next invalidation overwrites."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/gamepad-axis.json
+++ b/site/src/content/api/gamepad-axis.json
@@ -825,7 +825,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Secondary touchpad X (0..1). Steam Deck (right pad), other dual-touchpad hardware."
+          "description": "Secondary touchpad X (0..1) on dual-touchpad hardware. Device-specific: no built-in mapping writes this channel."
         },
         {
           "name": "Touchpad2Y",
@@ -846,7 +846,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Secondary touchpad Y (0..1)."
+          "description": "Secondary touchpad Y (0..1) on dual-touchpad hardware. Device-specific: no built-in mapping writes this channel."
         },
         {
           "name": "TouchpadX",
@@ -867,7 +867,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Primary touchpad X (0..1, left to right). PlayStation, Steam Deck (left pad), Steam Controller."
+          "description": "Primary touchpad X (0..1, left to right). Device-specific: no built-in mapping writes this channel."
         },
         {
           "name": "TouchpadY",
@@ -888,7 +888,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Primary touchpad Y (0..1, top to bottom)."
+          "description": "Primary touchpad Y (0..1, top to bottom). Device-specific: no built-in mapping writes this channel."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/gamepad-button.json
+++ b/site/src/content/api/gamepad-button.json
@@ -296,7 +296,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Capture / Screenshot button (Switch, Xbox Series)."
+          "description": "Capture / Screenshot button. Written by SwitchProGamepadMapping and, as the closest semantic match for its Quick Access button, SteamDeckGamepadMapping."
         },
         {
           "name": "DPadDown",
@@ -527,7 +527,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "First paddle / extra button (Xbox Elite, Steam Controller, PS5 Edge, Steam Deck L4)."
+          "description": "First paddle / extra button. Written by SteamDeckGamepadMapping (L4) only. Xbox Elite paddles do **not** reach this channel: the Windows path is XInput, whose XINPUT_GAMEPAD struct carries no paddle bits, and no browser mapper emits them. Reaching them needs WebHID and a custom GamepadDefinition."
         },
         {
           "name": "Paddle2",
@@ -548,7 +548,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Second paddle / extra button (Xbox Elite, Steam Deck R4, PS5 Edge)."
+          "description": "Second paddle / extra button. Written by SteamDeckGamepadMapping (R4) only — see Paddle1 for why Xbox Elite paddles are absent."
         },
         {
           "name": "Paddle3",
@@ -569,7 +569,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Third paddle / extra button (Xbox Elite, Steam Deck L5)."
+          "description": "Third paddle / extra button. Written by SteamDeckGamepadMapping (L5) only — see Paddle1 for why Xbox Elite paddles are absent."
         },
         {
           "name": "Paddle4",
@@ -590,7 +590,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Fourth paddle / extra button (Xbox Elite, Steam Deck R5)."
+          "description": "Fourth paddle / extra button. Written by SteamDeckGamepadMapping (R5) only — see Paddle1 for why Xbox Elite paddles are absent."
         },
         {
           "name": "RightShoulder",
@@ -695,7 +695,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Share / Create button (PS4/PS5, Xbox Series)."
+          "description": "Share / Create button. Written by XboxGamepadMapping (Xbox Series pads). On PlayStation pads the Share/Create button reports as Select instead — the browser puts it on the standard Back/Select slot."
         },
         {
           "name": "South",
@@ -758,7 +758,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Touchpad click (PlayStation)."
+          "description": "Touchpad **click**. Written by PlayStationGamepadMapping (DualShock 4, DualSense). Finger coordinates are a separate matter — see GamepadAxis.TouchpadX."
         },
         {
           "name": "West",

--- a/site/src/content/api/generic-dual-analog-gamepad-mapping.json
+++ b/site/src/content/api/generic-dual-analog-gamepad-mapping.json
@@ -1,6 +1,6 @@
 {
   "title": "GenericDualAnalogGamepadMapping",
-  "description": "Baseline mapping for dual-analog controllers that follow the standard W3C Gamepad API layout (axes 0–3 for both sticks, axes 4–7 auxiliary). Each signed stick axis is exposed three ways for ergonomic binding: - Two direction-split, non-negative channels (e.g. `LeftStickLeft` / `LeftStickRight`) for \"buttons-style\" subscriptions. - One signed aggregate channel (e.g. `LeftStickX`) for direct -1..1 consumption — useful for movement or aiming. Device-specific subclasses (Xbox, PlayStation, Switch Pro, etc.) inherit this layout and override only GamepadMapping.family.",
+  "description": "Baseline mapping for dual-analog controllers that follow the standard W3C Gamepad API layout (axes 0–3 for both sticks, axes 4–7 auxiliary). Each signed stick axis is exposed three ways for ergonomic binding: - Two direction-split, non-negative channels (e.g. `LeftStickLeft` / `LeftStickRight`) for \"buttons-style\" subscriptions. - One signed aggregate channel (e.g. `LeftStickX`) for direct -1..1 consumption — useful for movement or aiming. The standard layout ends at button index 16 (the Meta/Guide button). Browsers expose **one** device-specific slot beyond it, at index 17, and what sits there depends on the device — Share on an Xbox Series pad, Capture on a Switch Pro, the touchpad click on a DualShock 4 / DualSense. This baseline therefore declares nothing at 17; device subclasses pass their own entry through `extraButtons`. Device-specific subclasses (Xbox, PlayStation, Switch Pro, etc.) inherit this layout, override GamepadMapping.family, and add at most that one button.",
   "symbol": "GenericDualAnalogGamepadMapping",
   "kind": "class",
   "subsystem": "input",
@@ -21,7 +21,8 @@
       "paragraphs": [
         "Baseline mapping for dual-analog controllers that follow the standard W3C Gamepad API layout (axes 0–3 for both sticks, axes 4–7 auxiliary).",
         "Each signed stick axis is exposed three ways for ergonomic binding: - Two direction-split, non-negative channels (e.g. `LeftStickLeft` / `LeftStickRight`) for \"buttons-style\" subscriptions. - One signed aggregate channel (e.g. `LeftStickX`) for direct -1..1 consumption — useful for movement or aiming.",
-        "Device-specific subclasses (Xbox, PlayStation, Switch Pro, etc.) inherit this layout and override only GamepadMapping.family."
+        "The standard layout ends at button index 16 (the Meta/Guide button). Browsers expose **one** device-specific slot beyond it, at index 17, and what sits there depends on the device — Share on an Xbox Series pad, Capture on a Switch Pro, the touchpad click on a DualShock 4 / DualSense. This baseline therefore declares nothing at 17; device subclasses pass their own entry through `extraButtons`.",
+        "Device-specific subclasses (Xbox, PlayStation, Switch Pro, etc.) inherit this layout, override GamepadMapping.family, and add at most that one button."
       ],
       "importLine": "import { GenericDualAnalogGamepadMapping } from '@codexo/exojs'",
       "sourceLink": null
@@ -32,7 +33,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(): GenericDualAnalogGamepadMapping",
+          "signature": "new(extraButtons: readonly GamepadButton[]): GenericDualAnalogGamepadMapping",
           "signatureTokens": [
             {
               "text": "new",
@@ -40,6 +41,30 @@
             },
             {
               "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "extraButtons",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadButton",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
               "kind": "punctuation"
             },
             {
@@ -55,7 +80,13 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "extraButtons",
+              "type": "readonly GamepadButton[]",
+              "optional": false
+            }
+          ],
           "returnType": "GenericDualAnalogGamepadMapping",
           "description": ""
         }

--- a/site/src/content/api/graphics.json
+++ b/site/src/content/api/graphics.json
@@ -1782,7 +1782,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -1791,6 +1791,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -1805,9 +1821,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/has-bounding-box.json
+++ b/site/src/content/api/has-bounding-box.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -39,6 +39,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -53,9 +69,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": ""
+          "description": "The axis-aligned bounding box of this object. Pass out to write into a rectangle you own — every implementer honours it, so this form is always safe to retain and never allocates. Without out, the ShapeLike shapes return a **fresh** rectangle, while a node or view that maintains a cached box (see SceneNode.getBounds) returns that cached instance, which the next invalidation overwrites."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/htmltext.json
+++ b/site/src/content/api/htmltext.json
@@ -646,7 +646,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -655,6 +655,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -669,9 +685,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/image-layer-node.json
+++ b/site/src/content/api/image-layer-node.json
@@ -536,7 +536,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -545,6 +545,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -559,9 +575,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/input-manager.json
+++ b/site/src/content/api/input-manager.json
@@ -1644,7 +1644,7 @@
         },
         {
           "name": "onMouseWheel",
-          "signature": "onMouseWheel: Signal<[Vector]>",
+          "signature": "onMouseWheel: Signal<[deltaX, deltaY]>",
           "signatureTokens": [
             {
               "text": "onMouseWheel",
@@ -1667,7 +1667,15 @@
               "kind": "punctuation"
             },
             {
-              "text": "Vector",
+              "text": "deltaX",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "deltaY",
               "kind": "type"
             },
             {
@@ -1681,11 +1689,11 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "Fires once per frame in which the wheel moved, with the accumulated offset for that frame. deltaY is the usual scroll axis; deltaX carries horizontal wheels and trackpad swipes. Both are normalized out of the event's deltaMode, so a line- or page-mode wheel arrives in the same units as a pixel-mode one. The values are plain numbers rather than a Vector on purpose: the offset is reset to zero right after dispatch, so a shared instance would be stale by the time a listener that kept it read it again."
         },
         {
           "name": "onPinch",
-          "signature": "onPinch: Signal<[scale, center]>",
+          "signature": "onPinch: Signal<[scale, centerX, centerY]>",
           "signatureTokens": [
             {
               "text": "onPinch",
@@ -1716,7 +1724,15 @@
               "kind": "punctuation"
             },
             {
-              "text": "center",
+              "text": "centerX",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "centerY",
               "kind": "type"
             },
             {
@@ -1730,7 +1746,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Fires on every two-touch-pointer move where the distance between them changed. scale > 1 = spreading, < 1 = pinching."
+          "description": "Fires on every two-touch-pointer move where the distance between them changed. scale > 1 = spreading, < 1 = pinching; the center is the midpoint between the two pointers, in the same coordinate space as Pointer.position. The center arrives as two numbers rather than a Vector on purpose — a shared instance would be overwritten by the next gesture entry in the same frame."
         },
         {
           "name": "onPointerCancel",
@@ -2190,7 +2206,7 @@
         },
         {
           "name": "onRotate",
-          "signature": "onRotate: Signal<[angleDelta, center]>",
+          "signature": "onRotate: Signal<[angleDelta, centerX, centerY]>",
           "signatureTokens": [
             {
               "text": "onRotate",
@@ -2221,7 +2237,15 @@
               "kind": "punctuation"
             },
             {
-              "text": "center",
+              "text": "centerX",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "centerY",
               "kind": "type"
             },
             {
@@ -2235,7 +2259,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Fires on every two-touch-pointer move where the angle between them changed. angleDelta is in radians."
+          "description": "Fires on every two-touch-pointer move where the angle between them changed. angleDelta is in radians; the center is the midpoint between the two pointers — see onPinch for why it is not a Vector."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/label.json
+++ b/site/src/content/api/label.json
@@ -807,7 +807,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -816,6 +816,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -830,9 +846,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/line.json
+++ b/site/src/content/api/line.json
@@ -459,7 +459,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -468,6 +468,18 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -482,9 +494,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": false
+            }
+          ],
           "returnType": "Rectangle",
-          "description": ""
+          "description": "The axis-aligned bounding box of this object. Pass out to write into a rectangle you own — every implementer honours it, so this form is always safe to retain and never allocates. Without out, the ShapeLike shapes return a **fresh** rectangle, while a node or view that maintains a cached box (see SceneNode.getBounds) returns that cached instance, which the next invalidation overwrites."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/loader.json
+++ b/site/src/content/api/loader.json
@@ -6,10 +6,10 @@
   "subsystem": "assets",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 36,
+  "memberCount": 38,
   "counts": {
     "constructors": 1,
-    "methods": 25,
+    "methods": 27,
     "properties": 2,
     "events": 8
   },
@@ -299,7 +299,7 @@
             }
           ],
           "returnType": "LeafForPath<S>",
-          "description": "Seamless deferred access by path (asset-system v2). Returns SYNCHRONOUSLY: an already-loaded source returns the stored resource; an unknown source returns a placeholder handle immediately, starts the fetch, and fills the handle in place when the payload arrives (track it via loadState / loaded). Failed loads switch the handle to its failed representation; calling get again for a 'failed' source retries and heals the same handle in place. Invalid inputs and missing bindings throw synchronously before a fetch starts. The path is normalized to an AssetDefinitions type by its suffix (basename-only, longest-suffix-first), consulting the app-local registerType override, then the binding-declared type, then the global defineAsset default. A resource suffix yields its heal-in-place handle; a value suffix (json, txt, csv, …) yields a stable AssetRef. Only leaf-capable suffixes are accepted at compile time (ExtensionKindMap); dynamic strings resolving to an unregistered suffix or a non-leaf type throw with guidance. The same source always yields the same instance — also across load — and options are first-wins: conflicting options on a later call are ignored with a one-time dev warning."
+          "description": "Seamless deferred access by path (asset-system v2). Returns SYNCHRONOUSLY: an already-loaded source returns the stored resource; an unknown source returns a placeholder handle immediately, starts the fetch, and fills the handle in place when the payload arrives (track it via loadState / loaded). **This is an acquiring call, not a plain lookup.** Besides possibly starting a fetch it also **claims** the resolved key for this loader's lifetime, so the asset stays resident until a matching release (or, for scene.loader, until the scene tears down). That claim is the reason get is the right default: you almost always want the thing you are about to use to stay loaded. When you only want to know whether something is already in memory — without claiming it and without starting a fetch — use peek. Failed loads switch the handle to its failed representation; calling get again for a 'failed' source retries and heals the same handle in place. Invalid inputs and missing bindings throw synchronously before a fetch starts. The path is normalized to an AssetDefinitions type by its suffix (basename-only, longest-suffix-first), consulting the app-local registerType override, then the binding-declared type, then the global defineAsset default. A resource suffix yields its heal-in-place handle; a value suffix (json, txt, csv, …) yields a stable AssetRef. Only leaf-capable suffixes are accepted at compile time (ExtensionKindMap); dynamic strings resolving to an unregistered suffix or a non-leaf type throw with guidance. The same source always yields the same instance — also across load — and options are first-wins: conflicting options on a later call are ignored with a one-time dev warning."
         },
         {
           "name": "get",
@@ -532,7 +532,7 @@
             }
           ],
           "returnType": "CatalogResourceLeaf<T>",
-          "description": "Seamless deferred access by path (asset-system v2). Returns SYNCHRONOUSLY: an already-loaded source returns the stored resource; an unknown source returns a placeholder handle immediately, starts the fetch, and fills the handle in place when the payload arrives (track it via loadState / loaded). Failed loads switch the handle to its failed representation; calling get again for a 'failed' source retries and heals the same handle in place. Invalid inputs and missing bindings throw synchronously before a fetch starts. The path is normalized to an AssetDefinitions type by its suffix (basename-only, longest-suffix-first), consulting the app-local registerType override, then the binding-declared type, then the global defineAsset default. A resource suffix yields its heal-in-place handle; a value suffix (json, txt, csv, …) yields a stable AssetRef. Only leaf-capable suffixes are accepted at compile time (ExtensionKindMap); dynamic strings resolving to an unregistered suffix or a non-leaf type throw with guidance. The same source always yields the same instance — also across load — and options are first-wins: conflicting options on a later call are ignored with a one-time dev warning."
+          "description": "Seamless deferred access by path (asset-system v2). Returns SYNCHRONOUSLY: an already-loaded source returns the stored resource; an unknown source returns a placeholder handle immediately, starts the fetch, and fills the handle in place when the payload arrives (track it via loadState / loaded). **This is an acquiring call, not a plain lookup.** Besides possibly starting a fetch it also **claims** the resolved key for this loader's lifetime, so the asset stays resident until a matching release (or, for scene.loader, until the scene tears down). That claim is the reason get is the right default: you almost always want the thing you are about to use to stay loaded. When you only want to know whether something is already in memory — without claiming it and without starting a fetch — use peek. Failed loads switch the handle to its failed representation; calling get again for a 'failed' source retries and heals the same handle in place. Invalid inputs and missing bindings throw synchronously before a fetch starts. The path is normalized to an AssetDefinitions type by its suffix (basename-only, longest-suffix-first), consulting the app-local registerType override, then the binding-declared type, then the global defineAsset default. A resource suffix yields its heal-in-place handle; a value suffix (json, txt, csv, …) yields a stable AssetRef. Only leaf-capable suffixes are accepted at compile time (ExtensionKindMap); dynamic strings resolving to an unregistered suffix or a non-leaf type throw with guidance. The same source always yields the same instance — also across load — and options are first-wins: conflicting options on a later call are ignored with a one-time dev warning."
         },
         {
           "name": "get",
@@ -1446,6 +1446,212 @@
           ],
           "returnType": "Promise<void>",
           "description": "Load every asset packed into a binary container (.exoa) in a **single request**. A container is one file with an embedded index: its bytes are fetched once (and cached cross-session like any asset), then each slice is unpacked through its type's handler and stored under the entry's alias — retrievable with get exactly as if it had been loaded individually. Each entry's asset type must support byte-source construction (AssetHandler.createFromBytes); the factory-backed core types (textures, audio, JSON, text, binary, …) do. Throws on a malformed container, an unknown type, or a type that cannot be built from bytes."
+        },
+        {
+          "name": "peek",
+          "signature": "peek(path: [KindByPath<S>] extends [never] ? never : S): ResourceForKind<KindByPath<S>> | undefined",
+          "signatureTokens": [
+            {
+              "text": "peek",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "path",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "KindByPath",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "S",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "extends",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "never",
+              "kind": "keyword"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": " ? ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "never",
+              "kind": "keyword"
+            },
+            {
+              "text": " : ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "S",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ResourceForKind",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "KindByPath",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "S",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "undefined",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "path",
+              "type": "[KindByPath<S>] extends [never] ? never : S",
+              "optional": false
+            }
+          ],
+          "returnType": "ResourceForKind<KindByPath<S>> | undefined",
+          "description": "Pure in-memory lookup: the resource already stored for path, or undefined if nothing is held for it. The counterpart to get — and the one to reach for when the answer \"not loaded\" is a legitimate one rather than something to fix by loading. Unlike get, this **never** starts a fetch, **never** mints a placeholder handle, and **never** claims anything, so it cannot keep an asset alive by accident. Calling it in a loop is free. Invalid usage still fails loudly, exactly as it does on get: a path whose extension resolves to no registered type, or an input that is neither a path string nor an Asset.type(...) descriptor, throws. Only \"the key is fine, nothing is stored under it\" comes back as undefined. A catalog leaf needs no peek: the leaf *is* the handle, so read its loadState / loaded directly."
+        },
+        {
+          "name": "peek",
+          "signature": "peek(asset: Asset<T>): T | undefined",
+          "signatureTokens": [
+            {
+              "text": "peek",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "asset",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Asset",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "T",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "undefined",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "asset",
+              "type": "Asset<T>",
+              "optional": false
+            }
+          ],
+          "returnType": "T | undefined",
+          "description": "Pure in-memory lookup from an Asset.type(...) descriptor — see the path overload."
         },
         {
           "name": "registerSeamlessAdapter",

--- a/site/src/content/api/mesh.json
+++ b/site/src/content/api/mesh.json
@@ -406,7 +406,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -415,6 +415,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -429,9 +445,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/nine-slice-sprite.json
+++ b/site/src/content/api/nine-slice-sprite.json
@@ -430,7 +430,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -439,6 +439,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -453,9 +469,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/panel.json
+++ b/site/src/content/api/panel.json
@@ -786,7 +786,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -795,6 +795,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -809,9 +825,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/particle-system.json
+++ b/site/src/content/api/particle-system.json
@@ -917,7 +917,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -926,6 +926,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -940,9 +956,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/play-station-gamepad-mapping.json
+++ b/site/src/content/api/play-station-gamepad-mapping.json
@@ -1,6 +1,6 @@
 {
   "title": "PlayStationGamepadMapping",
-  "description": "Mapping for Sony PlayStation controllers, covering DualShock 4 and DualSense (PS4 / PS5) when connected via USB or Bluetooth. Inherits the full GenericDualAnalogGamepadMapping layout. PlayStation-specific controls (touchpad click, Share/Create, Capture) are surfaced through the Touchpad, Share, and Capture channels respectively.",
+  "description": "Mapping for Sony PlayStation controllers, covering DualShock 4 and DualSense (PS4 / PS5) when connected via USB or Bluetooth. Inherits the full GenericDualAnalogGamepadMapping layout and claims the one device-specific slot at index 17 for the touchpad **click**. Share/Create sits on the standard Select slot (index 8) on these pads, so it needs no entry of its own. Touchpad *coordinates* are not available here: browsers model the touchpad as a button, and the standard axis set stops after the two sticks. Reading finger positions requires WebHID and a custom `GamepadDefinition`.",
   "symbol": "PlayStationGamepadMapping",
   "kind": "class",
   "subsystem": "input",
@@ -20,7 +20,8 @@
       "members": [],
       "paragraphs": [
         "Mapping for Sony PlayStation controllers, covering DualShock 4 and DualSense (PS4 / PS5) when connected via USB or Bluetooth.",
-        "Inherits the full GenericDualAnalogGamepadMapping layout. PlayStation-specific controls (touchpad click, Share/Create, Capture) are surfaced through the Touchpad, Share, and Capture channels respectively."
+        "Inherits the full GenericDualAnalogGamepadMapping layout and claims the one device-specific slot at index 17 for the touchpad **click**. Share/Create sits on the standard Select slot (index 8) on these pads, so it needs no entry of its own.",
+        "Touchpad *coordinates* are not available here: browsers model the touchpad as a button, and the standard axis set stops after the two sticks. Reading finger positions requires WebHID and a custom `GamepadDefinition`."
       ],
       "importLine": "import { PlayStationGamepadMapping } from '@codexo/exojs'",
       "sourceLink": null

--- a/site/src/content/api/polygon.json
+++ b/site/src/content/api/polygon.json
@@ -421,7 +421,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -430,6 +430,18 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -444,9 +456,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": false
+            }
+          ],
           "returnType": "Rectangle",
-          "description": ""
+          "description": "The axis-aligned bounding box of this object. Pass out to write into a rectangle you own — every implementer honours it, so this form is always safe to retain and never allocates. Without out, the ShapeLike shapes return a **fresh** rectangle, while a node or view that maintains a cached box (see SceneNode.getBounds) returns that cached instance, which the next invalidation overwrites."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/progress-bar.json
+++ b/site/src/content/api/progress-bar.json
@@ -786,7 +786,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -795,6 +795,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -809,9 +825,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/readonly-rectangle.json
+++ b/site/src/content/api/readonly-rectangle.json
@@ -294,7 +294,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -303,6 +303,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -317,7 +333,13 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
           "description": ""
         },

--- a/site/src/content/api/rectangle.json
+++ b/site/src/content/api/rectangle.json
@@ -485,7 +485,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -494,6 +494,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -508,9 +524,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": ""
+          "description": "The axis-aligned bounding box of this object. Pass out to write into a rectangle you own — every implementer honours it, so this form is always safe to retain and never allocates. Without out, the ShapeLike shapes return a **fresh** rectangle, while a node or view that maintains a cached box (see SceneNode.getBounds) returns that cached instance, which the next invalidation overwrites."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/render-node.json
+++ b/site/src/content/api/render-node.json
@@ -356,7 +356,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -365,6 +365,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -379,9 +395,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/repeating-sprite.json
+++ b/site/src/content/api/repeating-sprite.json
@@ -438,7 +438,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -447,6 +447,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -461,9 +477,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -593,7 +593,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -602,6 +602,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -616,9 +632,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/scene-node.json
+++ b/site/src/content/api/scene-node.json
@@ -225,7 +225,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -234,6 +234,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -248,9 +264,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -788,7 +788,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -797,6 +797,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -811,9 +827,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/shape-like.json
+++ b/site/src/content/api/shape-like.json
@@ -258,7 +258,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -267,6 +267,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -281,9 +297,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": ""
+          "description": "The axis-aligned bounding box of this object. Pass out to write into a rectangle you own — every implementer honours it, so this form is always safe to retain and never allocates. Without out, the ShapeLike shapes return a **fresh** rectangle, while a node or view that maintains a cached box (see SceneNode.getBounds) returns that cached instance, which the next invalidation overwrites."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/sprite.json
+++ b/site/src/content/api/sprite.json
@@ -419,7 +419,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -428,6 +428,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -442,9 +458,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/stack.json
+++ b/site/src/content/api/stack.json
@@ -833,7 +833,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -842,6 +842,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -856,9 +872,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/steam-controller-gamepad-mapping.json
+++ b/site/src/content/api/steam-controller-gamepad-mapping.json
@@ -31,7 +31,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(): SteamControllerGamepadMapping",
+          "signature": "new(extraButtons: readonly GamepadButton[]): SteamControllerGamepadMapping",
           "signatureTokens": [
             {
               "text": "new",
@@ -39,6 +39,30 @@
             },
             {
               "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "extraButtons",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadButton",
+              "kind": "type"
+            },
+            {
+              "text": "[]",
               "kind": "punctuation"
             },
             {
@@ -54,7 +78,13 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "extraButtons",
+              "type": "readonly GamepadButton[]",
+              "optional": false
+            }
+          ],
           "returnType": "SteamControllerGamepadMapping",
           "description": ""
         }

--- a/site/src/content/api/switch-pro-gamepad-mapping.json
+++ b/site/src/content/api/switch-pro-gamepad-mapping.json
@@ -1,6 +1,6 @@
 {
   "title": "SwitchProGamepadMapping",
-  "description": "Mapping for the Nintendo Switch Pro Controller connected via USB or Bluetooth. Inherits the full GenericDualAnalogGamepadMapping layout. The Capture button is surfaced through the Capture channel; Home maps to Guide. Note that on some browsers the controller is only recognised after being paired through Steam or a dedicated driver.",
+  "description": "Mapping for the Nintendo Switch Pro Controller connected via USB or Bluetooth. Inherits the full GenericDualAnalogGamepadMapping layout and claims the one device-specific slot at index 17 for the Capture button; Home maps to Guide, Minus/Plus to Select/Start. Note that on some browsers the controller is only recognised after being paired through Steam or a dedicated driver.",
   "symbol": "SwitchProGamepadMapping",
   "kind": "class",
   "subsystem": "input",
@@ -20,7 +20,8 @@
       "members": [],
       "paragraphs": [
         "Mapping for the Nintendo Switch Pro Controller connected via USB or Bluetooth.",
-        "Inherits the full GenericDualAnalogGamepadMapping layout. The Capture button is surfaced through the Capture channel; Home maps to Guide. Note that on some browsers the controller is only recognised after being paired through Steam or a dedicated driver."
+        "Inherits the full GenericDualAnalogGamepadMapping layout and claims the one device-specific slot at index 17 for the Capture button; Home maps to Guide, Minus/Plus to Select/Start.",
+        "Note that on some browsers the controller is only recognised after being paired through Steam or a dedicated driver."
       ],
       "importLine": "import { SwitchProGamepadMapping } from '@codexo/exojs'",
       "sourceLink": null

--- a/site/src/content/api/text.json
+++ b/site/src/content/api/text.json
@@ -606,7 +606,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -615,6 +615,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -629,9 +645,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/tile-layer-node.json
+++ b/site/src/content/api/tile-layer-node.json
@@ -561,7 +561,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -570,6 +570,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -584,9 +600,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/tile-map-band.json
+++ b/site/src/content/api/tile-map-band.json
@@ -482,7 +482,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -491,6 +491,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -505,9 +521,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/tile-map-node.json
+++ b/site/src/content/api/tile-map-node.json
@@ -560,7 +560,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -569,6 +569,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -583,9 +599,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/uiroot.json
+++ b/site/src/content/api/uiroot.json
@@ -516,7 +516,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -525,6 +525,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -539,9 +555,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/vector.json
+++ b/site/src/content/api/vector.json
@@ -694,7 +694,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -703,6 +703,18 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -717,9 +729,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": false
+            }
+          ],
           "returnType": "Rectangle",
-          "description": ""
+          "description": "The axis-aligned bounding box of this object. Pass out to write into a rectangle you own — every implementer honours it, so this form is always safe to retain and never allocates. Without out, the ShapeLike shapes return a **fresh** rectangle, while a node or view that maintains a cached box (see SceneNode.getBounds) returns that cached instance, which the next invalidation overwrites."
         },
         {
           "name": "getNormals",

--- a/site/src/content/api/video.json
+++ b/site/src/content/api/video.json
@@ -535,7 +535,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -544,6 +544,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -558,9 +574,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getGlobalTransform",

--- a/site/src/content/api/view.json
+++ b/site/src/content/api/view.json
@@ -334,7 +334,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -343,6 +343,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -357,9 +373,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Return the world-space bounding rectangle of the currently visible area, recalculating if dirty. Used for frustum culling by Drawable.render."
+          "description": "Return the world-space bounding rectangle of the currently visible area, recalculating if dirty. Used for frustum culling by Drawable.render. Pass out to receive a copy you own. Without it the return value is this view's cached rectangle, which the next recalculation overwrites in place."
         },
         {
           "name": "getInverseTransform",

--- a/site/src/content/api/widget.json
+++ b/site/src/content/api/widget.json
@@ -769,7 +769,7 @@
         },
         {
           "name": "getBounds",
-          "signature": "getBounds(): Rectangle",
+          "signature": "getBounds(out?: Rectangle): Rectangle",
           "signatureTokens": [
             {
               "text": "getBounds",
@@ -778,6 +778,22 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "out",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rectangle",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -792,9 +808,15 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "out",
+              "type": "Rectangle",
+              "optional": true
+            }
+          ],
           "returnType": "Rectangle",
-          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix."
+          "description": "Axis-aligned bounding box of this node in its GLOBAL-transform space. That is world space for ordinary nodes, but GROUP-LOCAL space for nodes inside an engaged RetainedContainer transform group (the group matrix is applied on the GPU, not here) — this is deliberate and matches the rendering convention. For a true world-space extent of such a node, lift this rect by the group's getWorldTransform matrix. Pass out to receive a copy you own. Without it the return value is this node's **cached** rectangle, rebuilt in place whenever the transform or the local extent changes — retaining it across frames hands you a value that silently moves. The cache is why the no-arg form does not allocate: this runs per node per frame for culling and hit-testing."
         },
         {
           "name": "getChildAt",

--- a/site/src/content/api/xbox-gamepad-mapping.json
+++ b/site/src/content/api/xbox-gamepad-mapping.json
@@ -1,6 +1,6 @@
 {
   "title": "XboxGamepadMapping",
-  "description": "Mapping for Microsoft Xbox controllers (Xbox One, Xbox Series X/S, and compatible third-party XInput devices) connected via USB or Bluetooth. Inherits the full GenericDualAnalogGamepadMapping layout, which mirrors the W3C standard gamepad layout that XInput controllers follow natively. The Share button (Xbox Series) maps to the Share channel.",
+  "description": "Mapping for Microsoft Xbox controllers (Xbox One, Xbox Series X/S, and compatible third-party XInput devices) connected via USB or Bluetooth. Inherits the full GenericDualAnalogGamepadMapping layout, which mirrors the W3C standard gamepad layout that XInput controllers follow natively, and claims the one device-specific slot at index 17 for the Share button of the Xbox Series pads. The Elite paddles are deliberately absent: the Windows path is XInput, whose `XINPUT_GAMEPAD` struct has no paddle bits, and no browser mapper emits them. They are reachable only through WebHID and therefore belong to a custom `GamepadDefinition`, not here.",
   "symbol": "XboxGamepadMapping",
   "kind": "class",
   "subsystem": "input",
@@ -20,7 +20,8 @@
       "members": [],
       "paragraphs": [
         "Mapping for Microsoft Xbox controllers (Xbox One, Xbox Series X/S, and compatible third-party XInput devices) connected via USB or Bluetooth.",
-        "Inherits the full GenericDualAnalogGamepadMapping layout, which mirrors the W3C standard gamepad layout that XInput controllers follow natively. The Share button (Xbox Series) maps to the Share channel."
+        "Inherits the full GenericDualAnalogGamepadMapping layout, which mirrors the W3C standard gamepad layout that XInput controllers follow natively, and claims the one device-specific slot at index 17 for the Share button of the Xbox Series pads.",
+        "The Elite paddles are deliberately absent: the Windows path is XInput, whose `XINPUT_GAMEPAD` struct has no paddle bits, and no browser mapper emits them. They are reachable only through WebHID and therefore belong to a custom `GamepadDefinition`, not here."
       ],
       "importLine": "import { XboxGamepadMapping } from '@codexo/exojs'",
       "sourceLink": null

--- a/site/src/content/guide/input/mouse-and-pointer.mdx
+++ b/site/src/content/guide/input/mouse-and-pointer.mdx
@@ -121,9 +121,12 @@ declare const camera: { zoom: number };
 declare const map: Container;
 declare function showContextMenu(x: number, y: number): void;
 
-application.input.onPinch.add(scale => {
-    // scale > 1 = spreading fingers, scale < 1 = pinching
+application.input.onPinch.add((scale, centerX, centerY) => {
+    // scale > 1 = spreading fingers, scale < 1 = pinching.
+    // centerX/centerY are the midpoint between the two pointers — zoom
+    // towards it to keep the pinched spot under the fingers.
     camera.zoom *= scale;
+    map.setPosition(centerX, centerY);
 });
 
 application.input.onRotate.add(angleDelta => {

--- a/src/assets/Loader.ts
+++ b/src/assets/Loader.ts
@@ -889,7 +889,9 @@ export class Loader {
       ctor = resolved.ctor;
       source = resolved.source;
     } else {
-      throw new Error('Loader: peek() accepts a path string or an Asset.type(...) descriptor. A catalog leaf is already a handle — read its loadState instead.');
+      throw new Error(
+        'Loader: peek() accepts a path string or an Asset.type(...) descriptor. A catalog leaf is already a handle — read its loadState instead.',
+      );
     }
 
     return this._residency._hasStored(ctor, source) ? (this._residency._peekResource(ctor, source) ?? undefined) : undefined;

--- a/src/assets/Loader.ts
+++ b/src/assets/Loader.ts
@@ -653,7 +653,18 @@ export class Loader {
    * an already-loaded source returns the stored resource; an unknown source
    * returns a placeholder handle immediately, starts the fetch, and fills the
    * handle in place when the payload arrives (track it via `loadState` /
-   * `loaded`). Failed loads switch the handle to its failed representation;
+   * `loaded`).
+   *
+   * **This is an acquiring call, not a plain lookup.** Besides possibly
+   * starting a fetch it also **claims** the resolved key for this loader's
+   * lifetime, so the asset stays resident until a matching {@link release}
+   * (or, for `scene.loader`, until the scene tears down). That claim is the
+   * reason `get` is the right default: you almost always want the thing you
+   * are about to use to stay loaded. When you only want to know whether
+   * something is already in memory — without claiming it and without starting
+   * a fetch — use {@link peek}.
+   *
+   * Failed loads switch the handle to its failed representation;
    * calling `get` again for a `'failed'` source retries and heals the same
    * handle in place. Invalid inputs and missing bindings throw synchronously
    * before a fetch starts.
@@ -821,6 +832,67 @@ export class Loader {
       `Loader: type "${type}" inferred from "${path}" has no seamless adapter and is not a value type — ` +
         `use load(Asset.type('${type}', '${path}')) instead.`,
     );
+  }
+
+  /**
+   * Pure in-memory lookup: the resource already stored for `path`, or
+   * `undefined` if nothing is held for it.
+   *
+   * The counterpart to {@link get} — and the one to reach for when the answer
+   * "not loaded" is a legitimate one rather than something to fix by loading.
+   * Unlike `get`, this **never** starts a fetch, **never** mints a placeholder
+   * handle, and **never** claims anything, so it cannot keep an asset alive by
+   * accident. Calling it in a loop is free.
+   *
+   * Invalid usage still fails loudly, exactly as it does on `get`: a path
+   * whose extension resolves to no registered type, or an input that is
+   * neither a path string nor an `Asset.type(...)` descriptor, throws. Only
+   * "the key is fine, nothing is stored under it" comes back as `undefined`.
+   *
+   * A catalog leaf needs no `peek`: the leaf *is* the handle, so read its
+   * `loadState` / `loaded` directly.
+   *
+   * @example
+   * ```ts
+   * // Use the real texture if it happens to be resident, otherwise skip the
+   * // decoration entirely — without pulling it into memory.
+   * const sparkle = loader.peek('image/sparkle.png');
+   * if (sparkle !== undefined) {
+   *     stage.addChild(new Sprite(sparkle));
+   * }
+   * ```
+   *
+   * @remarks A custom type bound via `bindAsset` may legitimately store a
+   * nullish payload; such an entry reports `undefined` here and is
+   * indistinguishable from "not stored".
+   */
+  public peek<S extends string>(path: [KindByPath<S>] extends [never] ? never : S): ResourceForKind<KindByPath<S>> | undefined;
+  /** Pure in-memory lookup from an `Asset.type(...)` descriptor — see the path overload. */
+  public peek<T>(asset: Asset<T>): T | undefined;
+  public peek(input: string | object): unknown {
+    let ctor: AssetConstructor;
+    let source: string;
+
+    if (input instanceof AssetImpl) {
+      const { type, source: src } = input._config;
+      const resolved = this._typeRegistry.resolveTypeName(type) ?? this._valueTokenForKind(type);
+
+      if (resolved === undefined) {
+        throw new Error(`Loader: peek(Asset.type('${String(type)}', …)) — no type is registered under "${String(type)}".`);
+      }
+
+      ctor = resolved;
+      source = src;
+    } else if (typeof input === 'string') {
+      const resolved = this._resolveBarePath(input);
+
+      ctor = resolved.ctor;
+      source = resolved.source;
+    } else {
+      throw new Error('Loader: peek() accepts a path string or an Asset.type(...) descriptor. A catalog leaf is already a handle — read its loadState instead.');
+    }
+
+    return this._residency._hasStored(ctor, source) ? (this._residency._peekResource(ctor, source) ?? undefined) : undefined;
   }
 
   /**

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -552,8 +552,14 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
    * matrix is applied on the GPU, not here) — this is deliberate and matches
    * the rendering convention. For a true world-space extent of such a node,
    * lift this rect by the group's {@link getWorldTransform} matrix.
+   *
+   * Pass `out` to receive a copy you own. Without it the return value is this
+   * node's **cached** rectangle, rebuilt in place whenever the transform or
+   * the local extent changes — retaining it across frames hands you a value
+   * that silently moves. The cache is why the no-arg form does not allocate:
+   * this runs per node per frame for culling and hit-testing.
    */
-  public getBounds(): Rectangle {
+  public getBounds(out?: Rectangle): Rectangle {
     this.getGlobalTransform(); // ensures this node's own _globalTransformVersion is current
 
     if (this.flags.hasMask(SceneNodeTransformFlags.BoundsRect) || this._boundsBuiltAtVersion !== this._globalTransformVersion) {
@@ -562,7 +568,9 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
       this._boundsBuiltAtVersion = this._globalTransformVersion;
     }
 
-    return this._bounds.getRect();
+    const bounds = this._bounds.getRect();
+
+    return out === undefined ? bounds : out.copy(bounds);
   }
 
   public updateBounds(): this {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -96,7 +96,16 @@ export interface Destroyable {
 
 /** Anything that can produce an axis-aligned bounding {@link Rectangle}. */
 export interface HasBoundingBox {
-  getBounds(): Rectangle;
+  /**
+   * The axis-aligned bounding box of this object.
+   *
+   * Pass `out` to write into a rectangle you own — every implementer honours
+   * it, so this form is always safe to retain and never allocates. Without
+   * `out`, the {@link ShapeLike} shapes return a **fresh** rectangle, while a
+   * node or view that maintains a cached box (see {@link SceneNode.getBounds})
+   * returns that cached instance, which the next invalidation overwrites.
+   */
+  getBounds(out?: Rectangle): Rectangle;
 }
 
 /**

--- a/src/input/GamepadAxis.ts
+++ b/src/input/GamepadAxis.ts
@@ -235,14 +235,37 @@ export namespace GamepadAxis {
   /** Signed right-stick Y axis (-1..1). */
   export const RightStickY = axis(43);
 
-  // Touchpad XY (PlayStation 4/5, Steam Deck, dual-touchpad Steam-class hardware).
-  /** Primary touchpad X (0..1, left to right). PlayStation, Steam Deck (left pad), Steam Controller. */
+  // Touchpad XY — device-specific, written by no built-in mapping.
+  //
+  // The Gamepad API does not carry touchpad coordinates: its standard axis set
+  // stops after the two sticks, and browsers model a touchpad as a *button*
+  // (the click) rather than an axis pair. These four channels exist for custom
+  // `GamepadDefinition`s that source finger positions elsewhere — WebHID being
+  // the practical route — and stay at 0 otherwise. The touchpad click itself
+  // is a real channel: see `GamepadButton.Touchpad`.
+  /**
+   * Primary touchpad X (0..1, left to right).
+   *
+   * Device-specific: no built-in mapping writes this channel.
+   */
   export const TouchpadX = axis(44);
-  /** Primary touchpad Y (0..1, top to bottom). */
+  /**
+   * Primary touchpad Y (0..1, top to bottom).
+   *
+   * Device-specific: no built-in mapping writes this channel.
+   */
   export const TouchpadY = axis(45);
-  /** Secondary touchpad X (0..1). Steam Deck (right pad), other dual-touchpad hardware. */
+  /**
+   * Secondary touchpad X (0..1) on dual-touchpad hardware.
+   *
+   * Device-specific: no built-in mapping writes this channel.
+   */
   export const Touchpad2X = axis(46);
-  /** Secondary touchpad Y (0..1). */
+  /**
+   * Secondary touchpad Y (0..1) on dual-touchpad hardware.
+   *
+   * Device-specific: no built-in mapping writes this channel.
+   */
   export const Touchpad2Y = axis(47);
 
   // Auxiliary axes (4 bipolar axes split into 8 non-negative channels).

--- a/src/input/GamepadButton.ts
+++ b/src/input/GamepadButton.ts
@@ -148,19 +148,57 @@ export namespace GamepadButton {
   export const DPadRight = button(15);
   /** Home / Guide / PS button. */
   export const Guide = button(16);
-  /** Share / Create button (PS4/PS5, Xbox Series). */
+  /**
+   * Share / Create button.
+   *
+   * Written by {@link XboxGamepadMapping} (Xbox Series pads). On PlayStation
+   * pads the Share/Create button reports as {@link Select} instead — the
+   * browser puts it on the standard Back/Select slot.
+   */
   export const Share = button(17);
-  /** Capture / Screenshot button (Switch, Xbox Series). */
+  /**
+   * Capture / Screenshot button.
+   *
+   * Written by {@link SwitchProGamepadMapping} and, as the closest semantic
+   * match for its Quick Access button, {@link SteamDeckGamepadMapping}.
+   */
   export const Capture = button(18);
-  /** Touchpad click (PlayStation). */
+  /**
+   * Touchpad **click**.
+   *
+   * Written by {@link PlayStationGamepadMapping} (DualShock 4, DualSense).
+   * Finger coordinates are a separate matter — see `GamepadAxis.TouchpadX`.
+   */
   export const Touchpad = button(19);
-  /** First paddle / extra button (Xbox Elite, Steam Controller, PS5 Edge, Steam Deck L4). */
+  /**
+   * First paddle / extra button.
+   *
+   * Written by {@link SteamDeckGamepadMapping} (L4) only. Xbox Elite paddles
+   * do **not** reach this channel: the Windows path is XInput, whose
+   * `XINPUT_GAMEPAD` struct carries no paddle bits, and no browser mapper
+   * emits them. Reaching them needs WebHID and a custom `GamepadDefinition`.
+   */
   export const Paddle1 = button(20);
-  /** Second paddle / extra button (Xbox Elite, Steam Deck R4, PS5 Edge). */
+  /**
+   * Second paddle / extra button.
+   *
+   * Written by {@link SteamDeckGamepadMapping} (R4) only — see
+   * {@link Paddle1} for why Xbox Elite paddles are absent.
+   */
   export const Paddle2 = button(21);
-  /** Third paddle / extra button (Xbox Elite, Steam Deck L5). */
+  /**
+   * Third paddle / extra button.
+   *
+   * Written by {@link SteamDeckGamepadMapping} (L5) only — see
+   * {@link Paddle1} for why Xbox Elite paddles are absent.
+   */
   export const Paddle3 = button(22);
-  /** Fourth paddle / extra button (Xbox Elite, Steam Deck R5). */
+  /**
+   * Fourth paddle / extra button.
+   *
+   * Written by {@link SteamDeckGamepadMapping} (R5) only — see
+   * {@link Paddle1} for why Xbox Elite paddles are absent.
+   */
   export const Paddle4 = button(23);
   // Offsets 24..31 reserved for future named buttons / custom mapping use.
 }

--- a/src/input/GenericDualAnalogGamepadMapping.ts
+++ b/src/input/GenericDualAnalogGamepadMapping.ts
@@ -12,13 +12,24 @@ import { GamepadMapping, GamepadMappingFamily } from './GamepadMapping';
  *  - One signed aggregate channel (e.g. `LeftStickX`) for direct -1..1
  *    consumption — useful for movement or aiming.
  *
+ * The standard layout ends at button index 16 (the Meta/Guide button).
+ * Browsers expose **one** device-specific slot beyond it, at index 17, and
+ * what sits there depends on the device — Share on an Xbox Series pad,
+ * Capture on a Switch Pro, the touchpad click on a DualShock 4 / DualSense.
+ * This baseline therefore declares nothing at 17; device subclasses pass
+ * their own entry through `extraButtons`.
+ *
  * Device-specific subclasses (Xbox, PlayStation, Switch Pro, etc.) inherit
- * this layout and override only {@link GamepadMapping.family}.
+ * this layout, override {@link GamepadMapping.family}, and add at most that
+ * one button.
+ *
+ * @param extraButtons - Device-specific buttons appended after the standard
+ * layout. Their raw indices must not collide with 0–16.
  */
 export class GenericDualAnalogGamepadMapping extends GamepadMapping {
   public readonly family: GamepadMappingFamily = GamepadMappingFamily.GenericDualAnalog;
 
-  public constructor() {
+  public constructor(extraButtons: readonly GamepadButton[] = []) {
     super(
       [
         new GamepadButton(0, GamepadButton.South),
@@ -38,10 +49,7 @@ export class GenericDualAnalogGamepadMapping extends GamepadMapping {
         new GamepadButton(14, GamepadButton.DPadLeft),
         new GamepadButton(15, GamepadButton.DPadRight),
         new GamepadButton(16, GamepadButton.Guide),
-        new GamepadButton(17, GamepadButton.Share),
-        new GamepadButton(18, GamepadButton.Capture),
-        new GamepadButton(19, GamepadButton.Touchpad),
-        new GamepadButton(20, GamepadButton.Paddle1),
+        ...extraButtons,
       ],
       [
         // Direction-split (0..1).

--- a/src/input/InputManager.ts
+++ b/src/input/InputManager.ts
@@ -205,7 +205,6 @@ export class InputManager {
     },
   };
   private readonly wheelOffset = new Vector();
-  private readonly gestureCenter = new Vector();
   private readonly flags = new Flags<InputManagerFlag>();
   /** Keyboard transitions since the last flush, in true chronological order (see updateEvents). */
   private readonly keyEvents: KeyChannelEvent[] = [];
@@ -249,7 +248,18 @@ export class InputManager {
   public readonly onPointerTap = new Signal<[pointer: Pointer, x: number, y: number]>();
   public readonly onPointerSwipe = new Signal<[pointer: Pointer, x: number, y: number]>();
   public readonly onPointerCancel = new Signal<[pointer: Pointer, x: number, y: number]>();
-  public readonly onMouseWheel = new Signal<[Vector]>();
+  /**
+   * Fires once per frame in which the wheel moved, with the accumulated
+   * offset for that frame. `deltaY` is the usual scroll axis; `deltaX`
+   * carries horizontal wheels and trackpad swipes. Both are normalized out
+   * of the event's `deltaMode`, so a line- or page-mode wheel arrives in the
+   * same units as a pixel-mode one.
+   *
+   * The values are plain numbers rather than a `Vector` on purpose: the
+   * offset is reset to zero right after dispatch, so a shared instance would
+   * be stale by the time a listener that kept it read it again.
+   */
+  public readonly onMouseWheel = new Signal<[deltaX: number, deltaY: number]>();
   /**
    * Fires once per physical key press with the key's channel. OS auto-repeat
    * while a key is held does not fire again, so this matches the down
@@ -301,10 +311,23 @@ export class InputManager {
   /** Fires whenever any pad reports an axis value change. */
   public readonly onAnyGamepadAxisChange = new Signal<[Gamepad, GamepadAxis, number]>();
 
-  /** Fires on every two-touch-pointer move where the distance between them changed. `scale` > 1 = spreading, < 1 = pinching. */
-  public readonly onPinch = new Signal<[scale: number, center: Vector]>();
-  /** Fires on every two-touch-pointer move where the angle between them changed. `angleDelta` is in radians. */
-  public readonly onRotate = new Signal<[angleDelta: number, center: Vector]>();
+  /**
+   * Fires on every two-touch-pointer move where the distance between them
+   * changed. `scale` > 1 = spreading, < 1 = pinching; the center is the
+   * midpoint between the two pointers, in the same coordinate space as
+   * {@link Pointer.position}.
+   *
+   * The center arrives as two numbers rather than a `Vector` on purpose — a
+   * shared instance would be overwritten by the next gesture entry in the
+   * same frame.
+   */
+  public readonly onPinch = new Signal<[scale: number, centerX: number, centerY: number]>();
+  /**
+   * Fires on every two-touch-pointer move where the angle between them
+   * changed. `angleDelta` is in radians; the center is the midpoint between
+   * the two pointers — see {@link onPinch} for why it is not a `Vector`.
+   */
+  public readonly onRotate = new Signal<[angleDelta: number, centerX: number, centerY: number]>();
   /**
    * Fires when a pointer has been held without significant movement for
    * ≥ 500 ms of ENGINE time — frame deltas summed across the frames this
@@ -698,7 +721,6 @@ export class InputManager {
     this.pointerSlots.clear();
     this.freeSlots.length = 0;
     this.wheelOffset.destroy();
-    this.gestureCenter.destroy();
     this.flags.destroy();
 
     this.onPointerEnter.destroy();
@@ -1367,7 +1389,7 @@ export class InputManager {
     }
 
     if (this.flags.popMask(InputManagerFlag.MouseWheel)) {
-      this.onMouseWheel.dispatch(this.wheelOffset);
+      this.onMouseWheel.dispatch(this.wheelOffset.x, this.wheelOffset.y);
       this.wheelOffset.set(0, 0);
     }
 
@@ -1411,14 +1433,12 @@ export class InputManager {
       }
 
       if (entry.kind === 'pinch') {
-        this.gestureCenter.set(entry.x, entry.y);
-        this.onPinch.dispatch(entry.scale, this.gestureCenter);
+        this.onPinch.dispatch(entry.scale, entry.x, entry.y);
         continue;
       }
 
       if (entry.kind === 'rotate') {
-        this.gestureCenter.set(entry.x, entry.y);
-        this.onRotate.dispatch(entry.angleDelta, this.gestureCenter);
+        this.onRotate.dispatch(entry.angleDelta, entry.x, entry.y);
         continue;
       }
 

--- a/src/input/PlayStationGamepadMapping.ts
+++ b/src/input/PlayStationGamepadMapping.ts
@@ -1,3 +1,4 @@
+import { GamepadButton } from './GamepadButton';
 import { GamepadMappingFamily } from './GamepadMapping';
 import { GenericDualAnalogGamepadMapping } from './GenericDualAnalogGamepadMapping';
 
@@ -5,10 +6,20 @@ import { GenericDualAnalogGamepadMapping } from './GenericDualAnalogGamepadMappi
  * Mapping for Sony PlayStation controllers, covering DualShock 4 and
  * DualSense (PS4 / PS5) when connected via USB or Bluetooth.
  *
- * Inherits the full {@link GenericDualAnalogGamepadMapping} layout.
- * PlayStation-specific controls (touchpad click, Share/Create, Capture) are
- * surfaced through the Touchpad, Share, and Capture channels respectively.
+ * Inherits the full {@link GenericDualAnalogGamepadMapping} layout and claims
+ * the one device-specific slot at index 17 for the touchpad **click**.
+ * Share/Create sits on the standard Select slot (index 8) on these pads, so
+ * it needs no entry of its own.
+ *
+ * Touchpad *coordinates* are not available here: browsers model the touchpad
+ * as a button, and the standard axis set stops after the two sticks. Reading
+ * finger positions requires WebHID and a custom `GamepadDefinition`.
  */
 export class PlayStationGamepadMapping extends GenericDualAnalogGamepadMapping {
   public override readonly family = GamepadMappingFamily.PlayStation;
+
+  public constructor() {
+    // DUALSHOCK_BUTTON_TOUCHPAD == DUAL_SENSE_BUTTON_TOUCHPAD == 17.
+    super([new GamepadButton(17, GamepadButton.Touchpad)]);
+  }
 }

--- a/src/input/SwitchProGamepadMapping.ts
+++ b/src/input/SwitchProGamepadMapping.ts
@@ -1,3 +1,4 @@
+import { GamepadButton } from './GamepadButton';
 import { GamepadMappingFamily } from './GamepadMapping';
 import { GenericDualAnalogGamepadMapping } from './GenericDualAnalogGamepadMapping';
 
@@ -5,11 +6,18 @@ import { GenericDualAnalogGamepadMapping } from './GenericDualAnalogGamepadMappi
  * Mapping for the Nintendo Switch Pro Controller connected via USB or
  * Bluetooth.
  *
- * Inherits the full {@link GenericDualAnalogGamepadMapping} layout. The
- * Capture button is surfaced through the Capture channel; Home maps to Guide.
+ * Inherits the full {@link GenericDualAnalogGamepadMapping} layout and claims
+ * the one device-specific slot at index 17 for the Capture button; Home maps
+ * to Guide, Minus/Plus to Select/Start.
+ *
  * Note that on some browsers the controller is only recognised after being
  * paired through Steam or a dedicated driver.
  */
 export class SwitchProGamepadMapping extends GenericDualAnalogGamepadMapping {
   public override readonly family = GamepadMappingFamily.SwitchPro;
+
+  public constructor() {
+    // SWITCH_PRO_BUTTON_CAPTURE == BUTTON_INDEX_COUNT == 17.
+    super([new GamepadButton(17, GamepadButton.Capture)]);
+  }
 }

--- a/src/input/XboxGamepadMapping.ts
+++ b/src/input/XboxGamepadMapping.ts
@@ -1,3 +1,4 @@
+import { GamepadButton } from './GamepadButton';
 import { GamepadMappingFamily } from './GamepadMapping';
 import { GenericDualAnalogGamepadMapping } from './GenericDualAnalogGamepadMapping';
 
@@ -7,8 +8,19 @@ import { GenericDualAnalogGamepadMapping } from './GenericDualAnalogGamepadMappi
  *
  * Inherits the full {@link GenericDualAnalogGamepadMapping} layout, which
  * mirrors the W3C standard gamepad layout that XInput controllers follow
- * natively. The Share button (Xbox Series) maps to the Share channel.
+ * natively, and claims the one device-specific slot at index 17 for the
+ * Share button of the Xbox Series pads.
+ *
+ * The Elite paddles are deliberately absent: the Windows path is XInput,
+ * whose `XINPUT_GAMEPAD` struct has no paddle bits, and no browser mapper
+ * emits them. They are reachable only through WebHID and therefore belong to
+ * a custom `GamepadDefinition`, not here.
  */
 export class XboxGamepadMapping extends GenericDualAnalogGamepadMapping {
   public override readonly family = GamepadMappingFamily.Xbox;
+
+  public constructor() {
+    // Xbox Series X|S "Share": XBOX_SERIES_X_BUTTON_SHARE == BUTTON_INDEX_COUNT == 17.
+    super([new GamepadButton(17, GamepadButton.Share)]);
+  }
 }

--- a/src/math/Circle.ts
+++ b/src/math/Circle.ts
@@ -160,8 +160,8 @@ export class Circle implements ShapeLike {
     return (x === undefined || this.x === x) && (y === undefined || this.y === y) && (radius === undefined || this.radius === radius);
   }
 
-  public getBounds(): Rectangle {
-    return new Rectangle(this.x - this.radius, this.y - this.radius, this.radius * 2, this.radius * 2);
+  public getBounds(out: Rectangle = new Rectangle()): Rectangle {
+    return out.set(this.x - this.radius, this.y - this.radius, this.radius * 2, this.radius * 2);
   }
 
   /**

--- a/src/math/Ellipse.ts
+++ b/src/math/Ellipse.ts
@@ -119,8 +119,8 @@ export class Ellipse implements ShapeLike {
     return new Ellipse(this.x, this.y, this.rx, this.ry) as this;
   }
 
-  public getBounds(): Rectangle {
-    return new Rectangle(this.x - this.rx, this.y - this.ry, this.rx * 2, this.ry * 2);
+  public getBounds(out: Rectangle = new Rectangle()): Rectangle {
+    return out.set(this.x - this.rx, this.y - this.ry, this.rx * 2, this.ry * 2);
   }
 
   public getNormals(): Vector[] {

--- a/src/math/Line.ts
+++ b/src/math/Line.ts
@@ -108,12 +108,12 @@ export class Line implements ShapeLike {
     return new Line(this.fromX, this.fromY, this.toX, this.toY) as this;
   }
 
-  public getBounds(): Rectangle {
+  public getBounds(out: Rectangle = new Rectangle()): Rectangle {
     const { fromX, fromY, toX, toY } = this;
     const minX = Math.min(fromX, toX);
     const minY = Math.min(fromY, toY);
 
-    return new Rectangle(minX, minY, Math.max(fromX, toX) - minX, Math.max(fromY, toY) - minY);
+    return out.set(minX, minY, Math.max(fromX, toX) - minX, Math.max(fromY, toY) - minY);
   }
 
   public getNormals(): Vector[] {

--- a/src/math/Polygon.ts
+++ b/src/math/Polygon.ts
@@ -173,7 +173,7 @@ export class Polygon implements ShapeLike {
     );
   }
 
-  public getBounds(): Rectangle {
+  public getBounds(out: Rectangle = new Rectangle()): Rectangle {
     let minX = Infinity;
     let minY = Infinity;
     let maxX = -Infinity;
@@ -186,7 +186,7 @@ export class Polygon implements ShapeLike {
       maxY = Math.max(point.y, maxY);
     }
 
-    return new Rectangle(this.x + minX, this.y + minY, maxX - minX, maxY - minY);
+    return out.set(this.x + minX, this.y + minY, maxX - minX, maxY - minY);
   }
 
   /**

--- a/src/math/Rectangle.ts
+++ b/src/math/Rectangle.ts
@@ -55,7 +55,7 @@ export interface ReadonlyRectangle extends Collidable {
   readonly bottom: number;
   equals(rectangle?: Partial<RectangleLike>): boolean;
   clone(): Rectangle;
-  getBounds(): Rectangle;
+  getBounds(out?: Rectangle): Rectangle;
   containsRect(rect: Rectangle): boolean;
   /**
    * Unlike {@link Rectangle.transform}, `result` is REQUIRED here: the
@@ -208,8 +208,8 @@ export class Rectangle implements ShapeLike, ObservableVectorOwner, ReadonlyRect
     );
   }
 
-  public getBounds(): Rectangle {
-    return this.clone();
+  public getBounds(out?: Rectangle): Rectangle {
+    return out === undefined ? this.clone() : out.copy(this);
   }
 
   public getNormals(): Vector[] {

--- a/src/math/Vector.ts
+++ b/src/math/Vector.ts
@@ -81,8 +81,8 @@ export class Vector extends AbstractVector implements ShapeLike {
     return null;
   }
 
-  public getBounds(): Rectangle {
-    return Rectangle.temp.set(this.x, this.y, 0, 0);
+  public getBounds(out: Rectangle = new Rectangle()): Rectangle {
+    return out.set(this.x, this.y, 0, 0);
   }
 
   public contains(x: number, y: number): boolean {

--- a/src/rendering/View.ts
+++ b/src/rendering/View.ts
@@ -588,14 +588,19 @@ export class View implements ObservableVectorOwner {
   /**
    * Return the world-space bounding rectangle of the currently visible area, recalculating if dirty.
    * Used for frustum culling by {@link Drawable.render}.
+   *
+   * Pass `out` to receive a copy you own. Without it the return value is this
+   * view's cached rectangle, which the next recalculation overwrites in place.
    */
-  public getBounds(): Rectangle {
+  public getBounds(out?: Rectangle): Rectangle {
     if (this._flags.hasMask(ViewFlags.BoundingBox)) {
       this.updateBounds();
       this._flags.removeMask(ViewFlags.BoundingBox);
     }
 
-    return this._bounds.getRect();
+    const bounds = this._bounds.getRect();
+
+    return out === undefined ? bounds : out.copy(bounds);
   }
 
   protected updateBounds(): this {

--- a/src/ui/ScrollContainer.ts
+++ b/src/ui/ScrollContainer.ts
@@ -1,6 +1,5 @@
 import type { Stage } from '#core/Stage';
 import { Rectangle } from '#math/Rectangle';
-import type { Vector } from '#math/Vector';
 import { Container } from '#rendering/Container';
 
 import { Widget } from './Widget';
@@ -49,7 +48,7 @@ export class ScrollContainer extends Widget {
   /** Scratch rect reused by {@link ScrollContainer.updateBounds} — avoids an allocation on every bounds rebuild. */
   private readonly _viewportRect = new Rectangle();
 
-  private readonly _onWheel = (delta: Vector): void => {
+  private readonly _onWheel = (deltaX: number, deltaY: number): void => {
     const pos = this._stage?.app?.input.getPrimaryPointerPosition();
 
     if (pos === null || pos === undefined) {
@@ -62,7 +61,7 @@ export class ScrollContainer extends Widget {
       return;
     }
 
-    this.scrollBy(this._direction !== 'vertical' ? delta.x : 0, this._direction !== 'horizontal' ? delta.y : 0);
+    this.scrollBy(this._direction !== 'vertical' ? deltaX : 0, this._direction !== 'horizontal' ? deltaY : 0);
   };
 
   public constructor(options: ScrollContainerOptions) {

--- a/test/assets/loader-peek.test.ts
+++ b/test/assets/loader-peek.test.ts
@@ -104,10 +104,17 @@ describe('Loader.peek — pure in-memory lookup', () => {
 
   // Invalid usage fails loudly exactly as it does on get(); only "the key is
   // fine, nothing stored under it" is the undefined case.
+  // Both of these are rejected at compile time by the overloads too — an
+  // unregistered extension resolves `KindByPath` to `never`, and a plain object
+  // matches no overload. The runtime guards are what a JavaScript consumer, a
+  // dynamic string, or a `registerType` gap runs into, so they get their own
+  // coverage through a loosened view of the method.
+  const untyped = (loader: Loader): { peek(input: unknown): unknown } => loader as unknown as { peek(input: unknown): unknown };
+
   test('throws for a path whose extension resolves to no registered type', () => {
     const loader = createCoreLoader();
 
-    expect(() => loader.peek('data/config.unknownext' as string)).toThrow(/no type registered/i);
+    expect(() => untyped(loader).peek('data/config.unknownext')).toThrow(/no type registered/i);
 
     loader.destroy();
   });
@@ -115,7 +122,7 @@ describe('Loader.peek — pure in-memory lookup', () => {
   test('throws for an input that is neither a path nor a descriptor', () => {
     const loader = createCoreLoader();
 
-    expect(() => loader.peek({ not: 'an asset' } as never)).toThrow(/path string or an Asset\.type/i);
+    expect(() => untyped(loader).peek({ not: 'an asset' })).toThrow(/path string or an Asset\.type/i);
 
     loader.destroy();
   });

--- a/test/assets/loader-peek.test.ts
+++ b/test/assets/loader-peek.test.ts
@@ -1,0 +1,122 @@
+import { Asset } from '#assets/Asset';
+import { coreAssetBindings } from '#assets/coreAssetBindings';
+import { Loader } from '#assets/Loader';
+import { materializeAssetBindings } from '#extensions/materialize';
+
+/** Loader with all core asset bindings (mirrors createCoreLoader in the sibling loader tests). */
+function createCoreLoader(): Loader {
+  const loader = new Loader();
+  materializeAssetBindings(loader, coreAssetBindings);
+  return loader;
+}
+
+const originalFetch = global.fetch;
+
+function mockFetchJson(payload: unknown): void {
+  global.fetch = vi.fn(
+    async (): Promise<Response> =>
+      ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => payload,
+        text: async () => JSON.stringify(payload),
+        arrayBuffer: async () => new ArrayBuffer(8),
+      }) as unknown as Response,
+  );
+}
+
+// `get()` is an acquiring call: it resolves, claims, and starts a fetch when the
+// source is unknown. `peek()` is the pure lookup that was missing next to it —
+// the way to ask "is this already here?" without any of those side effects.
+describe('Loader.peek — pure in-memory lookup', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('returns undefined for a source that was never loaded', () => {
+    const loader = createCoreLoader();
+    mockFetchJson({ ok: true });
+
+    expect(loader.peek('data/config.json')).toBeUndefined();
+
+    loader.destroy();
+  });
+
+  test('starts no fetch, unlike get()', () => {
+    const loader = createCoreLoader();
+    mockFetchJson({ ok: true });
+
+    loader.peek('data/config.json');
+    loader.peek('data/config.json');
+
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    // The contrast that makes the point: the same call through get() does fetch.
+    loader.get('data/config.json');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    loader.destroy();
+  });
+
+  test('claims nothing, so it cannot keep an asset resident by accident', () => {
+    const loader = createCoreLoader();
+    mockFetchJson({ ok: true });
+
+    loader.peek('data/config.json');
+
+    expect(loader.inspect()).toEqual([]);
+
+    // Teeth for the assertion above: get() on the very same source does
+    // produce a residency row, so an empty inspect() is a real signal rather
+    // than a check that can never fail.
+    loader.get('data/config.json');
+
+    expect(loader.inspect()).not.toEqual([]);
+
+    loader.destroy();
+  });
+
+  test('returns the stored resource once the source is loaded', async () => {
+    const loader = createCoreLoader();
+    mockFetchJson({ level: 3 });
+
+    await loader.load('data/config.json');
+
+    expect(loader.peek('data/config.json')).toEqual({ level: 3 });
+
+    loader.destroy();
+  });
+
+  test('accepts an Asset.type(...) descriptor for the same lookup', async () => {
+    const loader = createCoreLoader();
+    mockFetchJson({ level: 3 });
+
+    expect(loader.peek(Asset.type('json', 'data/config.json'))).toBeUndefined();
+
+    await loader.load('data/config.json');
+
+    expect(loader.peek(Asset.type('json', 'data/config.json'))).toEqual({ level: 3 });
+
+    loader.destroy();
+  });
+
+  // Invalid usage fails loudly exactly as it does on get(); only "the key is
+  // fine, nothing stored under it" is the undefined case.
+  test('throws for a path whose extension resolves to no registered type', () => {
+    const loader = createCoreLoader();
+
+    expect(() => loader.peek('data/config.unknownext' as string)).toThrow(/no type registered/i);
+
+    loader.destroy();
+  });
+
+  test('throws for an input that is neither a path nor a descriptor', () => {
+    const loader = createCoreLoader();
+
+    expect(() => loader.peek({ not: 'an asset' } as never)).toThrow(/path string or an Asset\.type/i);
+
+    loader.destroy();
+  });
+});

--- a/test/core/scene-director.test.ts
+++ b/test/core/scene-director.test.ts
@@ -37,7 +37,6 @@ import { Signal } from '#core/Signal';
 import { Time } from '#core/Time';
 import type { Pointer } from '#input/Pointer';
 import { Rectangle } from '#math/Rectangle';
-import type { Vector } from '#math/Vector';
 import { RenderTexture } from '#rendering/texture/RenderTexture';
 
 interface InputManagerStub {
@@ -51,7 +50,7 @@ interface InputManagerStub {
   readonly onPointerTap: Signal<[Pointer]>;
   readonly onPointerSwipe: Signal<[Pointer]>;
   readonly onPointerCancel: Signal<[Pointer]>;
-  readonly onMouseWheel: Signal<[Vector]>;
+  readonly onMouseWheel: Signal<[deltaX: number, deltaY: number]>;
 }
 
 const createInputManagerStub = (): InputManagerStub => ({
@@ -65,7 +64,7 @@ const createInputManagerStub = (): InputManagerStub => ({
   onPointerTap: new Signal<[Pointer]>(),
   onPointerSwipe: new Signal<[Pointer]>(),
   onPointerCancel: new Signal<[Pointer]>(),
-  onMouseWheel: new Signal<[Vector]>(),
+  onMouseWheel: new Signal<[number, number]>(),
 });
 
 type ApplicationStub = Application & {

--- a/test/input/gamepad-mapping-families.test.ts
+++ b/test/input/gamepad-mapping-families.test.ts
@@ -66,7 +66,7 @@ describe('trivial device-family mappings', () => {
 // `DUAL_SENSE_BUTTON_TOUCHPAD` all sit at 17 with their counts at 18 — so there
 // is no index above 17 either.
 describe('the device-specific button slot at index 17', () => {
-  const slot17 = (mapping: { buttons: readonly { index: number; channel: number }[] }): number | undefined =>
+  const slot17 = (mapping: { buttons: ReadonlyArray<{ index: number; channel: number }> }): number | undefined =>
     mapping.buttons.find(button => button.index === 17)?.channel;
 
   test('an Xbox Series pad puts Share there', () => {
@@ -91,11 +91,7 @@ describe('the device-specific button slot at index 17', () => {
   });
 
   test('the three devices disagree about slot 17, so no baseline value can be right', () => {
-    const channels = new Set([
-      slot17(new XboxGamepadMapping()),
-      slot17(new SwitchProGamepadMapping()),
-      slot17(new PlayStationGamepadMapping()),
-    ]);
+    const channels = new Set([slot17(new XboxGamepadMapping()), slot17(new SwitchProGamepadMapping()), slot17(new PlayStationGamepadMapping())]);
 
     expect(channels.size).toBe(3);
   });

--- a/test/input/gamepad-mapping-families.test.ts
+++ b/test/input/gamepad-mapping-families.test.ts
@@ -4,7 +4,10 @@ import { GamepadMappingFamily } from '#input/GamepadMapping';
 import { GenericDualAnalogGamepadMapping } from '#input/GenericDualAnalogGamepadMapping';
 import { JoyConLeftGamepadMapping } from '#input/JoyConLeftGamepadMapping';
 import { JoyConRightGamepadMapping } from '#input/JoyConRightGamepadMapping';
+import { PlayStationGamepadMapping } from '#input/PlayStationGamepadMapping';
 import { SteamControllerGamepadMapping } from '#input/SteamControllerGamepadMapping';
+import { SwitchProGamepadMapping } from '#input/SwitchProGamepadMapping';
+import { XboxGamepadMapping } from '#input/XboxGamepadMapping';
 
 describe('trivial device-family mappings', () => {
   test('SteamControllerGamepadMapping inherits the generic dual-analog layout under its own family tag', () => {
@@ -52,5 +55,62 @@ describe('trivial device-family mappings', () => {
     expect(axisChannels.has(GamepadAxis.LeftStickX)).toBe(true);
     expect(axisChannels.has(GamepadAxis.LeftStickY)).toBe(true);
     expect(axisChannels.has(GamepadAxis.RightStickX)).toBe(false);
+  });
+});
+
+// Browsers append exactly one device-specific button after the standard layout,
+// at index 17, and which control lands there depends on the device. Chromium
+// spells this out in `device/gamepad/gamepad_standard_mappings.h`:
+// `BUTTON_INDEX_COUNT == 17`, then `XBOX_SERIES_X_BUTTON_SHARE`,
+// `SWITCH_PRO_BUTTON_CAPTURE`, `DUALSHOCK_BUTTON_TOUCHPAD` and
+// `DUAL_SENSE_BUTTON_TOUCHPAD` all sit at 17 with their counts at 18 — so there
+// is no index above 17 either.
+describe('the device-specific button slot at index 17', () => {
+  const slot17 = (mapping: { buttons: readonly { index: number; channel: number }[] }): number | undefined =>
+    mapping.buttons.find(button => button.index === 17)?.channel;
+
+  test('an Xbox Series pad puts Share there', () => {
+    const mapping = new XboxGamepadMapping();
+
+    expect(mapping.family).toBe(GamepadMappingFamily.Xbox);
+    expect(slot17(mapping)).toBe(GamepadButton.Share);
+  });
+
+  test('a Switch Pro controller puts Capture there', () => {
+    const mapping = new SwitchProGamepadMapping();
+
+    expect(mapping.family).toBe(GamepadMappingFamily.SwitchPro);
+    expect(slot17(mapping)).toBe(GamepadButton.Capture);
+  });
+
+  test('a DualShock 4 / DualSense puts the touchpad click there', () => {
+    const mapping = new PlayStationGamepadMapping();
+
+    expect(mapping.family).toBe(GamepadMappingFamily.PlayStation);
+    expect(slot17(mapping)).toBe(GamepadButton.Touchpad);
+  });
+
+  test('the three devices disagree about slot 17, so no baseline value can be right', () => {
+    const channels = new Set([
+      slot17(new XboxGamepadMapping()),
+      slot17(new SwitchProGamepadMapping()),
+      slot17(new PlayStationGamepadMapping()),
+    ]);
+
+    expect(channels.size).toBe(3);
+  });
+
+  test('no built-in standard-layout mapping claims an index above 17', () => {
+    const mappings = [new XboxGamepadMapping(), new SwitchProGamepadMapping(), new PlayStationGamepadMapping(), new SteamControllerGamepadMapping()];
+
+    for (const mapping of mappings) {
+      expect(mapping.buttons.filter(button => button.index > 17)).toEqual([]);
+    }
+  });
+
+  // The raw Steam Controller is not normalized by Chromium at all, so it keeps
+  // the bare generic layout — including no slot-17 entry. See NEU-H2.
+  test('the Steam Controller claims nothing there', () => {
+    expect(slot17(new SteamControllerGamepadMapping())).toBeUndefined();
   });
 });

--- a/test/input/generic-gamepad-mapping.test.ts
+++ b/test/input/generic-gamepad-mapping.test.ts
@@ -123,17 +123,34 @@ describe('GamepadMapping (via GenericDualAnalogGamepadMapping)', () => {
 });
 
 describe('GenericDualAnalogGamepadMapping', () => {
-  test('maps menu and extended buttons including guide, share, capture, touchpad, and paddle1', () => {
+  test('maps the menu buttons and stops at the standard layout', () => {
     const mapping = new GenericDualAnalogGamepadMapping();
     const buttonsByIndex = new Map(mapping.buttons.map(button => [button.index, button.channel]));
 
     expect(buttonsByIndex.get(8)).toBe(GamepadButton.Select);
     expect(buttonsByIndex.get(9)).toBe(GamepadButton.Start);
     expect(buttonsByIndex.get(16)).toBe(GamepadButton.Guide);
-    expect(buttonsByIndex.get(17)).toBe(GamepadButton.Share);
-    expect(buttonsByIndex.get(18)).toBe(GamepadButton.Capture);
-    expect(buttonsByIndex.get(19)).toBe(GamepadButton.Touchpad);
-    expect(buttonsByIndex.get(20)).toBe(GamepadButton.Paddle1);
+  });
+
+  // The standard layout ends at 16 (Meta/Guide) and browsers expose exactly one
+  // device-specific slot after it, at 17 — Share on an Xbox Series pad, Capture
+  // on a Switch Pro, the touchpad click on a DualShock 4 / DualSense. Claiming
+  // 17 in the baseline made every one of those fire the wrong channel, and 18+
+  // were never delivered at all.
+  test('claims nothing beyond the standard layout', () => {
+    const mapping = new GenericDualAnalogGamepadMapping();
+    const indices = mapping.buttons.map(button => button.index);
+
+    expect(Math.max(...indices)).toBe(16);
+    expect(indices.filter(index => index > 16)).toEqual([]);
+  });
+
+  test('appends device-specific buttons handed to the constructor', () => {
+    const mapping = new GenericDualAnalogGamepadMapping([new GamepadButton(17, GamepadButton.Touchpad)]);
+    const buttonsByIndex = new Map(mapping.buttons.map(button => [button.index, button.channel]));
+
+    expect(buttonsByIndex.get(16)).toBe(GamepadButton.Guide);
+    expect(buttonsByIndex.get(17)).toBe(GamepadButton.Touchpad);
   });
 
   test('maps additional axes and reserves larger per-gamepad channel space', () => {

--- a/test/input/gesture-journal-ordering.test.ts
+++ b/test/input/gesture-journal-ordering.test.ts
@@ -23,7 +23,6 @@
 import type { Application } from '#core/Application';
 import { Time } from '#core/Time';
 import { InputManager } from '#input/InputManager';
-import type { Vector } from '#math/Vector';
 import { BrowserPlatform } from '#platform/BrowserPlatform';
 
 // ---------------------------------------------------------------------------
@@ -360,19 +359,16 @@ describe('InputManager — destroy clears gesture holds and queued state', () =>
 });
 
 // ---------------------------------------------------------------------------
-// Shared scratch vector: center coordinates must not leak between entries
+// Center coordinates must not leak between entries
 // ---------------------------------------------------------------------------
 
 describe('InputManager — gesture center coordinates across multiple queued gestures in one frame', () => {
-  test('two pinch occurrences queued in the same frame each dispatch with their own, distinct center — the reused scratch Vector must not leak', () => {
+  test('two pinch occurrences queued in the same frame each dispatch with their own, distinct center', () => {
     const { im, canvas } = createInputManager();
     const seenCenters: Array<{ x: number; y: number }> = [];
 
-    im.onPinch.add((_scale, center: Vector) => {
-      // Clone synchronously — `center` is a mutable Vector InputManager
-      // reuses across every dispatch, so it MUST be read here, not stashed
-      // by reference and inspected after the fact.
-      seenCenters.push({ x: center.x, y: center.y });
+    im.onPinch.add((_scale, centerX, centerY) => {
+      seenCenters.push({ x: centerX, y: centerY });
     });
 
     settleTwoTouchBaseline(im, canvas, 10, 0); // distance=10, center=(5,0)

--- a/test/input/input-manager-events.test.ts
+++ b/test/input/input-manager-events.test.ts
@@ -505,12 +505,12 @@ describe('InputManager — mouse wheel', () => {
 
   test('wheel event while focused writes the offset, dispatches onMouseWheel, then resets to zero', () => {
     const { im, canvas } = createInputManager();
-    // The dispatched vector is a mutable internal instance reset to (0, 0)
-    // right after dispatch, so capture its value synchronously inside the
-    // handler rather than reading `mock.calls` afterwards.
+    // The payload is two plain numbers, so `mock.calls` stays valid after the
+    // internal accumulator is reset — that is the point of not handing out a
+    // reused Vector here.
     const seen: Array<{ x: number; y: number }> = [];
-    const onWheel = vi.fn((vector: { x: number; y: number }) => {
-      seen.push({ x: vector.x, y: vector.y });
+    const onWheel = vi.fn((deltaX: number, deltaY: number) => {
+      seen.push({ x: deltaX, y: deltaY });
     });
 
     im.onMouseWheel.add(onWheel);
@@ -529,11 +529,39 @@ describe('InputManager — mouse wheel', () => {
     im.destroy();
   });
 
+  // The offset accumulator is reset to (0, 0) immediately after dispatch. When
+  // the payload was that very Vector instance, anything a listener retained
+  // silently turned into (0, 0) one statement later; two numbers cannot.
+  test('a listener that keeps the wheel payload still holds the right values after the accumulator resets', () => {
+    const { im, canvas } = createInputManager();
+    const retained: Array<[number, number]> = [];
+
+    im.onMouseWheel.add((deltaX, deltaY) => {
+      retained.push([deltaX, deltaY]);
+    });
+
+    canvas.dispatchEvent(new FocusEvent('focus'));
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaX: 4, deltaY: -8 }));
+    im.preUpdate(0 as never);
+
+    // A second, differently-valued frame must not rewrite what the first one
+    // handed out.
+    canvas.dispatchEvent(new WheelEvent('wheel', { deltaX: 1, deltaY: 2 }));
+    im.preUpdate(0 as never);
+
+    expect(retained).toEqual([
+      [4, -8],
+      [1, 2],
+    ]);
+
+    im.destroy();
+  });
+
   test('multiple wheel events within one frame accumulate instead of overwriting, normalized across deltaModes', () => {
     const { im, canvas } = createInputManager();
     const seen: Array<{ x: number; y: number }> = [];
-    const onWheel = vi.fn((vector: { x: number; y: number }) => {
-      seen.push({ x: vector.x, y: vector.y });
+    const onWheel = vi.fn((deltaX: number, deltaY: number) => {
+      seen.push({ x: deltaX, y: deltaY });
     });
 
     im.onMouseWheel.add(onWheel);

--- a/test/math/shape-bounds-ownership.test.ts
+++ b/test/math/shape-bounds-ownership.test.ts
@@ -1,0 +1,85 @@
+import { Circle } from '#math/Circle';
+import { Ellipse } from '#math/Ellipse';
+import { Line } from '#math/Line';
+import { Polygon } from '#math/Polygon';
+import { Rectangle } from '#math/Rectangle';
+import type { ShapeLike } from '#math/ShapeLike';
+import { Vector } from '#math/Vector';
+
+// One rule for every shape: `getBounds(out?)` writes into `out` when given one
+// and returns a fresh rectangle otherwise. Before this contract the four
+// implementations disagreed -- Rectangle cloned, Circle/Polygon allocated, and
+// Vector handed out the global `Rectangle.temp`, so whether a returned box
+// survived the next call depended on which shape you happened to ask.
+const shapes: ReadonlyArray<{ readonly name: string; readonly make: () => ShapeLike; readonly expected: readonly [number, number, number, number] }> = [
+  { name: 'Rectangle', make: () => new Rectangle(2, 3, 10, 20), expected: [2, 3, 10, 20] },
+  { name: 'Circle', make: () => new Circle(10, 10, 4), expected: [6, 6, 8, 8] },
+  { name: 'Ellipse', make: () => new Ellipse(10, 10, 4, 2), expected: [6, 8, 8, 4] },
+  { name: 'Line', make: () => new Line(8, 1, 2, 5), expected: [2, 1, 6, 4] },
+  { name: 'Polygon', make: () => new Polygon([new Vector(0, 0), new Vector(4, 0), new Vector(4, 6)], 1, 1), expected: [1, 1, 4, 6] },
+  { name: 'Vector', make: () => new Vector(3, 4), expected: [3, 4, 0, 0] },
+];
+
+const asTuple = (rect: Rectangle): [number, number, number, number] => [rect.x, rect.y, rect.width, rect.height];
+
+describe('ShapeLike.getBounds — one ownership rule for every shape', () => {
+  for (const { name, make, expected } of shapes) {
+    describe(name, () => {
+      test('without `out`, returns a rectangle the caller owns', () => {
+        const shape = make();
+        const first = shape.getBounds();
+        const second = shape.getBounds();
+
+        expect(asTuple(first)).toEqual([...expected]);
+        expect(first).not.toBe(second);
+
+        // Mutating what we were handed must not reach the shape or the next
+        // caller -- the failure mode `Vector`'s shared `Rectangle.temp` had.
+        first.set(-99, -99, -99, -99);
+
+        expect(asTuple(shape.getBounds())).toEqual([...expected]);
+      });
+
+      test('with `out`, writes into it and returns that very instance', () => {
+        const shape = make();
+        const out = new Rectangle(-1, -1, -1, -1);
+        const result = shape.getBounds(out);
+
+        expect(result).toBe(out);
+        expect(asTuple(out)).toEqual([...expected]);
+      });
+
+      test('with `out`, allocates nothing the caller has to discard', () => {
+        const shape = make();
+        const out = new Rectangle();
+
+        expect(shape.getBounds(out)).toBe(shape.getBounds(out));
+      });
+
+      test('never hands out the shared Rectangle.temp scratch', () => {
+        const shape = make();
+
+        expect(shape.getBounds()).not.toBe(Rectangle.temp);
+      });
+    });
+  }
+
+  // The specific regression: `Vector.getBounds()` used to return
+  // `Rectangle.temp`, so two points asked in sequence reported the same box and
+  // any unrelated user of the scratch clobbered the answer.
+  test('two Vectors measured in sequence keep their own boxes', () => {
+    const a = new Vector(1, 2).getBounds();
+    const b = new Vector(30, 40).getBounds();
+
+    expect(asTuple(a)).toEqual([1, 2, 0, 0]);
+    expect(asTuple(b)).toEqual([30, 40, 0, 0]);
+  });
+
+  test('using Rectangle.temp for something else does not disturb a returned box', () => {
+    const bounds = new Vector(1, 2).getBounds();
+
+    Rectangle.temp.set(999, 999, 999, 999);
+
+    expect(asTuple(bounds)).toEqual([1, 2, 0, 0]);
+  });
+});

--- a/test/ui/scroll-container.test.ts
+++ b/test/ui/scroll-container.test.ts
@@ -8,7 +8,6 @@ import type { Application } from '#core/Application';
 import { Signal } from '#core/Signal';
 import type { Stage } from '#core/Stage';
 import { Rectangle } from '#math/Rectangle';
-import { Vector } from '#math/Vector';
 import { Container } from '#rendering/Container';
 import { ScrollContainer } from '#ui/ScrollContainer';
 
@@ -17,8 +16,8 @@ import { ScrollContainer } from '#ui/ScrollContainer';
 // ---------------------------------------------------------------------------
 
 /** Build a minimal Stage whose `app.input` carries a real onMouseWheel Signal. */
-const makeStage = (pointerPos: { x: number; y: number } | null | undefined = null): { stage: Stage; onMouseWheel: Signal<[Vector]> } => {
-  const onMouseWheel = new Signal<[Vector]>();
+const makeStage = (pointerPos: { x: number; y: number } | null | undefined = null): { stage: Stage; onMouseWheel: Signal<[deltaX: number, deltaY: number]> } => {
+  const onMouseWheel = new Signal<[deltaX: number, deltaY: number]>();
   const app = {
     input: {
       onMouseWheel,
@@ -161,7 +160,7 @@ describe('ScrollContainer mouse-wheel routing', () => {
     stubContentBounds(scroll, new Rectangle(0, 0, 500, 500));
     scroll._setStage(stage);
 
-    onMouseWheel.dispatch(new Vector(0, 50));
+    onMouseWheel.dispatch(0, 50);
 
     expect(scroll.scrollY).toBe(0);
   });
@@ -173,7 +172,7 @@ describe('ScrollContainer mouse-wheel routing', () => {
     stubContentBounds(scroll, new Rectangle(0, 0, 500, 500));
     scroll._setStage(stage);
 
-    onMouseWheel.dispatch(new Vector(0, 50));
+    onMouseWheel.dispatch(0, 50);
 
     expect(scroll.scrollY).toBe(0);
   });
@@ -185,7 +184,7 @@ describe('ScrollContainer mouse-wheel routing', () => {
     stubContentBounds(scroll, new Rectangle(0, 0, 500, 500));
     scroll._setStage(stage);
 
-    onMouseWheel.dispatch(new Vector(30, 20));
+    onMouseWheel.dispatch(30, 20);
 
     expect(scroll.scrollX).toBe(0);
     expect(scroll.scrollY).toBe(20);
@@ -198,7 +197,7 @@ describe('ScrollContainer mouse-wheel routing', () => {
     stubContentBounds(scroll, new Rectangle(0, 0, 500, 500));
     scroll._setStage(stage);
 
-    onMouseWheel.dispatch(new Vector(30, 20));
+    onMouseWheel.dispatch(30, 20);
 
     expect(scroll.scrollX).toBe(30);
     expect(scroll.scrollY).toBe(0);
@@ -211,7 +210,7 @@ describe('ScrollContainer mouse-wheel routing', () => {
     stubContentBounds(scroll, new Rectangle(0, 0, 500, 500));
     scroll._setStage(stage);
 
-    onMouseWheel.dispatch(new Vector(30, 20));
+    onMouseWheel.dispatch(30, 20);
 
     expect(scroll.scrollX).toBe(30);
     expect(scroll.scrollY).toBe(20);
@@ -252,7 +251,7 @@ describe('ScrollContainer viewport bounds (ME-58)', () => {
     stubContentBounds(scroll, new Rectangle(0, 0, 5000, 5000));
     scroll._setStage(stage);
 
-    onMouseWheel.dispatch(new Vector(0, 50));
+    onMouseWheel.dispatch(0, 50);
 
     expect(scroll.scrollY).toBe(0);
   });

--- a/test/ui/scroll-container.test.ts
+++ b/test/ui/scroll-container.test.ts
@@ -16,7 +16,9 @@ import { ScrollContainer } from '#ui/ScrollContainer';
 // ---------------------------------------------------------------------------
 
 /** Build a minimal Stage whose `app.input` carries a real onMouseWheel Signal. */
-const makeStage = (pointerPos: { x: number; y: number } | null | undefined = null): { stage: Stage; onMouseWheel: Signal<[deltaX: number, deltaY: number]> } => {
+const makeStage = (
+  pointerPos: { x: number; y: number } | null | undefined = null,
+): { stage: Stage; onMouseWheel: Signal<[deltaX: number, deltaY: number]> } => {
   const onMouseWheel = new Signal<[deltaX: number, deltaY: number]>();
   const app = {
     input: {


### PR DESCRIPTION
Six review points from `.workspace/reviews/2026-08-08-review-master.md`, four of which were sitting on the decision list until this session.

## ME-18 — one ownership rule for `getBounds`

`ShapeLike.getBounds()` had three different answers to "may I keep this?": `Rectangle` cloned, `Circle`/`Ellipse`/`Line`/`Polygon` allocated, and `Vector` returned the global `Rectangle.temp` — actively unsafe, since any unrelated user of the scratch overwrote it under the caller.

Every shape now takes `getBounds(out?: Rectangle)`. `SceneNode` and `View` keep their version-stamped cache (that path runs per node per frame for culling and hit-testing) but honour `out` too, so the with-`out` form is uniformly safe to retain across the whole `HasBoundingBox` surface.

A `WeakMap<shape, Rectangle>` cache was considered and rejected — shapes are freely mutable through `set`/`copy` and carry no bounds version stamp, so it would need invalidation wired into every setter of every shape class or serve stale boxes silently.

## NEU-N3 — the generic gamepad mapping was wrong, not just incomplete

Found by verifying the existing mappings against the Chromium source rather than trusting them. `device/gamepad/gamepad_standard_mappings.h`: `BUTTON_INDEX_COUNT == 17`, and index 17 is the single device-specific slot — `XBOX_SERIES_X_BUTTON_SHARE`, `SWITCH_PRO_BUTTON_CAPTURE`, `DUALSHOCK_BUTTON_TOUCHPAD`, `DUAL_SENSE_BUTTON_TOUCHPAD` all sit there, each with its count at 18, so nothing exists above 17.

`GenericDualAnalogGamepadMapping` hard-wired 17 to `Share` and 18/19/20 to `Capture`/`Touchpad`/`Paddle1`. On a DualShock 4 or DualSense the touchpad click therefore fired the **Share** channel while `Touchpad` stayed silent; on a Switch Pro so did Capture. 18–20 were never delivered by any browser. A test asserted the old wiring.

## ME-65 — the channels that genuinely cannot be reached

Same verification pass. Touchpad *coordinates* are not in the Gamepad API at all (`AXIS_INDEX_COUNT == 4`; a touchpad is modelled as a button), and the Xbox Elite paddles are not either — the Windows path is XInput, whose `XINPUT_GAMEPAD` struct has no paddle bits. Both are now documented as device-specific rather than left looking like an oversight.

## ME-62 — no more reused `Vector`s out of signals

`onMouseWheel`, `onPinch` and `onRotate` handed out mutable instances the manager overwrites immediately — the wheel offset is reset one statement after dispatch. Now plain numbers. The gesture center scratch is gone entirely; the journal entry already carried `x`/`y`.

## ME-72 — `Loader.peek()` instead of renaming `get()`

The recommendation here was originally `acquire()`, and it was reversed: `loader.get(` has 922 call sites and is the primary access path, so moving it to a resource-management verb would put that word on the beginner path — the opposite of why the seamless model exists. What was missing was the pure read, and that is what `peek()` adds: no fetch, no placeholder handle, no claim.

## NEU-N1 — dead `/register` wiring

`preview.html` still mapped four import-map entries onto `register.js` files PR #476 deleted.

---

**Breaking:** `getBounds()` on shapes no longer returns `Rectangle.temp` (`Vector`); wheel/gesture handlers receive numbers instead of a `Vector`; `Share`/`Capture`/`Touchpad`/`Paddle1` are no longer written by the generic dual-analog mapping.

Verified: `pnpm verify:quick` (11/11 gates), full `pnpm test` (9542 passing), and a mutation probe on the `Vector`/`Rectangle.temp` regression to confirm the new ownership test actually fails when the old behaviour returns.