### PR TITLE
feat(bench): CPU profiling, multi-value cell selection, and batch-stress archetypes

### DIFF
--- a/packages/exojs-bench/src/rendering/EngineAdapter.ts
+++ b/packages/exojs-bench/src/rendering/EngineAdapter.ts
@@ -4,7 +4,17 @@ import type { BaseCellResult } from '../shared/result';
 export type Backend = 'webgl2' | 'webgpu';
 
 /** Identifier for one of the fixed set of scene archetypes exercised by the benchmark. */
-export type ArchetypeId = 'static-heavy' | 'dynamic-heavy' | 'deep-hierarchy' | 'overdraw' | 'batch-breaking' | 'split-screen';
+export type ArchetypeId =
+  | 'static-heavy'
+  | 'dynamic-heavy'
+  | 'deep-hierarchy'
+  | 'overdraw'
+  | 'batch-breaking'
+  | 'batch-breaking-atlased'
+  | 'split-screen'
+  | 'mixed-blend'
+  | 'mixed-material'
+  | 'mixed-material-atlased';
 
 /** Structural definition of a scene archetype, independent of any engine or backend. */
 export interface ArchetypeSpec {
@@ -47,6 +57,38 @@ export interface ArchetypeSpec {
    * `archetypes.ts`.
    */
   readonly viewCount?: number;
+  /**
+   * Number of distinct fixed-function blend modes cycled across the scene's
+   * leaves. `undefined`/`1` means every leaf keeps the engine's default
+   * (`Normal`), which is what every pre-existing archetype does.
+   *
+   * The mode for leaf `i` is `floor(i / blendRunLength) % blendModeCount`, so
+   * the scene contains long same-mode runs rather than alternating per sprite —
+   * a per-sprite alternation would degenerate to one draw call per sprite on
+   * ANY batcher and would measure nothing but flush overhead. Only modes with a
+   * fixed-function GPU blend equation are used (normal / add / multiply /
+   * screen), because those exist on both arms; the engine's backdrop-aware
+   * "advanced" modes have no Pixi equivalent that costs the same, so including
+   * them would make the arms incomparable.
+   */
+  readonly blendModeCount?: number;
+  /** Run length (in leaf index space) of one blend-mode plateau; see {@link blendModeCount}. */
+  readonly blendRunLength?: number;
+  /**
+   * Number of distinct custom sprite materials cycled across the scene's
+   * leaves, or `undefined`/`0` for the default (material-less) sprite path.
+   *
+   * ExoJS-ONLY, like `viewCount`: Pixi 8 has no per-Sprite custom-shader API
+   * (its equivalent is a `Mesh` with its own `Shader`, a different geometry
+   * path entirely), so the Pixi arm renders the same scene WITHOUT materials.
+   * An archetype that sets this is therefore an ExoJS-internal probe on the
+   * material dimension — read it against the otherwise-identical
+   * `mixed-blend` archetype to isolate the custom-material cost — and NOT a
+   * cross-arm wall-clock comparison.
+   */
+  readonly materialCount?: number;
+  /** Run length (in leaf index space) of one material plateau; see {@link materialCount}. */
+  readonly materialRunLength?: number;
 }
 
 /** One matrix cell: a single (engine, config, backend, archetype, node count) combination to measure. */

--- a/packages/exojs-bench/src/rendering/adapters/exojs.ts
+++ b/packages/exojs-bench/src/rendering/adapters/exojs.ts
@@ -1,10 +1,14 @@
 import { Application } from '#core/Application';
 import { Color } from '#core/Color';
 import { Container } from '#rendering/Container';
+import { ShaderSource } from '#rendering/material/ShaderSource';
+import { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import { RetainedContainer } from '#rendering/RetainedContainer';
 import { Sprite } from '#rendering/sprite/Sprite';
+import { spriteVertexGlsl } from '#rendering/sprite/spriteMaterialSources';
 import { Texture } from '#rendering/texture/Texture';
+import { BlendModes } from '#rendering/types';
 import { View } from '#rendering/View';
 import type { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
@@ -22,6 +26,53 @@ const SPRITE_SIZE = 8;
 const WOBBLE_AMPLITUDE = 2;
 /** Phase step per frame for the mutation wobble. */
 const WOBBLE_SPEED = 0.15;
+
+/**
+ * Fixed-function blend modes cycled by the `mixed-blend` / `mixed-material`
+ * archetypes. Deliberately only modes 0-4 (`isAdvancedBlendMode` false, see
+ * `#rendering/types`): those map to a GPU blend equation and have a
+ * one-to-one Pixi equivalent. An advanced mode would route through the
+ * backdrop-capture compositor here and through a completely different (or
+ * absent) path on the other arm, so the comparison would be meaningless.
+ */
+const CYCLED_BLEND_MODES: readonly BlendModes[] = [BlendModes.Normal, BlendModes.Additive, BlendModes.Multiply, BlendModes.Screen];
+
+/**
+ * Fragment source for one of the `mixed-material` archetype's custom sprite
+ * materials. Intentionally near-trivial (base-texture sample times a per-material
+ * uniform): the archetype measures the CPU cost of the custom-material BATCHING
+ * path (shader/uniform/texture rebinding per batch), not fragment ALU. A heavy
+ * fragment would move the bottleneck to the GPU and hide the thing under test.
+ */
+const materialFragmentGlsl = `#version 300 es
+precision mediump float;
+in vec2 v_texcoord;
+in vec4 v_color;
+uniform sampler2D u_texture;
+uniform vec4 u_userColor;
+out vec4 fragColor;
+void main() {
+  fragColor = texture(u_texture, v_texcoord) * v_color * u_userColor;
+}`;
+
+/** WGSL twin of {@link materialFragmentGlsl} so the same material also runs on the WebGPU backend. */
+const materialFragmentWgsl = `
+struct UserUniforms { color: vec4<f32> };
+@group(2) @binding(0) var<uniform> u_user: UserUniforms;
+
+@fragment
+fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  let base = textureSample(u_texture, u_sampler, input.texcoord);
+  return base * input.color * u_user.color;
+}
+`.trim();
+
+/** Build one of `total` distinct custom sprite materials (distinct instances — the batcher keys on identity). */
+const createDistinctMaterial = (index: number, total: number): SpriteMaterial =>
+  new SpriteMaterial({
+    shader: new ShaderSource({ glsl: { vertex: spriteVertexGlsl, fragment: materialFragmentGlsl }, wgsl: materialFragmentWgsl }),
+    uniforms: { u_userColor: [1, 1 - index / Math.max(1, total), 1, 1] },
+  });
 
 /** A pre-selected leaf sprite and its resting grid position — the only nodes `mutate` disturbs. */
 interface MutableLeaf {
@@ -105,6 +156,8 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
   let app: Application | null = null;
   let root: Container | null = null;
   let textures: Texture[] = [];
+  /** Custom sprite materials built for the `mixed-material` archetype; empty for every other archetype. */
+  let materials: SpriteMaterial[] = [];
   let mutableLeaves: MutableLeaf[] = [];
   /** Leaf indices the most recent buildScene selected for mutation — the source of {@link EngineAdapter.mutationSignature}. */
   let mutableIndices: number[] = [];
@@ -157,6 +210,20 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
 
       for (let t = 0; t < spec.textureCount; t++) {
         textures.push(createDistinctTexture(t, spec.textureCount));
+      }
+
+      // State-churn dimensions (see `ArchetypeSpec.blendModeCount` /
+      // `materialCount`). Absent on every pre-existing archetype, which then
+      // keeps exactly the old behaviour: one blend mode, no materials.
+      const blendModeCount = Math.max(1, Math.min(spec.blendModeCount ?? 1, CYCLED_BLEND_MODES.length));
+      const blendRunLength = Math.max(1, spec.blendRunLength ?? 1);
+      const materialCount = Math.max(0, spec.materialCount ?? 0);
+      const materialRunLength = Math.max(1, spec.materialRunLength ?? 1);
+
+      materials = [];
+
+      for (let m = 0; m < materialCount; m++) {
+        materials.push(createDistinctMaterial(m, materialCount));
       }
 
       // Nested-container spine whose depth equals `nestingDepth`; leaves are
@@ -217,6 +284,19 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
         const sprite = new Sprite(textures[Math.floor(i / spine.length) % textures.length]!);
 
         sprite.cullable = spec.cullingEnabled;
+
+        // Blend-mode / material plateaus keyed on the GLOBAL leaf index, using
+        // the same formula the Pixi arm uses, so both arms assign the identical
+        // mode to the identical sprite and the resulting draw-call structure is
+        // comparable. Left at the engine default when the archetype does not
+        // set the dimension.
+        if (blendModeCount > 1) {
+          sprite.blendMode = CYCLED_BLEND_MODES[Math.floor(i / blendRunLength) % blendModeCount]!;
+        }
+
+        if (materials.length > 0) {
+          sprite.material = materials[Math.floor(i / materialRunLength) % materials.length]!;
+        }
 
         // `overdraw` stacks nodeCount full-viewport quads at the origin to
         // force genuine fill-bound behaviour; every other archetype lays
@@ -329,11 +409,16 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
         texture.destroy();
       }
 
+      for (const material of materials) {
+        material.destroy();
+      }
+
       for (const view of views) {
         view.destroy();
       }
 
       textures = [];
+      materials = [];
       mutableLeaves = [];
       mutableIndices = [];
       views = [];

--- a/packages/exojs-bench/src/rendering/adapters/pixi.ts
+++ b/packages/exojs-bench/src/rendering/adapters/pixi.ts
@@ -34,6 +34,14 @@ const WOBBLE_AMPLITUDE = 2;
 /** Phase step per frame for the mutation wobble. */
 const WOBBLE_SPEED = 0.15;
 
+/**
+ * Pixi blend-mode names matching, one-to-one and in the same order, the ExoJS
+ * arm's `CYCLED_BLEND_MODES` (Normal / Additive / Multiply / Screen). All four
+ * are fixed-function GPU blend equations on both engines, so a leaf assigned
+ * index `k` costs each arm the same kind of state change.
+ */
+const CYCLED_BLEND_MODES = ['normal', 'add', 'multiply', 'screen'] as const;
+
 /** A pre-selected leaf sprite and its resting grid position — the only nodes `mutate` disturbs. */
 interface MutableLeaf {
   readonly sprite: Sprite;
@@ -179,6 +187,16 @@ export const createPixiAdapter = (): EngineAdapter => {
       // Shared, canonical mutation selection — the SAME helper the ExoJS arm
       // routes through, so both arms select the byte-for-byte identical index set
       // and the harness's cross-arm determinism assertion holds.
+      // Blend-mode plateaus, computed by the SAME formula as the ExoJS arm
+      // (`adapters/exojs.ts`), so both arms hand the identical mode to the
+      // identical leaf index. `spec.materialCount` is deliberately IGNORED here:
+      // Pixi 8 has no per-Sprite custom-shader API, so the `mixed-material`
+      // archetype renders on this arm as plain `mixed-blend` — disclosed in
+      // `ArchetypeSpec.materialCount` and in the report's Methodology, never
+      // presented as a like-for-like row.
+      const blendModeCount = Math.max(1, Math.min(spec.blendModeCount ?? 1, CYCLED_BLEND_MODES.length));
+      const blendRunLength = Math.max(1, spec.blendRunLength ?? 1);
+
       const selectedIndices = selectMutationIndices(nodeCount, spec.mutationFraction, seed);
       const selectedSet = new Set(selectedIndices);
       const leaves: MutableLeaf[] = [];
@@ -190,6 +208,10 @@ export const createPixiAdapter = (): EngineAdapter => {
         const sprite = new Sprite(textures[Math.floor(i / spine.length) % textures.length]!);
 
         sprite.cullable = spec.cullingEnabled;
+
+        if (blendModeCount > 1) {
+          sprite.blendMode = CYCLED_BLEND_MODES[Math.floor(i / blendRunLength) % blendModeCount]!;
+        }
 
         // `overdraw` stacks nodeCount full-viewport quads at the origin (anchor
         // defaults to (0,0)/top-left on both engines) for genuine fill-bound

--- a/packages/exojs-bench/src/rendering/archetypes.ts
+++ b/packages/exojs-bench/src/rendering/archetypes.ts
@@ -69,6 +69,61 @@ export const ARCHETYPES: readonly ArchetypeSpec[] = [
   // wall-clock comparison — a competitor arm renders it as an ordinary
   // single-view static-heavy scene instead.
   { id: 'split-screen', nodeCounts: SCALING_COUNTS, nestingDepth: 4, textureCount: 1, mutationFraction: 0, cullingEnabled: false, viewCount: 4 },
+  // State-churn archetypes. `batch-breaking` already covers ONE batch-breaking
+  // axis (texture-slot exhaustion); these two cover the other two axes a real
+  // mixed scene hits — blend mode, and (ExoJS-only) custom material — because
+  // both engines' sprite batchers treat them as hard flush boundaries:
+  //   - ExoJS WebGL2: `WebGl2SpriteRenderer._renderDefault` flushes on
+  //     `blendModeChanged`; `_renderCustom` flushes on material OR base-texture
+  //     change (WebGl2SpriteRenderer.ts:507-564).
+  //   - Pixi 8: `Batcher.add` starts a new batch when `blendMode` differs from
+  //     the current batch's.
+  //
+  // `blendRunLength: 64` (not 1) is deliberate: alternating blend modes per
+  // sprite would flush per sprite on any batcher and would measure nothing but
+  // flush overhead. A 64-leaf plateau produces a realistic "a few hundred state
+  // switches per frame" scene whose draw-call count the report records, so the
+  // measured CPU cost can be read per batch rather than per node.
+  { id: 'mixed-blend', nodeCounts: GPU_BOUND_COUNTS, nestingDepth: 2, textureCount: 4, mutationFraction: 0, cullingEnabled: false, blendModeCount: 4, blendRunLength: 64 },
+  // Identical to `mixed-blend` in every field EXCEPT `materialCount`, so the
+  // delta between the two rows on the ExoJS arm is exactly the custom-material
+  // path's cost. NOT a cross-arm comparison: the Pixi arm cannot express
+  // per-sprite custom shaders and renders this as plain `mixed-blend` (see
+  // `ArchetypeSpec.materialCount`).
+  {
+    id: 'mixed-material',
+    nodeCounts: GPU_BOUND_COUNTS,
+    nestingDepth: 2,
+    textureCount: 4,
+    mutationFraction: 0,
+    cullingEnabled: false,
+    blendModeCount: 4,
+    blendRunLength: 64,
+    materialCount: 4,
+    materialRunLength: 64,
+  },
+  // ATLAS CONTROLS. Each is byte-for-byte its partner archetype with
+  // `textureCount: 1` — i.e. exactly the scene a runtime texture-atlas packer
+  // would produce if it merged that partner's N distinct base textures into a
+  // single atlas page and rewrote every sprite's UV frame. Nothing else about
+  // the scene changes (node count, nesting, blend plateaus, materials), so the
+  // measured delta `partner - atlased` IS the upper bound on what a runtime
+  // atlas packer could buy on this hardware, with no modelling or estimation in
+  // between. `textureCount: 1` is the ideal case (zero packing waste, one page,
+  // no per-frame repack cost), so the delta is an upper bound, never a forecast.
+  { id: 'batch-breaking-atlased', nodeCounts: GPU_BOUND_COUNTS, nestingDepth: 2, textureCount: 1, mutationFraction: 0, cullingEnabled: false },
+  {
+    id: 'mixed-material-atlased',
+    nodeCounts: GPU_BOUND_COUNTS,
+    nestingDepth: 2,
+    textureCount: 1,
+    mutationFraction: 0,
+    cullingEnabled: false,
+    blendModeCount: 4,
+    blendRunLength: 64,
+    materialCount: 4,
+    materialRunLength: 64,
+  },
 ];
 
 /**

--- a/packages/exojs-bench/src/rendering/driver.ts
+++ b/packages/exojs-bench/src/rendering/driver.ts
@@ -470,6 +470,36 @@ const applyFilter = (cells: readonly CellSpec[], filter: Partial<CellSpec>): Cel
 };
 
 /**
+ * Multi-value cell selection: a cell survives when, for every field the
+ * selection lists, the cell's value appears in that field's list. The
+ * single-valued {@link applyFilter} could only ever pin ONE archetype or ONE
+ * engine per invocation, which forced a multi-archetype comparison to be split
+ * across several process launches — i.e. across several browser sessions,
+ * breaking the same-session rule the whole report rests on. This lets one
+ * session cover exactly the arms and archetypes a given question needs, and
+ * nothing else.
+ */
+export interface MatrixSelection {
+  /** Engine labels to keep (e.g. `['exojs', 'pixi']`), or omitted for all. */
+  readonly engines?: readonly string[];
+  /** Engine config labels to keep (e.g. `['current', 'retained']`), or omitted for all. */
+  readonly configs?: readonly string[];
+  /** Archetype ids to keep, or omitted for all. */
+  readonly archetypes?: readonly string[];
+  /** Node counts to keep, or omitted for all. */
+  readonly nodeCounts?: readonly number[];
+}
+
+const applySelection = (cells: readonly CellSpec[], selection: MatrixSelection): CellSpec[] =>
+  cells.filter(
+    cell =>
+      (selection.engines === undefined || selection.engines.includes(cell.engine)) &&
+      (selection.configs === undefined || selection.configs.includes(cell.config)) &&
+      (selection.archetypes === undefined || selection.archetypes.includes(cell.archetype)) &&
+      (selection.nodeCounts === undefined || selection.nodeCounts.includes(cell.nodeCount)),
+  );
+
+/**
  * Callback invoked the instant a cell finishes measuring, BEFORE the run
  * continues to the next cell. The CLI wires this to the incremental checkpoint
  * writer (`shared/checkpoint.ts`) so a later crash never discards finished work.
@@ -696,6 +726,212 @@ const runBackend = async (options: {
   return { provenance, results };
 };
 
+/** One aggregated row of a CPU profile: a source location and the self time attributed to it. */
+export interface ProfileRow {
+  /** Function name as the V8 sampler reported it (empty for top-level/anonymous frames). */
+  readonly functionName: string;
+  /** Source URL the frame came from, trimmed to a repository-relative path where possible. */
+  readonly source: string;
+  /** Self time in milliseconds, summed over every sampler node with this (function, source, line). */
+  readonly selfMs: number;
+  /** Share of the whole profile's self time, in percent. */
+  readonly selfPercent: number;
+}
+
+/** Result of one CPU-profiling run: the cell profiled, the wall clock it took, and self time by frame. */
+export interface ProfileOutcome {
+  /** The cell that was profiled. */
+  readonly spec: CellSpec;
+  /** GPU/backend provenance for the profiled session. */
+  readonly provenance: Provenance;
+  /** Number of frames the profiled loop rendered. */
+  readonly frames: number;
+  /** Wall clock the in-page frame loop took, in milliseconds. */
+  readonly wallMs: number;
+  /** Total self time the sampler attributed, in milliseconds (below `wallMs` by the sampler's blind spots). */
+  readonly totalSelfMs: number;
+  /** Self time per source frame, descending. */
+  readonly rows: readonly ProfileRow[];
+  /** Self time aggregated per source FILE, descending — the view that answers "which subsystem". */
+  readonly byFile: ReadonlyArray<{ readonly source: string; readonly selfMs: number; readonly selfPercent: number }>;
+}
+
+/** Minimal shape of the `Profiler.stop` payload this driver consumes. */
+interface CdpProfile {
+  readonly nodes: ReadonlyArray<{
+    readonly id: number;
+    readonly hitCount?: number;
+    readonly callFrame: { readonly functionName: string; readonly url: string; readonly lineNumber: number };
+  }>;
+  readonly startTime: number;
+  readonly endTime: number;
+  readonly samples?: readonly number[];
+  readonly timeDeltas?: readonly number[];
+}
+
+/**
+ * Shorten a profiler URL to something readable: the Vite dev server serves
+ * engine source from the repo root, so `http://127.0.0.1:PORT/@fs/C:/…/exojs/src/x.ts`
+ * and `/src/x.ts` both collapse to `src/x.ts`; a pre-bundled competitor keeps
+ * its `node_modules/.vite/deps/…` identity, which is exactly what distinguishes
+ * "time inside Pixi" from "time inside the engine".
+ */
+const shortenProfileUrl = (url: string): string => {
+  if (url.length === 0) {
+    return '(native)';
+  }
+
+  const withoutQuery = url.split('?')[0]!;
+  const marker = withoutQuery.lastIndexOf('/exojs/');
+
+  if (marker >= 0) {
+    return withoutQuery.slice(marker + '/exojs/'.length);
+  }
+
+  try {
+    return new URL(withoutQuery).pathname.replace(/^\/+/, '');
+  } catch {
+    return withoutQuery;
+  }
+};
+
+/**
+ * Run one cell under the V8 CPU sampler and return self time attributed by
+ * source frame.
+ *
+ * The sampler is started BETWEEN the in-page setup phase and the frame loop
+ * (see `page/harness.ts`'s `__profileSetup` / `__profileFrames`), so engine
+ * init, scene construction and warmup are outside the capture and the profile
+ * describes the per-frame path only.
+ *
+ * Self time is derived from `samples` + `timeDeltas` when the sampler provides
+ * them (exact per-sample attribution) and falls back to distributing the
+ * profile's wall span across `hitCount` otherwise. Sampling at 50µs rather than
+ * the 1000µs default is what makes a 0.1ms/frame retained cell resolvable at
+ * all; it costs profile size, not accuracy.
+ */
+export const profileCell = async (options: {
+  spec: CellSpec;
+  /** Frames rendered inside the sampled window. */
+  frames?: number;
+  /** Frames rendered before sampling starts, to settle shader compile / JIT. */
+  warmupFrames?: number;
+  /** Sampling interval in microseconds. */
+  intervalUs?: number;
+}): Promise<ProfileOutcome> => {
+  const { spec } = options;
+  const frames = options.frames ?? 200;
+  const warmupFrames = options.warmupFrames ?? 30;
+  const engineVersion = readEngineVersion();
+  const server = await startViteServer(engineVersion);
+
+  try {
+    const baseUrl = server.resolvedUrls?.local[0];
+
+    if (baseUrl === undefined) {
+      throw new Error('The Vite dev server did not report a local URL.');
+    }
+
+    const flags = spec.backend === 'webgpu' ? WEBGPU_LAUNCH_FLAGS : LAUNCH_FLAGS;
+    const browser = await chromium.launch({ channel: 'chromium', headless: true, args: [...flags] });
+
+    try {
+      const page = await browser.newPage();
+
+      await page.goto(baseUrl, { waitUntil: 'load' });
+      await page.waitForFunction(() => typeof globalThis.__profileSetup === 'function');
+
+      const client = await page.context().newCDPSession(page);
+
+      await client.send('Profiler.enable');
+      await client.send('Profiler.setSamplingInterval', { interval: options.intervalUs ?? 50 });
+
+      await page.evaluate(args => globalThis.__profileSetup!(args.cell, args.warmup), { cell: spec, warmup: warmupFrames });
+      await client.send('Profiler.start');
+
+      const wallMs = await page.evaluate(count => globalThis.__profileFrames!(count), frames);
+      const stopped = (await client.send('Profiler.stop')) as unknown as { profile: CdpProfile };
+      const profile = stopped.profile;
+
+      const adapter = spec.backend === 'webgpu' ? 'profiled webgpu session' : await readRendererInPage(page);
+
+      await page.evaluate(() => globalThis.__profileDispose!());
+
+      // Per-node self time. `timeDeltas[i]` is the interval BEFORE `samples[i]`
+      // in microseconds, so charging it to `samples[i]` attributes each
+      // observed interval to the frame that was on top at its end — the
+      // standard reading of a V8 CPU profile.
+      const selfUsByNode = new Map<number, number>();
+
+      if (profile.samples !== undefined && profile.timeDeltas !== undefined) {
+        for (let i = 0; i < profile.samples.length; i++) {
+          const nodeId = profile.samples[i]!;
+          const delta = profile.timeDeltas[i] ?? 0;
+
+          selfUsByNode.set(nodeId, (selfUsByNode.get(nodeId) ?? 0) + delta);
+        }
+      } else {
+        const totalHits = profile.nodes.reduce((sum, node) => sum + (node.hitCount ?? 0), 0);
+        const spanUs = profile.endTime - profile.startTime;
+
+        for (const node of profile.nodes) {
+          if (totalHits > 0 && node.hitCount) {
+            selfUsByNode.set(node.id, (node.hitCount / totalHits) * spanUs);
+          }
+        }
+      }
+
+      const byFrame = new Map<string, { functionName: string; source: string; selfMs: number }>();
+      const byFile = new Map<string, number>();
+      let totalSelfMs = 0;
+
+      for (const node of profile.nodes) {
+        const selfMs = (selfUsByNode.get(node.id) ?? 0) / 1000;
+
+        if (selfMs <= 0) {
+          continue;
+        }
+
+        const source = `${shortenProfileUrl(node.callFrame.url)}:${node.callFrame.lineNumber + 1}`;
+        const fileSource = shortenProfileUrl(node.callFrame.url);
+        const key = `${node.callFrame.functionName}@${source}`;
+        const existing = byFrame.get(key);
+
+        if (existing === undefined) {
+          byFrame.set(key, { functionName: node.callFrame.functionName, source, selfMs });
+        } else {
+          existing.selfMs += selfMs;
+        }
+
+        byFile.set(fileSource, (byFile.get(fileSource) ?? 0) + selfMs);
+        totalSelfMs += selfMs;
+      }
+
+      const rows: ProfileRow[] = [...byFrame.values()]
+        .map(entry => ({ ...entry, selfPercent: totalSelfMs > 0 ? (entry.selfMs / totalSelfMs) * 100 : 0 }))
+        .sort((a, b) => b.selfMs - a.selfMs);
+
+      const files = [...byFile.entries()]
+        .map(([source, selfMs]) => ({ source, selfMs, selfPercent: totalSelfMs > 0 ? (selfMs / totalSelfMs) * 100 : 0 }))
+        .sort((a, b) => b.selfMs - a.selfMs);
+
+      return {
+        spec,
+        provenance: { adapter, backend: spec.backend, flags, headless: true, engineVersion, timestamp: new Date().toISOString(), software: isSoftwareRenderer(adapter) },
+        frames,
+        wallMs,
+        totalSelfMs,
+        rows,
+        byFile: files,
+      };
+    } finally {
+      await browser.close();
+    }
+  } finally {
+    await server.close();
+  }
+};
+
 /** Full outcome of a matrix run: per-backend provenance, competitor-library provenance, and every cell result. */
 export interface MatrixOutcome {
   /** One provenance stamp per backend exercised. */
@@ -723,6 +959,8 @@ export interface MatrixOutcome {
 export const runMatrix = async (options: {
   backends: readonly Backend[];
   filter?: Partial<CellSpec>;
+  /** Multi-value selection applied after `filter`; see {@link MatrixSelection}. */
+  selection?: MatrixSelection;
   /**
    * Forces every selected cell's timed-frame count to this value. Reserved for
    * the smoke test, which measures a single tiny cell and needs only a handful
@@ -737,7 +975,8 @@ export const runMatrix = async (options: {
   const libraries = readLibraryProvenance(LIBRARY_ARMS);
   const allCells = buildMatrix(ADAPTER_CAPABILITIES, options.backends);
   const filtered = options.filter ? applyFilter(allCells, options.filter) : allCells;
-  const cells = options.timedFramesOverride === undefined ? filtered : filtered.map(cell => ({ ...cell, timedFrames: options.timedFramesOverride! }));
+  const selected = options.selection ? applySelection(filtered, options.selection) : filtered;
+  const cells = options.timedFramesOverride === undefined ? selected : selected.map(cell => ({ ...cell, timedFrames: options.timedFramesOverride! }));
 
   if (cells.length === 0) {
     throw new Error('The baseline matrix is empty: no adapter supports the requested backends/filter.');

--- a/packages/exojs-bench/src/rendering/index.ts
+++ b/packages/exojs-bench/src/rendering/index.ts
@@ -9,6 +9,6 @@
 // mutation-determinism, the incremental checkpoint writer, CLI arg parsing) live
 // under `../shared`.
 
-export { type LibraryProvenance, type MatrixOutcome, type Provenance, runMatrix } from './driver';
+export { type LibraryProvenance, type MatrixOutcome, type MatrixSelection, profileCell, type ProfileOutcome, type ProfileRow, type Provenance, runMatrix } from './driver';
 export type { ArchetypeId, Backend, CellResult, CellSpec } from './EngineAdapter';
 export { type ReportData, writeReport } from './report';

--- a/packages/exojs-bench/src/rendering/page/harness.ts
+++ b/packages/exojs-bench/src/rendering/page/harness.ts
@@ -676,8 +676,76 @@ const runBaselineCell = async (cell: CellSpec): Promise<CellResult> => {
   return runCell(adapter, cell, canvas);
 };
 
+/**
+ * Split-phase entry points used ONLY by the CPU-profiling mode
+ * (`driver.ts::profileCell`). `runCell` is unusable for profiling because a
+ * single `page.evaluate` covers engine init, scene construction, warmup, the
+ * timed frames AND teardown — a profile taken across it is dominated by
+ * one-shot setup cost and says nothing about the per-frame path. Splitting the
+ * cell into `setup` / `frames` / `dispose` lets the Node driver start the CDP
+ * sampler between setup and frames, so the captured profile contains the frame
+ * loop and nothing else.
+ *
+ * Frames run SYNCHRONOUSLY here (a straight loop, no `requestAnimationFrame`)
+ * on purpose: rAF pacing would inject idle time between frames and dilute the
+ * sample density over exactly the code under study. This makes the phase
+ * unsuitable for wall-clock reporting — it is never used for one — but ideal
+ * for attributing self time.
+ */
+const profileState: { adapter: EngineAdapter | null; frame: number } = { adapter: null, frame: 0 };
+
+const profileSetup = async (cell: CellSpec, warmupFrames: number): Promise<void> => {
+  const archetype = ARCHETYPES.find(candidate => candidate.id === cell.archetype);
+
+  if (archetype === undefined) {
+    throw new Error(`Unknown archetype '${cell.archetype}'.`);
+  }
+
+  const canvas = freshStageCanvas();
+  const adapter = await resolveAdapter(cell.engine, cell.config);
+
+  await adapter.init(canvas, cell.backend);
+  adapter.buildScene(archetype, cell.nodeCount, SEED);
+
+  for (let frame = 0; frame < warmupFrames; frame++) {
+    adapter.mutate(frame);
+    adapter.renderFrame();
+  }
+
+  profileState.adapter = adapter;
+  profileState.frame = warmupFrames;
+};
+
+const profileFrames = (count: number): number => {
+  const adapter = profileState.adapter;
+
+  if (adapter === null) {
+    throw new Error('__profileFrames was called before __profileSetup.');
+  }
+
+  const startedAt = performance.now();
+
+  for (let i = 0; i < count; i++) {
+    adapter.mutate(profileState.frame++);
+    adapter.renderFrame();
+  }
+
+  return performance.now() - startedAt;
+};
+
+const profileDispose = (): void => {
+  profileState.adapter?.teardown();
+  profileState.adapter = null;
+};
+
 declare global {
   var __runBaselineCell: ((cell: CellSpec) => Promise<CellResult>) | undefined;
+  var __profileSetup: ((cell: CellSpec, warmupFrames: number) => Promise<void>) | undefined;
+  var __profileFrames: ((count: number) => number) | undefined;
+  var __profileDispose: (() => void) | undefined;
 }
 
 globalThis.__runBaselineCell = runBaselineCell;
+globalThis.__profileSetup = profileSetup;
+globalThis.__profileFrames = profileFrames;
+globalThis.__profileDispose = profileDispose;

--- a/packages/exojs-bench/src/run.ts
+++ b/packages/exojs-bench/src/run.ts
@@ -4,8 +4,8 @@ import { resolve } from 'node:path';
 // graph — the `@codexo/exojs-physics` source arm — is loaded lazily via a
 // dynamic `import()` inside `runPhysicsDomain`, so a rendering run never pays for it.
 import type { PhysicsAdapter, PhysicsCellResult, PhysicsCellSpec } from './physics';
-import type { ArchetypeId, Backend, CellResult, CellSpec } from './rendering';
-import { runMatrix, writeReport } from './rendering';
+import type { ArchetypeId, Backend, CellResult, CellSpec, MatrixSelection } from './rendering';
+import { profileCell, runMatrix, writeReport } from './rendering';
 import { parseArgs } from './shared/args';
 import { createCheckpointWriter } from './shared/checkpoint';
 
@@ -22,6 +22,20 @@ const DEFAULT_PHYSICS_OUT_DIR = '.workspace/output/physics/';
 /** Backends run when `--backend` is not given. `buildMatrix` gates each to the adapters that support it. */
 const DEFAULT_BACKENDS: readonly Backend[] = ['webgl2', 'webgpu'];
 
+/** Split a comma-separated CLI list into trimmed, non-empty values, or `undefined` when the flag was absent. */
+const parseList = (raw: string | undefined): string[] | undefined => {
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  const values = raw
+    .split(',')
+    .map(value => value.trim())
+    .filter(value => value.length > 0);
+
+  return values.length > 0 ? values : undefined;
+};
+
 /** Parse and validate the `--domain` selector (defaults to `rendering`). */
 const resolveDomain = (raw: string | undefined): Domain => {
   if (raw === undefined) {
@@ -33,6 +47,65 @@ const resolveDomain = (raw: string | undefined): Domain => {
   }
 
   throw new Error(`--domain must be one of [${DOMAINS.join(', ')}] (got '${raw}').`);
+};
+
+/**
+ * `--profile` mode: run the SELECTED cells under the V8 CPU sampler and print
+ * self time by source file and by function, instead of measuring wall clock.
+ *
+ * This answers a different question than the matrix does. The matrix says how
+ * expensive a frame is; the profile says WHICH code made it expensive, which is
+ * the only way to tell an optimisation candidate that would move a real number
+ * from one that would not. Output is deliberately printed rather than written
+ * into `results.*`: a profile is not a comparable datapoint and must never end
+ * up in the same table as one.
+ */
+const runProfileMode = async (
+  args: Map<string, string>,
+  selection: { engines?: string[]; configs?: string[]; archetypes?: ArchetypeId[]; nodeCounts?: number[] },
+  backends: readonly Backend[],
+): Promise<void> => {
+  const frames = Number.parseInt(args.get('profile-frames') ?? '200', 10);
+  const topRows = Number.parseInt(args.get('profile-top') ?? '25', 10);
+  const engines = selection.engines ?? ['exojs'];
+  const configs = selection.configs ?? ['current'];
+  const archetypes = selection.archetypes ?? (['static-heavy'] as ArchetypeId[]);
+  const nodeCounts = selection.nodeCounts ?? [25_000];
+
+  for (const backend of backends) {
+    for (const engine of engines) {
+      for (const config of configs) {
+        for (const archetype of archetypes) {
+          for (const nodeCount of nodeCounts) {
+            const outcome = await profileCell({
+              spec: { engine, config, backend, archetype, nodeCount, timedFrames: frames, warmupFrames: 30 },
+              frames,
+            });
+
+            console.log(
+              `\n=== CPU profile: engine=${engine} config=${config} backend=${backend} archetype=${archetype} n=${nodeCount} ===\n` +
+                `  ${outcome.frames} synchronous frames in ${outcome.wallMs.toFixed(1)}ms wall (${(outcome.wallMs / outcome.frames).toFixed(3)}ms/frame), ` +
+                `${outcome.totalSelfMs.toFixed(1)}ms attributed self time; adapter="${outcome.provenance.adapter}"`,
+            );
+
+            console.log('\n  -- self time by FILE --');
+
+            for (const file of outcome.byFile.slice(0, topRows)) {
+              console.log(`    ${file.selfPercent.toFixed(1).padStart(5)}%  ${(file.selfMs / outcome.frames).toFixed(4).padStart(9)} ms/frame  ${file.source}`);
+            }
+
+            console.log('\n  -- self time by FUNCTION --');
+
+            for (const row of outcome.rows.slice(0, topRows)) {
+              console.log(
+                `    ${row.selfPercent.toFixed(1).padStart(5)}%  ${(row.selfMs / outcome.frames).toFixed(4).padStart(9)} ms/frame  ${row.functionName || '(anonymous)'}  @ ${row.source}`,
+              );
+            }
+          }
+        }
+      }
+    }
+  }
 };
 
 /** Run the rendering benchmark domain end-to-end and write its report artifacts. */
@@ -51,23 +124,32 @@ const runRenderingDomain = async (args: Map<string, string>): Promise<void> => {
   // Partial<CellSpec> it accepts).
   const filter: { -readonly [K in keyof CellSpec]?: CellSpec[K] } = {};
 
-  if (archetypeArg !== undefined) {
-    filter.archetype = archetypeArg as ArchetypeId;
-  }
-
-  if (engineArg !== undefined) {
-    filter.engine = engineArg;
-  }
-
-  if (nodesArg !== undefined) {
-    const nodeCount = Number.parseInt(nodesArg, 10);
+  // `--archetype`, `--engine`, `--config` and `--nodes` each accept a
+  // COMMA-SEPARATED list. A single value behaves exactly as before; a list
+  // routes through `MatrixSelection` so one invocation — and therefore ONE
+  // browser session per arm — can cover several archetypes/arms at once. Before
+  // this, comparing two archetypes meant two process launches, i.e. two
+  // sessions, which the same-session rule forbids for a cross-arm claim.
+  const archetypes = parseList(archetypeArg) as ArchetypeId[] | undefined;
+  const engines = parseList(engineArg);
+  const configs = parseList(args.get('config'));
+  const nodeCounts = parseList(nodesArg)?.map(value => {
+    const nodeCount = Number.parseInt(value, 10);
 
     if (Number.isNaN(nodeCount)) {
-      throw new Error(`--nodes must be an integer (got '${nodesArg}').`);
+      throw new Error(`--nodes must be an integer or a comma-separated list of integers (got '${nodesArg}').`);
     }
 
-    filter.nodeCount = nodeCount;
-  }
+    return nodeCount;
+  });
+
+  const selection: MatrixSelection = {
+    ...(engines !== undefined && { engines }),
+    ...(configs !== undefined && { configs }),
+    ...(archetypes !== undefined && { archetypes }),
+    ...(nodeCounts !== undefined && { nodeCounts }),
+  };
+  const hasSelection = Object.keys(selection).length > 0;
 
   // `--frames` overrides EVERY cell's
   // timed-frame count regardless of node count, so a smoke/spot-check run can
@@ -89,14 +171,29 @@ const runRenderingDomain = async (args: Map<string, string>): Promise<void> => {
     timedFramesOverride = frames;
   }
 
-  const isSubset = backendArg !== undefined || archetypeArg !== undefined || nodesArg !== undefined || engineArg !== undefined || timedFramesOverride !== undefined;
+  if (args.get('profile') !== undefined) {
+    await runProfileMode(
+      args,
+      {
+        ...(engines !== undefined && { engines }),
+        ...(configs !== undefined && { configs }),
+        ...(archetypes !== undefined && { archetypes }),
+        ...(nodeCounts !== undefined && { nodeCounts }),
+      },
+      backends,
+    );
+
+    return;
+  }
+
+  const isSubset = backendArg !== undefined || hasSelection || timedFramesOverride !== undefined;
 
   if (isSubset) {
     console.warn('SUBSET RUN — not a reportable comparison (see the same-session rule).');
   }
 
   console.log(
-    `Running rendering benchmark: backends=[${backends.join(', ')}]${engineArg ? `, engine=${engineArg}` : ''}${archetypeArg ? `, archetype=${archetypeArg}` : ''}${nodesArg ? `, nodes=${nodesArg}` : ''}${timedFramesOverride !== undefined ? `, frames=${timedFramesOverride} (OVERRIDE — thin sampling, not reportable)` : ''}`,
+    `Running rendering benchmark: backends=[${backends.join(', ')}]${engines ? `, engine=[${engines.join(', ')}]` : ''}${configs ? `, config=[${configs.join(', ')}]` : ''}${archetypes ? `, archetype=[${archetypes.join(', ')}]` : ''}${nodeCounts ? `, nodes=[${nodeCounts.join(', ')}]` : ''}${timedFramesOverride !== undefined ? `, frames=${timedFramesOverride} (OVERRIDE — thin sampling, not reportable)` : ''}`,
   );
 
   // Incremental, crash-safe checkpoint: each cell is persisted the instant it
@@ -106,7 +203,8 @@ const runRenderingDomain = async (args: Map<string, string>): Promise<void> => {
 
   const data = await runMatrix({
     backends,
-    ...(isSubset && { filter }),
+    filter,
+    ...(hasSelection && { selection }),
     ...(timedFramesOverride !== undefined && { timedFramesOverride }),
     onCellResult: result => checkpoint.append(result),
   });


### PR DESCRIPTION
The harness changes the Pixi comparison run (`.workspace/benchmarks/2026-08-12-rendering-vs-pixi.md`) was built on. Kept because the questions they answer recur: they are the measurement apparatus behind `NEU-O7` and `NEU-O8`, and the regression check once those are fixed.

## `profileCell`

Runs one cell under the V8 CPU sampler and reports self time per frame and per source file. The sampler starts *between* the in-page setup phase and the frame loop, so scene construction stays out of the profile. URLs collapse to repository-relative paths, while a pre-bundled competitor keeps its `node_modules/.vite/deps/…` identity — which is exactly what separates "time inside the engine" from "time inside Pixi".

## `MatrixSelection`

A cell survives when, for every field the selection lists, its value appears in that field's list. `applyFilter` could pin only ONE archetype or ONE engine per invocation, which forced a multi-archetype comparison to be split across several process launches — across several browser sessions, breaking the same-session rule the whole report rests on.

## Four archetypes on the batching axis

The pre-existing archetypes stress the transform and hierarchy paths; none of them makes the batcher work.

- **`mixed-blend`** — cycles fixed-function blend modes across the leaves in long plateaus. Only modes with a fixed-function GPU equation are used (normal/add/multiply/screen), because those exist on both arms; the backdrop-aware "advanced" modes have no equal-cost Pixi equivalent and would make the arms incomparable.
- **`mixed-material`** — cycles custom sprite materials. ExoJS-only, like `viewCount`: Pixi 8 has no per-Sprite custom-shader API (its equivalent is a `Mesh` with its own `Shader`, a different geometry path), so the Pixi arm renders the same scene without materials. Read it against `mixed-blend` to isolate the custom-material cost; it is not a cross-arm wall-clock comparison.
- **`batch-breaking-atlased` / `mixed-material-atlased`** — the same scenes collapsed onto one texture page, so the texture-slot ceiling is a measured control rather than an estimate.

Both cycles use plateaus (`floor(i / runLength) % count`), not per-sprite alternation: alternating per sprite degenerates to one draw call per sprite on any batcher and would measure nothing but flush overhead.

`pnpm verify:quick`: all 11 gates pass.