### PR TITLE
fix(rendering): stop submitting a render pass per WebGPU custom-material batch

### DIFF
--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -26,14 +26,14 @@ import {
 import { packSnapViewport } from './webgpuSnapViewport';
 import { stencilContentDepthStencilState } from './WebGpuStencilState';
 import {
-  collectScalarUniforms,
+  applyUserUniformUpload,
   collectTextureBindings,
   createUserUniformState,
-  packUserUniforms,
+  planUserUniformUpload,
   resetUserUniformState,
   resolveUserUniformBindGroup,
-  userUniformBufferBytes,
   type UserUniformState,
+  type UserUniformUpload,
 } from './webgpuUserUniforms';
 
 /**
@@ -402,6 +402,13 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
   private _customBaseTextureLayout: GPUBindGroupLayout | null = null;
   private _currentMaterial: SpriteMaterial | null = null;
   private _currentBaseTexture: Texture | RenderTexture | null = null;
+  // Material uniform buffers a draw already recorded into the currently open
+  // pass reads from. A batch about to rewrite one of them has to end that pass
+  // first — see the hazard checks in flush(). Keyed to the pass identity so a
+  // pass ended by anyone (the coordinator at a genuine boundary, another
+  // renderer) clears it on the next acquisition.
+  private _uniformHazardPass: WebGpuActiveRenderPass | null = null;
+  private readonly _uniformBuffersInPass = new Set<GPUBuffer>();
   // Local bounds resolved for the sprite currently being packed. Geometry-mode
   // boundary snapping now happens in the vertex shader, so this is always the
   // sprite's logical local bounds; the field lets _packInstance read the value
@@ -706,10 +713,6 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     const scissor = backend.getScissorRect();
     const maskClipsAll = scissor !== null && (scissor.width <= 0 || scissor.height <= 0);
 
-    // A custom-material batch re-uploads its per-material user-uniform buffer at
-    // offset 0 every flush, so two custom flushes must not share one submit; end
-    // the pass after a custom batch (default batches accumulate and are submitted
-    // together at the next genuine boundary).
     const isCustom = this._currentMaterial !== null;
     const willDraw = this._instanceCount > 0 && !maskClipsAll && this._indexBuffer !== null && this._currentBlendMode !== null;
 
@@ -722,6 +725,13 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       let active = backend._passCoordinator.acquirePass();
 
       this._instanceArena.syncPass(active);
+      this._syncUniformHazardPass(active);
+
+      // A custom batch's user uniforms are packed (not uploaded) here, so the
+      // hazard below can be answered before anything is recorded into the pass.
+      const material = this._currentMaterial;
+      const customResources = material === null ? null : this._getOrCreateCustomResources(material, device);
+      const uniformPlan = material === null ? null : planUserUniformUpload(material, customResources!, device, 'sprite:material-user-uniform-buffer');
 
       // A texture this batch samples whose content/size changed since it was last
       // uploaded will have its re-upload land on the queue timeline before the
@@ -729,30 +739,29 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       // open pass. End (submit) the pass first so those draws capture the
       // pre-mutation content, then reopen and re-upload into the fresh slice.
       if (this._instanceArena.cursor > 0 && this._batchWouldMutateTexture(backend)) {
-        backend._passCoordinator.endPass();
-        active = backend._passCoordinator.acquirePass();
-        this._instanceArena.resetPass();
-        this._instanceArena.syncPass(active);
+        active = this._reopenPass(backend);
       }
 
       // Resolving the transform storage may reallocate (and free) its GPU buffer;
       // earlier batches in this open pass still reference the old one, so end the
       // pass first when it already holds batches, then reopen with a fresh slice.
       if (this._instanceArena.cursor > 0 && backend._transformStorageWouldGrow(needCount)) {
-        backend._passCoordinator.endPass();
-        active = backend._passCoordinator.acquirePass();
-        this._instanceArena.resetPass();
-        this._instanceArena.syncPass(active);
+        active = this._reopenPass(backend);
+      }
+
+      // Same shape, for the material's own uniform buffer: this batch is about to
+      // write it at offset 0, and a draw already recorded into the open pass reads
+      // that exact buffer — writes land on the queue timeline ahead of the whole
+      // submit, so the earlier draw would silently pick up this batch's values.
+      if (customResources !== null && uniformPlan !== null && this._uniformWriteWouldAlias(uniformPlan)) {
+        active = this._reopenPass(backend);
       }
 
       if (!this._instanceArena.fits(batchBytes)) {
         // Growing reallocates the arena buffer; end (submit) the pass first so no
         // in-flight draw references the buffer we are about to destroy.
         if (this._instanceArena.cursor > 0) {
-          backend._passCoordinator.endPass();
-          active = backend._passCoordinator.acquirePass();
-          this._instanceArena.resetPass();
-          this._instanceArena.syncPass(active);
+          active = this._reopenPass(backend);
         }
 
         this._instanceArena.grow(device, batchBytes);
@@ -771,7 +780,6 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       const storage = backend.getTransformStorageBuffer(needCount);
       const transformBindGroup = this._getOrCreateTransformBindGroup(device, uniformBuffer, storage.buffer, storage.tintBuffer);
 
-      const material = this._currentMaterial;
       const stencil = backend._passCoordinator.stencilActive;
 
       if (material === null) {
@@ -786,8 +794,12 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
         pass.drawIndexed(indicesPerSprite, this._instanceCount, 0, 0, 0);
       } else {
         pass.pushDebugGroup('SpriteMaterial (custom)');
-        this._drawCustomBatch(pass, device, backend, material, transformBindGroup, stencil, instanceBuffer, offset);
+        this._drawCustomBatch(pass, device, backend, material, customResources!, uniformPlan!, transformBindGroup, stencil, instanceBuffer, offset);
         pass.popDebugGroup();
+
+        // This draw now reads the material's uniform buffer for as long as the
+        // pass stays open, which is what the alias check above consults.
+        this._uniformBuffersInPass.add(customResources!.userUniformBuffer!);
       }
 
       backend.stats.batches++;
@@ -821,12 +833,9 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       }
     }
 
-    // Batch flushes no longer submit; the backend ends the pass at genuine
-    // boundaries. The exception is a custom-material batch, isolated above.
-    if (isCustom) {
-      backend._passCoordinator.endPass();
-    }
-
+    // Batch flushes never submit; the backend ends the pass at genuine
+    // boundaries, and the hazard checks above end it early when this batch would
+    // retroactively change data an already-recorded draw reads.
     this._instanceCount = 0;
     this._maxNodeIndex = 0;
     this._resetSlots();
@@ -899,6 +908,53 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     }
 
     return false;
+  }
+
+  /**
+   * Discard the per-pass uniform-hazard bookkeeping when `active` is a pass this
+   * renderer has not recorded into yet. The pass may have been ended by the
+   * coordinator at a genuine boundary or by another renderer, so pass identity —
+   * not this renderer's own actions — is what the set is keyed to.
+   */
+  private _syncUniformHazardPass(active: WebGpuActiveRenderPass): void {
+    if (this._uniformHazardPass === active) {
+      return;
+    }
+
+    this._uniformHazardPass = active;
+    this._uniformBuffersInPass.clear();
+  }
+
+  /**
+   * End (submit) the open pass and reopen a fresh one, resetting everything
+   * scoped to a single pass: the instance arena's slice and the set of uniform
+   * buffers the pass's draws read.
+   */
+  private _reopenPass(backend: WebGpuBackend): WebGpuActiveRenderPass {
+    backend._passCoordinator.endPass();
+
+    const active = backend._passCoordinator.acquirePass();
+
+    this._instanceArena.resetPass();
+    this._instanceArena.syncPass(active);
+    this._syncUniformHazardPass(active);
+
+    return active;
+  }
+
+  /**
+   * Whether this batch's planned uniform write would land on a buffer a draw
+   * already recorded into the open pass reads. `queue.writeBuffer` is ordered
+   * against the *submit*, not against the individual draws inside it, so the
+   * earlier draw would sample this batch's values. A buffer being replaced
+   * counts too: the apply step destroys the outgrown one.
+   */
+  private _uniformWriteWouldAlias(upload: UserUniformUpload): boolean {
+    if (upload.staleBuffer !== null && this._uniformBuffersInPass.has(upload.staleBuffer)) {
+      return true;
+    }
+
+    return upload.writes && this._uniformBuffersInPass.has(upload.buffer);
   }
 
   /**
@@ -1449,17 +1505,18 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     device: GPUDevice,
     backend: WebGpuBackend,
     material: SpriteMaterial,
+    resources: CustomSpriteResources,
+    uniformUpload: UserUniformUpload,
     transformBindGroup: GPUBindGroup,
     stencil: boolean,
     instanceBuffer: GPUBuffer,
     instanceByteOffset: number,
   ): void {
-    const resources = this._getOrCreateCustomResources(material, device);
     const baseTexture = this._currentBaseTexture ?? Texture.empty;
 
-    // Uploaded only when the material's uniform values changed since the last
-    // frame; a static material issues zero writes here.
-    this._uploadUserUniforms(material, resources, device);
+    // Planned before the pass was settled; the write only happens when the
+    // material's values actually changed since its last upload.
+    applyUserUniformUpload(uniformUpload, resources, device);
 
     const pipeline = this._getOrCreateCustomPipeline(resources, this._currentBlendMode!, backend.renderTargetFormat, stencil, device);
 
@@ -1639,39 +1696,6 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     }
 
     return device.createBindGroupLayout({ label: 'sprite:material-bind-group-layout', entries });
-  }
-
-  private _uploadUserUniforms(material: SpriteMaterial, resources: CustomSpriteResources, device: GPUDevice): void {
-    const scalarValues = collectScalarUniforms(material);
-
-    // Always keep a UBO (even if empty) since binding 0 of the user layout is
-    // fixed. Min size 16 bytes to satisfy WebGPU's minimum buffer size. The
-    // buffer is reused across frames — only (re)created when the slot count
-    // outgrows its capacity.
-    const bufferBytes = userUniformBufferBytes(scalarValues.length);
-    let forceWrite = false;
-
-    if (resources.userUniformBuffer === null || resources.userUniformBufferCapacity < bufferBytes) {
-      resources.userUniformBuffer?.destroy();
-      resources.userUniformBufferCapacity = bufferBytes;
-      resources.userUniformBuffer = device.createBuffer({
-        label: 'sprite:material-user-uniform-buffer',
-        size: bufferBytes,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-      });
-      // A fresh buffer holds undefined contents and voids any bind group that
-      // referenced the old identity.
-      forceWrite = true;
-      resources.userUniform.bindGroup = null;
-      resources.userUniform.bindGroupBuffer = null;
-    }
-
-    // Pack into the reused scratch and upload only when the values changed.
-    if (packUserUniforms(scalarValues, resources.userUniform, forceWrite)) {
-      const data = resources.userUniform.data;
-
-      device.queue.writeBuffer(resources.userUniformBuffer, 0, data.buffer, data.byteOffset, bufferBytes);
-    }
   }
 
   private _getUserBindGroup(material: SpriteMaterial, resources: CustomSpriteResources, backend: WebGpuBackend, device: GPUDevice): GPUBindGroup {

--- a/src/rendering/webgpu/webgpuUserUniforms.ts
+++ b/src/rendering/webgpu/webgpuUserUniforms.ts
@@ -90,6 +90,87 @@ export interface UserUniformState {
   bindGroupSamplers: GPUSampler[];
 }
 
+/**
+ * What one batch is about to do to a material's user-uniform buffer, decided
+ * before anything is recorded into the open render pass.
+ *
+ * The upload is split into a plan and an apply step because the write is a
+ * hazard, not a detail: it lands on the queue timeline ahead of the whole
+ * submit, so a draw already recorded into the open pass would read this batch's
+ * values instead of its own. The caller answers that with its pass, then
+ * applies — see {@link planUserUniformUpload} and {@link applyUserUniformUpload}.
+ */
+export interface UserUniformUpload {
+  /** The buffer this batch binds, freshly created when the previous one was too small. */
+  readonly buffer: GPUBuffer;
+  /** Whether the packed bytes differ from what `buffer` already holds. */
+  readonly writes: boolean;
+  /** Byte length the write covers, starting at offset 0. */
+  readonly byteLength: number;
+  /** The outgrown buffer this upload replaces, destroyed by the apply step. */
+  readonly staleBuffer: GPUBuffer | null;
+}
+
+/** The subset of a material's cached GPU resources this module owns. */
+export interface UserUniformResources {
+  userUniformBuffer: GPUBuffer | null;
+  userUniformBufferCapacity: number;
+  readonly userUniform: UserUniformState;
+}
+
+/**
+ * Pack `material`'s scalar uniforms and decide what the upload needs, without
+ * touching the queue: the returned {@link UserUniformUpload} says which buffer
+ * the batch binds and whether the bytes must be re-uploaded at all. A material
+ * whose values did not change since its last upload writes nothing.
+ *
+ * A buffer that outgrew its capacity is replaced here but the old one is NOT
+ * destroyed yet — it may still be read by a draw in the open pass, and the
+ * caller needs {@link UserUniformUpload.staleBuffer} to see that before
+ * {@link applyUserUniformUpload} frees it.
+ */
+export function planUserUniformUpload(material: Material, resources: UserUniformResources, device: GPUDevice, label: string): UserUniformUpload {
+  const scalarValues = collectScalarUniforms(material);
+  // Always keep a UBO (even if empty) since binding 0 of the user layout is
+  // fixed, with WebGPU's 16-byte minimum as the floor.
+  const byteLength = userUniformBufferBytes(scalarValues.length);
+  const needsNewBuffer = resources.userUniformBuffer === null || resources.userUniformBufferCapacity < byteLength;
+  let staleBuffer: GPUBuffer | null = null;
+
+  if (needsNewBuffer) {
+    staleBuffer = resources.userUniformBuffer;
+    resources.userUniformBufferCapacity = byteLength;
+    resources.userUniformBuffer = device.createBuffer({
+      label,
+      size: byteLength,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    // A fresh buffer holds undefined contents and voids any bind group that
+    // referenced the old identity.
+    resources.userUniform.bindGroup = null;
+    resources.userUniform.bindGroupBuffer = null;
+  }
+
+  return {
+    buffer: resources.userUniformBuffer!,
+    // A recreated buffer holds undefined contents, so it always writes.
+    writes: packUserUniforms(scalarValues, resources.userUniform, needsNewBuffer),
+    byteLength,
+    staleBuffer,
+  };
+}
+
+/** Free the outgrown buffer and upload the packed bytes, once the pass is settled. */
+export function applyUserUniformUpload(upload: UserUniformUpload, resources: UserUniformResources, device: GPUDevice): void {
+  upload.staleBuffer?.destroy();
+
+  if (upload.writes) {
+    const data = resources.userUniform.data;
+
+    device.queue.writeBuffer(upload.buffer, 0, data.buffer, data.byteOffset, upload.byteLength);
+  }
+}
+
 /** Fresh, empty {@link UserUniformState} for a newly created material resource bundle. */
 export function createUserUniformState(): UserUniformState {
   return {

--- a/test/rendering/webgpu-custom-material-render-passes.test.ts
+++ b/test/rendering/webgpu-custom-material-render-passes.test.ts
@@ -1,0 +1,178 @@
+/**
+ * WebGPU custom-material batches share a render pass.
+ *
+ * Every custom-material flush used to end (and submit) its own render pass, so
+ * a scene whose sprites carry materials paid one `beginRenderPass` +
+ * `queue.submit` per BATCH instead of one per frame. The custom path binds a
+ * single base texture, so it also flushes on every base-texture change — the
+ * two together turn N sprites over N textures into N render passes.
+ *
+ * The submit existed to order one hazard: a batch re-uploads its material's
+ * user-uniform buffer at offset 0, and two draws in one submit would both read
+ * the last write. That is a write-after-read hazard on a specific buffer, not a
+ * property of custom batches — an unchanged material writes nothing at all.
+ *
+ * These tests drive the REAL WebGpuBackend + sprite renderer against a mock
+ * device (see webgpuMockEnvironment) and require that batches which write
+ * nothing share one pass, while a batch that does rewrite a buffer an earlier
+ * draw in the open pass already read still gets its own.
+ */
+
+import { Color } from '#core/Color';
+import { ShaderSource } from '#rendering/material/ShaderSource';
+import { SpriteMaterial } from '#rendering/material/SpriteMaterial';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Sprite } from '#rendering/sprite/Sprite';
+import type { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { createCanvasTexture, createMockBackend, createMockWebGpuEnvironment } from './webgpuMockEnvironment';
+
+const renderFrame = (backend: WebGpuBackend, nodes: readonly RenderNode[]): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+
+  for (const node of nodes) {
+    node.render(backend);
+  }
+
+  backend.flush();
+};
+
+// Fragment-only WGSL: the engine prepends the canonical sprite vertex module.
+const spriteFragmentWgsl = `
+struct UserUniforms { color: vec4<f32> };
+@group(2) @binding(0) var<uniform> u_user: UserUniforms;
+
+@fragment
+fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  let base = textureSample(u_texture, u_sampler, input.texcoord);
+  return vec4<f32>(base.rgb * u_user.color.rgb, 1.0);
+}
+`.trim();
+
+const createMaterial = (color: Float32Array): SpriteMaterial =>
+  new SpriteMaterial({
+    shader: new ShaderSource({ wgsl: spriteFragmentWgsl }),
+    uniforms: { u_userColor: color },
+  });
+
+describe('WebGPU custom-material batches and render passes', () => {
+  test('sprites on distinct base textures flush separately but stay in one render pass', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createMockBackend(environment);
+      const material = createMaterial(new Float32Array([1, 0, 0.5, 1]));
+      const nodes = [new Sprite(createCanvasTexture()), new Sprite(createCanvasTexture()), new Sprite(createCanvasTexture())];
+
+      for (const sprite of nodes) {
+        sprite.material = material;
+      }
+
+      // Warmup: first frame creates the material's buffer and uploads it once.
+      renderFrame(backend, nodes);
+
+      const drawMark = environment.drawIndexedCount();
+
+      renderFrame(backend, nodes);
+
+      // The custom path binds one base texture, so three textures are still
+      // three batches — that part is the separate multi-texture question.
+      expect(environment.drawIndexedCount()).toBe(drawMark + 3);
+      // But nothing wrote a buffer an earlier draw reads, so one pass carries
+      // all three.
+      expect(backend.stats.renderPasses).toBe(1);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('distinct materials with unchanged uniforms share one render pass', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createMockBackend(environment);
+      const texture = createCanvasTexture();
+      const nodes = [new Sprite(texture), new Sprite(texture), new Sprite(texture)];
+
+      nodes[0]!.material = createMaterial(new Float32Array([1, 0, 0, 1]));
+      nodes[1]!.material = createMaterial(new Float32Array([0, 1, 0, 1]));
+      nodes[2]!.material = createMaterial(new Float32Array([0, 0, 1, 1]));
+
+      renderFrame(backend, nodes);
+
+      const drawMark = environment.drawIndexedCount();
+
+      renderFrame(backend, nodes);
+
+      expect(environment.drawIndexedCount()).toBe(drawMark + 3);
+      expect(backend.stats.renderPasses).toBe(1);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('a default batch and a custom batch share one render pass', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createMockBackend(environment);
+      const texture = createCanvasTexture();
+      const plain = new Sprite(texture);
+      const custom = new Sprite(createCanvasTexture());
+
+      custom.material = createMaterial(new Float32Array([1, 1, 0, 1]));
+
+      // Warmup: the first frame legitimately splits the pass, because a texture
+      // sampled by a batch is uploaded lazily and that upload would retroactively
+      // change draws already recorded.
+      renderFrame(backend, [plain, custom, new Sprite(texture)]);
+      renderFrame(backend, [plain, custom, new Sprite(texture)]);
+
+      expect(backend.stats.renderPasses).toBe(1);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('a material rewritten between two of its own batches gets a fresh pass for the second', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createMockBackend(environment);
+      const material = createMaterial(new Float32Array([1, 0, 0, 1]));
+      const nodes = [new Sprite(createCanvasTexture()), new Sprite(createCanvasTexture()), new Sprite(createCanvasTexture())];
+
+      for (const sprite of nodes) {
+        sprite.material = material;
+      }
+
+      // Warmup, so the lazy texture uploads are not what splits the pass below.
+      renderFrame(backend, nodes);
+
+      // Each sprite has its own base texture, so rendering the next one flushes
+      // the previous batch. Mutating the uniforms between the second and third
+      // render means the flush of the SECOND batch rewrites the very buffer the
+      // FIRST batch's draw — already recorded into the open pass — reads.
+      backend.resetStats();
+      backend.clear(Color.black);
+      nodes[0]!.render(backend);
+      nodes[1]!.render(backend);
+      material.uniforms.u_userColor = new Float32Array([0, 1, 0, 1]);
+      nodes[2]!.render(backend);
+      backend.flush();
+
+      expect(backend.stats.renderPasses).toBe(2);
+
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+});


### PR DESCRIPTION
`NEU-O6` from the review master — the one open HIGH, and the only finding on the list that takes the browser down.

## What it was

Every custom-material flush ended and submitted its own render pass. The custom sprite path also binds a *single* base texture, so it flushes on every base-texture change. Together, N sprites over N textures became N render passes and N `queue.submit` calls per frame.

Measured on `mixed-material` (4 materials, 4 textures), headless Chromium, NVIDIA Blackwell, `--frames` overridden for iteration speed:

| n | GPU frame before | after |
|---|---|---|
| 1 000 | 226 ms | **6.98 ms** |
| 5 000 | 17.7 s | **23.6 ms** |
| 25 000 | wedged the tab | **81.6 ms** |

CPU per frame at n = 1 000 goes 20.2 ms → 3.3 ms. Draw-call counts are unchanged at every size (1 000 / 5 000 / 25 000): the cost was the pass and the submit wrapped around each draw, not the draw.

Verified by isolation before writing the fix — stubbing out the per-flush `endPass()` alone reproduced the same 226 ms → 7 ms at identical draw counts.

## Why the submit was there, and what replaces it

It ordered a real hazard: a batch re-uploads its material's user-uniform buffer at offset 0, and `queue.writeBuffer` is ordered against the *submit*, not against the individual draws inside it — so a draw already recorded into the open pass would sample the later batch's values.

That hazard belongs to one buffer on one write, not to custom batches as a class. A material whose uniform values did not change writes nothing at all, which is the overwhelmingly common case.

The upload therefore splits in two:

- `planUserUniformUpload` packs the material's uniforms into the existing CPU mirror and reports whether the bytes differ from what the buffer holds. It touches no queue, so the answer is available *before* anything is recorded into the pass. A buffer that outgrew its capacity is replaced here but not yet destroyed — the old identity is handed back as `staleBuffer`, because a draw in the open pass may still read it.
- `flush` answers the hazard exactly the way it already answers the two existing ones (a texture upload that would mutate content mid-pass, transform storage that would reallocate): end the pass only when this batch would rewrite a buffer an already-recorded draw reads.
- `applyUserUniformUpload` frees the outgrown buffer and issues the write, once the pass is settled.

The three copies of the end-reopen-reset sequence collapse into `_reopenPass`, which also resets the new per-pass bookkeeping. Pass membership is keyed to the pass object's identity, so a pass ended by anyone — the coordinator at a genuine boundary, another renderer — clears it on the next acquisition.

## Tests

`test/rendering/webgpu-custom-material-render-passes.test.ts` drives the real backend + sprite renderer against the mock device and pins both directions: batches that write nothing share one pass (across base textures, across distinct materials, and mixed with default batches), while a material rewritten between two of its own batches still gets a fresh pass for the second. All four failed before this change.

Full rendering suite: 1705 tests pass. `pnpm verify:quick`: all 11 gates pass.

## Found on the way, not fixed here

- `WebGpuMeshRenderer` ends the pass after **every** instanced draw (`:545`, `:909`) — the same defect class, and wider, since it is not limited to custom materials. Recorded as its own point.
- The custom path's missing multi-texture batching is what leaves 25 000 draws on the table at n = 25 000. It is shared with the WebGL2 backend and changes the material shader contract (`u_texture` is a single binding in both WGSL and GLSL), so it needs a decision, not a patch.