### PR TITLE
perf(rendering): cache WebGL2 texture binds per unit and stop double-binding

### DIFF
--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -259,7 +259,12 @@ export class WebGl2Backend implements RenderBackend {
   private _renderGroupTransformId = 0;
   private _shader: Shader | null = null;
   private _blendMode: BlendModes | null = null;
-  private _texture: Texture | RenderTexture | null = null;
+  // What GL currently has bound to TEXTURE_2D on each texture unit, indexed by
+  // unit. Keyed on the `WebGLTexture` handle rather than the user-side
+  // `Texture`, so a releaseGpu / re-upload cycle — which hands the same
+  // `Texture` a brand new handle — can never match a stale slot. A hole
+  // (`undefined`) means "unit never touched", which reads as a miss and binds.
+  private readonly _boundHandles: Array<WebGLTexture | null> = [];
   private _textureUnit = 0;
   private _vao: WebGl2VertexArrayObject | null = null;
   private _clearColor: Color = new Color();
@@ -928,18 +933,15 @@ export class WebGl2Backend implements RenderBackend {
     }
 
     if (texture === null) {
-      if (this._texture !== null) {
-        this._context.bindTexture(this._context.TEXTURE_2D, null);
-        this._texture = null;
-      }
+      this._bindTextureHandle(null);
 
       return this;
     }
 
-    const textureState = this._syncTexture(texture);
-
-    this._context.bindTexture(this._context.TEXTURE_2D, textureState.handle);
-    this._texture = texture;
+    // `_syncTexture` performs the bind itself (through the same per-unit cache)
+    // because its parameter and upload calls act on whatever is bound to the
+    // active unit — binding a second time here would only duplicate GL work.
+    this._syncTexture(texture);
 
     return this;
   }
@@ -951,12 +953,35 @@ export class WebGl2Backend implements RenderBackend {
    * renderer's private node-data texture) must route the unit switch through
    * here instead of calling `gl.activeTexture` directly — otherwise the cache
    * goes stale and a later {@link bindTexture} can skip its own `activeTexture`
-   * call, binding to the wrong unit. After this returns the caller may issue its
-   * own raw `gl.bindTexture` on the now-active unit.
+   * call, binding to the wrong unit. Bind the handle itself with
+   * {@link bindRawTexture} rather than `gl.bindTexture`, so the per-unit bind
+   * cache keeps mirroring GL.
    * @internal
    */
   public setActiveTextureUnit(unit: number): this {
     this._setTextureUnit(unit);
+
+    return this;
+  }
+
+  /**
+   * Bind a raw `WebGLTexture` (or `null`) to the active texture unit through
+   * the backend's per-unit bind cache.
+   *
+   * For renderer-private handles that have no user-side {@link Texture} — the
+   * text renderer's node-data texture is the only one today. Going through here
+   * instead of `gl.bindTexture` keeps the cache coherent: the backend both
+   * skips a redundant re-bind of this handle and still re-binds when a managed
+   * texture has to take the unit back.
+   *
+   * A raw handle deleted behind the cache's back needs no notification: GL
+   * unbinds it everywhere, and a deleted `WebGLTexture` can never be handed out
+   * again, so a slot still naming it can only ever cost one redundant bind —
+   * never suppress a needed one.
+   * @internal
+   */
+  public bindRawTexture(handle: WebGLTexture | null): this {
+    this._bindTextureHandle(handle);
 
     return this;
   }
@@ -1085,6 +1110,38 @@ export class WebGl2Backend implements RenderBackend {
       this._textureUnit = unit;
 
       gl.activeTexture(gl.TEXTURE0 + unit);
+    }
+  }
+
+  /**
+   * Bind `handle` to the active texture unit, skipping the call when GL already
+   * has it there. Per-unit rather than global: the same handle legitimately
+   * occupies several units at once (batched sprite slots), so a single
+   * last-bound slot would either miss those binds or suppress needed ones.
+   */
+  private _bindTextureHandle(handle: WebGLTexture | null): void {
+    const unit = this._textureUnit;
+
+    if (this._boundHandles[unit] === handle) {
+      return;
+    }
+
+    this._context.bindTexture(this._context.TEXTURE_2D, handle);
+    this._boundHandles[unit] = handle;
+  }
+
+  /**
+   * Drop every cached binding of `handle`. Deleting a texture unbinds it from
+   * every unit of the current context (GL spec), so the cache has to follow
+   * without issuing any GL call of its own.
+   */
+  private _forgetTextureHandle(handle: WebGLTexture): void {
+    const boundHandles = this._boundHandles;
+
+    for (let unit = 0; unit < boundHandles.length; unit++) {
+      if (boundHandles[unit] === handle) {
+        boundHandles[unit] = null;
+      }
     }
   }
 
