### PR TITLE
perf(rendering): skip material grouping on single-material scopes and drop its per-draw allocations

### DIFF
--- a/scripts/test-typecheck-baseline.json
+++ b/scripts/test-typecheck-baseline.json
@@ -86,7 +86,7 @@
     "test/rendering/filters/web-gl2-shader-filter.test.ts": 3,
     "test/rendering/gradient.test.ts": 1,
     "test/rendering/mask-source.test.ts": 1,
-    "test/rendering/material-grouping.test.ts": 15,
+    "test/rendering/material-grouping.test.ts": 5,
     "test/rendering/pass/web-gpu-pass-coordinator.test.ts": 1,
     "test/rendering/render-dispatch.test.ts": 1,
     "test/rendering/render-effects.test.ts": 3,

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -57,6 +57,13 @@ interface RetainedBackendHooks {
 interface MutableGroupScope extends GroupScope {
   _nextSeq: number;
   firstZ: number | null;
+  /**
+   * First-draw material of this scope, the `hasMixedMaterial` counterpart of
+   * {@link MutableGroupScope.firstZ}. `firstPipelineKey === null` means "no draw
+   * seen yet"; `firstBindKey` is only meaningful once it is set.
+   */
+  firstPipelineKey: number | null;
+  firstBindKey: number;
 }
 
 /**
@@ -403,6 +410,8 @@ export class RenderPlanBuilder {
     //     and paint the scope in the wrong order.
     //   - `_nextSeq`: a later normally-emitted sibling (e.g. a nested Container)
     //     in the same scope must not collide with a replayed slot's seq.
+    // The matching `hasMixedMaterial` fold needs no mirror here: it hangs off
+    // `_pushDrawEntry` below, which this path already goes through.
     const scope = this._currentScope();
 
     if (slot.seq >= scope._nextSeq) {
@@ -587,12 +596,15 @@ export class RenderPlanBuilder {
       kind: RenderEntryKind.Group,
       entries: [],
       hasMixedZ: false,
+      hasMixedMaterial: false,
       preserveDrawOrder: false,
       transformNode: null,
       retainedInstructions: null,
       retainedRecordTarget: null,
       _nextSeq: 0,
       firstZ: null,
+      firstPipelineKey: null,
+      firstBindKey: 0,
     };
 
     this._groupPool[this._groupPoolCursor] = scope;
@@ -600,12 +612,15 @@ export class RenderPlanBuilder {
 
     scope.entries.length = 0;
     scope.hasMixedZ = false;
+    scope.hasMixedMaterial = false;
     scope.preserveDrawOrder = preserveDrawOrder;
     scope.transformNode = null;
     scope.retainedInstructions = null;
     scope.retainedRecordTarget = null;
     scope._nextSeq = 0;
     scope.firstZ = null;
+    scope.firstPipelineKey = null;
+    scope.firstBindKey = 0;
 
     return scope;
   }
@@ -639,6 +654,25 @@ export class RenderPlanBuilder {
     return command;
   }
 
+  /**
+   * Fold a draw's material into the scope's `hasMixedMaterial` flag. Lives in
+   * {@link _pushDrawEntry} rather than beside the `firstZ`/`hasMixedZ` updates
+   * because materials exist on draws only: `_pushDrawEntry` is the single funnel
+   * every draw entry — freshly collected or retained-replayed — passes through,
+   * so no emit path can silently skip the bookkeeping and leave the flag `false`
+   * while the scope really does hold several materials.
+   */
+  private _foldMaterialIntoScope(scope: MutableGroupScope, command: DrawCommand): void {
+    const material = command.material;
+
+    if (scope.firstPipelineKey === null) {
+      scope.firstPipelineKey = material.pipelineKey;
+      scope.firstBindKey = material.bindKey;
+    } else if (!scope.hasMixedMaterial && (scope.firstPipelineKey !== material.pipelineKey || scope.firstBindKey !== material.bindKey)) {
+      scope.hasMixedMaterial = true;
+    }
+  }
+
   private _pushDrawEntry(seq: number, zIndex: number, command: DrawCommand): void {
     let entry = this._drawEntryPool[this._drawEntryPoolCursor];
 
@@ -652,7 +686,11 @@ export class RenderPlanBuilder {
     }
 
     this._drawEntryPoolCursor++;
-    this._currentScope().entries.push(entry);
+
+    const scope = this._currentScope();
+
+    this._foldMaterialIntoScope(scope, command);
+    scope.entries.push(entry);
   }
 
   private _pushGroupEntry(seq: number, zIndex: number, scope: GroupScope): void {

--- a/src/rendering/plan/RenderPlanOptimizer.ts
+++ b/src/rendering/plan/RenderPlanOptimizer.ts
@@ -1,9 +1,7 @@
-import type { DrawCommand, MaterialKey } from './RenderCommand';
+import type { DrawCommand } from './RenderCommand';
 import { RenderEntryKind } from './RenderCommand';
 import type { RenderPlan } from './RenderPlan';
 import type { DrawScopeEntry, GroupScope, ScopeEntry } from './RenderScope';
-
-const groupKey = (material: MaterialKey): string => `${material.pipelineKey}:${material.bindKey}`;
 
 const aabbOverlap = (a: DrawCommand, b: DrawCommand): boolean => a.minX < b.maxX && a.maxX > b.minX && a.minY < b.maxY && a.maxY > b.minY;
 
@@ -48,49 +46,63 @@ export class RenderPlanOptimizer {
       return;
     }
 
-    let segStart = 0;
+    // Two O(1) prechecks that make the whole segment scan disappear in the
+    // common case. The scan can only ever move a draw when the scope holds more
+    // than one material AND is allowed to reorder; without both, every segment
+    // walks its draws, allocates the per-z buckets, and then bails. A scope with
+    // a single material is by far the most frequent shape, so gating here — not
+    // deep inside `_overlapAwareGroup` — is what actually removes the cost.
+    if (scope.hasMixedMaterial && !scope.preserveDrawOrder) {
+      let segStart = 0;
 
-    for (let i = 0; i <= n; i++) {
-      // In-bounds when i < n.
-      const entry = i < n ? entries[i]! : null;
-      const isBoundary = entry === null || entry.kind === RenderEntryKind.Group || entry.kind === RenderEntryKind.Barrier;
+      for (let i = 0; i <= n; i++) {
+        // In-bounds when i < n.
+        const entry = i < n ? entries[i]! : null;
+        const isBoundary = entry === null || entry.kind === RenderEntryKind.Group || entry.kind === RenderEntryKind.Barrier;
 
-      if (isBoundary && i > segStart) {
-        const segEnd = i;
-        const segLen = segEnd - segStart;
-
-        if (segLen >= 1) {
-          this._materialGroupSegment(entries, segStart, segEnd, scope.preserveDrawOrder);
+        if (isBoundary && i > segStart) {
+          this._materialGroupSegment(entries, segStart, i);
         }
 
-        segStart = i + 1;
-      } else if (isBoundary) {
-        segStart = i + 1;
+        if (isBoundary) {
+          segStart = i + 1;
+        }
       }
     }
 
     this._assignGroupIndices(scope);
   }
 
+  /**
+   * Assigns the adjacency `groupIndex` the backends batch on. Runs on every
+   * scope unconditionally — unlike the reordering above, this is not an
+   * optimization the plan can go without.
+   *
+   * The previous material is carried as its two numeric key fields rather than a
+   * `${pipelineKey}:${bindKey}` string, so the walk allocates nothing per draw.
+   */
   private static _assignGroupIndices(scope: GroupScope): void {
     let nextGroupIndex = 1;
-    let prevKey: string | null = null;
-    let prevZ: number | null = null;
+    let hasPrev = false;
+    let prevPipelineKey = 0;
+    let prevBindKey = 0;
+    let prevZ = 0;
 
     for (const entry of scope.entries) {
       if (entry.kind !== RenderEntryKind.Draw) {
-        prevKey = null;
-        prevZ = null;
+        hasPrev = false;
 
         continue;
       }
 
-      const key = groupKey(entry.command.material);
+      const material = entry.command.material;
       const z = entry.zIndex;
 
-      if (prevKey === null || prevZ === null || key !== prevKey || z !== prevZ) {
+      if (!hasPrev || material.pipelineKey !== prevPipelineKey || material.bindKey !== prevBindKey || z !== prevZ) {
         nextGroupIndex++;
-        prevKey = key;
+        hasPrev = true;
+        prevPipelineKey = material.pipelineKey;
+        prevBindKey = material.bindKey;
         prevZ = z;
       }
 
@@ -98,21 +110,19 @@ export class RenderPlanOptimizer {
     }
   }
 
-  private static _materialGroupSegment(entries: ScopeEntry[], start: number, end: number, preserveDrawOrder: boolean): void {
-    const len = end - start;
-
-    if (len <= 1) {
+  private static _materialGroupSegment(entries: ScopeEntry[], start: number, end: number): void {
+    if (end - start <= 1) {
       return;
     }
 
-    const draws: Array<{ entry: DrawScopeEntry; origIdx: number }> = [];
+    const draws: DrawScopeEntry[] = [];
 
     for (let i = start; i < end; i++) {
       // In-bounds: start..end-1 lie within entries.
       const entry = entries[i]!;
 
       if (entry.kind === RenderEntryKind.Draw) {
-        draws.push({ entry, origIdx: i });
+        draws.push(entry);
       }
     }
 
@@ -120,37 +130,59 @@ export class RenderPlanOptimizer {
       return;
     }
 
-    if (!preserveDrawOrder) {
-      const zGroups = new Map<number, Array<{ entry: DrawScopeEntry; origIdx: number }>>();
+    const zGroups = new Map<number, DrawScopeEntry[]>();
 
-      for (const d of draws) {
-        const z = d.entry.zIndex;
-        const list = zGroups.get(z) ?? [];
+    for (const draw of draws) {
+      const list = zGroups.get(draw.zIndex);
 
-        list.push(d);
-        zGroups.set(z, list);
+      if (list === undefined) {
+        zGroups.set(draw.zIndex, [draw]);
+      } else {
+        list.push(draw);
       }
+    }
 
-      for (const zGroup of zGroups.values()) {
-        if (zGroup.length > 1) {
-          this._overlapAwareGroup(zGroup, entries, start, end);
-        }
+    for (const zGroup of zGroups.values()) {
+      if (zGroup.length > 1) {
+        this._overlapAwareGroup(zGroup, entries, start, end);
       }
     }
   }
 
-  private static _overlapAwareGroup(zGroup: Array<{ entry: DrawScopeEntry; origIdx: number }>, entries: ScopeEntry[], segStart: number, segEnd: number): void {
-    const keyGroups = new Map<string, Array<{ entry: DrawScopeEntry; origIdx: number }>>();
+  private static _overlapAwareGroup(zGroup: DrawScopeEntry[], entries: ScopeEntry[], segStart: number, segEnd: number): void {
+    // Bucket the z-group by material. The bucket index is a nested
+    // pipelineKey -> bindKey -> bucket map rather than a `${pipelineKey}:${bindKey}`
+    // string key: both ids come from monotonically growing intern registries
+    // with no documented upper bound, so a bit-packed composite would be a
+    // latent collision, and a string key would allocate once per draw.
+    // `keyGroups` keeps the buckets in first-seen order, which is the order the
+    // single-string map iterated in and the order the reorder below picks its
+    // one winning bucket from.
+    const bucketIndex = new Map<number, Map<number, DrawScopeEntry[]>>();
+    const keyGroups: DrawScopeEntry[][] = [];
 
-    for (const d of zGroup) {
-      const key = groupKey(d.entry.command.material);
-      const list = keyGroups.get(key) ?? [];
+    for (const draw of zGroup) {
+      const material = draw.command.material;
+      let byBindKey = bucketIndex.get(material.pipelineKey);
 
-      list.push(d);
-      keyGroups.set(key, list);
+      if (byBindKey === undefined) {
+        byBindKey = new Map<number, DrawScopeEntry[]>();
+        bucketIndex.set(material.pipelineKey, byBindKey);
+      }
+
+      const bucket = byBindKey.get(material.bindKey);
+
+      if (bucket === undefined) {
+        const created = [draw];
+
+        byBindKey.set(material.bindKey, created);
+        keyGroups.push(created);
+      } else {
+        bucket.push(draw);
+      }
     }
 
-    if (keyGroups.size <= 1) {
+    if (keyGroups.length <= 1) {
       return;
     }
 
@@ -158,9 +190,9 @@ export class RenderPlanOptimizer {
     // O(n) scan; with many same-z draws (e.g. cycled textures over a flat list)
     // that made this method O(n^2). A scope's entries are distinct objects, so a
     // single Map over `entries[segStart..segEnd)` yields the same first-match
-    // index `indexOf` returned — and the only reorder this method performs is the
-    // last thing it does before `break`, so no lookup ever runs against stale
-    // positions (the map stays valid for the whole scan).
+    // index `indexOf` returned — and this method performs at most one reorder,
+    // after which it returns, so no lookup ever runs against stale positions
+    // (the map stays valid for the whole scan).
     const positionIndex = new Map<ScopeEntry, number>();
 
     for (let i = segStart; i < segEnd; i++) {
@@ -168,101 +200,112 @@ export class RenderPlanOptimizer {
       positionIndex.set(entries[i]!, i);
     }
 
-    for (const group of keyGroups.values()) {
-      if (group.length <= 1) {
-        continue;
+    for (const group of keyGroups) {
+      if (this._tryReorderKeyGroup(group, entries, segStart, segEnd, positionIndex)) {
+        return;
       }
-
-      const positions: number[] = [];
-
-      for (const g of group) {
-        const pos = positionIndex.get(g.entry);
-
-        // The map holds only entries in [segStart, segEnd); a hit is in range.
-        if (pos !== undefined) {
-          positions.push(pos);
-        }
-      }
-
-      positions.sort((a, b) => a - b);
-
-      if (positions.length === 0) {
-        continue;
-      }
-
-      // Non-empty (guarded above); positions are valid indices in [segStart, segEnd).
-      const first = positions[0]!;
-      const last = positions[positions.length - 1]!;
-
-      if (last - first + 1 === positions.length) {
-        continue;
-      }
-
-      let blocked = false;
-
-      for (let p = first + 1; p < last && !blocked; p++) {
-        // In-bounds: p in (first, last) ⊂ [segStart, segEnd).
-        const mid = entries[p]!;
-
-        if (mid.kind !== RenderEntryKind.Draw) {
-          continue;
-        }
-
-        const midKey = groupKey(mid.command.material);
-
-        // group has length >= 1 (guarded above).
-        if (midKey === groupKey(group[0]!.entry.command.material)) {
-          continue;
-        }
-
-        for (const g of group) {
-          if (aabbOverlap(g.entry.command, mid.command)) {
-            blocked = true;
-
-            break;
-          }
-        }
-      }
-
-      if (blocked) {
-        continue;
-      }
-
-      const beforeFirst: ScopeEntry[] = [];
-
-      for (let p = segStart; p < first; p++) {
-        // In-bounds: p < first <= segEnd.
-        beforeFirst.push(entries[p]!);
-      }
-
-      const afterLast: ScopeEntry[] = [];
-
-      for (let p = last + 1; p < segEnd; p++) {
-        // In-bounds: p < segEnd.
-        afterLast.push(entries[p]!);
-      }
-
-      const groupSet = new Set(group.map(g => g.entry));
-      const betweenNonGroup: ScopeEntry[] = [];
-
-      for (let p = first; p <= last; p++) {
-        // In-bounds: first..last ⊂ [segStart, segEnd).
-        const entry = entries[p]!;
-
-        if (!groupSet.has(entry as DrawScopeEntry)) {
-          betweenNonGroup.push(entry);
-        }
-      }
-
-      const groupEntries: ScopeEntry[] = group.map(g => g.entry);
-      const reordered: ScopeEntry[] = [...beforeFirst, ...groupEntries, ...betweenNonGroup, ...afterLast];
-
-      for (let p = segStart; p < segEnd; p++) {
-        // reordered has exactly segEnd-segStart entries; p-segStart is in-bounds.
-        entries[p] = reordered[p - segStart]!;
-      }
-
-      break;
     }
+  }
+
+  /**
+   * Attempts to pull one material bucket's draws together into a contiguous run.
+   * Returns `true` when `entries[segStart..segEnd)` was rewritten, which ends the
+   * scan: the reorder invalidates the caller's `positionIndex`, so at most one
+   * bucket may win per segment.
+   */
+  private static _tryReorderKeyGroup(
+    group: DrawScopeEntry[],
+    entries: ScopeEntry[],
+    segStart: number,
+    segEnd: number,
+    positionIndex: Map<ScopeEntry, number>,
+  ): boolean {
+    if (group.length <= 1) {
+      return false;
+    }
+
+    const positions: number[] = [];
+
+    for (const draw of group) {
+      const pos = positionIndex.get(draw);
+
+      // The map holds only entries in [segStart, segEnd); a hit is in range.
+      if (pos !== undefined) {
+        positions.push(pos);
+      }
+    }
+
+    positions.sort((a, b) => a - b);
+
+    if (positions.length === 0) {
+      return false;
+    }
+
+    // Non-empty (guarded above); positions are valid indices in [segStart, segEnd).
+    const first = positions[0]!;
+    const last = positions[positions.length - 1]!;
+
+    if (last - first + 1 === positions.length) {
+      return false;
+    }
+
+    // group has length >= 1 (guarded above).
+    const groupMaterial = group[0]!.command.material;
+
+    for (let p = first + 1; p < last; p++) {
+      // In-bounds: p in (first, last) ⊂ [segStart, segEnd).
+      const mid = entries[p]!;
+
+      if (mid.kind !== RenderEntryKind.Draw) {
+        continue;
+      }
+
+      const midMaterial = mid.command.material;
+
+      if (midMaterial.pipelineKey === groupMaterial.pipelineKey && midMaterial.bindKey === groupMaterial.bindKey) {
+        continue;
+      }
+
+      for (const draw of group) {
+        if (aabbOverlap(draw.command, mid.command)) {
+          return false;
+        }
+      }
+    }
+
+    const beforeFirst: ScopeEntry[] = [];
+
+    for (let p = segStart; p < first; p++) {
+      // In-bounds: p < first <= segEnd.
+      beforeFirst.push(entries[p]!);
+    }
+
+    const afterLast: ScopeEntry[] = [];
+
+    for (let p = last + 1; p < segEnd; p++) {
+      // In-bounds: p < segEnd.
+      afterLast.push(entries[p]!);
+    }
+
+    const groupSet = new Set<ScopeEntry>(group);
+    const betweenNonGroup: ScopeEntry[] = [];
+
+    for (let p = first; p <= last; p++) {
+      // In-bounds: first..last ⊂ [segStart, segEnd).
+      const entry = entries[p]!;
+
+      if (!groupSet.has(entry)) {
+        betweenNonGroup.push(entry);
+      }
+    }
+
+    const reordered: ScopeEntry[] = [...beforeFirst, ...group, ...betweenNonGroup, ...afterLast];
+
+    for (let p = segStart; p < segEnd; p++) {
+      // reordered has exactly segEnd-segStart entries; p-segStart is in-bounds.
+      entries[p] = reordered[p - segStart]!;
+    }
+
+    return true;
   }
 }

--- a/src/rendering/plan/RenderScope.ts
+++ b/src/rendering/plan/RenderScope.ts
@@ -75,6 +75,15 @@ export interface GroupScope {
   readonly kind: RenderEntryKind.Group;
   entries: ScopeEntry[];
   hasMixedZ: boolean;
+  /**
+   * `true` once this scope has seen two draws whose materials differ in
+   * `pipelineKey` or `bindKey`. Maintained incrementally while the plan is
+   * collected, exactly like {@link GroupScope.hasMixedZ}, and read by
+   * {@link RenderPlanOptimizer} to skip the material-grouping pass outright:
+   * with a single material the pass provably cannot reorder anything, so the
+   * per-draw bookkeeping it would otherwise allocate is pure waste.
+   */
+  hasMixedMaterial: boolean;
   preserveDrawOrder: boolean;
   /**
    * The transform-group boundary node whose world matrix scopes this group's

--- a/test/rendering/material-grouping.test.ts
+++ b/test/rendering/material-grouping.test.ts
@@ -1,13 +1,16 @@
 import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
-import { type DrawCommand, RenderEntryKind } from '#rendering/plan/RenderCommand';
+import { type DrawCommand, type MaterialKey, RenderEntryKind } from '#rendering/plan/RenderCommand';
 import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
+import type { GroupScope } from '#rendering/plan/RenderScope';
+import type { RetainedDrawData } from '#rendering/plan/RetainedPlanCache';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import { createRenderStats, resetRenderStats } from '#rendering/RenderStats';
 import { RenderTarget } from '#rendering/RenderTarget';
 import { RenderTexture } from '#rendering/texture/RenderTexture';
+import { BlendModes } from '#rendering/types';
 
 class BoxDrawable extends Drawable {
   public constructor(public readonly id: string) {
@@ -15,6 +18,68 @@ class BoxDrawable extends Drawable {
     this._setLocalBounds(0, 0, 16, 16);
   }
 }
+
+const mkTypedMaterialKey = (pipelineKey: number, bindKey: number): MaterialKey => ({
+  rendererId: 1,
+  blendMode: BlendModes.Normal,
+  textureId: -1,
+  shaderId: -1,
+  pipelineKey,
+  bindKey,
+});
+
+/** A drawable whose material key is dictated by the test rather than derived. */
+class KeyedDrawable extends Drawable {
+  public constructor(
+    private readonly pipelineKey: number,
+    private readonly bindKey: number,
+  ) {
+    super();
+    this._setLocalBounds(0, 0, 16, 16);
+  }
+
+  public override _getOrComputeMaterialKey(): MaterialKey {
+    return mkTypedMaterialKey(this.pipelineKey, this.bindKey);
+  }
+}
+
+/** Replays fixed retained slots instead of collecting children — the `_replayRetainedDraw` path. */
+class ReplayOnlyContainer extends Container {
+  public constructor(private readonly slots: readonly RetainedDrawData[]) {
+    super();
+  }
+
+  protected override _collectContent(builder: RenderPlanBuilder): void {
+    for (const slot of this.slots) {
+      builder._replayRetainedDraw(slot);
+    }
+  }
+}
+
+const mkSlot = (drawable: Drawable, seq: number, pipelineKey: number, bindKey: number): RetainedDrawData => ({
+  drawable,
+  seq,
+  zIndex: 0,
+  material: mkTypedMaterialKey(pipelineKey, bindKey),
+  minX: 0,
+  minY: 0,
+  maxX: 16,
+  maxY: 16,
+});
+
+/**
+ * A `Container` passed to `build` gets wrapped in its own group scope, so the
+ * collected draws live one level below the plan root.
+ */
+const childGroupScope = (root: GroupScope): GroupScope => {
+  const entry = root.entries[0];
+
+  if (entry?.kind !== RenderEntryKind.Group) {
+    throw new Error('expected the plan root to hold a single group entry');
+  }
+
+  return entry.scope;
+};
 
 const mkMaterialKey = (pipelineKey: number, bindKey: number) => ({
   rendererId: 1,
@@ -55,9 +120,40 @@ const createDrawEntry = (drawable: Drawable, opts: DrawEntryOpts = {}) => {
   };
 };
 
+/**
+ * Mirrors the `hasMixedMaterial` flag RenderPlanBuilder maintains incrementally
+ * while collecting, so hand-built scopes behave like collected ones. The
+ * optimizer skips material grouping outright when the flag is false, so a
+ * fixture that forgot it would silently test nothing.
+ */
+const deriveHasMixedMaterial = (entries: readonly object[]): boolean => {
+  let firstPipelineKey: number | null = null;
+  let firstBindKey = 0;
+
+  for (const entry of entries) {
+    const candidate = entry as { kind: RenderEntryKind; command?: DrawCommand };
+
+    if (candidate.kind !== RenderEntryKind.Draw || candidate.command === undefined) {
+      continue;
+    }
+
+    const { pipelineKey, bindKey } = candidate.command.material;
+
+    if (firstPipelineKey === null) {
+      firstPipelineKey = pipelineKey;
+      firstBindKey = bindKey;
+    } else if (firstPipelineKey !== pipelineKey || firstBindKey !== bindKey) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 interface CreatePlanOpts {
   entries: object[];
   hasMixedZ?: boolean;
+  hasMixedMaterial?: boolean;
   preserveDrawOrder?: boolean;
 }
 
@@ -144,7 +240,11 @@ const createPlan = (opts: CreatePlanOpts) => {
           kind: RenderEntryKind.Group as const,
           entries: opts.entries as [],
           hasMixedZ: opts.hasMixedZ ?? false,
+          hasMixedMaterial: opts.hasMixedMaterial ?? deriveHasMixedMaterial(opts.entries),
           preserveDrawOrder: opts.preserveDrawOrder ?? false,
+          transformNode: null,
+          retainedInstructions: null,
+          retainedRecordTarget: null,
         },
       },
     ],
@@ -226,7 +326,11 @@ describe('material grouping', () => {
             kind: RenderEntryKind.Group as const,
             entries: [createDrawEntry(b, { pipelineKey: 100, bindKey: 100 })],
             hasMixedZ: false,
+            hasMixedMaterial: false,
             preserveDrawOrder: false,
+            transformNode: null,
+            retainedInstructions: null,
+            retainedRecordTarget: null,
           },
         },
         createDrawEntry(b, { pipelineKey: 100, bindKey: 100 }),
@@ -418,6 +522,141 @@ describe('material grouping', () => {
       if (groupEntry.kind === RenderEntryKind.Group) {
         expect(groupEntry.scope.preserveDrawOrder).toBe(true);
       }
+    } finally {
+      RenderPlanBuilder.release(builder);
+    }
+  });
+
+  test('single-material scope: skipping the material pass changes nothing', () => {
+    // Three interleaved same-material draws. Whether the optimizer runs the
+    // material pass or skips it on `hasMixedMaterial: false`, the resulting draw
+    // order and groupIndex sequence must be identical — that equality is what
+    // makes the skip safe.
+    const mkEntries = () => {
+      const a = new BoxDrawable('a');
+      const b = new BoxDrawable('b');
+      const c = new BoxDrawable('c');
+
+      return [
+        createDrawEntry(a, { pipelineKey: 100, bindKey: 100, aabb: { minX: 0, minY: 0, maxX: 16, maxY: 16 } }),
+        createDrawEntry(b, { pipelineKey: 100, bindKey: 100, aabb: { minX: 50, minY: 50, maxX: 66, maxY: 66 } }),
+        createDrawEntry(c, { pipelineKey: 100, bindKey: 100, aabb: { minX: 0, minY: 0, maxX: 16, maxY: 16 } }),
+      ];
+    };
+
+    const skipped = createPlan({ entries: mkEntries(), hasMixedMaterial: false });
+    const forced = createPlan({ entries: mkEntries(), hasMixedMaterial: true });
+
+    RenderPlanOptimizer.optimize(skipped);
+    RenderPlanOptimizer.optimize(forced);
+
+    const ids = (plan: ReturnType<typeof createPlan>) => plan.passes[0].root.entries.map((e: any) => ((e.command as DrawCommand).drawable as BoxDrawable).id);
+
+    expect(ids(skipped)).toEqual(ids(forced));
+    expect(getGroupIndices(skipped)).toEqual(getGroupIndices(forced));
+    expect(getGroupIndices(skipped)).toEqual([2, 2, 2]);
+  });
+
+  test('hasMixedMaterial false suppresses the overlap-aware reorder a mixed scope would get', () => {
+    // Same fixture as the reorder test above, but with the precheck flag forced
+    // off: the reorder must not happen. Proves the flag is load-bearing rather
+    // than decorative, so a builder that stops maintaining it fails loudly.
+    const a = new BoxDrawable('a');
+    const b = new BoxDrawable('b');
+    const c = new BoxDrawable('c');
+
+    const plan = createPlan({
+      entries: [
+        createDrawEntry(a, { pipelineKey: 100, bindKey: 100, aabb: { minX: 0, minY: 0, maxX: 16, maxY: 16 } }),
+        createDrawEntry(b, { pipelineKey: 200, bindKey: 200, aabb: { minX: 50, minY: 50, maxX: 66, maxY: 66 } }),
+        createDrawEntry(c, { pipelineKey: 100, bindKey: 100, aabb: { minX: 0, minY: 0, maxX: 16, maxY: 16 } }),
+      ],
+      hasMixedMaterial: false,
+    });
+
+    RenderPlanOptimizer.optimize(plan);
+
+    const materials = getMaterials(plan);
+
+    expect(materials.map((m: any) => m.pipelineKey)).toEqual([100, 200, 100]);
+  });
+
+  test('collected single-material scope leaves hasMixedMaterial false', () => {
+    const { backend } = createRuntime();
+    const container = new Container();
+
+    container.addChild(new KeyedDrawable(100, 100));
+    container.addChild(new KeyedDrawable(100, 100));
+
+    const builder = RenderPlanBuilder.acquire();
+
+    try {
+      const scope = childGroupScope(builder.build(container, backend).passes[0]!.root);
+
+      expect(scope.entries).toHaveLength(2);
+      expect(scope.hasMixedMaterial).toBe(false);
+    } finally {
+      RenderPlanBuilder.release(builder);
+    }
+  });
+
+  test('collected scope sets hasMixedMaterial on a differing pipelineKey or bindKey', () => {
+    const { backend } = createRuntime();
+
+    for (const second of [new KeyedDrawable(200, 100), new KeyedDrawable(100, 200)]) {
+      const container = new Container();
+
+      container.addChild(new KeyedDrawable(100, 100));
+      container.addChild(second);
+
+      const builder = RenderPlanBuilder.acquire();
+
+      try {
+        const scope = childGroupScope(builder.build(container, backend).passes[0]!.root);
+
+        expect(scope.entries).toHaveLength(2);
+        expect(scope.hasMixedMaterial).toBe(true);
+      } finally {
+        RenderPlanBuilder.release(builder);
+      }
+    }
+  });
+
+  test('the retained-replay path folds replayed materials into hasMixedMaterial', () => {
+    const { backend } = createRuntime();
+    const a = new BoxDrawable('a');
+    const b = new BoxDrawable('b');
+
+    const mixed = new ReplayOnlyContainer([mkSlot(a, 0, 100, 100), mkSlot(b, 1, 200, 200)]);
+    const uniform = new ReplayOnlyContainer([mkSlot(a, 0, 100, 100), mkSlot(b, 1, 100, 100)]);
+
+    const builder = RenderPlanBuilder.acquire();
+
+    try {
+      expect(childGroupScope(builder.build(mixed, backend).passes[0]!.root).hasMixedMaterial).toBe(true);
+      expect(childGroupScope(builder.build(uniform, backend).passes[0]!.root).hasMixedMaterial).toBe(false);
+    } finally {
+      RenderPlanBuilder.release(builder);
+    }
+  });
+
+  test('a recycled pooled scope does not carry hasMixedMaterial across frames', () => {
+    const { backend } = createRuntime();
+    const mixed = new Container();
+
+    mixed.addChild(new KeyedDrawable(100, 100));
+    mixed.addChild(new KeyedDrawable(200, 200));
+
+    const uniform = new Container();
+
+    uniform.addChild(new KeyedDrawable(100, 100));
+    uniform.addChild(new KeyedDrawable(100, 100));
+
+    const builder = RenderPlanBuilder.acquire();
+
+    try {
+      expect(childGroupScope(builder.build(mixed, backend).passes[0]!.root).hasMixedMaterial).toBe(true);
+      expect(childGroupScope(builder.build(uniform, backend).passes[0]!.root).hasMixedMaterial).toBe(false);
     } finally {
       RenderPlanBuilder.release(builder);
     }

--- a/test/rendering/render-plan-grouping-key-audit.test.ts
+++ b/test/rendering/render-plan-grouping-key-audit.test.ts
@@ -146,6 +146,36 @@ const createDrawEntry = (
   },
 });
 
+/**
+ * Mirrors the `hasMixedMaterial` flag RenderPlanBuilder maintains incrementally
+ * while collecting, so hand-built scopes behave like collected ones. The
+ * optimizer skips material grouping outright when the flag is false, so a
+ * fixture that forgot it would silently test nothing.
+ */
+const deriveHasMixedMaterial = (entries: readonly object[]): boolean => {
+  let firstPipelineKey: number | null = null;
+  let firstBindKey = 0;
+
+  for (const entry of entries) {
+    const candidate = entry as { kind: RenderEntryKind; command?: DrawCommand };
+
+    if (candidate.kind !== RenderEntryKind.Draw || candidate.command === undefined) {
+      continue;
+    }
+
+    const { pipelineKey, bindKey } = candidate.command.material;
+
+    if (firstPipelineKey === null) {
+      firstPipelineKey = pipelineKey;
+      firstBindKey = bindKey;
+    } else if (firstPipelineKey !== pipelineKey || firstBindKey !== bindKey) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 const createPlan = (entries: object[]) => {
   const { backend, destroy } = createBuildBackend();
 
@@ -160,6 +190,7 @@ const createPlan = (entries: object[]) => {
             kind: RenderEntryKind.Group as const,
             entries: entries as GroupScope['entries'],
             hasMixedZ: false,
+            hasMixedMaterial: deriveHasMixedMaterial(entries),
             preserveDrawOrder: false,
           },
         },
@@ -615,6 +646,7 @@ describe('render plan grouping key audit', () => {
           kind: RenderEntryKind.Group as const,
           entries: [createDrawEntry(nested, 100, 200)],
           hasMixedZ: false,
+          hasMixedMaterial: false,
           preserveDrawOrder: false,
         },
       };

--- a/test/rendering/render-plan.test.ts
+++ b/test/rendering/render-plan.test.ts
@@ -520,6 +520,9 @@ describe('render plan', () => {
             kind: RenderEntryKind.Group,
             entries: [firstEntry, secondEntry],
             hasMixedZ: false,
+            // The two draws really do use different materials, so the material
+            // pass must be allowed to run — otherwise this asserts nothing.
+            hasMixedMaterial: true,
           },
         },
       ],
@@ -639,6 +642,7 @@ describe('render plan', () => {
             kind: RenderEntryKind.Group as const,
             entries: [createDraw(a, { pk: 100, bk: 100 }), createDraw(b, { pk: 100, bk: 100 })],
             hasMixedZ: false,
+            hasMixedMaterial: false,
             preserveDrawOrder: false,
           },
         },


### PR DESCRIPTION
`RenderPlanOptimizer` allocated per draw and per frame in order to do nothing at all in the most common case: `_materialGroupSegment` built a `{ entry, origIdx }` wrapper per draw, `_overlapAwareGroup` additionally built a freshly concatenated template-string map key per draw, and the whole thing then bailed out at `keyGroups.size <= 1` whenever the scope used a single material — after roughly 25 000 object and 25 000 string allocations at 25k nodes. `_assignGroupIndices`, which runs unconditionally on every scope, built one more string per draw per frame on top.

## Change

**The dead wrapper.** `origIdx` was written and never read — `_overlapAwareGroup` recovers positions exclusively from its `positionIndex` map. `draws`/`zGroups`/the material buckets are now plain `DrawScopeEntry[]`.

**The string keys.** `_assignGroupIndices` carries the previous material as its two numeric key fields instead of a `${pipelineKey}:${bindKey}` string, allocating nothing per draw. `_overlapAwareGroup` buckets through a nested `pipelineKey -> bindKey -> bucket` map rather than a packed composite: both ids come from monotonically growing intern registries with no documented upper bound, so bit-packing would be a latent collision.

Bucket iteration order is load-bearing — only the *first* eligible bucket is reordered, then the scan stops — and a nested map iterates pipelineKey-major, which is not the insertion order the single-string map had. The nested map is therefore the lookup index only; a side array holds the buckets in first-seen order and the scan walks that. Order is identical to before.

**The actual win: a `hasMixedMaterial` precheck.** `GroupScope` gains a flag maintained incrementally during collect, exactly like the existing `hasMixedZ`, and the optimizer skips the material-grouping pass outright when a scope only ever saw one material — provably a no-op in that case, since every z-group then has exactly one key.

The flag is folded in `_pushDrawEntry` rather than mirrored at the three `hasMixedZ` sites. `hasMixedZ` needs three because group and barrier entries also carry a `zIndex`; materials exist on draws only, and `_pushDrawEntry` is the single funnel every draw entry passes through — freshly collected and retained-replayed alike. That makes the "a replayed slot skips the bookkeeping and leaves the flag false" failure mode structurally impossible instead of a discipline to remember per site. The segment scan is additionally gated on `!preserveDrawOrder`, where it was already a provable no-op; the now-dead parameter was removed from `_materialGroupSegment`.

## Measured

Headless Chromium, ANGLE / NVIDIA RTX 5070 Ti (D3D11), 25 000 nodes, `cpuMsMedian`, three single-cell runs per row.

| Archetype | Arm | Before | After | |
|---|---|---|---|---|
| `static-heavy` | current | 11.167 / 11.160 / 11.643 | 9.248 / 8.760 / 8.637 | **−22 %** |
| `static-heavy` | retained | 0.175 / 0.180 / 0.162 | 0.160 / 0.143 / 0.150 | −13 % (0.02 ms) |
| `mixed-material-atlased` | current | 19.450 / 16.435 / 18.183 | 15.055 / 15.415 / 16.185 | **−15 %** |
| `mixed-material-atlased` | retained | 15.580 / 15.847 / 15.287 | 13.470 / 13.063 / 13.120 | **−16 %** |

Draw counts unchanged in every cell (7 / 8 / 782). Worth noting that the `mixed-material-atlased` gain does **not** come from the new flag — that scope is mixed by definition, so the gate never fires there. It is the dead wrapper and the string keys, i.e. the work on the path that always runs.

Runs must be one archetype per process: a multi-archetype run shares a browser session and the cells contaminate each other. The same `mixed-material-atlased` retained cell read as a +13 % regression inside a three-archetype run and as a −16 % improvement measured on its own.

## Is the reordering this pays for ever reached?

Instrumented the reorder site and ran the whole node suite (520 files / 9633 tests): **4 hits.** Three come from `test/perf/rendering/structural-sprite.test.ts` through the real scene graph — scenario "alternating blend coalesces by material when sprites do not overlap", asserting `drawCalls === 2` instead of 10 — and one from the hand-built optimizer fixture. So the feature is load-bearing and covered end to end, not only synthetically.

Caveat kept honest: that scenario is constructed specifically to trigger it (alternating blend, guaranteed non-overlap). Zero hits came from any other builder-driven scene in the suite — sprite batching, particles, tilemap, nine-slice, repeating, retained, allocation, sweep. "Reachable" is proven; "fires in a realistic scene" is not. The feature is untouched here; after this change it costs nothing when it cannot apply.

## Tests

Added coverage pinning the flag: a single-material scope produces the same `groupIndex` sequence as before, a two-material scope still gets the overlap-aware grouping, and cases covering the retained-replay path and pool recycling specifically.

`scripts/test-typecheck-baseline.json`: adding a required `GroupScope` field pushed `material-grouping.test.ts` over its ratchet budget. Rather than raise the budget the fixture was completed (`transformNode`/`retainedInstructions`/`retainedRecordTarget`), taking it from 15 to 5; the ratchet turns both ways, so the baseline records the improvement. The remaining 5 are pre-existing and unrelated.

Green: `test:core test/rendering`, `vitest run --project=rendering-perf`, full node suite, `lint`, `typecheck`, `typecheck:test`, `docs:api:generate` (no diff — the touched types are `@internal`).

## Known leftovers, deliberately out of scope

- The `hasMixedZ` sort in `_optimizeGroup` still allocates an `{ entry, index }` wrapper per entry. Same bug class, already gated behind `hasMixedZ`.
- `positionIndex` is rebuilt per z-group inside `_overlapAwareGroup`. Pre-existing, and now only reachable when `hasMixedMaterial` is true.