### PR TITLE
docs(rendering): drop alpha from RenderNode's class JSDoc

### DIFF
--- a/site/src/content/api/render-node.json
+++ b/site/src/content/api/render-node.json
@@ -1,6 +1,6 @@
 {
   "title": "RenderNode",
-  "description": "SceneNode that can produce visual output. Adds the rendering pipeline features on top of the structural transform/bounds carried by SceneNode: `tint`, `alpha`, `blendMode`, post-process `filters`, an optional `mask` (via MaskSource), bitmap caching (`cacheAsBitmap`), and the interaction surface (`interactive`, `draggable`, all the pointer Signals). `RenderNode.render(backend)` is the per-frame visual entry point. The base implementation collects a render plan, optimizes local ordering, and plays it through the active backend. Subclasses of note: Container (children), Sprite (textured quad), Mesh (custom geometry), Graphics (immediate-mode shapes), Text (glyph-atlas text), Video (video texture), ParticleSystem (particles).",
+  "description": "SceneNode that can produce visual output. Adds the rendering pipeline features on top of the structural transform/bounds carried by SceneNode: `tint`, `blendMode`, post-process `filters`, an optional `mask` (via MaskSource), bitmap caching (`cacheAsBitmap`), and the interaction surface (`interactive`, `draggable`, all the pointer Signals). `RenderNode.render(backend)` is the per-frame visual entry point. The base implementation collects a render plan, optimizes local ordering, and plays it through the active backend. Subclasses of note: Container (children), Sprite (textured quad), Mesh (custom geometry), Graphics (immediate-mode shapes), Text (glyph-atlas text), Video (video texture), ParticleSystem (particles).",
   "symbol": "RenderNode",
   "kind": "class",
   "subsystem": "rendering",
@@ -19,7 +19,7 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "SceneNode that can produce visual output. Adds the rendering pipeline features on top of the structural transform/bounds carried by SceneNode: `tint`, `alpha`, `blendMode`, post-process `filters`, an optional `mask` (via MaskSource), bitmap caching (`cacheAsBitmap`), and the interaction surface (`interactive`, `draggable`, all the pointer Signals).",
+        "SceneNode that can produce visual output. Adds the rendering pipeline features on top of the structural transform/bounds carried by SceneNode: `tint`, `blendMode`, post-process `filters`, an optional `mask` (via MaskSource), bitmap caching (`cacheAsBitmap`), and the interaction surface (`interactive`, `draggable`, all the pointer Signals).",
         "`RenderNode.render(backend)` is the per-frame visual entry point. The base implementation collects a render plan, optimizes local ordering, and plays it through the active backend.",
         "Subclasses of note: Container (children), Sprite (textured quad), Mesh (custom geometry), Graphics (immediate-mode shapes), Text (glyph-atlas text), Video (video texture), ParticleSystem (particles)."
       ],

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -64,7 +64,7 @@ export type MaskSource = Rectangle | Texture | RenderTexture | RenderNode | null
 /**
  * {@link SceneNode} that can produce visual output. Adds the rendering
  * pipeline features on top of the structural transform/bounds carried by
- * SceneNode: `tint`, `alpha`, `blendMode`, post-process `filters`, an
+ * SceneNode: `tint`, `blendMode`, post-process `filters`, an
  * optional `mask` (via {@link MaskSource}), bitmap caching
  * (`cacheAsBitmap`), and the interaction surface
  * (`interactive`, `draggable`, all the pointer Signals).


### PR DESCRIPTION
`NEU-O4` from the review master.

`RenderNode`'s class-level doc comment listed `alpha` among the properties it adds on top of `SceneNode`. No such property exists anywhere on `RenderNode`, `SceneNode` or `Container` — the only alpha-adjacent state in the engine is `Drawable.tint`'s `Color` alpha channel, a per-leaf tint component, not a subtree-composite alpha.

Found while checking `ME-19`'s batching-barrier candidates: "Alpha < 1" was on that list and turned out to have no testable property behind it.

`site/src/content/api/render-node.json` regenerated via `pnpm docs:api:generate`.

**On the rest of that spike branch:** the `ME-19` flatten prototype is deliberately *not* here. Its own second measurement round refuted both assumptions it rested on — over the full frame path (build + optimize + play) no delta cleared the 30 % noise floor, and in headless Chromium/WebGL2 the real `gl.drawArraysInstanced` count was exactly 1 before and after, while `build()` got 15–35 % more expensive. `WebGl2SpriteRenderer` decides flushes purely on state continuity across the whole draw stream; `_beginRenderGroup`/`_endRenderGroup` are optional `RenderPlanPlayer` hooks that no backend implements. Recorded in the review master as measured-and-dropped.

`pnpm verify:quick`: all 11 gates pass.