### PR TITLE
fix(input)!: stop routing standard-mapped pads through a raw HID layout

### DIFF
--- a/site/src/content/api/arcade-stick-gamepad-mapping.json
+++ b/site/src/content/api/arcade-stick-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 7,
+  "memberCount": 8,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 4,
+    "properties": 5,
     "events": 0
   },
   "sections": [
@@ -246,6 +246,27 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "layout",
+          "signature": "layout: GamepadMappingLayout",
+          "signatureTokens": [
+            {
+              "text": "layout",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMappingLayout",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Index space this mapping's button and axis indices are written against. Defaults to GamepadMappingLayout.Standard. A mapping that encodes raw HID report order must declare GamepadMappingLayout.Raw, so resolveGamepadDefinition can discard it when the browser reports the same device as already standard-normalised."
         },
         {
           "name": "promptLabels",

--- a/site/src/content/api/gamepad-descriptor.json
+++ b/site/src/content/api/gamepad-descriptor.json
@@ -1,16 +1,16 @@
 {
   "title": "GamepadDescriptor",
-  "description": "Parsed metadata extracted from a browser `Gamepad.id` string. `vendorId` and `productId` are four-hex-digit strings (e.g. `\"045e\"`, `\"028e\"`). `productKey` is the colon-joined pair (`\"045e:028e\"`), used as a compact lookup key. `name` is the human-readable portion of the id with the vendor/product tokens removed, or `null` when the id contained only identifiers.",
+  "description": "Parsed metadata extracted from a browser `Gamepad.id` string. `vendorId` and `productId` are four-hex-digit strings (e.g. `\"045e\"`, `\"028e\"`). `productKey` is the colon-joined pair (`\"045e:028e\"`), used as a compact lookup key. `name` is the human-readable portion of the id with the vendor/product tokens removed, or `null` when the id contained only identifiers. `mapping` is the browser's own verdict, verbatim — `\"standard\"` when it has normalised the device into the W3C layout, `\"\"` when it hands the raw HID report through.",
   "symbol": "GamepadDescriptor",
   "kind": "interface",
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 7,
+  "memberCount": 8,
   "counts": {
     "constructors": 0,
     "methods": 0,
-    "properties": 7,
+    "properties": 8,
     "events": 0
   },
   "sections": [
@@ -20,7 +20,7 @@
       "members": [],
       "paragraphs": [
         "Parsed metadata extracted from a browser `Gamepad.id` string.",
-        "`vendorId` and `productId` are four-hex-digit strings (e.g. `\"045e\"`, `\"028e\"`). `productKey` is the colon-joined pair (`\"045e:028e\"`), used as a compact lookup key. `name` is the human-readable portion of the id with the vendor/product tokens removed, or `null` when the id contained only identifiers."
+        "`vendorId` and `productId` are four-hex-digit strings (e.g. `\"045e\"`, `\"028e\"`). `productKey` is the colon-joined pair (`\"045e:028e\"`), used as a compact lookup key. `name` is the human-readable portion of the id with the vendor/product tokens removed, or `null` when the id contained only identifiers. `mapping` is the browser's own verdict, verbatim — `\"standard\"` when it has normalised the device into the W3C layout, `\"\"` when it hands the raw HID report through."
       ],
       "importLine": "import { GamepadDescriptor } from '@codexo/exojs'",
       "sourceLink": null
@@ -86,6 +86,27 @@
             {
               "text": "string",
               "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "mapping",
+          "signature": "mapping: GamepadMappingType",
+          "signatureTokens": [
+            {
+              "text": "mapping",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMappingType",
+              "kind": "type"
             }
           ],
           "params": [],

--- a/site/src/content/api/gamepad-mapping-layout.json
+++ b/site/src/content/api/gamepad-mapping-layout.json
@@ -1,0 +1,77 @@
+{
+  "title": "GamepadMappingLayout",
+  "description": "Which index space a GamepadMapping's button and axis indices live in. Almost every mapping is written against the W3C \"standard\" layout the browser normalises known devices into. A `Raw` mapping instead encodes a device's unnormalised HID report order, which is only correct while the browser leaves that device unnormalised — see SteamDeckGamepadMapping, the one built-in mapping in that category.",
+  "symbol": "GamepadMappingLayout",
+  "kind": "enum",
+  "subsystem": "input",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 2,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Which index space a GamepadMapping's button and axis indices live in.",
+        "Almost every mapping is written against the W3C \"standard\" layout the browser normalises known devices into. A `Raw` mapping instead encodes a device's unnormalised HID report order, which is only correct while the browser leaves that device unnormalised — see SteamDeckGamepadMapping, the one built-in mapping in that category."
+      ],
+      "importLine": "import { GamepadMappingLayout } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "members",
+      "title": "Members",
+      "members": [
+        {
+          "name": "Raw",
+          "signature": "Raw",
+          "signatureTokens": [
+            {
+              "text": "Raw",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "Standard",
+          "signature": "Standard",
+          "signatureTokens": [
+            {
+              "text": "Standard",
+              "kind": "name"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/input/GamepadMapping.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/input/GamepadMapping.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/input/GamepadMapping.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/input/GamepadMapping.ts"
+}

--- a/site/src/content/api/gamepad-mapping.json
+++ b/site/src/content/api/gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 7,
+  "memberCount": 8,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 4,
+    "properties": 5,
     "events": 0
   },
   "sections": [
@@ -354,6 +354,27 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "layout",
+          "signature": "layout: GamepadMappingLayout",
+          "signatureTokens": [
+            {
+              "text": "layout",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMappingLayout",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Index space this mapping's button and axis indices are written against. Defaults to GamepadMappingLayout.Standard. A mapping that encodes raw HID report order must declare GamepadMappingLayout.Raw, so resolveGamepadDefinition can discard it when the browser reports the same device as already standard-normalised."
         },
         {
           "name": "promptLabels",

--- a/site/src/content/api/generic-dual-analog-gamepad-mapping.json
+++ b/site/src/content/api/generic-dual-analog-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 7,
+  "memberCount": 8,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 4,
+    "properties": 5,
     "events": 0
   },
   "sections": [
@@ -33,7 +33,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(extraButtons: readonly GamepadButton[], promptLabels?: ReadonlyMap<GamepadPromptControl, string>): GenericDualAnalogGamepadMapping",
+          "signature": "new(extraButtons: readonly GamepadButton[], promptLabels?: ReadonlyMap<GamepadPromptControl, string>, family: GamepadMappingFamily): GenericDualAnalogGamepadMapping",
           "signatureTokens": [
             {
               "text": "new",
@@ -108,6 +108,22 @@
               "kind": "punctuation"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "family",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMappingFamily",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -130,6 +146,11 @@
               "name": "promptLabels",
               "type": "ReadonlyMap<GamepadPromptControl, string>",
               "optional": true
+            },
+            {
+              "name": "family",
+              "type": "GamepadMappingFamily",
+              "optional": false
             }
           ],
           "returnType": "GenericDualAnalogGamepadMapping",
@@ -323,6 +344,27 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "layout",
+          "signature": "layout: GamepadMappingLayout",
+          "signatureTokens": [
+            {
+              "text": "layout",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMappingLayout",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Index space this mapping's button and axis indices are written against. Defaults to GamepadMappingLayout.Standard. A mapping that encodes raw HID report order must declare GamepadMappingLayout.Raw, so resolveGamepadDefinition can discard it when the browser reports the same device as already standard-normalised."
         },
         {
           "name": "promptLabels",

--- a/site/src/content/api/joy-con-left-gamepad-mapping.json
+++ b/site/src/content/api/joy-con-left-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 7,
+  "memberCount": 8,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 4,
+    "properties": 5,
     "events": 0
   },
   "sections": [
@@ -250,6 +250,27 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "layout",
+          "signature": "layout: GamepadMappingLayout",
+          "signatureTokens": [
+            {
+              "text": "layout",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMappingLayout",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Index space this mapping's button and axis indices are written against. Defaults to GamepadMappingLayout.Standard. A mapping that encodes raw HID report order must declare GamepadMappingLayout.Raw, so resolveGamepadDefinition can discard it when the browser reports the same device as already standard-normalised."
         },
         {
           "name": "promptLabels",

--- a/site/src/content/api/joy-con-right-gamepad-mapping.json
+++ b/site/src/content/api/joy-con-right-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 7,
+  "memberCount": 8,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 4,
+    "properties": 5,
     "events": 0
   },
   "sections": [
@@ -249,6 +249,27 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "layout",
+          "signature": "layout: GamepadMappingLayout",
+          "signatureTokens": [
+            {
+              "text": "layout",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMappingLayout",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Index space this mapping's button and axis indices are written against. Defaults to GamepadMappingLayout.Standard. A mapping that encodes raw HID report order must declare GamepadMappingLayout.Raw, so resolveGamepadDefinition can discard it when the browser reports the same device as already standard-normalised."
         },
         {
           "name": "promptLabels",

--- a/site/src/content/api/play-station-gamepad-mapping.json
+++ b/site/src/content/api/play-station-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 8,
+  "memberCount": 9,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 5,
+    "properties": 6,
     "events": 0
   },
   "sections": [
@@ -286,6 +286,27 @@
           "params": [],
           "returnType": null,
           "description": "Console generation this instance was built for."
+        },
+        {
+          "name": "layout",
+          "signature": "layout: GamepadMappingLayout",
+          "signatureTokens": [
+            {
+              "text": "layout",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMappingLayout",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Index space this mapping's button and axis indices are written against. Defaults to GamepadMappingLayout.Standard. A mapping that encodes raw HID report order must declare GamepadMappingLayout.Raw, so resolveGamepadDefinition can discard it when the browser reports the same device as already standard-normalised."
         },
         {
           "name": "promptLabels",

--- a/site/src/content/api/steam-controller-gamepad-mapping.json
+++ b/site/src/content/api/steam-controller-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 7,
+  "memberCount": 8,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 4,
+    "properties": 5,
     "events": 0
   },
   "sections": [
@@ -31,7 +31,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(extraButtons: readonly GamepadButton[], promptLabels?: ReadonlyMap<GamepadPromptControl, string>): SteamControllerGamepadMapping",
+          "signature": "new(extraButtons: readonly GamepadButton[], promptLabels?: ReadonlyMap<GamepadPromptControl, string>, family: GamepadMappingFamily): SteamControllerGamepadMapping",
           "signatureTokens": [
             {
               "text": "new",
@@ -106,6 +106,22 @@
               "kind": "punctuation"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "family",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMappingFamily",
+              "kind": "type"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -128,6 +144,11 @@
               "name": "promptLabels",
               "type": "ReadonlyMap<GamepadPromptControl, string>",
               "optional": true
+            },
+            {
+              "name": "family",
+              "type": "GamepadMappingFamily",
+              "optional": false
             }
           ],
           "returnType": "SteamControllerGamepadMapping",
@@ -321,6 +342,27 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "layout",
+          "signature": "layout: GamepadMappingLayout",
+          "signatureTokens": [
+            {
+              "text": "layout",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMappingLayout",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Index space this mapping's button and axis indices are written against. Defaults to GamepadMappingLayout.Standard. A mapping that encodes raw HID report order must declare GamepadMappingLayout.Raw, so resolveGamepadDefinition can discard it when the browser reports the same device as already standard-normalised."
         },
         {
           "name": "promptLabels",

--- a/site/src/content/api/steam-deck-gamepad-mapping.json
+++ b/site/src/content/api/steam-deck-gamepad-mapping.json
@@ -1,16 +1,16 @@
 {
   "title": "SteamDeckGamepadMapping",
-  "description": "Mapping for the Valve Steam Deck (and the new Valve Controller via vendor fallback) when its raw HID gamepad is exposed directly to the browser — i.e. when Steam Input is *not* intercepting the device. With Steam Input intercepting, the device appears as `28de:11ff` \"Steam Virtual Gamepad\" with a standard W3C layout instead, and is routed to GenericDualAnalogGamepadMapping. The raw layout is non-standard: face buttons live at indices 3-6 (not the W3C-standard 0-3), the D-pad lives at indices 16-19, paddles at 20-23, and triggers report as analog axes 8/9 rather than buttons 6/7. Indices are derived from the Linux SDL_GameControllerDB entry for `Valve Steam Deck`.",
+  "description": "Mapping for the Valve Steam Deck (and the new Valve Controller via vendor fallback) when its raw HID gamepad is exposed directly to the browser — i.e. when Steam Input is *not* intercepting the device. With Steam Input intercepting, the device appears as `28de:11ff` \"Steam Virtual Gamepad\" with a standard W3C layout instead, and is routed to GenericDualAnalogGamepadMapping. The raw layout is non-standard: face buttons live at indices 3-6 (not the W3C-standard 0-3), the D-pad lives at indices 16-19, paddles at 20-23, and triggers report as analog axes 8/9 rather than buttons 6/7. Indices are derived from the Linux SDL_GameControllerDB entry for `Valve Steam Deck`. Because those indices are raw rather than W3C-standard, this mapping declares GamepadMappingLayout.Raw: should a browser ever report the same device as `mapping: \"standard\"`, `resolveGamepadDefinition` discards this layout in favour of the generic one rather than routing standard indices through raw slots.",
   "symbol": "SteamDeckGamepadMapping",
   "kind": "class",
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 7,
+  "memberCount": 8,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 4,
+    "properties": 5,
     "events": 0
   },
   "sections": [
@@ -20,7 +20,8 @@
       "members": [],
       "paragraphs": [
         "Mapping for the Valve Steam Deck (and the new Valve Controller via vendor fallback) when its raw HID gamepad is exposed directly to the browser — i.e. when Steam Input is *not* intercepting the device. With Steam Input intercepting, the device appears as `28de:11ff` \"Steam Virtual Gamepad\" with a standard W3C layout instead, and is routed to GenericDualAnalogGamepadMapping.",
-        "The raw layout is non-standard: face buttons live at indices 3-6 (not the W3C-standard 0-3), the D-pad lives at indices 16-19, paddles at 20-23, and triggers report as analog axes 8/9 rather than buttons 6/7. Indices are derived from the Linux SDL_GameControllerDB entry for `Valve Steam Deck`."
+        "The raw layout is non-standard: face buttons live at indices 3-6 (not the W3C-standard 0-3), the D-pad lives at indices 16-19, paddles at 20-23, and triggers report as analog axes 8/9 rather than buttons 6/7. Indices are derived from the Linux SDL_GameControllerDB entry for `Valve Steam Deck`.",
+        "Because those indices are raw rather than W3C-standard, this mapping declares GamepadMappingLayout.Raw: should a browser ever report the same device as `mapping: \"standard\"`, `resolveGamepadDefinition` discards this layout in favour of the generic one rather than routing standard indices through raw slots."
       ],
       "importLine": "import { SteamDeckGamepadMapping } from '@codexo/exojs'",
       "sourceLink": null
@@ -246,6 +247,27 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "layout",
+          "signature": "layout: Raw",
+          "signatureTokens": [
+            {
+              "text": "layout",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Raw",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Index space this mapping's button and axis indices are written against. Defaults to GamepadMappingLayout.Standard. A mapping that encodes raw HID report order must declare GamepadMappingLayout.Raw, so resolveGamepadDefinition can discard it when the browser reports the same device as already standard-normalised."
         },
         {
           "name": "promptLabels",

--- a/site/src/content/api/switch-pro-gamepad-mapping.json
+++ b/site/src/content/api/switch-pro-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 7,
+  "memberCount": 8,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 4,
+    "properties": 5,
     "events": 0
   },
   "sections": [
@@ -247,6 +247,27 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "layout",
+          "signature": "layout: GamepadMappingLayout",
+          "signatureTokens": [
+            {
+              "text": "layout",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMappingLayout",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Index space this mapping's button and axis indices are written against. Defaults to GamepadMappingLayout.Standard. A mapping that encodes raw HID report order must declare GamepadMappingLayout.Raw, so resolveGamepadDefinition can discard it when the browser reports the same device as already standard-normalised."
         },
         {
           "name": "promptLabels",

--- a/site/src/content/api/xbox-gamepad-mapping.json
+++ b/site/src/content/api/xbox-gamepad-mapping.json
@@ -6,11 +6,11 @@
   "subsystem": "input",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 7,
+  "memberCount": 8,
   "counts": {
     "constructors": 1,
     "methods": 2,
-    "properties": 4,
+    "properties": 5,
     "events": 0
   },
   "sections": [
@@ -247,6 +247,27 @@
           "params": [],
           "returnType": null,
           "description": "Identifies the device family this mapping targets."
+        },
+        {
+          "name": "layout",
+          "signature": "layout: GamepadMappingLayout",
+          "signatureTokens": [
+            {
+              "text": "layout",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "GamepadMappingLayout",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Index space this mapping's button and axis indices are written against. Defaults to GamepadMappingLayout.Standard. A mapping that encodes raw HID report order must declare GamepadMappingLayout.Raw, so resolveGamepadDefinition can discard it when the browser reports the same device as already standard-normalised."
         },
         {
           "name": "promptLabels",

--- a/src/input/GamepadDefinitions.ts
+++ b/src/input/GamepadDefinitions.ts
@@ -1,5 +1,6 @@
 import { ArcadeStickGamepadMapping } from './ArcadeStickGamepadMapping';
 import type { GamepadMapping } from './GamepadMapping';
+import { GamepadMappingLayout } from './GamepadMapping';
 import { GenericDualAnalogGamepadMapping } from './GenericDualAnalogGamepadMapping';
 import { JoyConLeftGamepadMapping } from './JoyConLeftGamepadMapping';
 import { JoyConRightGamepadMapping } from './JoyConRightGamepadMapping';
@@ -35,6 +36,9 @@ export type GamepadDefinitionResult =
  * `productKey` is the colon-joined pair (`"045e:028e"`), used as a compact lookup key.
  * `name` is the human-readable portion of the id with the vendor/product tokens removed,
  * or `null` when the id contained only identifiers.
+ * `mapping` is the browser's own verdict, verbatim — `"standard"` when it has
+ * normalised the device into the W3C layout, `""` when it hands the raw HID
+ * report through.
  */
 export interface GamepadDescriptor {
   id: string;
@@ -44,6 +48,7 @@ export interface GamepadDescriptor {
   productId: string | null;
   productKey: string | null;
   name: string | null;
+  mapping: BrowserGamepad['mapping'];
 }
 
 /**
@@ -199,6 +204,7 @@ export const parseGamepadDescriptor = (gamepad: BrowserGamepad): GamepadDescript
     productId,
     productKey,
     name: parseName(label),
+    mapping: gamepad.mapping,
   };
 };
 
@@ -215,11 +221,37 @@ export const resolveDefinition = (definition: GamepadDefinition, descriptor: Gam
 };
 
 /**
+ * Discards a {@link GamepadMappingLayout.Raw} mapping when the browser reports
+ * the device as already standard-normalised.
+ *
+ * A raw mapping encodes one device's unnormalised HID report order, so routing
+ * standard indices through it produces silently wrong channels — the Steam Deck
+ * expects its face cluster at 3-6, which a standard-mapped pad puts at 0-3. The
+ * resolved family and name are kept: the device is still what the definition
+ * says it is, and its prompt labels are a property of the hardware, not of the
+ * index space the browser chose to report it in. Prompt UIs should keep gating
+ * on {@link GamepadMapping.hasChannel}, which now honestly answers `false` for
+ * the paddles the generic layout has no room for.
+ */
+const withStandardLayoutGuard = (resolved: ResolvedGamepadDefinition, descriptor: GamepadDescriptor): ResolvedGamepadDefinition => {
+  if (descriptor.mapping !== 'standard' || resolved.mapping.layout !== GamepadMappingLayout.Raw) {
+    return resolved;
+  }
+
+  return {
+    ...resolved,
+    mapping: new GenericDualAnalogGamepadMapping([], resolved.mapping.promptLabels, resolved.mapping.family),
+  };
+};
+
+/**
  * Resolves the best-matching {@link ResolvedGamepadDefinition} for a connected gamepad.
  *
  * Iterates `definitions` in order — exact product IDs first, then vendor fallbacks,
  * then a generic catch-all — and returns the first match. Falls back to
- * {@link GenericDualAnalogGamepadMapping} when no definition matches.
+ * {@link GenericDualAnalogGamepadMapping} when no definition matches, and
+ * replaces a matched {@link GamepadMappingLayout.Raw} mapping with the generic
+ * layout when the browser reports `mapping: "standard"` for the device.
  *
  * @example
  * const resolved = resolveGamepadDefinition(navigator.getGamepads()[0]!);
@@ -235,7 +267,7 @@ export const resolveGamepadDefinition = (
     const resolvedDefinition = resolveDefinition(definition, descriptor);
 
     if (resolvedDefinition) {
-      return resolvedDefinition;
+      return withStandardLayoutGuard(resolvedDefinition, descriptor);
     }
   }
 
@@ -311,7 +343,10 @@ const exactDeviceDefinitions: GamepadDefinition[] = [
 const vendorFallbackDefinitions: GamepadDefinition[] = [
   createStaticGamepadDefinition('Microsoft Controller', () => new XboxGamepadMapping(), '045e'),
   createStaticGamepadDefinition('Sony Controller', () => new PlayStationGamepadMapping(), '054c'),
-  createStaticGamepadDefinition('Valve Controller', () => new SteamDeckGamepadMapping(), '28de'),
+  // Deliberately generic, not the Steam Deck layout: that layout is raw HID
+  // order for one specific device, and handing it to any unrecognised Valve
+  // product would route every channel through the wrong index.
+  createStaticGamepadDefinition('Valve Controller', () => new GenericDualAnalogGamepadMapping(), '28de'),
 ];
 
 const genericFallbackDefinition = createStaticGamepadDefinition('Generic Gamepad', () => new GenericDualAnalogGamepadMapping());

--- a/src/input/GamepadMapping.ts
+++ b/src/input/GamepadMapping.ts
@@ -21,6 +21,22 @@ export enum GamepadMappingFamily {
 }
 
 /**
+ * Which index space a {@link GamepadMapping}'s button and axis indices live in.
+ *
+ * Almost every mapping is written against the W3C "standard" layout the browser
+ * normalises known devices into. A `Raw` mapping instead encodes a device's
+ * unnormalised HID report order, which is only correct while the browser leaves
+ * that device unnormalised — see {@link SteamDeckGamepadMapping}, the one
+ * built-in mapping in that category.
+ */
+export enum GamepadMappingLayout {
+  /** Indices follow the W3C standard layout. */
+  Standard = 'standard',
+  /** Indices follow the device's raw HID report order. */
+  Raw = 'raw',
+}
+
+/**
  * Abstract translation layer between the browser's raw {@link https://developer.mozilla.org/en-US/docs/Web/API/Gamepad Gamepad API}
  * indices and ExoJS-canonical channel buffers.
  *
@@ -32,6 +48,16 @@ export enum GamepadMappingFamily {
 export abstract class GamepadMapping {
   /** Identifies the device family this mapping targets. */
   public abstract readonly family: GamepadMappingFamily;
+
+  /**
+   * Index space this mapping's button and axis indices are written against.
+   *
+   * Defaults to {@link GamepadMappingLayout.Standard}. A mapping that encodes
+   * raw HID report order must declare {@link GamepadMappingLayout.Raw}, so
+   * `resolveGamepadDefinition` can discard it when the browser reports the same
+   * device as already standard-normalised.
+   */
+  public readonly layout: GamepadMappingLayout = GamepadMappingLayout.Standard;
 
   /** Ordered list of buttons, indexed by the Gamepad API button index. */
   public readonly buttons: readonly GamepadButton[];

--- a/src/input/GenericDualAnalogGamepadMapping.ts
+++ b/src/input/GenericDualAnalogGamepadMapping.ts
@@ -28,11 +28,19 @@ import type { GamepadPromptControl } from './GamepadPromptLayouts';
  * layout. Their raw indices must not collide with 0–16.
  * @param promptLabels - Device-specific prompt labels, see
  * {@link GamepadMapping.promptLabels}.
+ * @param family - Device family to report. Subclasses override the field
+ * instead; the parameter exists so a known device that turns out to be
+ * standard-normalised can keep its family — and therefore its prompt
+ * labels — while falling back to this layout.
  */
 export class GenericDualAnalogGamepadMapping extends GamepadMapping {
-  public readonly family: GamepadMappingFamily = GamepadMappingFamily.GenericDualAnalog;
+  public readonly family: GamepadMappingFamily;
 
-  public constructor(extraButtons: readonly GamepadButton[] = [], promptLabels?: ReadonlyMap<GamepadPromptControl, string>) {
+  public constructor(
+    extraButtons: readonly GamepadButton[] = [],
+    promptLabels?: ReadonlyMap<GamepadPromptControl, string>,
+    family: GamepadMappingFamily = GamepadMappingFamily.GenericDualAnalog,
+  ) {
     super(
       [
         new GamepadButton(0, GamepadButton.South),
@@ -83,5 +91,7 @@ export class GenericDualAnalogGamepadMapping extends GamepadMapping {
       ],
       promptLabels,
     );
+
+    this.family = family;
   }
 }

--- a/src/input/SteamDeckGamepadMapping.ts
+++ b/src/input/SteamDeckGamepadMapping.ts
@@ -1,6 +1,6 @@
 import { GamepadAxis } from './GamepadAxis';
 import { GamepadButton } from './GamepadButton';
-import { GamepadMapping, GamepadMappingFamily } from './GamepadMapping';
+import { GamepadMapping, GamepadMappingFamily, GamepadMappingLayout } from './GamepadMapping';
 
 /**
  * Mapping for the Valve Steam Deck (and the new Valve Controller via vendor
@@ -14,9 +14,17 @@ import { GamepadMapping, GamepadMappingFamily } from './GamepadMapping';
  * W3C-standard 0-3), the D-pad lives at indices 16-19, paddles at 20-23, and
  * triggers report as analog axes 8/9 rather than buttons 6/7. Indices are
  * derived from the Linux SDL_GameControllerDB entry for `Valve Steam Deck`.
+ *
+ * Because those indices are raw rather than W3C-standard, this mapping declares
+ * {@link GamepadMappingLayout.Raw}: should a browser ever report the same
+ * device as `mapping: "standard"`, `resolveGamepadDefinition` discards this
+ * layout in favour of the generic one rather than routing standard indices
+ * through raw slots.
  */
 export class SteamDeckGamepadMapping extends GamepadMapping {
   public readonly family: GamepadMappingFamily = GamepadMappingFamily.SteamDeck;
+
+  public override readonly layout = GamepadMappingLayout.Raw;
 
   public constructor() {
     super(

--- a/test/core/__snapshots__/root-index-snapshot.test.ts.snap
+++ b/test/core/__snapshots__/root-index-snapshot.test.ts.snap
@@ -76,6 +76,7 @@ exports[`root index export surface snapshot > sorted runtime export names match 
   "GamepadButton",
   "GamepadMapping",
   "GamepadMappingFamily",
+  "GamepadMappingLayout",
   "GamepadPromptLayouts",
   "GenericDualAnalogGamepadMapping",
   "Geometry",

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -172,6 +172,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "GamepadInfo: interface",
   "GamepadMapping: class",
   "GamepadMappingFamily: enum",
+  "GamepadMappingLayout: enum",
   "GamepadPromptControl: type alias",
   "GamepadPromptLayouts: class",
   "GamepadSlotStrategy: type alias",

--- a/test/input/gamepad.test.ts
+++ b/test/input/gamepad.test.ts
@@ -30,6 +30,7 @@ const buildDefinition = (mapping = new GenericDualAnalogGamepadMapping()) => ({
     vendorId: null,
     productId: null,
     productKey: null,
+    mapping: 'standard' as const,
   },
   mapping,
 });

--- a/test/input/specialized-gamepad-mapping.test.ts
+++ b/test/input/specialized-gamepad-mapping.test.ts
@@ -2,9 +2,17 @@ import { ArcadeStickGamepadMapping } from '#input/ArcadeStickGamepadMapping';
 import { Gamepad } from '#input/Gamepad';
 import { GamepadButton } from '#input/GamepadButton';
 import { parseGamepadDescriptor, resolveGamepadDefinition } from '#input/GamepadDefinitions';
-import { GamepadMappingFamily } from '#input/GamepadMapping';
+import { GamepadMappingFamily, GamepadMappingLayout } from '#input/GamepadMapping';
+import { GamepadPromptLayouts } from '#input/GamepadPromptLayouts';
+import { GenericDualAnalogGamepadMapping } from '#input/GenericDualAnalogGamepadMapping';
+import { JoyConLeftGamepadMapping } from '#input/JoyConLeftGamepadMapping';
+import { JoyConRightGamepadMapping } from '#input/JoyConRightGamepadMapping';
+import { PlayStationGamepadMapping } from '#input/PlayStationGamepadMapping';
+import { SteamControllerGamepadMapping } from '#input/SteamControllerGamepadMapping';
 import { SteamDeckGamepadMapping } from '#input/SteamDeckGamepadMapping';
+import { SwitchProGamepadMapping } from '#input/SwitchProGamepadMapping';
 import { ChannelSize } from '#input/types';
+import { XboxGamepadMapping } from '#input/XboxGamepadMapping';
 
 type BrowserGamepad = NonNullable<ReturnType<Navigator['getGamepads']>[number]>;
 
@@ -30,6 +38,7 @@ const steamDeckDefinition = () => ({
     vendorId: '28de',
     productId: '1205',
     productKey: '28de:1205',
+    mapping: '' as const,
   },
   mapping: new SteamDeckGamepadMapping(),
 });
@@ -138,7 +147,9 @@ describe('specialized gamepad mappings', () => {
     expect(resolved.name).toBe('Steam Virtual Gamepad');
   });
 
-  test('falls back unknown Valve PIDs to Steam Deck mapping via vendor 28de', () => {
+  // The Steam Deck layout is raw HID order for one specific device, so the
+  // vendor fallback must not hand it to an unrecognised Valve product.
+  test('falls back unknown Valve PIDs to the generic layout via vendor 28de', () => {
     const resolved = resolveGamepadDefinition(
       parseGamepadDescriptor({
         id: 'Valve Future Hardware (Vendor: 28de Product: 9999)',
@@ -146,7 +157,83 @@ describe('specialized gamepad mappings', () => {
       } as Parameters<typeof parseGamepadDescriptor>[0]),
     );
 
-    expect(resolved.mapping.family).toBe(GamepadMappingFamily.SteamDeck);
+    expect(resolved.mapping.family).toBe(GamepadMappingFamily.GenericDualAnalog);
+    expect(resolved.mapping.layout).toBe(GamepadMappingLayout.Standard);
     expect(resolved.name).toBe('Valve Controller');
+  });
+
+  test('only the Steam Deck mapping declares a raw layout', () => {
+    const mappings = [
+      new SteamDeckGamepadMapping(),
+      new GenericDualAnalogGamepadMapping(),
+      new SteamControllerGamepadMapping(),
+      new ArcadeStickGamepadMapping(),
+      new JoyConLeftGamepadMapping(),
+      new JoyConRightGamepadMapping(),
+      new PlayStationGamepadMapping(),
+      new XboxGamepadMapping(),
+      new SwitchProGamepadMapping(),
+    ];
+
+    for (const mapping of mappings) {
+      const expected = mapping instanceof SteamDeckGamepadMapping ? GamepadMappingLayout.Raw : GamepadMappingLayout.Standard;
+
+      expect(mapping.layout).toBe(expected);
+    }
+  });
+
+  test('a Steam Deck the browser reports as standard-mapped drops the raw layout but keeps its identity', () => {
+    const resolved = resolveGamepadDefinition(
+      parseGamepadDescriptor({
+        id: 'Valve Steam Deck (Vendor: 28de Product: 1205)',
+        index: 0,
+        mapping: 'standard',
+      } as Parameters<typeof parseGamepadDescriptor>[0]),
+    );
+    const buttonsByIndex = new Map(resolved.mapping.buttons.map(button => [button.index, button.channel]));
+
+    // Standard indices, not the SDL-derived raw ones.
+    expect(resolved.mapping.layout).toBe(GamepadMappingLayout.Standard);
+    expect(buttonsByIndex.get(0)).toBe(GamepadButton.South);
+    expect(buttonsByIndex.get(3)).toBe(GamepadButton.North);
+
+    // The device is still a Steam Deck, so name, family and prompt labels stay.
+    expect(resolved.name).toBe('Steam Deck');
+    expect(resolved.mapping.family).toBe(GamepadMappingFamily.SteamDeck);
+    expect(GamepadPromptLayouts.getControlLabels(resolved.mapping).get('ButtonSouth')).toBe('A');
+
+    // The generic layout has no paddles, and hasChannel says so.
+    expect(resolved.mapping.hasChannel(GamepadButton.Paddle1)).toBe(false);
+  });
+
+  test('a Steam Deck the browser hands through raw keeps the raw layout', () => {
+    const resolved = resolveGamepadDefinition(
+      parseGamepadDescriptor({
+        id: 'Valve Steam Deck (Vendor: 28de Product: 1205)',
+        index: 0,
+        mapping: '',
+      } as Parameters<typeof parseGamepadDescriptor>[0]),
+    );
+    const buttonsByIndex = new Map(resolved.mapping.buttons.map(button => [button.index, button.channel]));
+
+    expect(resolved.mapping.layout).toBe(GamepadMappingLayout.Raw);
+    expect(buttonsByIndex.get(3)).toBe(GamepadButton.South);
+    expect(resolved.mapping.hasChannel(GamepadButton.Paddle1)).toBe(true);
+  });
+
+  test('a standard-mapped device with a standard-layout mapping is left alone', () => {
+    const resolved = resolveGamepadDefinition(
+      parseGamepadDescriptor({
+        id: 'Joy-Con (L) (Vendor: 057e Product: 2006)',
+        index: 0,
+        mapping: 'standard',
+      } as Parameters<typeof parseGamepadDescriptor>[0]),
+    );
+
+    // The solo Joy-Con is standard-mapped *and* deliberately incomplete — the
+    // guard must not backfill it with generic channels it does not have.
+    expect(resolved.mapping).toBeInstanceOf(JoyConLeftGamepadMapping);
+    expect(resolved.mapping.hasChannel(GamepadButton.RightTrigger)).toBe(false);
+    expect(resolved.mapping.hasChannel(GamepadButton.DPadUp)).toBe(false);
   });
 });


### PR DESCRIPTION
`resolveGamepadDefinition` never asked the browser how it had mapped a
device — `parseGamepadDescriptor` dropped `Gamepad.mapping` on the floor — so
a matched vendor/product definition won unconditionally. That is fine for the
mappings written against the W3C standard layout, but `SteamDeckGamepadMapping`
encodes the device's raw HID report order: face cluster at 3-6, D-pad at 16-19,
paddles at 20-23, triggers on axes 8/9. Routing standard indices through those
slots produces silently wrong channels on every button.

`GamepadMapping` now declares which index space it is written against through
`GamepadMappingLayout`, defaulting to `Standard`; the Steam Deck is the one
built-in mapping that declares `Raw`. `GamepadDescriptor` carries the browser's
own `mapping` verdict, and when it reads "standard" while the matched mapping
is raw, the generic layout wins.

The resolved name and family are deliberately kept, so a standard-mapped Steam
Deck still prompts with A/B/X/Y, View/Menu and L1/L2 — the labels are a
property of the hardware, not of the index space the browser reports it in. The
paddles it loses are covered by `hasChannel`, which now honestly answers false
for them.

The wider half of the same hole needed no layout tag: the vendor fallback for
`28de` handed the raw Steam Deck layout to *every* unrecognised Valve product.
It falls back to the generic layout now, and the raw one is reachable only
through the exact `28de:1205` product ID.

Deliberately not done: treating the standard-layout mappings as overlays on the
generic one. A solo Joy-Con reports `mapping: "standard"` but physically has
half the buttons, so backfilling its undeclared indices would put a
`RightTrigger` on index 7 and a D-pad on 12-15 of a device that has neither,
destroying exactly the `hasChannel` honesty the hardware probe established.

BREAKING CHANGE: `GamepadDescriptor` gains a required `mapping` field, so code
that builds one by hand rather than through `parseGamepadDescriptor` must
supply it. Unrecognised Valve devices (vendor `28de` without a known product
ID) now resolve to `GenericDualAnalogGamepadMapping` instead of
`SteamDeckGamepadMapping`.