@@ -1549,7 +1606,7 @@ export class WebGl2Backend implements RenderBackend {
     this._renderer = null;
     this._shader = null;
     this._blendMode = null;
-    this._texture = null;
+    this._boundHandles.length = 0;
     this._boundFramebuffer = null;
     this._activeDrawCommand = null;
     this._transformTextureCount = -1;
@@ -1711,7 +1768,7 @@ export class WebGl2Backend implements RenderBackend {
     // the next bind must run unconditionally rather than short-circuiting on a
     // stale identity match.
     this._boundFramebuffer = null;
-    this._texture = null;
+    this._boundHandles.length = 0;
     this._textureUnit = 0;
     this._vao = null;
     this._shader = null;
@@ -1791,7 +1848,7 @@ export class WebGl2Backend implements RenderBackend {
     }
 
     for (const texture of [...this._textureStates.keys()]) {
-      this._evictTexture(texture, false);
+      this._evictTexture(texture);
     }
   }
 
@@ -1823,12 +1880,12 @@ export class WebGl2Backend implements RenderBackend {
 
     if (!state) {
       this._subscribeToDestroy(texture, this._textureDestroyHandlers, () => {
-        this._evictTexture(texture, true);
+        this._evictTexture(texture);
       });
 
       if (texture instanceof Texture) {
         this._subscribeToRelease(texture, this._textureReleaseHandlers, () => {
-          this._evictTexture(texture, true, false);
+          this._evictTexture(texture, false);
         });
       }
 
@@ -1885,7 +1942,7 @@ export class WebGl2Backend implements RenderBackend {
     this._unsubscribeFromDestroy(target, this._renderTargetDestroyHandlers);
 
     if (target instanceof RenderTexture) {
-      this._evictTexture(target, false);
+      this._evictTexture(target);
     }
 
     if (state) {
@@ -1924,7 +1981,7 @@ export class WebGl2Backend implements RenderBackend {
    * real, later `destroy()`. The release subscription is always dropped —
    * `_getTextureState` re-subscribes it fresh if the handle is bound again.
    */
-  private _evictTexture(texture: Texture | RenderTexture, rebind: boolean, unsubscribeDestroy = true): void {
+  private _evictTexture(texture: Texture | RenderTexture, unsubscribeDestroy = true): void {
     const state = this._textureStates.get(texture);
 
     if (unsubscribeDestroy) {
@@ -1936,23 +1993,11 @@ export class WebGl2Backend implements RenderBackend {
     }
 
     if (state) {
-      if (this._texture === texture) {
-        this._context.bindTexture(this._context.TEXTURE_2D, null);
-        this._texture = null;
-      }
-
       this._context.deleteTexture(state.handle);
+      this._forgetTextureHandle(state.handle);
       this._accountant.free(state.accountedBytes);
       state.accountedBytes = 0;
       this._textureStates.delete(texture);
-    }
-
-    if (this._texture === texture) {
-      this._texture = null;
-    }
-
-    if (rebind && this._texture !== null) {
-      this.bindTexture(this._texture);
     }
   }
 
@@ -2157,7 +2202,7 @@ export class WebGl2Backend implements RenderBackend {
     const state = this._getTextureState(texture);
     const version = texture instanceof RenderTexture ? texture.textureVersion : texture.version;
 
-    gl.bindTexture(gl.TEXTURE_2D, state.handle);
+    this._bindTextureHandle(state.handle);
 
     if (state.version !== version) {
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, texture.scaleMode);

--- a/src/rendering/webgl2/WebGl2TextRenderer.ts
+++ b/src/rendering/webgl2/WebGl2TextRenderer.ts
@@ -266,7 +266,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
 
     vao.connect(this._createVaoRuntime(gl, vaoHandle));
 
-    const nodeDataTexture = this._createNodeDataTexture(gl, initialNodeCapacity);
+    const nodeDataTexture = this._createNodeDataTexture(backend, initialNodeCapacity);
 
     this._connection = { gl, buffers, vertexBuffer, indexBuffer, vao, nodeDataTexture, nodeDataCapacity: initialNodeCapacity };
   }
@@ -429,17 +429,19 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       let cap = c.nodeDataCapacity;
       while (cap < nodeCount) cap *= 2;
       gl.deleteTexture(c.nodeDataTexture);
-      c.nodeDataTexture = this._createNodeDataTexture(gl, cap);
+      c.nodeDataTexture = this._createNodeDataTexture(this.getBackend(), cap);
       c.nodeDataCapacity = cap;
     }
 
-    // Route the unit switch through the backend so its texture-unit cache stays
-    // in sync. A raw gl.activeTexture here would leave the cache reading unit 0,
-    // and the atlas bindTexture(_, 0) in _drawBatches would then skip its own
-    // switch and bind the atlas to unit 1 — leaving the SDF sampler (unit 0)
-    // empty and the text invisible whenever it is the first draw of a frame.
-    this.getBackend().setActiveTextureUnit(1);
-    gl.bindTexture(gl.TEXTURE_2D, c.nodeDataTexture);
+    // Route both the unit switch and the bind through the backend so its
+    // texture-unit and per-unit bind caches stay in sync. A raw gl.activeTexture
+    // here would leave the unit cache reading unit 0, and the atlas
+    // bindTexture(_, 0) in _drawBatches would then skip its own switch and bind
+    // the atlas to unit 1 — leaving the SDF sampler (unit 0) empty and the text
+    // invisible whenever it is the first draw of a frame. A raw gl.bindTexture
+    // would likewise leave the bind cache claiming unit 1 still holds whatever
+    // managed texture was there last.
+    this.getBackend().setActiveTextureUnit(1).bindRawTexture(c.nodeDataTexture);
     gl.texSubImage2D(
       gl.TEXTURE_2D,
       0,
@@ -924,16 +926,23 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
 
   // ── WebGL helpers ─────────────────────────────────────────────────────────
 
-  private _createNodeDataTexture(gl: WebGL2RenderingContext, capacity: number): WebGLTexture {
+  /**
+   * Allocate the renderer-private node-data texture. Both binds go through the
+   * backend so its per-unit bind cache keeps mirroring GL — the allocation
+   * happens on whatever unit is active, and leaving that unit's cached handle
+   * stale would let a later managed bind on the same unit be skipped.
+   */
+  private _createNodeDataTexture(backend: WebGl2Backend, capacity: number): WebGLTexture {
+    const gl = backend.context;
     const tex = gl.createTexture();
     if (tex === null) throw new Error('WebGl2TextRenderer: could not create node data texture.');
-    gl.bindTexture(gl.TEXTURE_2D, tex);
+    backend.bindRawTexture(tex);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F, nodeTexels, capacity, 0, gl.RGBA, gl.FLOAT, null);
-    gl.bindTexture(gl.TEXTURE_2D, null);
+    backend.bindRawTexture(null);
     return tex;
   }
 

--- a/test/rendering/webgl2-texture-bind-cache.test.ts
+++ b/test/rendering/webgl2-texture-bind-cache.test.ts
@@ -1,0 +1,223 @@
+/**
+ * WebGL2 per-unit texture bind cache.
+ *
+ * A logical bind used to cost two `gl.bindTexture` calls — `_syncTexture` bound
+ * unconditionally and `bindTexture` bound the very same handle again — and the
+ * backend remembered only the single last-bound texture, so nothing was ever
+ * skipped across units. These tests drive the REAL `WebGl2Backend` against the
+ * recording fake context and count the `gl.bindTexture` calls per unit, which
+ * is exactly the state the defect showed up in.
+ *
+ * The cache is keyed on the `WebGLTexture` handle rather than the user-side
+ * `Texture`, so a `releaseGpu` cycle — same `Texture`, brand new handle — must
+ * still re-bind; that is asserted here too.
+ */
+
+import type { Application } from '#core/Application';
+import { DataTexture } from '#rendering/texture/DataTexture';
+import { TextureFormat } from '#rendering/types';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { createFakeCanvas, createFakeWebGl2Context, GlRecorder, installFakeWebGl2Globals } from '../perf/rendering/fakeWebGl2';
+
+interface RecordedBind {
+  /** Texture unit that was active when the bind was issued. */
+  readonly unit: number;
+  readonly handle: unknown;
+}
+
+interface BindHarness {
+  readonly backend: WebGl2Backend;
+  /** Every `gl.bindTexture` issued since the last {@link reset}, in order. */
+  readonly binds: RecordedBind[];
+  readonly recorder: GlRecorder;
+  reset(): void;
+  destroy(): void;
+}
+
+const createBindHarness = (): BindHarness => {
+  installFakeWebGl2Globals();
+
+  const recorder = new GlRecorder();
+  const context = createFakeWebGl2Context(recorder);
+  const binds: RecordedBind[] = [];
+  const mutable = context as unknown as Record<string, unknown>;
+
+  // The fake context is a Proxy with no `set` trap, so these land on its target
+  // and every backend call goes through the spies.
+  const originalActiveTexture = context.activeTexture.bind(context) as (unit: number) => void;
+  const originalBindTexture = context.bindTexture.bind(context) as (target: number, handle: unknown) => void;
+  let activeUnit = 0;
+
+  mutable['activeTexture'] = (unit: number): void => {
+    activeUnit = unit - context.TEXTURE0;
+    originalActiveTexture(unit);
+  };
+  mutable['bindTexture'] = (target: number, handle: unknown): void => {
+    binds.push({ unit: activeUnit, handle });
+    originalBindTexture(target, handle);
+  };
+
+  const app = {
+    canvas: createFakeCanvas(64, 64, context),
+    options: { canvas: { width: 64, height: 64 }, rendering: { debug: false } },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  binds.length = 0;
+
+  return {
+    backend,
+    binds,
+    recorder,
+    reset(): void {
+      binds.length = 0;
+    },
+    destroy(): void {
+      backend.destroy();
+    },
+  };
+};
+
+const createTexture = (): DataTexture<TextureFormat.Rgba8> => new DataTexture({ width: 4, height: 4, format: TextureFormat.Rgba8 });
+
+describe('WebGL2 texture bind cache', () => {
+  let harness: BindHarness;
+
+  beforeEach(() => {
+    harness = createBindHarness();
+  });
+
+  afterEach(() => {
+    harness.destroy();
+  });
+
+  test('a logical bind issues exactly one gl.bindTexture', () => {
+    const texture = createTexture();
+
+    harness.backend.bindTexture(texture, 0);
+
+    expect(harness.binds).toHaveLength(1);
+
+    texture.destroy();
+  });
+
+  test('re-binding the same texture to the same unit issues no further gl.bindTexture', () => {
+    const texture = createTexture();
+
+    harness.backend.bindTexture(texture, 0);
+    harness.reset();
+
+    harness.backend.bindTexture(texture, 0);
+    harness.backend.bindTexture(texture, 0);
+
+    expect(harness.binds).toEqual([]);
+
+    texture.destroy();
+  });
+
+  test('the same texture on a second unit binds again — the cache is per unit, not global', () => {
+    const texture = createTexture();
+
+    harness.backend.bindTexture(texture, 0);
+    harness.reset();
+
+    harness.backend.bindTexture(texture, 1);
+
+    expect(harness.binds).toHaveLength(1);
+    expect(harness.binds[0]!.unit).toBe(1);
+
+    texture.destroy();
+  });
+
+  test('a unit remembers its binding across a detour to another unit', () => {
+    const first = createTexture();
+    const second = createTexture();
+
+    harness.backend.bindTexture(first, 0);
+    harness.backend.bindTexture(second, 1);
+    harness.reset();
+
+    // Unit 0 still holds `first` and unit 1 still holds `second`; neither
+    // needs a re-bind, even though the "last bound texture" is `second`.
+    harness.backend.bindTexture(first, 0);
+    harness.backend.bindTexture(second, 1);
+
+    expect(harness.binds).toEqual([]);
+
+    first.destroy();
+    second.destroy();
+  });
+
+  test('a texture upload still runs when the bind itself is skipped', () => {
+    const texture = createTexture();
+
+    harness.backend.bindTexture(texture, 0);
+    harness.reset();
+
+    const uploadsBefore = harness.recorder.textureUploads;
+
+    texture.commitRect(0, 1, 4, 1);
+    harness.backend.bindTexture(texture, 0);
+
+    // Only the bind is cached: the version bump must still reach GL, and it
+    // targets the texture the cache knows is already bound to unit 0.
+    expect(harness.binds).toEqual([]);
+    expect(harness.recorder.textureUploads).toBe(uploadsBefore + 1);
+
+    texture.destroy();
+  });
+
+  test('unbinding a unit is cached too', () => {
+    const texture = createTexture();
+
+    harness.backend.bindTexture(texture, 0);
+    harness.reset();
+
+    harness.backend.bindTexture(null, 0);
+    harness.backend.bindTexture(null, 0);
+
+    expect(harness.binds).toEqual([{ unit: 0, handle: null }]);
+
+    texture.destroy();
+  });
+
+  test('releasing a texture drops its cached handle, so the next bind re-binds', () => {
+    const texture = createTexture();
+
+    harness.backend.bindTexture(texture, 0);
+    harness.reset();
+
+    // The handle is deleted and re-created; the same `Texture` identity must
+    // not short-circuit the bind of its new handle.
+    texture.releaseGpu();
+    harness.backend.bindTexture(texture, 0);
+
+    expect(harness.binds).toHaveLength(1);
+    expect(harness.binds[0]!.unit).toBe(0);
+
+    texture.destroy();
+  });
+
+  test('a raw handle bound through the backend takes over the unit coherently', () => {
+    const texture = createTexture();
+    const raw = harness.backend.context.createTexture()!;
+
+    harness.backend.bindTexture(texture, 1);
+    harness.reset();
+
+    harness.backend.setActiveTextureUnit(1).bindRawTexture(raw);
+    // Repeating the raw bind is skipped …
+    harness.backend.bindRawTexture(raw);
+    // … but the managed texture has to take unit 1 back.
+    harness.backend.bindTexture(texture, 1);
+
+    expect(harness.binds).toHaveLength(2);
+    expect(harness.binds[0]).toEqual({ unit: 1, handle: raw });
+    expect(harness.binds[1]!.unit).toBe(1);
+    expect(harness.binds[1]!.handle).not.toBe(raw);
+
+    texture.destroy();
+  });
+});


### PR DESCRIPTION
Every logical texture bind issued **two** `gl.bindTexture` calls, and there was no per-unit bind cache at all: `_syncTexture` bound unconditionally, then `bindTexture` bound the same handle again, and `bindTexture` had no early-out even for a texture already bound to the same unit. The only cached state was a single global "last bound texture" slot.

## Change

- `_texture` (one global slot) becomes `_boundHandles[unit]`, keyed on the `WebGLTexture` **handle** rather than the user-side `Texture`. A `releaseGpu`/re-upload cycle hands the same `Texture` a fresh handle, so an object-keyed cache would match a stale slot; a handle-keyed one cannot.
- `_syncTexture` binds through the cache and `bindTexture` no longer re-binds. The version/upload/parameter block is untouched — only the bind is cached, never an upload.
- Raw-handle binds go through a new `@internal bindRawTexture(handle)` instead of `gl.bindTexture`, so the cache stays coherent rather than merely un-poisoned. Three sites in `WebGl2TextRenderer` were converted; `_createNodeDataTexture` now takes the backend instead of the raw context.
- `_evictTexture` sweeps every unit holding the deleted handle. GL already unbinds a deleted texture everywhere, so the sweep issues no GL call of its own.

## Two findings beyond the stated scope

- **`_evictTexture(…, rebind)` was dead.** After the two `_texture === texture` clears, `_texture` could only be non-null if it pointed at a *different*, already-bound texture — so the rebind re-bound something that was already bound. Parameter removed, four call sites updated.
- **A latent bug in the old evict path:** its null-bind hit *whatever unit was active*, not the unit the evicted texture actually occupied. The per-unit sweep replaces that.

## Measured

`textureBinds` counts real `gl.bindTexture` calls on the live context (the bench proxies the method and forwards unchanged) — the same ruler against which Pixi reports 0. Headless Chromium, ANGLE / NVIDIA RTX 5070 Ti (D3D11), 25 000 nodes:

| Archetype | Arm | Draws | Binds before | Binds after |
|---|---|---|---|---|
| `static-heavy` | current | 7 | 42 | **0** |
| `static-heavy` | retained | 8 | 48 | **0** |
| `mixed-blend` | current | 782 | 9384 | **0** |
| `mixed-blend` | retained | 782 | 9384 | **0** |
| `mixed-material-atlased` | current | 782 | 4692 | **0** |
| `mixed-material-atlased` | retained | 782 | 4692 | **0** |

Draw counts unchanged throughout. In steady state the engine now issues zero `gl.bindTexture` calls per frame.

Wall clock on `mixed-blend` @25k, three single-cell runs each: retained 1.310 / 1.387 / 1.417 ms → 0.998 / 1.080 / 0.993 ms (**−25 %**); current 23.603 / 23.340 / 24.150 ms → 23.145 / 23.045 / 23.437 ms (−2 %, bands touch). The 42.6 % `gl.bindTexture` share from the original profile does not translate into a 42 % frame win: in the immediate arm other CPU work dominates so heavily that the eliminated binds sit inside the noise band. The counter is the load-bearing evidence here, not the wall clock.

## Tests

New `test/rendering/webgl2-texture-bind-cache.test.ts` (8 tests) drives the real backend against the existing fake WebGL2 recording context, spying on `activeTexture`/`bindTexture` to record `(unit, handle)` pairs: one bind per logical bind, repeat bind on the same unit skipped, same texture on a second unit binds again, a unit remembers its binding across a detour, upload still runs when the bind is skipped, null-unbind cached, `releaseGpu` invalidates the slot, raw-bind takeover and handback. Re-introducing the second `gl.bindTexture` turns 7 of the 8 red.

Green: `test:core test/rendering`, `test:browser:webgl`, full node suite, `lint`, `typecheck`, `typecheck:test`, `docs:api:check`, `verify:quick`.

## Note for reviewers

Because `bindTexture` can now skip, a custom pass that grabs `backend.context` and calls `gl.bindTexture` directly is no longer self-healing on the next managed bind of that unit. No first-party code does this (checked `src/`, `packages/`, `examples/`); `bindRawTexture` is the supported route.