### PR TITLE
fix(input): label paddles and per-generation PlayStation buttons in prompts

### DIFF
--- a/site/src/content/api/arcade-stick-gamepad-mapping.json
+++ b/site/src/content/api/arcade-stick-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 6,
+  "memberCount": 7,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 3,
+    "properties": 4,
     "events": 0
   },
   "sections": [
@@ -246,6 +246,51 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "promptLabels",
+          "signature": "promptLabels?: ReadonlyMap<GamepadPromptControl, string>",
+          "signatureTokens": [
+            {
+              "text": "promptLabels",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Device-specific prompt labels, applied on top of the family label set by GamepadPromptLayouts.getControlLabels. A GamepadMappingFamily spans several product generations whose buttons are not all named the same — the PlayStation Select button reads \"Select\" on a PS3 pad, \"Share\" on a DualShock 4 and \"Create\" on a DualSense, yet all three share one family. Declare only the controls that differ from the family default here; undefined means the family set already labels this device correctly."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/gamepad-mapping.json
+++ b/site/src/content/api/gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 6,
+  "memberCount": 7,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 3,
+    "properties": 4,
     "events": 0
   },
   "sections": [
@@ -31,7 +31,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(buttons: readonly GamepadButton[], axes: readonly GamepadAxis[]): GamepadMapping",
+          "signature": "new(buttons: readonly GamepadButton[], axes: readonly GamepadAxis[], promptLabels?: ReadonlyMap<GamepadPromptControl, string>): GamepadMapping",
           "signatureTokens": [
             {
               "text": "new",
@@ -94,6 +94,46 @@
               "kind": "punctuation"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "promptLabels",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -116,6 +156,11 @@
               "name": "axes",
               "type": "readonly GamepadAxis[]",
               "optional": false
+            },
+            {
+              "name": "promptLabels",
+              "type": "ReadonlyMap<GamepadPromptControl, string>",
+              "optional": true
             }
           ],
           "returnType": "GamepadMapping",
@@ -309,6 +354,51 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "promptLabels",
+          "signature": "promptLabels?: ReadonlyMap<GamepadPromptControl, string>",
+          "signatureTokens": [
+            {
+              "text": "promptLabels",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Device-specific prompt labels, applied on top of the family label set by GamepadPromptLayouts.getControlLabels. A GamepadMappingFamily spans several product generations whose buttons are not all named the same — the PlayStation Select button reads \"Select\" on a PS3 pad, \"Share\" on a DualShock 4 and \"Create\" on a DualSense, yet all three share one family. Declare only the controls that differ from the family default here; undefined means the family set already labels this device correctly."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/gamepad-prompt-control.json
+++ b/site/src/content/api/gamepad-prompt-control.json
@@ -31,7 +31,7 @@
       "members": [
         {
           "name": "GamepadPromptControl",
-          "signature": "\"DPad\" | \"DPadUp\" | \"DPadDown\" | \"DPadLeft\" | \"DPadRight\" | \"ButtonNorth\" | \"ButtonWest\" | \"ButtonEast\" | \"ButtonSouth\" | \"LeftShoulder\" | \"RightShoulder\" | \"LeftTrigger\" | \"RightTrigger\" | \"Select\" | \"Start\" | \"LeftStick\" | \"RightStick\"",
+          "signature": "\"DPad\" | \"DPadUp\" | \"DPadDown\" | \"DPadLeft\" | \"DPadRight\" | \"ButtonNorth\" | \"ButtonWest\" | \"ButtonEast\" | \"ButtonSouth\" | \"LeftShoulder\" | \"RightShoulder\" | \"LeftTrigger\" | \"RightTrigger\" | \"Select\" | \"Start\" | \"LeftStick\" | \"RightStick\" | \"Paddle1\" | \"Paddle2\" | \"Paddle3\" | \"Paddle4\"",
           "signatureTokens": [
             {
               "text": "\"DPad\"",
@@ -163,6 +163,38 @@
             },
             {
               "text": "\"RightStick\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"Paddle1\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"Paddle2\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"Paddle3\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"Paddle4\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/gamepad-prompt-layouts.json
+++ b/site/src/content/api/gamepad-prompt-layouts.json
@@ -118,7 +118,7 @@
         },
         {
           "name": "getControlLabels",
-          "signature": "getControlLabels(family: GamepadMappingFamily): ReadonlyMap<GamepadPromptControl, string>",
+          "signature": "getControlLabels(source: GamepadMapping | GamepadMappingFamily): ReadonlyMap<GamepadPromptControl, string>",
           "signatureTokens": [
             {
               "text": "getControlLabels",
@@ -129,11 +129,19 @@
               "kind": "punctuation"
             },
             {
-              "text": "family",
+              "text": "source",
               "kind": "param"
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMapping",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -175,13 +183,13 @@
           ],
           "params": [
             {
-              "name": "family",
-              "type": "GamepadMappingFamily",
+              "name": "source",
+              "type": "GamepadMapping | GamepadMappingFamily",
               "optional": false
             }
           ],
           "returnType": "ReadonlyMap<GamepadPromptControl, string>",
-          "description": "Returns the label map for the given device family, e.g. { ButtonSouth → \"A\" } for Xbox or { ButtonSouth → \"Cross\" } for PlayStation. Falls back to generic labels when family has no registered label set."
+          "description": "Returns the label map for a device, e.g. { ButtonSouth → \"A\" } for Xbox or { ButtonSouth → \"Cross\" } for PlayStation. Falls back to generic labels when the family has no registered label set. Pass the connected pad's GamepadMapping rather than its family whenever you have one: a family spans several product generations, and the mapping contributes the labels that differ between them through GamepadMapping.promptLabels — \"Share\" on a DualShock 4 where the family default reads \"Create\". The merged map is cached per mapping."
         },
         {
           "name": "getControlPosition",

--- a/site/src/content/api/generic-dual-analog-gamepad-mapping.json
+++ b/site/src/content/api/generic-dual-analog-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 6,
+  "memberCount": 7,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 3,
+    "properties": 4,
     "events": 0
   },
   "sections": [
@@ -33,7 +33,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(extraButtons: readonly GamepadButton[]): GenericDualAnalogGamepadMapping",
+          "signature": "new(extraButtons: readonly GamepadButton[], promptLabels?: ReadonlyMap<GamepadPromptControl, string>): GenericDualAnalogGamepadMapping",
           "signatureTokens": [
             {
               "text": "new",
@@ -68,6 +68,46 @@
               "kind": "punctuation"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "promptLabels",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -85,6 +125,11 @@
               "name": "extraButtons",
               "type": "readonly GamepadButton[]",
               "optional": false
+            },
+            {
+              "name": "promptLabels",
+              "type": "ReadonlyMap<GamepadPromptControl, string>",
+              "optional": true
             }
           ],
           "returnType": "GenericDualAnalogGamepadMapping",
@@ -278,6 +323,51 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "promptLabels",
+          "signature": "promptLabels?: ReadonlyMap<GamepadPromptControl, string>",
+          "signatureTokens": [
+            {
+              "text": "promptLabels",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Device-specific prompt labels, applied on top of the family label set by GamepadPromptLayouts.getControlLabels. A GamepadMappingFamily spans several product generations whose buttons are not all named the same — the PlayStation Select button reads \"Select\" on a PS3 pad, \"Share\" on a DualShock 4 and \"Create\" on a DualSense, yet all three share one family. Declare only the controls that differ from the family default here; undefined means the family set already labels this device correctly."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/joy-con-left-gamepad-mapping.json
+++ b/site/src/content/api/joy-con-left-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 6,
+  "memberCount": 7,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 3,
+    "properties": 4,
     "events": 0
   },
   "sections": [
@@ -250,6 +250,51 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "promptLabels",
+          "signature": "promptLabels?: ReadonlyMap<GamepadPromptControl, string>",
+          "signatureTokens": [
+            {
+              "text": "promptLabels",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Device-specific prompt labels, applied on top of the family label set by GamepadPromptLayouts.getControlLabels. A GamepadMappingFamily spans several product generations whose buttons are not all named the same — the PlayStation Select button reads \"Select\" on a PS3 pad, \"Share\" on a DualShock 4 and \"Create\" on a DualSense, yet all three share one family. Declare only the controls that differ from the family default here; undefined means the family set already labels this device correctly."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/joy-con-right-gamepad-mapping.json
+++ b/site/src/content/api/joy-con-right-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 6,
+  "memberCount": 7,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 3,
+    "properties": 4,
     "events": 0
   },
   "sections": [
@@ -249,6 +249,51 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "promptLabels",
+          "signature": "promptLabels?: ReadonlyMap<GamepadPromptControl, string>",
+          "signatureTokens": [
+            {
+              "text": "promptLabels",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Device-specific prompt labels, applied on top of the family label set by GamepadPromptLayouts.getControlLabels. A GamepadMappingFamily spans several product generations whose buttons are not all named the same — the PlayStation Select button reads \"Select\" on a PS3 pad, \"Share\" on a DualShock 4 and \"Create\" on a DualSense, yet all three share one family. Declare only the controls that differ from the family default here; undefined means the family set already labels this device correctly."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/play-station-gamepad-mapping.json
+++ b/site/src/content/api/play-station-gamepad-mapping.json
@@ -1,16 +1,16 @@
 {
   "title": "PlayStationGamepadMapping",
-  "description": "Mapping for Sony PlayStation controllers, covering DualShock 4 and DualSense (PS4 / PS5) when connected via USB or Bluetooth. Inherits the full GenericDualAnalogGamepadMapping layout and claims the one device-specific slot at index 17 for the touchpad **click**. Share/Create sits on the standard Select slot (index 8) on these pads, so it needs no entry of its own. Touchpad *coordinates* are not available here: browsers model the touchpad as a button, and the standard axis set stops after the two sticks. Reading finger positions requires WebHID and a custom `GamepadDefinition`.",
+  "description": "Mapping for Sony PlayStation controllers, covering DualShock 3, DualShock 4 and DualSense (PS3 / PS4 / PS5) when connected via USB or Bluetooth. Inherits the full GenericDualAnalogGamepadMapping layout. On PS4 and PS5 pads it claims the one device-specific slot at index 17 for the touchpad **click**; a PS3 pad has no touchpad and stops at the standard index 16. Select/Share/Create sits on the standard Select slot (index 8) on all three, so it needs no entry of its own — but it is printed differently on each, which is what GamepadMapping.promptLabels carries here. Touchpad *coordinates* are not available: browsers model the touchpad as a button, and the standard axis set stops after the two sticks. Reading finger positions requires WebHID and a custom `GamepadDefinition`.",
   "symbol": "PlayStationGamepadMapping",
   "kind": "class",
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 6,
+  "memberCount": 8,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 3,
+    "properties": 5,
     "events": 0
   },
   "sections": [
@@ -19,9 +19,9 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Mapping for Sony PlayStation controllers, covering DualShock 4 and DualSense (PS4 / PS5) when connected via USB or Bluetooth.",
-        "Inherits the full GenericDualAnalogGamepadMapping layout and claims the one device-specific slot at index 17 for the touchpad **click**. Share/Create sits on the standard Select slot (index 8) on these pads, so it needs no entry of its own.",
-        "Touchpad *coordinates* are not available here: browsers model the touchpad as a button, and the standard axis set stops after the two sticks. Reading finger positions requires WebHID and a custom `GamepadDefinition`."
+        "Mapping for Sony PlayStation controllers, covering DualShock 3, DualShock 4 and DualSense (PS3 / PS4 / PS5) when connected via USB or Bluetooth.",
+        "Inherits the full GenericDualAnalogGamepadMapping layout. On PS4 and PS5 pads it claims the one device-specific slot at index 17 for the touchpad **click**; a PS3 pad has no touchpad and stops at the standard index 16. Select/Share/Create sits on the standard Select slot (index 8) on all three, so it needs no entry of its own — but it is printed differently on each, which is what GamepadMapping.promptLabels carries here.",
+        "Touchpad *coordinates* are not available: browsers model the touchpad as a button, and the standard axis set stops after the two sticks. Reading finger positions requires WebHID and a custom `GamepadDefinition`."
       ],
       "importLine": "import { PlayStationGamepadMapping } from '@codexo/exojs'",
       "sourceLink": null
@@ -32,7 +32,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(): PlayStationGamepadMapping",
+          "signature": "new(generation: PlayStationGeneration): PlayStationGamepadMapping",
           "signatureTokens": [
             {
               "text": "new",
@@ -41,6 +41,18 @@
             {
               "text": "(",
               "kind": "punctuation"
+            },
+            {
+              "text": "generation",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PlayStationGeneration",
+              "kind": "type"
             },
             {
               "text": ")",
@@ -55,7 +67,13 @@
               "kind": "type"
             }
           ],
-          "params": [],
+          "params": [
+            {
+              "name": "generation",
+              "type": "PlayStationGeneration",
+              "optional": false
+            }
+          ],
           "returnType": "PlayStationGamepadMapping",
           "description": ""
         }
@@ -247,6 +265,72 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "generation",
+          "signature": "generation: PlayStationGeneration",
+          "signatureTokens": [
+            {
+              "text": "generation",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PlayStationGeneration",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Console generation this instance was built for."
+        },
+        {
+          "name": "promptLabels",
+          "signature": "promptLabels?: ReadonlyMap<GamepadPromptControl, string>",
+          "signatureTokens": [
+            {
+              "text": "promptLabels",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Device-specific prompt labels, applied on top of the family label set by GamepadPromptLayouts.getControlLabels. A GamepadMappingFamily spans several product generations whose buttons are not all named the same — the PlayStation Select button reads \"Select\" on a PS3 pad, \"Share\" on a DualShock 4 and \"Create\" on a DualSense, yet all three share one family. Declare only the controls that differ from the family default here; undefined means the family set already labels this device correctly."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/play-station-generation.json
+++ b/site/src/content/api/play-station-generation.json
@@ -1,0 +1,90 @@
+{
+  "title": "PlayStationGeneration",
+  "description": "Console generation a PlayStationGamepadMapping targets. The three generations share one button layout but not one set of button names, and only the two newer ones have a touchpad — so the generation decides both the prompt labels and whether index 17 exists.",
+  "symbol": "PlayStationGeneration",
+  "kind": "enum",
+  "subsystem": "input",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 3,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Console generation a PlayStationGamepadMapping targets.",
+        "The three generations share one button layout but not one set of button names, and only the two newer ones have a touchpad — so the generation decides both the prompt labels and whether index 17 exists."
+      ],
+      "importLine": "import { PlayStationGeneration } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "members",
+      "title": "Members",
+      "members": [
+        {
+          "name": "PS3",
+          "signature": "PS3",
+          "signatureTokens": [
+            {
+              "text": "PS3",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "PS4",
+          "signature": "PS4",
+          "signatureTokens": [
+            {
+              "text": "PS4",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "PS5",
+          "signature": "PS5",
+          "signatureTokens": [
+            {
+              "text": "PS5",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/input/PlayStationGamepadMapping.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/input/PlayStationGamepadMapping.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/input/PlayStationGamepadMapping.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/input/PlayStationGamepadMapping.ts"
+}

--- a/site/src/content/api/steam-controller-gamepad-mapping.json
+++ b/site/src/content/api/steam-controller-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 6,
+  "memberCount": 7,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 3,
+    "properties": 4,
     "events": 0
   },
   "sections": [
@@ -31,7 +31,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(extraButtons: readonly GamepadButton[]): SteamControllerGamepadMapping",
+          "signature": "new(extraButtons: readonly GamepadButton[], promptLabels?: ReadonlyMap<GamepadPromptControl, string>): SteamControllerGamepadMapping",
           "signatureTokens": [
             {
               "text": "new",
@@ -66,6 +66,46 @@
               "kind": "punctuation"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "promptLabels",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -83,6 +123,11 @@
               "name": "extraButtons",
               "type": "readonly GamepadButton[]",
               "optional": false
+            },
+            {
+              "name": "promptLabels",
+              "type": "ReadonlyMap<GamepadPromptControl, string>",
+              "optional": true
             }
           ],
           "returnType": "SteamControllerGamepadMapping",
@@ -276,6 +321,51 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "promptLabels",
+          "signature": "promptLabels?: ReadonlyMap<GamepadPromptControl, string>",
+          "signatureTokens": [
+            {
+              "text": "promptLabels",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Device-specific prompt labels, applied on top of the family label set by GamepadPromptLayouts.getControlLabels. A GamepadMappingFamily spans several product generations whose buttons are not all named the same — the PlayStation Select button reads \"Select\" on a PS3 pad, \"Share\" on a DualShock 4 and \"Create\" on a DualSense, yet all three share one family. Declare only the controls that differ from the family default here; undefined means the family set already labels this device correctly."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/steam-deck-gamepad-mapping.json
+++ b/site/src/content/api/steam-deck-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 6,
+  "memberCount": 7,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 3,
+    "properties": 4,
     "events": 0
   },
   "sections": [
@@ -246,6 +246,51 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "promptLabels",
+          "signature": "promptLabels?: ReadonlyMap<GamepadPromptControl, string>",
+          "signatureTokens": [
+            {
+              "text": "promptLabels",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Device-specific prompt labels, applied on top of the family label set by GamepadPromptLayouts.getControlLabels. A GamepadMappingFamily spans several product generations whose buttons are not all named the same — the PlayStation Select button reads \"Select\" on a PS3 pad, \"Share\" on a DualShock 4 and \"Create\" on a DualSense, yet all three share one family. Declare only the controls that differ from the family default here; undefined means the family set already labels this device correctly."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/switch-pro-gamepad-mapping.json
+++ b/site/src/content/api/switch-pro-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 6,
+  "memberCount": 7,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 3,
+    "properties": 4,
     "events": 0
   },
   "sections": [
@@ -247,6 +247,51 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "promptLabels",
+          "signature": "promptLabels?: ReadonlyMap<GamepadPromptControl, string>",
+          "signatureTokens": [
+            {
+              "text": "promptLabels",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Device-specific prompt labels, applied on top of the family label set by GamepadPromptLayouts.getControlLabels. A GamepadMappingFamily spans several product generations whose buttons are not all named the same — the PlayStation Select button reads \"Select\" on a PS3 pad, \"Share\" on a DualShock 4 and \"Create\" on a DualSense, yet all three share one family. Declare only the controls that differ from the family default here; undefined means the family set already labels this device correctly."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/xbox-gamepad-mapping.json
+++ b/site/src/content/api/xbox-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 6,
+  "memberCount": 7,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 3,
+    "properties": 4,
     "events": 0
   },
   "sections": [
@@ -247,6 +247,51 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "promptLabels",
+          "signature": "promptLabels?: ReadonlyMap<GamepadPromptControl, string>",
+          "signatureTokens": [
+            {
+              "text": "promptLabels",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ReadonlyMap",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadPromptControl",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Device-specific prompt labels, applied on top of the family label set by GamepadPromptLayouts.getControlLabels. A GamepadMappingFamily spans several product generations whose buttons are not all named the same — the PlayStation Select button reads \"Select\" on a PS3 pad, \"Share\" on a DualShock 4 and \"Create\" on a DualSense, yet all three share one family. Declare only the controls that differ from the family default here; undefined means the family set already labels this device correctly."
         }
       ],
       "paragraphs": [],

--- a/src/input/GamepadDefinitions.ts
+++ b/src/input/GamepadDefinitions.ts
@@ -3,7 +3,7 @@ import type { GamepadMapping } from './GamepadMapping';
 import { GenericDualAnalogGamepadMapping } from './GenericDualAnalogGamepadMapping';
 import { JoyConLeftGamepadMapping } from './JoyConLeftGamepadMapping';
 import { JoyConRightGamepadMapping } from './JoyConRightGamepadMapping';
-import { PlayStationGamepadMapping } from './PlayStationGamepadMapping';
+import { PlayStationGamepadMapping, PlayStationGeneration } from './PlayStationGamepadMapping';
 import { SteamControllerGamepadMapping } from './SteamControllerGamepadMapping';
 import { SteamDeckGamepadMapping } from './SteamDeckGamepadMapping';
 import { SwitchProGamepadMapping } from './SwitchProGamepadMapping';
@@ -253,10 +253,14 @@ const exactDeviceDefinitions: GamepadDefinition[] = [
   createStaticGamepadDefinition('Xbox One Elite Controller', () => new XboxGamepadMapping(), '045e:02e3'),
   createStaticGamepadDefinition('Xbox Elite Wireless Controller Series 2', () => new XboxGamepadMapping(), ['045e:0b00', '045e:0b05', '045e:0b22']),
   createStaticGamepadDefinition('Xbox Series Controller', () => new XboxGamepadMapping(), ['045e:0b12', '045e:0b13']),
-  createStaticGamepadDefinition('PlayStation 3 Controller', () => new PlayStationGamepadMapping(), '054c:0268'),
-  createStaticGamepadDefinition('DualShock 4 Controller', () => new PlayStationGamepadMapping(), ['054c:05c4', '054c:09cc', '054c:0ba0']),
-  createStaticGamepadDefinition('DualSense Controller', () => new PlayStationGamepadMapping(), '054c:0ce6'),
-  createStaticGamepadDefinition('DualSense Edge Controller', () => new PlayStationGamepadMapping(), '054c:0df2'),
+  createStaticGamepadDefinition('PlayStation 3 Controller', () => new PlayStationGamepadMapping(PlayStationGeneration.PS3), '054c:0268'),
+  createStaticGamepadDefinition('DualShock 4 Controller', () => new PlayStationGamepadMapping(PlayStationGeneration.PS4), [
+    '054c:05c4',
+    '054c:09cc',
+    '054c:0ba0',
+  ]),
+  createStaticGamepadDefinition('DualSense Controller', () => new PlayStationGamepadMapping(PlayStationGeneration.PS5), '054c:0ce6'),
+  createStaticGamepadDefinition('DualSense Edge Controller', () => new PlayStationGamepadMapping(PlayStationGeneration.PS5), '054c:0df2'),
   createStaticGamepadDefinition('Joy-Con (L)', () => new JoyConLeftGamepadMapping(), '057e:2006'),
   createStaticGamepadDefinition('Joy-Con (R)', () => new JoyConRightGamepadMapping(), '057e:2007'),
   createStaticGamepadDefinition('Joy-Con Charging Grip', () => new SwitchProGamepadMapping(), '057e:200e'),
@@ -287,14 +291,20 @@ const exactDeviceDefinitions: GamepadDefinition[] = [
   createStaticGamepadDefinition('PowerA Switch Controller', () => new SwitchProGamepadMapping(), '20d6:a713'),
   createStaticGamepadDefinition('PowerA OPS Pro Wireless Controller', () => new GenericDualAnalogGamepadMapping(), '20d6:4033'),
   createStaticGamepadDefinition('PowerA OPS Wireless Controller', () => new GenericDualAnalogGamepadMapping(), '20d6:4026'),
-  createStaticGamepadDefinition('Nacon Revolution 3 Controller', () => new PlayStationGamepadMapping(), '146b:0611'),
-  createStaticGamepadDefinition('Nacon Revolution Unlimited Pro Controller', () => new PlayStationGamepadMapping(), '146b:0d08'),
-  createStaticGamepadDefinition('Nacon Revolution Infinity Controller', () => new PlayStationGamepadMapping(), '146b:0d10'),
-  createStaticGamepadDefinition('Nacon Revolution 5 Pro Controller', () => new PlayStationGamepadMapping(), ['3285:0d17', '3285:0d19']),
-  createStaticGamepadDefinition('Razer Raiju Controller', () => new PlayStationGamepadMapping(), '1532:1000'),
-  createStaticGamepadDefinition('Razer Raiju Mobile Controller', () => new PlayStationGamepadMapping(), ['1532:0705', '1532:0707']),
-  createStaticGamepadDefinition('Razer Raiju Tournament Edition Controller', () => new PlayStationGamepadMapping(), ['1532:1007', '1532:100a']),
-  createStaticGamepadDefinition('Razer Raiju Ultimate Controller', () => new PlayStationGamepadMapping(), ['1532:1004', '1532:1009']),
+  createStaticGamepadDefinition('Nacon Revolution 3 Controller', () => new PlayStationGamepadMapping(PlayStationGeneration.PS4), '146b:0611'),
+  createStaticGamepadDefinition('Nacon Revolution Unlimited Pro Controller', () => new PlayStationGamepadMapping(PlayStationGeneration.PS4), '146b:0d08'),
+  createStaticGamepadDefinition('Nacon Revolution Infinity Controller', () => new PlayStationGamepadMapping(PlayStationGeneration.PS4), '146b:0d10'),
+  createStaticGamepadDefinition('Nacon Revolution 5 Pro Controller', () => new PlayStationGamepadMapping(PlayStationGeneration.PS5), [
+    '3285:0d17',
+    '3285:0d19',
+  ]),
+  createStaticGamepadDefinition('Razer Raiju Controller', () => new PlayStationGamepadMapping(PlayStationGeneration.PS4), '1532:1000'),
+  createStaticGamepadDefinition('Razer Raiju Mobile Controller', () => new PlayStationGamepadMapping(PlayStationGeneration.PS4), ['1532:0705', '1532:0707']),
+  createStaticGamepadDefinition('Razer Raiju Tournament Edition Controller', () => new PlayStationGamepadMapping(PlayStationGeneration.PS4), [
+    '1532:1007',
+    '1532:100a',
+  ]),
+  createStaticGamepadDefinition('Razer Raiju Ultimate Controller', () => new PlayStationGamepadMapping(PlayStationGeneration.PS4), ['1532:1004', '1532:1009']),
   createStaticGamepadDefinition('Razer Raion Controller', () => new ArcadeStickGamepadMapping(), '1532:1100'),
 ];
 

--- a/src/input/GamepadMapping.ts
+++ b/src/input/GamepadMapping.ts
@@ -2,6 +2,7 @@ import type { GamepadAxis } from './GamepadAxis';
 import type { GamepadAxisChannel } from './GamepadAxis';
 import type { GamepadButton } from './GamepadButton';
 import type { GamepadButtonChannel } from './GamepadButton';
+import type { GamepadPromptControl } from './GamepadPromptLayouts';
 
 /**
  * Discriminant tag identifying which device family a {@link GamepadMapping} belongs to.
@@ -38,9 +39,23 @@ export abstract class GamepadMapping {
   /** Ordered list of axes, indexed by the Gamepad API axis index. */
   public readonly axes: readonly GamepadAxis[];
 
-  protected constructor(buttons: readonly GamepadButton[], axes: readonly GamepadAxis[]) {
+  /**
+   * Device-specific prompt labels, applied on top of the family label set by
+   * {@link GamepadPromptLayouts.getControlLabels}.
+   *
+   * A {@link GamepadMappingFamily} spans several product generations whose
+   * buttons are not all named the same — the PlayStation `Select` button reads
+   * "Select" on a PS3 pad, "Share" on a DualShock 4 and "Create" on a
+   * DualSense, yet all three share one family. Declare only the controls that
+   * differ from the family default here; `undefined` means the family set
+   * already labels this device correctly.
+   */
+  public readonly promptLabels?: ReadonlyMap<GamepadPromptControl, string> | undefined;
+
+  protected constructor(buttons: readonly GamepadButton[], axes: readonly GamepadAxis[], promptLabels?: ReadonlyMap<GamepadPromptControl, string>) {
     this.buttons = buttons;
     this.axes = axes;
+    this.promptLabels = promptLabels;
   }
 
   /**

--- a/src/input/GamepadPromptLayouts.ts
+++ b/src/input/GamepadPromptLayouts.ts
@@ -1,5 +1,6 @@
 import type { GamepadButtonChannel } from './GamepadButton';
 import { GamepadButton } from './GamepadButton';
+import type { GamepadMapping } from './GamepadMapping';
 import { GamepadMappingFamily } from './GamepadMapping';
 
 /**
@@ -28,7 +29,11 @@ export type GamepadPromptControl =
   | 'Select'
   | 'Start'
   | 'LeftStick'
-  | 'RightStick';
+  | 'RightStick'
+  | 'Paddle1'
+  | 'Paddle2'
+  | 'Paddle3'
+  | 'Paddle4';
 
 const basePositions = new Map<GamepadPromptControl, readonly [number, number]>([
   ['DPad', [0.22, 0.58]],
@@ -48,6 +53,12 @@ const basePositions = new Map<GamepadPromptControl, readonly [number, number]>([
   ['Start', [0.54, 0.5]],
   ['LeftStick', [0.38, 0.66]],
   ['RightStick', [0.62, 0.66]],
+  // Paddles sit on the back of the device; the silhouette shows them below the
+  // grips, upper pair first, mirrored left/right the way the channels are.
+  ['Paddle1', [0.32, 0.82]],
+  ['Paddle2', [0.68, 0.82]],
+  ['Paddle3', [0.26, 0.92]],
+  ['Paddle4', [0.74, 0.92]],
 ]);
 
 const channelMap = new Map<GamepadPromptControl, GamepadButtonChannel>([
@@ -67,7 +78,16 @@ const channelMap = new Map<GamepadPromptControl, GamepadButtonChannel>([
   ['DPadDown', GamepadButton.DPadDown],
   ['DPadLeft', GamepadButton.DPadLeft],
   ['DPadRight', GamepadButton.DPadRight],
+  ['Paddle1', GamepadButton.Paddle1],
+  ['Paddle2', GamepadButton.Paddle2],
+  ['Paddle3', GamepadButton.Paddle3],
+  ['Paddle4', GamepadButton.Paddle4],
 ]);
+
+const createLabels = (
+  base: ReadonlyMap<GamepadPromptControl, string>,
+  overrides: ReadonlyArray<readonly [GamepadPromptControl, string]>,
+): ReadonlyMap<GamepadPromptControl, string> => new Map<GamepadPromptControl, string>([...base, ...overrides]);
 
 const genericLabels = new Map<GamepadPromptControl, string>([
   ['ButtonNorth', 'North'],
@@ -82,6 +102,10 @@ const genericLabels = new Map<GamepadPromptControl, string>([
   ['Start', 'Start'],
   ['LeftStick', 'L3'],
   ['RightStick', 'R3'],
+  ['Paddle1', 'P1'],
+  ['Paddle2', 'P2'],
+  ['Paddle3', 'P3'],
+  ['Paddle4', 'P4'],
 ]);
 
 const xboxLabels = new Map<GamepadPromptControl, string>([
@@ -97,8 +121,18 @@ const xboxLabels = new Map<GamepadPromptControl, string>([
   ['Start', 'Menu'],
   ['LeftStick', 'L3'],
   ['RightStick', 'R3'],
+  // Elite Series 2 prints P1-P4 on the paddles.
+  ['Paddle1', 'P1'],
+  ['Paddle2', 'P2'],
+  ['Paddle3', 'P3'],
+  ['Paddle4', 'P4'],
 ]);
 
+/**
+ * DualSense names. The PlayStation family also covers PS3 pads ("Select" /
+ * "Start") and DualShock 4 ("Share"); those generations override the two
+ * differing entries through {@link GamepadMapping.promptLabels}.
+ */
 const playStationLabels = new Map<GamepadPromptControl, string>([
   ['ButtonNorth', 'Triangle'],
   ['ButtonWest', 'Square'],
@@ -129,17 +163,55 @@ const switchLabels = new Map<GamepadPromptControl, string>([
   ['RightStick', 'R3'],
 ]);
 
+/**
+ * Solo Joy-Con (L). The SL/SR rail buttons report paddle channels — see
+ * {@link JoyConLeftGamepadMapping} — and this half takes the two left-hand
+ * slots, so only those two carry a label.
+ */
+const joyConLeftLabels = createLabels(switchLabels, [
+  ['Paddle1', 'SL'],
+  ['Paddle3', 'SR'],
+]);
+
+/** Solo Joy-Con (R), taking the two right-hand paddle slots. */
+const joyConRightLabels = createLabels(switchLabels, [
+  ['Paddle2', 'SR'],
+  ['Paddle4', 'SL'],
+]);
+
+/**
+ * Steam Deck. Valve prints A/B/X/Y on the face cluster and View/Menu beside
+ * it, but keeps the PlayStation-style L1/R1/L2/R2 shoulder names, so this is
+ * neither the generic nor the Xbox set. The back paddles are L4/R4/L5/R5, in
+ * the {@link GamepadButton.Paddle1}-to-`Paddle4` order
+ * {@link SteamDeckGamepadMapping} writes them in.
+ */
+const steamDeckLabels = createLabels(genericLabels, [
+  ['ButtonNorth', 'Y'],
+  ['ButtonWest', 'X'],
+  ['ButtonEast', 'B'],
+  ['ButtonSouth', 'A'],
+  ['Select', 'View'],
+  ['Start', 'Menu'],
+  ['Paddle1', 'L4'],
+  ['Paddle2', 'R4'],
+  ['Paddle3', 'L5'],
+  ['Paddle4', 'R5'],
+]);
+
 const promptLabelsByFamily = new Map<GamepadMappingFamily, ReadonlyMap<GamepadPromptControl, string>>([
   [GamepadMappingFamily.GenericDualAnalog, genericLabels],
   [GamepadMappingFamily.Xbox, xboxLabels],
   [GamepadMappingFamily.PlayStation, playStationLabels],
   [GamepadMappingFamily.SwitchPro, switchLabels],
-  [GamepadMappingFamily.JoyConLeft, switchLabels],
-  [GamepadMappingFamily.JoyConRight, switchLabels],
+  [GamepadMappingFamily.JoyConLeft, joyConLeftLabels],
+  [GamepadMappingFamily.JoyConRight, joyConRightLabels],
   [GamepadMappingFamily.SteamController, genericLabels],
-  [GamepadMappingFamily.SteamDeck, genericLabels],
+  [GamepadMappingFamily.SteamDeck, steamDeckLabels],
   [GamepadMappingFamily.ArcadeStick, genericLabels],
 ]);
+
+const mappingLabelCache = new WeakMap<GamepadMapping, ReadonlyMap<GamepadPromptControl, string>>();
 
 /**
  * Static utility that drives in-game controller-prompt UI.
@@ -169,6 +241,10 @@ export class GamepadPromptLayouts {
     'Start',
     'LeftStick',
     'RightStick',
+    'Paddle1',
+    'Paddle2',
+    'Paddle3',
+    'Paddle4',
   ];
 
   /**
@@ -181,12 +257,41 @@ export class GamepadPromptLayouts {
   }
 
   /**
-   * Returns the label map for the given device family, e.g. `{ ButtonSouth → "A" }`
-   * for Xbox or `{ ButtonSouth → "Cross" }` for PlayStation.
-   * Falls back to generic labels when `family` has no registered label set.
+   * Returns the label map for a device, e.g. `{ ButtonSouth → "A" }` for Xbox
+   * or `{ ButtonSouth → "Cross" }` for PlayStation. Falls back to generic
+   * labels when the family has no registered label set.
+   *
+   * Pass the connected pad's {@link GamepadMapping} rather than its family
+   * whenever you have one: a family spans several product generations, and the
+   * mapping contributes the labels that differ between them through
+   * {@link GamepadMapping.promptLabels} — "Share" on a DualShock 4 where the
+   * family default reads "Create". The merged map is cached per mapping.
+   *
+   * @example
+   * ```ts
+   * const labels = GamepadPromptLayouts.getControlLabels(gamepad.mapping);
+   * hint.text = `Press ${labels.get('ButtonSouth')} to jump`;
+   * ```
    */
-  public static getControlLabels(family: GamepadMappingFamily): ReadonlyMap<GamepadPromptControl, string> {
-    return promptLabelsByFamily.get(family) ?? genericLabels;
+  public static getControlLabels(source: GamepadMappingFamily | GamepadMapping): ReadonlyMap<GamepadPromptControl, string> {
+    if (typeof source === 'string') {
+      return promptLabelsByFamily.get(source) ?? genericLabels;
+    }
+
+    const familyLabels = promptLabelsByFamily.get(source.family) ?? genericLabels;
+
+    if (source.promptLabels === undefined) {
+      return familyLabels;
+    }
+
+    let labels = mappingLabelCache.get(source);
+
+    if (labels === undefined) {
+      labels = createLabels(familyLabels, [...source.promptLabels]);
+      mappingLabelCache.set(source, labels);
+    }
+
+    return labels;
   }
 
   /**

--- a/src/input/GenericDualAnalogGamepadMapping.ts
+++ b/src/input/GenericDualAnalogGamepadMapping.ts
@@ -1,6 +1,7 @@
 import { GamepadAxis } from './GamepadAxis';
 import { GamepadButton } from './GamepadButton';
 import { GamepadMapping, GamepadMappingFamily } from './GamepadMapping';
+import type { GamepadPromptControl } from './GamepadPromptLayouts';
 
 /**
  * Baseline mapping for dual-analog controllers that follow the standard
@@ -25,11 +26,13 @@ import { GamepadMapping, GamepadMappingFamily } from './GamepadMapping';
  *
  * @param extraButtons - Device-specific buttons appended after the standard
  * layout. Their raw indices must not collide with 0–16.
+ * @param promptLabels - Device-specific prompt labels, see
+ * {@link GamepadMapping.promptLabels}.
  */
 export class GenericDualAnalogGamepadMapping extends GamepadMapping {
   public readonly family: GamepadMappingFamily = GamepadMappingFamily.GenericDualAnalog;
 
-  public constructor(extraButtons: readonly GamepadButton[] = []) {
+  public constructor(extraButtons: readonly GamepadButton[] = [], promptLabels?: ReadonlyMap<GamepadPromptControl, string>) {
     super(
       [
         new GamepadButton(0, GamepadButton.South),
@@ -78,6 +81,7 @@ export class GenericDualAnalogGamepadMapping extends GamepadMapping {
         new GamepadAxis(7, GamepadAxis.AuxiliaryAxis3Negative, { invert: true }),
         new GamepadAxis(7, GamepadAxis.AuxiliaryAxis3Positive),
       ],
+      promptLabels,
     );
   }
 }

--- a/src/input/PlayStationGamepadMapping.ts
+++ b/src/input/PlayStationGamepadMapping.ts
@@ -1,25 +1,68 @@
 import { GamepadButton } from './GamepadButton';
 import { GamepadMappingFamily } from './GamepadMapping';
+import type { GamepadPromptControl } from './GamepadPromptLayouts';
 import { GenericDualAnalogGamepadMapping } from './GenericDualAnalogGamepadMapping';
 
 /**
- * Mapping for Sony PlayStation controllers, covering DualShock 4 and
- * DualSense (PS4 / PS5) when connected via USB or Bluetooth.
+ * Console generation a {@link PlayStationGamepadMapping} targets.
  *
- * Inherits the full {@link GenericDualAnalogGamepadMapping} layout and claims
- * the one device-specific slot at index 17 for the touchpad **click**.
- * Share/Create sits on the standard Select slot (index 8) on these pads, so
- * it needs no entry of its own.
+ * The three generations share one button layout but not one set of button
+ * names, and only the two newer ones have a touchpad — so the generation
+ * decides both the prompt labels and whether index 17 exists.
+ */
+export enum PlayStationGeneration {
+  /** DualShock 3 and PS3-era third-party pads: "Select" / "Start", no touchpad. */
+  PS3 = 'ps3',
+  /** DualShock 4 and PS4-era third-party pads: "Share" / "Options". */
+  PS4 = 'ps4',
+  /** DualSense and DualSense Edge: "Create" / "Options". */
+  PS5 = 'ps5',
+}
+
+const generationLabels = new Map<PlayStationGeneration, ReadonlyMap<GamepadPromptControl, string>>([
+  [
+    PlayStationGeneration.PS3,
+    new Map<GamepadPromptControl, string>([
+      ['Select', 'Select'],
+      ['Start', 'Start'],
+    ]),
+  ],
+  [PlayStationGeneration.PS4, new Map<GamepadPromptControl, string>([['Select', 'Share']])],
+]);
+
+// DUALSHOCK_BUTTON_TOUCHPAD == DUAL_SENSE_BUTTON_TOUCHPAD == 17; a PS3 pad
+// stops at the standard index 16 and gets no entry.
+const createExtraButtons = (generation: PlayStationGeneration): GamepadButton[] =>
+  generation === PlayStationGeneration.PS3 ? [] : [new GamepadButton(17, GamepadButton.Touchpad)];
+
+/**
+ * Mapping for Sony PlayStation controllers, covering DualShock 3, DualShock 4
+ * and DualSense (PS3 / PS4 / PS5) when connected via USB or Bluetooth.
  *
- * Touchpad *coordinates* are not available here: browsers model the touchpad
- * as a button, and the standard axis set stops after the two sticks. Reading
- * finger positions requires WebHID and a custom `GamepadDefinition`.
+ * Inherits the full {@link GenericDualAnalogGamepadMapping} layout. On PS4 and
+ * PS5 pads it claims the one device-specific slot at index 17 for the touchpad
+ * **click**; a PS3 pad has no touchpad and stops at the standard index 16.
+ * Select/Share/Create sits on the standard Select slot (index 8) on all three,
+ * so it needs no entry of its own — but it is printed differently on each,
+ * which is what {@link GamepadMapping.promptLabels} carries here.
+ *
+ * Touchpad *coordinates* are not available: browsers model the touchpad as a
+ * button, and the standard axis set stops after the two sticks. Reading finger
+ * positions requires WebHID and a custom `GamepadDefinition`.
+ *
+ * @param generation - Console generation of the physical pad. Defaults to
+ * {@link PlayStationGeneration.PS5}, the layout an unrecognised Sony device is
+ * most likely to have.
  */
 export class PlayStationGamepadMapping extends GenericDualAnalogGamepadMapping {
   public override readonly family = GamepadMappingFamily.PlayStation;
 
-  public constructor() {
-    // DUALSHOCK_BUTTON_TOUCHPAD == DUAL_SENSE_BUTTON_TOUCHPAD == 17.
-    super([new GamepadButton(17, GamepadButton.Touchpad)]);
+  /** Console generation this instance was built for. */
+  public readonly generation: PlayStationGeneration;
+
+  public constructor(generation: PlayStationGeneration = PlayStationGeneration.PS5) {
+    super(createExtraButtons(generation), generationLabels.get(generation));
+
+    this.generation = generation;
   }
 }

--- a/test/core/__snapshots__/root-index-snapshot.test.ts.snap
+++ b/test/core/__snapshots__/root-index-snapshot.test.ts.snap
@@ -131,6 +131,7 @@ exports[`root index export surface snapshot > sorted runtime export names match 
   "PhasedSceneTransition",
   "PixelSnapMode",
   "PlayStationGamepadMapping",
+  "PlayStationGeneration",
   "Pointer",
   "PointerButton",
   "PointerState",

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -300,6 +300,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "PlatformWindowEventMap: interface",
   "PlayOptions: interface",
   "PlayStationGamepadMapping: class",
+  "PlayStationGeneration: enum",
   "Playable: interface",
   "PlaybackOptions: interface",
   "PointLike: interface",

--- a/test/input/gamepad-mapping-families.test.ts
+++ b/test/input/gamepad-mapping-families.test.ts
@@ -4,7 +4,7 @@ import { GamepadMappingFamily } from '#input/GamepadMapping';
 import { GenericDualAnalogGamepadMapping } from '#input/GenericDualAnalogGamepadMapping';
 import { JoyConLeftGamepadMapping } from '#input/JoyConLeftGamepadMapping';
 import { JoyConRightGamepadMapping } from '#input/JoyConRightGamepadMapping';
-import { PlayStationGamepadMapping } from '#input/PlayStationGamepadMapping';
+import { PlayStationGamepadMapping, PlayStationGeneration } from '#input/PlayStationGamepadMapping';
 import { SteamControllerGamepadMapping } from '#input/SteamControllerGamepadMapping';
 import { SwitchProGamepadMapping } from '#input/SwitchProGamepadMapping';
 import { XboxGamepadMapping } from '#input/XboxGamepadMapping';
@@ -92,6 +92,16 @@ describe('the device-specific button slot at index 17', () => {
 
     expect(mapping.family).toBe(GamepadMappingFamily.PlayStation);
     expect(slot17(mapping)).toBe(GamepadButton.Touchpad);
+    expect(slot17(new PlayStationGamepadMapping(PlayStationGeneration.PS4))).toBe(GamepadButton.Touchpad);
+  });
+
+  // A PS3 pad has no touchpad, so the standard layout ends at index 16 for it.
+  test('a PlayStation 3 controller claims nothing there', () => {
+    const mapping = new PlayStationGamepadMapping(PlayStationGeneration.PS3);
+
+    expect(mapping.family).toBe(GamepadMappingFamily.PlayStation);
+    expect(slot17(mapping)).toBeUndefined();
+    expect(mapping.hasChannel(GamepadButton.Touchpad)).toBe(false);
   });
 
   test('the three devices disagree about slot 17, so no baseline value can be right', () => {

--- a/test/input/gamepad-prompt-profiles.test.ts
+++ b/test/input/gamepad-prompt-profiles.test.ts
@@ -1,6 +1,11 @@
 import { GamepadButton } from '#input/GamepadButton';
 import { GamepadMappingFamily } from '#input/GamepadMapping';
 import { GamepadPromptLayouts } from '#input/GamepadPromptLayouts';
+import { JoyConLeftGamepadMapping } from '#input/JoyConLeftGamepadMapping';
+import { JoyConRightGamepadMapping } from '#input/JoyConRightGamepadMapping';
+import { PlayStationGamepadMapping, PlayStationGeneration } from '#input/PlayStationGamepadMapping';
+import { SteamDeckGamepadMapping } from '#input/SteamDeckGamepadMapping';
+import { SwitchProGamepadMapping } from '#input/SwitchProGamepadMapping';
 
 describe('GamepadPromptLayouts', () => {
   test('exposes stable control keys and base positions', () => {
@@ -35,5 +40,95 @@ describe('GamepadPromptLayouts', () => {
 
     expect(fallback).toBe(generic);
     expect(fallback.get('ButtonSouth')).toBe('South');
+  });
+
+  test('covers every paddle channel with a control, a position and a channel entry', () => {
+    const controlChannelMap = GamepadPromptLayouts.getControlChannelMap();
+    const paddles = [
+      ['Paddle1', GamepadButton.Paddle1],
+      ['Paddle2', GamepadButton.Paddle2],
+      ['Paddle3', GamepadButton.Paddle3],
+      ['Paddle4', GamepadButton.Paddle4],
+    ] as const;
+
+    for (const [control, channel] of paddles) {
+      expect(GamepadPromptLayouts.controls).toContain(control);
+      expect(controlChannelMap.get(control)).toBe(channel);
+      expect(GamepadPromptLayouts.getControlPosition(control)).not.toEqual([0.5, 0.5]);
+    }
+  });
+
+  test('labels the solo Joy-Con rail buttons on the paddle slots each half occupies', () => {
+    const leftLabels = GamepadPromptLayouts.getControlLabels(GamepadMappingFamily.JoyConLeft);
+    const rightLabels = GamepadPromptLayouts.getControlLabels(GamepadMappingFamily.JoyConRight);
+
+    // The channels the mappings actually write — see JoyCon*GamepadMapping.
+    expect(leftLabels.get('Paddle1')).toBe('SL');
+    expect(leftLabels.get('Paddle3')).toBe('SR');
+    expect(rightLabels.get('Paddle2')).toBe('SR');
+    expect(rightLabels.get('Paddle4')).toBe('SL');
+
+    // Switch glyphs stay intact, and neither half claims the other's slots.
+    expect(leftLabels.get('LeftShoulder')).toBe('L');
+    expect(leftLabels.get('LeftTrigger')).toBe('ZL');
+    expect(leftLabels.has('Paddle2')).toBe(false);
+    expect(rightLabels.has('Paddle1')).toBe(false);
+  });
+
+  test('every paddle channel a built-in mapping writes has a label in that family', () => {
+    const mappings = [new JoyConLeftGamepadMapping(), new JoyConRightGamepadMapping(), new SteamDeckGamepadMapping()];
+    const paddleControls = ['Paddle1', 'Paddle2', 'Paddle3', 'Paddle4'] as const;
+    const channelsByControl = GamepadPromptLayouts.getControlChannelMap();
+
+    for (const mapping of mappings) {
+      const labels = GamepadPromptLayouts.getControlLabels(mapping);
+
+      for (const control of paddleControls) {
+        if (mapping.hasChannel(channelsByControl.get(control)!)) {
+          expect(labels.get(control)).toBeDefined();
+        }
+      }
+    }
+  });
+
+  test('labels the Steam Deck with its printed names rather than the generic set', () => {
+    const labels = GamepadPromptLayouts.getControlLabels(GamepadMappingFamily.SteamDeck);
+
+    expect(labels.get('ButtonSouth')).toBe('A');
+    expect(labels.get('ButtonNorth')).toBe('Y');
+    expect(labels.get('Select')).toBe('View');
+    expect(labels.get('Start')).toBe('Menu');
+    // Valve keeps the PlayStation-style shoulder names — neither the generic
+    // nor the Xbox set is right here.
+    expect(labels.get('LeftShoulder')).toBe('L1');
+    expect(labels.get('LeftTrigger')).toBe('L2');
+    expect(labels.get('Paddle1')).toBe('L4');
+    expect(labels.get('Paddle2')).toBe('R4');
+    expect(labels.get('Paddle3')).toBe('L5');
+    expect(labels.get('Paddle4')).toBe('R5');
+  });
+
+  test('applies a mapping-specific label on top of its family set', () => {
+    const dualShock4 = GamepadPromptLayouts.getControlLabels(new PlayStationGamepadMapping(PlayStationGeneration.PS4));
+    const dualSense = GamepadPromptLayouts.getControlLabels(new PlayStationGamepadMapping(PlayStationGeneration.PS5));
+    const playStation3 = GamepadPromptLayouts.getControlLabels(new PlayStationGamepadMapping(PlayStationGeneration.PS3));
+
+    expect(dualShock4.get('Select')).toBe('Share');
+    expect(dualSense.get('Select')).toBe('Create');
+    expect(playStation3.get('Select')).toBe('Select');
+    expect(playStation3.get('Start')).toBe('Start');
+
+    // Everything the generation does not override stays on the family set.
+    expect(dualShock4.get('ButtonSouth')).toBe('Cross');
+    expect(dualShock4.get('Start')).toBe('Options');
+  });
+
+  test('returns the family map itself for a mapping without overrides and caches merged maps', () => {
+    const switchPro = new SwitchProGamepadMapping();
+    const dualShock4 = new PlayStationGamepadMapping(PlayStationGeneration.PS4);
+
+    expect(GamepadPromptLayouts.getControlLabels(switchPro)).toBe(GamepadPromptLayouts.getControlLabels(GamepadMappingFamily.SwitchPro));
+    expect(GamepadPromptLayouts.getControlLabels(dualShock4)).toBe(GamepadPromptLayouts.getControlLabels(dualShock4));
+    expect(GamepadPromptLayouts.getControlLabels(dualShock4)).not.toBe(GamepadPromptLayouts.getControlLabels(GamepadMappingFamily.PlayStation));
   });
 });


### PR DESCRIPTION
`GamepadPromptLayouts` had two holes, both found while verifying the solo
Joy-Con mappings against hardware.

`GamepadPromptControl` knew no paddles, so none of the label tables covered
`Paddle1`-`Paddle4`. After the Joy-Con fix the SL/SR rail buttons sit on
paddle channels and had no prompt label at all, and the Steam Deck's
L4/R4/L5/R5 never had one either. Paddles are now prompt controls with
positions, channel entries and per-family labels: SL/SR on the two slots each
Joy-Con half occupies, L4/R4/L5/R5 on the Steam Deck, P1-P4 elsewhere.

The Steam Deck also inherited the generic label set, which prints "South" and
"Select" where Valve prints "A" and "View". It gets its own set — Xbox-style
face buttons and View/Menu, but the PlayStation-style L1/R1/L2/R2 shoulder
names Valve actually uses, so neither existing table fit.

`playStationLabels` labelled `Select` as "Create", which is the DualSense
name; the same family covers the DualShock 4 ("Share") and PS3 pads
("Select"). A family cannot answer this on its own, so `GamepadMapping` gains
an optional `promptLabels` map for the entries that differ from its family,
`PlayStationGamepadMapping` takes a `PlayStationGeneration`, and
`getControlLabels` accepts a mapping and merges the two (cached per mapping).
Passing a family still works and still returns the family set.

The generation settles a second question the class could not answer before: a
PS3 pad has no touchpad, but the mapping declared the touchpad click at index
17 for every PlayStation device, so `hasChannel(GamepadButton.Touchpad)`
answered `true` for a DualShock 3. It now stops at the standard index 16.