### PR TITLE
perf(rendering)!: keep the WebGPU render pass open across renderer switches

### DIFF
--- a/packages/exojs-bench/src/rendering/EngineAdapter.ts
+++ b/packages/exojs-bench/src/rendering/EngineAdapter.ts
@@ -15,7 +15,8 @@ export type ArchetypeId =
   | 'mixed-blend'
   | 'mixed-material'
   | 'mixed-material-atlased'
-  | 'instanced-batch';
+  | 'instanced-batch'
+  | 'mixed-sprite-mesh';
 
 /** Structural definition of a scene archetype, independent of any engine or backend. */
 export interface ArchetypeSpec {
@@ -104,6 +105,29 @@ export interface ArchetypeSpec {
    * archetype reaches.
    */
   readonly batchSize?: number;
+  /**
+   * Spacing, in leaf index space, at which a single {@link Mesh} leaf replaces a
+   * sprite: leaf `i` is a mesh when `i % meshEvery === meshEvery - 1`.
+   * `undefined` keeps the sprite-only scene every other archetype builds.
+   *
+   * Renderer SWITCHES are the measured dimension, so the scene is deliberately
+   * lopsided — long sprite runs punctuated by one mesh — rather than two equal
+   * plateaus. Equal plateaus would fill half the frame with mesh leaves, and the
+   * default mesh path costs one draw call per leaf, so the measurement would be
+   * swamped by per-mesh draw-call cost and say nothing about the switch. One
+   * mesh per run puts `~nodeCount / meshEvery` switch PAIRS in the frame while
+   * keeping the mesh draw-call count in the same order as the sprite batch
+   * count.
+   *
+   * On WebGPU each switch used to end the open render pass and `queue.submit`,
+   * and the mesh renderer ended its own pass again at the tail of every flush —
+   * so the frame's submit count scaled with the switch count.
+   *
+   * ExoJS-ONLY, like `viewCount` and `materialCount` — a competitor arm builds
+   * its ordinary sprite scene instead, so this archetype carries no cross-arm
+   * meaning.
+   */
+  readonly meshEvery?: number;
 }
 
 /** One matrix cell: a single (engine, config, backend, archetype, node count) combination to measure. */

--- a/packages/exojs-bench/src/rendering/adapters/exojs.ts
+++ b/packages/exojs-bench/src/rendering/adapters/exojs.ts
@@ -5,6 +5,7 @@ import { Container } from '#rendering/Container';
 import { Geometry } from '#rendering/geometry/Geometry';
 import { ShaderSource } from '#rendering/material/ShaderSource';
 import { SpriteMaterial } from '#rendering/material/SpriteMaterial';
+import { Mesh } from '#rendering/mesh/Mesh';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import { RenderBatch } from '#rendering/RenderBatch';
 import { RetainedContainer } from '#rendering/RetainedContainer';
@@ -17,6 +18,19 @@ import type { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { mutationSignature, selectMutationIndices } from '../../shared/mutation';
 import type { ArchetypeSpec, Backend, EngineAdapter } from '../EngineAdapter';
+
+/**
+ * One mesh leaf for the `mixed-sprite-mesh` archetype: the same SPRITE_SIZE quad
+ * a sprite leaf covers, as a flat six-vertex triangle list with full-texture UVs.
+ * Deliberately the plainest mesh the renderer has — no material, no indices — so
+ * the archetype measures the renderer SWITCH and not mesh-specific work.
+ */
+const createLeafMesh = (texture: Texture): Mesh =>
+  new Mesh({
+    vertices: new Float32Array([0, 0, SPRITE_SIZE, 0, SPRITE_SIZE, SPRITE_SIZE, 0, 0, SPRITE_SIZE, SPRITE_SIZE, 0, SPRITE_SIZE]),
+    uvs: new Float32Array([0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]),
+    texture,
+  });
 
 /**
  * One SPRITE_SIZE quad in local space, the single geometry every instance of the
@@ -340,6 +354,7 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
       const blendRunLength = Math.max(1, spec.blendRunLength ?? 1);
       const materialCount = Math.max(0, spec.materialCount ?? 0);
       const materialRunLength = Math.max(1, spec.materialRunLength ?? 1);
+      const meshEvery = Math.max(0, spec.meshEvery ?? 0);
 
       materials = [];
 
@@ -402,21 +417,30 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
         // (24 textures, depth-2 spine) would not break batches at all. Cycling
         // per bucket position makes each stream sweep all textures, overflowing
         // the slots as intended.
-        const sprite = new Sprite(textures[Math.floor(i / spine.length) % textures.length]!);
+        // Sprite/mesh interleave (see `ArchetypeSpec.meshEvery`): every Nth leaf
+        // draws the same SPRITE_SIZE quad through the MESH renderer, so each one
+        // costs a renderer switch out and back while nothing else about the
+        // scene changes. Left unset, every leaf is a sprite — the pre-existing
+        // shape.
+        const leafTexture = textures[Math.floor(i / spine.length) % textures.length]!;
+        const isMesh = meshEvery > 0 && i % meshEvery === meshEvery - 1;
+        const leaf: Sprite | Mesh = isMesh ? createLeafMesh(leafTexture) : new Sprite(leafTexture);
 
-        sprite.cullable = spec.cullingEnabled;
+        leaf.cullable = spec.cullingEnabled;
 
         // Blend-mode / material plateaus keyed on the GLOBAL leaf index, using
         // the same formula the Pixi arm uses, so both arms assign the identical
         // mode to the identical sprite and the resulting draw-call structure is
         // comparable. Left at the engine default when the archetype does not
-        // set the dimension.
+        // set the dimension. Materials are a sprite-only dimension: the
+        // `SpriteMaterial` instances built above have no mesh counterpart, and
+        // no archetype combines `materialCount` with `meshRunLength`.
         if (blendModeCount > 1) {
-          sprite.blendMode = CYCLED_BLEND_MODES[Math.floor(i / blendRunLength) % blendModeCount]!;
+          leaf.blendMode = CYCLED_BLEND_MODES[Math.floor(i / blendRunLength) % blendModeCount]!;
         }
 
-        if (materials.length > 0) {
-          sprite.material = materials[Math.floor(i / materialRunLength) % materials.length]!;
+        if (materials.length > 0 && leaf instanceof Sprite) {
+          leaf.material = materials[Math.floor(i / materialRunLength) % materials.length]!;
         }
 
         // `overdraw` stacks nodeCount full-viewport quads at the origin to
@@ -431,19 +455,22 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
         // positioned at the origin rather than centred, to actually cover the
         // visible area rather than half of it) makes nodeCount the real fill
         // multiplier: nodeCount x VIEWPORT_WIDTH x VIEWPORT_HEIGHT overdraw.
-        if (overdraw) {
-          sprite.width = VIEWPORT_WIDTH;
-          sprite.height = VIEWPORT_HEIGHT;
+        // `overdraw` never sets `meshRunLength`, so this stays a sprite path.
+        if (overdraw && leaf instanceof Sprite) {
+          leaf.width = VIEWPORT_WIDTH;
+          leaf.height = VIEWPORT_HEIGHT;
         }
 
         const x = overdraw ? 0 : GRID_MARGIN + (i % columns) * cellWidth + cellWidth / 2;
         const y = overdraw ? 0 : GRID_MARGIN + Math.floor(i / columns) * cellHeight + cellHeight / 2;
 
-        sprite.setPosition(x, y);
-        spine[i % spine.length]!.addChild(sprite);
+        leaf.setPosition(x, y);
+        spine[i % spine.length]!.addChild(leaf);
 
-        if (selectedSet.has(i)) {
-          leaves.push({ sprite, baseX: x, baseY: y });
+        // Mesh leaves have no mutable-leaf shape (the archetype that builds them
+        // sets `mutationFraction: 0`, so `selectedSet` is empty there anyway).
+        if (selectedSet.has(i) && leaf instanceof Sprite) {
+          leaves.push({ sprite: leaf, baseX: x, baseY: y });
         }
       }
 

--- a/packages/exojs-bench/src/rendering/archetypes.ts
+++ b/packages/exojs-bench/src/rendering/archetypes.ts
@@ -122,6 +122,16 @@ export const ARCHETYPES: readonly ArchetypeSpec[] = [
   // call, so the frame cost scaled with the CALL count rather than the instance
   // count. ExoJS-only — see `ArchetypeSpec.batchSize`.
   { id: 'instanced-batch', nodeCounts: GPU_BOUND_COUNTS, nestingDepth: 1, textureCount: 1, mutationFraction: 0, cullingEnabled: false, batchSize: 64 },
+  // The only archetype that puts TWO renderers in one frame. Every other one
+  // draws through a single renderer, so the cost of handing the draw stream from
+  // one to the next — a pass end plus a `queue.submit` per switch on WebGPU —
+  // was invisible to the whole matrix. `meshEvery: 64` mirrors the blend and
+  // material plateaus in switch density (a few hundred in a 25k frame, the shape
+  // a real mixed scene of sprites plus custom geometry produces) while keeping
+  // the mesh leaf count low: the default mesh path draws one call per leaf, so
+  // an even sprite/mesh split would measure per-mesh draw-call cost instead of
+  // the switch. ExoJS-only — see `ArchetypeSpec.meshEvery`.
+  { id: 'mixed-sprite-mesh', nodeCounts: GPU_BOUND_COUNTS, nestingDepth: 2, textureCount: 1, mutationFraction: 0, cullingEnabled: false, meshEvery: 64 },
   {
     id: 'mixed-material-atlased',
     nodeCounts: GPU_BOUND_COUNTS,

--- a/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
+++ b/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
@@ -231,7 +231,17 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
 
       const mode = system.renderMode;
       const resources = this._getOrCreateResources(mode, device);
-      const pipeline = this._getPipeline(resources, drawCall.blendMode, backend.renderTargetFormat, backend._passCoordinator.stencilActive);
+      const coordinator = backend._passCoordinator;
+
+      // The pass survives a renderer switch, so it can still hold another
+      // renderer's draws. Resolving the texture binding below syncs dirty
+      // content on the queue timeline, ahead of the deferred submit, which
+      // would retroactively change a recorded draw sampling that same texture.
+      if (coordinator.passHasDraws && backend._textureUploadWouldMutate(drawCall.texture)) {
+        coordinator.endPass();
+      }
+
+      const pipeline = this._getPipeline(resources, drawCall.blendMode, backend.renderTargetFormat, coordinator.stencilActive);
       const textureBinding = backend.getTextureBinding(drawCall.texture);
       const textureBindGroup = device.createBindGroup({
         layout: this._textureBindGroupLayout!,
@@ -275,7 +285,7 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
       // One coordinator-owned pass per drawcall: each system's writeBuffers
       // target offset 0, so the pass must be submitted before the next system
       // overwrites those buffers. acquirePass/endPass preserve that 1:1 ratio.
-      const pass = backend._passCoordinator.acquirePass().pass;
+      const pass = coordinator.acquirePass().pass;
 
       pass.setBindGroup(0, uniformBindGroup);
       pass.setPipeline(pipeline);
@@ -298,10 +308,11 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
         pass.draw(resources.instanced ? resources.indexCount : drawCount, instanceCount, 0, 0);
       }
 
+      coordinator.markPassDraws();
       backend.stats.batches++;
       backend.stats.drawCalls++;
 
-      backend._passCoordinator.endPass();
+      coordinator.endPass();
     }
 
     this._drawCallCount = 0;

--- a/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
@@ -3,7 +3,6 @@
 import { Matrix } from '@codexo/exojs';
 import type {
   RenderTexture,
-  WebGpuActiveRenderPass,
   WebGpuRetainedBatchPayload,
   WebGpuRetainedBatchReplayer,
   WebGpuRetainedNodeIndexRange,
@@ -182,7 +181,6 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
   private _currentTexture: Texture | null = null;
 
   // ── Retained-batch replay state ───────────────────────────────────────────
-  private _lastReplayPass: WebGpuActiveRenderPass | null = null;
   private readonly _stagedReplayGroupData = new Float32Array(16);
   // Reused single-slot texture list handed to the backend at record time; a
   // tile chunk batch always binds exactly one tileset texture (slot 0).
@@ -257,7 +255,6 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     this._writtenViewUpdateId = -1;
     this._writtenGroupTransformId = -1;
     this._hasWrittenProjection = false;
-    this._lastReplayPass = null;
   }
 
   public render(node: TileChunkNode): void {
@@ -411,9 +408,27 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     const scissor = backend.getScissorRect();
     const maskClipsAll = scissor !== null && (scissor.width <= 0 || scissor.height <= 0);
 
-    const pass = backend._passCoordinator.acquirePass().pass;
+    const coordinator = backend._passCoordinator;
+    const willDraw =
+      this._quadIndex > 0 && !maskClipsAll && this._instanceBuffer !== null && this._indexBuffer !== null && this._currentBlendMode !== null && this._currentTexture !== null;
 
-    if (this._quadIndex > 0 && !maskClipsAll && this._instanceBuffer !== null && this._indexBuffer !== null && this._currentBlendMode !== null && this._currentTexture !== null) {
+    // The pass survives a renderer switch, so it can hold ANOTHER renderer's
+    // draws by the time this flush runs. Resolving the shared transform storage
+    // below may free the buffer those draws bind, and syncing the tileset
+    // texture may re-upload content they sample — both land on the queue
+    // timeline ahead of the deferred submit. End (submit) the pass first so
+    // they keep what they were recorded against.
+    if (
+      willDraw &&
+      coordinator.passHasDraws &&
+      (backend._textureUploadWouldMutate(this._currentTexture!) || backend._transformStorageWouldGrow(this._maxNodeIndex + 1))
+    ) {
+      coordinator.endPass();
+    }
+
+    const pass = coordinator.acquirePass().pass;
+
+    if (willDraw) {
       device.queue.writeBuffer(this._instanceBuffer, 0, this._instanceData, 0, this._quadIndex * instanceStrideBytes);
 
       const storage = backend.getTransformStorageBuffer(this._maxNodeIndex + 1);
@@ -430,6 +445,7 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
       pass.setIndexBuffer(this._indexBuffer, 'uint16');
       pass.drawIndexed(indicesPerInstance, this._quadIndex, 0, 0, 0);
 
+      coordinator.markPassDraws();
       backend.stats.batches++;
       backend.stats.drawCalls++;
     }
@@ -454,7 +470,7 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
       );
     }
 
-    backend._passCoordinator.endPass();
+    coordinator.endPass();
 
     this._quadIndex = 0;
     this._maxNodeIndex = 0;
@@ -587,15 +603,14 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     }
 
     const coordinator = backend._passCoordinator;
-    let activePass = coordinator.activePass;
-    const passHasDraws = activePass !== null && this._lastReplayPass === activePass;
 
     // Same-frame texture mutation guard: resolving the bindings below
     // re-uploads mutated content on the queue timeline BEFORE the deferred
     // submit, which would retroactively change draws already recorded into
     // the open pass. End (submit) the pass first so they keep the
-    // pre-mutation content.
-    if (passHasDraws) {
+    // pre-mutation content. The texture cache is shared and the pass survives
+    // a renderer switch, so any recorded draw is at risk, not just one of ours.
+    if (coordinator.passHasDraws) {
       for (const texture of payload.textures) {
         if (backend._textureUploadWouldMutate(texture)) {
           coordinator.endPass();
@@ -632,7 +647,7 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     }
 
     if (uboDirty) {
-      activePass = coordinator.activePass;
+      const activePass = coordinator.activePass;
 
       if (activePass !== null && bundle.drawsInPass === activePass) {
         // Rewriting the UBO would retroactively re-project this bundle's
@@ -659,7 +674,7 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     pass.drawIndexed(indicesPerInstance, payload.instanceCount, 0, 0, 0);
 
     bundle.drawsInPass = active;
-    this._lastReplayPass = active;
+    coordinator.markPassDraws();
     backend.stats.batches++;
     backend.stats.drawCalls++;
   }

--- a/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
@@ -409,26 +409,29 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     const maskClipsAll = scissor !== null && (scissor.width <= 0 || scissor.height <= 0);
 
     const coordinator = backend._passCoordinator;
-    const willDraw =
-      this._quadIndex > 0 && !maskClipsAll && this._instanceBuffer !== null && this._indexBuffer !== null && this._currentBlendMode !== null && this._currentTexture !== null;
 
     // The pass survives a renderer switch, so it can hold ANOTHER renderer's
     // draws by the time this flush runs. Resolving the shared transform storage
     // below may free the buffer those draws bind, and syncing the tileset
     // texture may re-upload content they sample — both land on the queue
     // timeline ahead of the deferred submit. End (submit) the pass first so
-    // they keep what they were recorded against.
+    // they keep what they were recorded against. Only the conditions this check
+    // actually needs are repeated from the draw condition below: hoisting the
+    // whole predicate into a boolean would cost the narrowing the draw block
+    // relies on.
     if (
-      willDraw &&
+      this._quadIndex > 0 &&
+      !maskClipsAll &&
+      this._currentTexture !== null &&
       coordinator.passHasDraws &&
-      (backend._textureUploadWouldMutate(this._currentTexture!) || backend._transformStorageWouldGrow(this._maxNodeIndex + 1))
+      (backend._textureUploadWouldMutate(this._currentTexture) || backend._transformStorageWouldGrow(this._maxNodeIndex + 1))
     ) {
       coordinator.endPass();
     }
 
     const pass = coordinator.acquirePass().pass;
 
-    if (willDraw) {
+    if (this._quadIndex > 0 && !maskClipsAll && this._instanceBuffer !== null && this._indexBuffer !== null && this._currentBlendMode !== null && this._currentTexture !== null) {
       device.queue.writeBuffer(this._instanceBuffer, 0, this._instanceData, 0, this._quadIndex * instanceStrideBytes);
 
       const storage = backend.getTransformStorageBuffer(this._maxNodeIndex + 1);

--- a/src/rendering/filters/WebGpuShaderFilter.ts
+++ b/src/rendering/filters/WebGpuShaderFilter.ts
@@ -233,6 +233,7 @@ export class WebGpuShaderFilter extends Filter {
           pass.setBindGroup(1, userBindGroup);
           pass.draw(4);
 
+          gpu._passCoordinator.markPassDraws();
           gpu.stats.drawCalls++;
 
           gpu._passCoordinator.endPass();

--- a/src/rendering/webgpu/WebGpuBackdropBlendCompositor.ts
+++ b/src/rendering/webgpu/WebGpuBackdropBlendCompositor.ts
@@ -471,6 +471,7 @@ export class WebGpuBackdropBlendCompositor {
     pass.setIndexBuffer(this._indexBuffer!, 'uint16');
     pass.drawIndexed(6);
 
+    manager._passCoordinator.markPassDraws();
     manager.stats.batches++;
     manager.stats.drawCalls++;
 

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -423,7 +423,7 @@ export class WebGpuBackend implements RenderBackend {
       // mirroring the renderers' flush-time `wouldGrow` guard (which runs too
       // late here — `reserve` frees the buffer before any renderer flushes).
       if (this._passCoordinatorInstance?.hasActivePass === true && storage.wouldGrow(reserveCount)) {
-        this._flushActiveRenderer();
+        this._flushActiveRendererAndEndPass();
       }
 
       storage.reserve(this._device, reserveCount, this._accountant);
@@ -493,7 +493,7 @@ export class WebGpuBackend implements RenderBackend {
     // top-level render() calls. Top-level plans (depth back to 0) keep their rows
     // so cross-call batching survives to the frame-end flush.
     if (this._drawPlanDepth > 0) {
-      this._flushActiveRenderer();
+      this._flushActiveRendererAndEndPass();
       this._getTransformStorage().buffer.rewindTo(planBase, planHash);
     }
 
@@ -579,7 +579,7 @@ export class WebGpuBackend implements RenderBackend {
       this._poisonActiveRetainedCaptures();
     }
 
-    this._flushActiveRenderer();
+    this._flushActiveRendererAndEndPass();
     this._stats.renderPasses++;
     pass.execute(this);
 
@@ -599,7 +599,7 @@ export class WebGpuBackend implements RenderBackend {
     assertLiveRenderTarget(nextRenderTarget);
 
     if (this._renderTarget !== nextRenderTarget) {
-      this._flushActiveRenderer();
+      this._flushActiveRendererAndEndPass();
 
       if (this._renderTarget !== this._rootRenderTarget) {
         this._unsubscribeRenderTarget(this._renderTarget);
@@ -617,7 +617,7 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   public pushScissorRect(bounds: Rectangle): this {
-    this._flushActiveRenderer();
+    this._flushActiveRendererAndEndPass();
 
     this._clipBoundsStack.push(bounds.clone());
 
@@ -651,7 +651,7 @@ export class WebGpuBackend implements RenderBackend {
       this._poisonActiveRetainedCaptures();
     }
 
-    this._flushActiveRenderer();
+    this._flushActiveRendererAndEndPass();
     this._setActiveRenderer(null);
 
     if (!this._maskCompositorConnected) {
@@ -677,7 +677,7 @@ export class WebGpuBackend implements RenderBackend {
       this._poisonActiveRetainedCaptures();
     }
 
-    this._flushActiveRenderer();
+    this._flushActiveRendererAndEndPass();
     this._setActiveRenderer(null);
 
     if (!this._backdropBlendCompositorConnected) {
@@ -715,7 +715,7 @@ export class WebGpuBackend implements RenderBackend {
       return this;
     }
 
-    this._flushActiveRenderer();
+    this._flushActiveRendererAndEndPass();
 
     const removedClip = this._clipBoundsStack.pop();
 
@@ -737,7 +737,7 @@ export class WebGpuBackend implements RenderBackend {
     // per-target depth/stencil attachment across the clip scope's passes and
     // draws the shape silhouette into the stencil aspect. Content renderers
     // select stencil-enabled pipeline variants while the clip is in effect.
-    this._flushActiveRenderer();
+    this._flushActiveRendererAndEndPass();
     this._setActiveRenderer(null);
     this._passCoordinator.pushStencilClip(shape, transform);
 
@@ -749,7 +749,7 @@ export class WebGpuBackend implements RenderBackend {
       return this;
     }
 
-    this._flushActiveRenderer();
+    this._flushActiveRendererAndEndPass();
     this._setActiveRenderer(null);
     this._passCoordinator.popStencilClip();
 
@@ -803,7 +803,7 @@ export class WebGpuBackend implements RenderBackend {
     // flush forced one draw call per render() call (each render() re-applies the
     // same camera view), defeating cross-call batching.
     if (this._renderTarget.view !== view) {
-      this._flushActiveRenderer();
+      this._flushActiveRendererAndEndPass();
     }
     this._renderTarget.setView(view);
 
@@ -825,7 +825,7 @@ export class WebGpuBackend implements RenderBackend {
     // The open pass is always the currently bound target, so this is precisely
     // the target the clear applies to.
     if (this._passCoordinatorInstance?.hasActivePass === true) {
-      this._flushActiveRenderer();
+      this._flushActiveRendererAndEndPass();
     }
 
     this._clearRequested = true;
@@ -846,7 +846,7 @@ export class WebGpuBackend implements RenderBackend {
     }
 
     if (this._renderer) {
-      this._flushActiveRenderer();
+      this._flushActiveRendererAndEndPass();
     } else if (this._clearRequested) {
       // No active renderer but a clear is pending: open an empty coordinator
       // pass so createColorAttachment consumes the clear state once.
@@ -1087,21 +1087,33 @@ export class WebGpuBackend implements RenderBackend {
     return rect;
   }
 
+  /**
+   * Hand the draw stream to `renderer`, draining the outgoing one first. The
+   * GPU pass is NOT ended: a renderer switch is a batching boundary, not a
+   * submit boundary, so a mixed sprite/mesh scene records both renderers' draws
+   * into one pass instead of paying a pass plus a `queue.submit` per
+   * alternation. What the pass end used to buy — every renderer's hazard guards
+   * only ever seeing its own draws — is replaced by
+   * `WebGpuPassCoordinator.passHasDraws`, which the guards against SHARED
+   * resources (transform storage growth, managed texture re-upload) consult
+   * instead of their own cursors.
+   */
   private _setActiveRenderer(renderer: Renderer | null): void {
     if (this._renderer !== renderer) {
-      this._flushActiveRenderer();
+      this._renderer?.flush();
       this._renderer = renderer;
     }
   }
 
-  private _flushActiveRenderer(): void {
+  private _flushActiveRendererAndEndPass(): void {
     this._renderer?.flush();
     // Ending the active GPU pass — and thus `queue.submit` — is centralized here
-    // so it happens only at genuine boundaries (renderer switch, render-target /
-    // view / scissor / stencil change, compositor, execute, plan / frame end),
-    // NOT once per batch flush. Instanced renderers record consecutive batch
-    // flushes into the same open pass (via WebGpuInstanceArena) and no longer end
-    // it themselves, collapsing thousands of per-draw submits into one per frame.
+    // so it happens only at genuine boundaries (render-target / view / scissor /
+    // stencil change, compositor, execute, plan / frame end), NOT once per batch
+    // flush and not on a renderer switch. Instanced renderers record consecutive
+    // batch flushes into the same open pass (via WebGpuInstanceArena) and no
+    // longer end it themselves, collapsing thousands of per-draw submits into
+    // one per frame.
     this._passCoordinatorInstance?.endPass();
   }
 
@@ -2457,7 +2469,7 @@ export class WebGpuBackend implements RenderBackend {
       // code destroys a texture mid-frame between two same-frame render() calls;
       // never called from within a renderer flush, so this is not reentrant.
       if (this._passCoordinatorInstance?.hasActivePass === true) {
-        this._flushActiveRenderer();
+        this._flushActiveRendererAndEndPass();
       }
 
       state.texture.destroy();

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -864,6 +864,11 @@ export class WebGpuBackend implements RenderBackend {
     this.onDeviceRestored.destroy();
     this.onRenderError.destroy();
     this._setActiveRenderer(null);
+    // A renderer switch no longer ends the pass, so `_setActiveRenderer(null)`
+    // can leave one open here. Drop it rather than submit it: the teardown below
+    // destroys the very buffers those draws bind, and the frame's pixels have
+    // nowhere left to go.
+    this._passCoordinatorInstance?.discardPass();
     this.rendererRegistry.destroy();
     this._destroyManagedTextures();
     this._renderTexturePool.destroy();
@@ -1860,6 +1865,13 @@ export class WebGpuBackend implements RenderBackend {
     // Disconnect renderers so they release pipelines / buffers / bind
     // groups tied to the dead device. They reconnect during _initialize().
     this.rendererRegistry.disconnect();
+
+    // Whatever those flushes recorded — and anything a renderer switch left
+    // open before the loss — belongs to the dead device. The coordinator
+    // survives recovery and `acquirePass` short-circuits on an open pass, so a
+    // pass left set here would be handed to the RESTORED device and every later
+    // frame would record into the dead encoder. Drop it, never submit it.
+    this._passCoordinatorInstance?.discardPass();
 
     if (this._maskCompositorConnected) {
       this._maskCompositor.disconnect();

--- a/src/rendering/webgpu/WebGpuMaskCompositor.ts
+++ b/src/rendering/webgpu/WebGpuMaskCompositor.ts
@@ -231,6 +231,7 @@ export class WebGpuMaskCompositor {
     pass.setIndexBuffer(this._indexBuffer!, 'uint16');
     pass.drawIndexed(6);
 
+    manager._passCoordinator.markPassDraws();
     manager.stats.batches++;
     manager.stats.drawCalls++;
 

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -394,6 +394,11 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
   // pass object on every acquire, so a pass ended by anyone else (a target
   // switch, a stencil clip, another renderer) is distinguished automatically.
   private _instancedBatchPass: WebGpuActiveRenderPass | null = null;
+  // The open pass this renderer has actually RECORDED draws into — set only
+  // after a draw is encoded, by both the immediate-batch path and `flush()`.
+  // `_instancedBatchPass` alone cannot answer that: it is set when the cursors
+  // are bound to a pass, which happens before anything is recorded.
+  private _ownDrawsPass: WebGpuActiveRenderPass | null = null;
   private _instancedBatchUniformSlots = 0;
   private readonly _instancedBatchUniformBuffersInPass = new Set<GPUBuffer>();
   private _instancedNodeIndexBuffer: GPUBuffer | null = null;
@@ -539,6 +544,12 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
 
     this._syncInstancedBatchPass(active);
 
+    // Two predicates, deliberately different. `ownDraws` gates the hazards
+    // against buffers only THIS renderer binds; `passHasDraws` gates the two
+    // shared ones (transform storage, managed texture content), because the
+    // pass survives a renderer switch and the draw at risk may be a sprite's.
+    const ownDraws = this._ownDrawsPass === active;
+
     // Sized for everything this pass has taken SO FAR plus this batch, captured
     // before the guard below may reset the cursors. Sizing to the single batch
     // that remains after a reopen would peg both buffers at one batch forever:
@@ -552,17 +563,16 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     // Every reallocation below frees a buffer an earlier draw in this pass still
     // references, and every write below lands ahead of the whole submit; both
     // are answered by ending (submitting) the pass and reopening with fresh
-    // slices. With no earlier draw of ours in the pass there is nothing to
-    // protect, so the common single-batch case never splits.
+    // slices. With no earlier draw in the pass there is nothing to protect, so
+    // the common single-batch case never splits.
     if (
-      this._instancedNodeIndexFrameBytes > 0 &&
-      (geometryWouldRewrite ||
-        backend._textureUploadWouldMutate(texture) ||
-        backend._transformStorageWouldGrow(maxNodeIndex + 1) ||
-        this._instancedNodeIndexWouldGrow(targetNodeIndexBytes) ||
-        this._instancedUniformWouldGrow(targetUniformSlots) ||
-        (attributeBytes > 0 && !this._instancedAttributeArena.fits(attributeBytes)) ||
-        (uniformPlan !== null && this._instancedBatchUniformWriteWouldAlias(uniformPlan)))
+      (coordinator.passHasDraws && (backend._textureUploadWouldMutate(texture) || backend._transformStorageWouldGrow(maxNodeIndex + 1))) ||
+      (ownDraws &&
+        (geometryWouldRewrite ||
+          this._instancedNodeIndexWouldGrow(targetNodeIndexBytes) ||
+          this._instancedUniformWouldGrow(targetUniformSlots) ||
+          (attributeBytes > 0 && !this._instancedAttributeArena.fits(attributeBytes)) ||
+          (uniformPlan !== null && this._instancedBatchUniformWriteWouldAlias(uniformPlan))))
     ) {
       active = this._reopenInstancedBatchPass(backend);
     }
@@ -620,6 +630,8 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     pass.setIndexBuffer(staticGeometry.indexBuffer, 'uint16');
     pass.drawIndexed(staticGeometry.indexCount, count);
 
+    this._ownDrawsPass = active;
+    coordinator.markPassDraws();
     backend.stats.batches++;
     backend.stats.drawCalls++;
   }
@@ -646,6 +658,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
   /** Drop the pass association so the next sync restarts every cursor. */
   private _resetInstancedBatchPass(): void {
     this._instancedBatchPass = null;
+    this._ownDrawsPass = null;
     this._instancedNodeIndexFrameBytes = 0;
     this._instancedBatchUniformSlots = 0;
     this._instancedBatchUniformBuffersInPass.clear();
@@ -704,13 +717,18 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
       return;
     }
 
+    const coordinator = backend._passCoordinator;
+
     // Phases 2-4 below rewrite the shared vertex/index/uniform and instanced
-    // node-index buffers from offset 0, and may reallocate them. Immediate
-    // `drawInstancedBatch` draws left in the open pass still read those exact
-    // buffers, and `queue.writeBuffer` lands ahead of the whole submit — so end
-    // (submit) that pass before touching anything.
-    if (this._instancedBatchPass !== null && this._instancedBatchPass === backend._passCoordinator.activePass) {
-      backend._passCoordinator.endPass();
+    // node-index buffers from offset 0, and may reallocate them. Draws of OURS
+    // left in the open pass — from `drawInstancedBatch` or from an earlier
+    // flush — still read those exact buffers, and `queue.writeBuffer` lands
+    // ahead of the whole submit, so end (submit) that pass before touching
+    // anything. Another renderer's draws in the pass are not at risk here: none
+    // of these buffers is shared, and the pass now survives a renderer switch
+    // precisely so they can stay.
+    if (this._ownDrawsPass !== null && this._ownDrawsPass === coordinator.activePass) {
+      coordinator.endPass();
     }
 
     this._resetInstancedBatchPass();
@@ -868,11 +886,23 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
       device.queue.writeBuffer(this._uniformBuffer!, 0, defaultUniformData, 0, defaultUniformBytes);
     }
 
+    // Any draw still in the open pass at this point belongs to ANOTHER renderer
+    // (ours were submitted above). The loop below resolves textures and the
+    // shared transform storage — both can mutate a resource that draw already
+    // reads, and both land on the queue timeline ahead of the deferred submit.
+    // Checking costs two walks over the draw calls, so it only runs when there
+    // is something to protect: a mesh-only frame skips it entirely.
+    if (coordinator.passHasDraws && (this._flushWouldMutateTexture(backend) || backend._transformStorageWouldGrow(this._maxInstancedNodeIndex() + 1))) {
+      coordinator.endPass();
+    }
+
     // Phase 5: single render pass with one drawIndexed per mesh, switching
     // pipeline+bind groups between default and custom paths as needed. The
     // coordinator owns the GPU pass (load/clear resolution, pass count and
-    // scissor are applied there) and ends + submits it below.
-    const pass = backend._passCoordinator.acquirePass().pass;
+    // scissor are applied there); it stays OPEN afterwards so a following
+    // sprite/text flush merges into the same submit.
+    const active = coordinator.acquirePass();
+    const pass = active.pass;
 
     const renderTargetFormat = backend.renderTargetFormat;
     // A clip scope flushes the active renderer on push/pop, so every draw call
@@ -1029,6 +1059,14 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
         const cursor = customDrawCursors.get(dc.customShader) ?? 0;
         pass.setBindGroup(0, resources.meshUniformBindGroup, [cursor * meshUniformAlignment]);
 
+        // This draw reads the material's user-uniform buffer for as long as the
+        // pass stays open — which it now does past the end of this flush. A
+        // later `drawInstancedBatch` with the same material consults exactly
+        // this set before writing that buffer.
+        if (resources.userUniformBuffer !== null) {
+          this._instancedBatchUniformBuffersInPass.add(resources.userUniformBuffer);
+        }
+
         if (dc.texture !== lastTexture) {
           lastTexture = dc.texture;
           pass.setBindGroup(1, this._getOrCreateMeshTextureBindGroup(resources, backend, dc.texture));
@@ -1047,8 +1085,17 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
       backend.stats.drawCalls++;
     }
 
-    backend._passCoordinator.endPass();
-    this._resetInstancedBatchPass();
+    // The pass stays open. Its cursors carry the flush's own consumption
+    // forward so a following `drawInstancedBatch` in the same pass appends
+    // AFTER these draws' slices instead of overwriting the bytes they read:
+    // `_instancedNodeIndexFrameBytes` was advanced per batch by
+    // `_uploadInstancedNodeIndices`, and `instancedDrawCursor` is the number of
+    // instanced-uniform slots taken.
+    this._instancedBatchPass = active;
+    this._ownDrawsPass = active;
+    this._instancedBatchUniformSlots = instancedDrawCursor;
+    this._instancedAttributeArena.syncPass(active);
+    coordinator.markPassDraws();
 
     this._resetFrame();
   }
@@ -1392,6 +1439,50 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     return length;
   }
 
+  /**
+   * Highest transform-storage slot the instanced batches of this flush will
+   * reference, or `-1` when none does. Walks the same batching decision the
+   * draw loop makes, so the answer matches the `getTransformStorageBuffer`
+   * calls it will issue; the default and custom paths bake their transforms
+   * into vertices and touch no slot at all.
+   */
+  private _maxInstancedNodeIndex(): number {
+    let max = -1;
+
+    for (let i = 0; i < this._drawCallCount; i++) {
+      const batchLength = this._getStaticBatchLength(i);
+
+      if (batchLength < 2) {
+        continue;
+      }
+
+      for (let j = 0; j < batchLength; j++) {
+        // batchLength is bounded so i + j stays < _drawCallCount, and a static
+        // batch candidate always carries a command.
+        const nodeIndex = this._drawCalls[i + j]!.command!.nodeIndex >>> 0;
+
+        if (nodeIndex > max) {
+          max = nodeIndex;
+        }
+      }
+
+      i += batchLength - 1;
+    }
+
+    return max;
+  }
+
+  /** Whether any texture this flush binds would be re-uploaded or resized when synced. */
+  private _flushWouldMutateTexture(backend: WebGpuBackend): boolean {
+    for (let i = 0; i < this._drawCallCount; i++) {
+      if (backend._textureUploadWouldMutate(this._drawCalls[i]!.texture)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   private _isStaticBatchCandidate(drawCall: MeshDrawCall): boolean {
     const command = drawCall.command;
 
@@ -1715,9 +1806,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     // may re-upload mutated content on the queue timeline before the deferred
     // submit, retroactively changing draws already in the open pass. End it
     // first so those draws keep their pre-mutation content.
-    let activePass = coordinator.activePass;
-
-    if (activePass !== null && state.drawsInPass === activePass && backend._textureUploadWouldMutate(texture)) {
+    if (coordinator.passHasDraws && backend._textureUploadWouldMutate(texture)) {
       coordinator.endPass();
       state.drawsInPass = null;
     }
@@ -1728,7 +1817,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     const view = backend.view;
 
     if (state.uboView !== view || state.uboViewUpdateId !== view.updateId) {
-      activePass = coordinator.activePass;
+      const activePass = coordinator.activePass;
 
       if (activePass !== null && state.drawsInPass === activePass) {
         coordinator.endPass();
@@ -1764,6 +1853,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     pass.drawIndexed(geometry.indexCount, payload.instanceCount);
 
     state.drawsInPass = active;
+    coordinator.markPassDraws();
     backend.stats.batches++;
     backend.stats.drawCalls++;
   }

--- a/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
@@ -14,7 +14,7 @@ import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { WebGpuInstanceArena } from './WebGpuInstanceArena';
-import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
+import type { WebGpuActiveRenderPass, WebGpuPassCoordinator } from './WebGpuPassCoordinator';
 import {
   retainedGroupUniformBytes,
   type WebGpuRetainedBatchPayload,
@@ -203,9 +203,6 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
   private _currentTexture: Texture | RenderTexture | null = null;
 
   // ── Retained-batch replay state ───────────────────────────────────────────
-  // The open pass replayed retained batches were last recorded into — feeds
-  // the "does the open pass already hold draws?" checks alongside the arena.
-  private _lastReplayPass: WebGpuActiveRenderPass | null = null;
   // Scratch for the packed group matrix compared at replay (see _replayRetainedBatch).
   private readonly _stagedReplayGroupData = new Float32Array(16);
   // Reused single-slot texture list handed to the backend at record time; the
@@ -285,7 +282,6 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     this._maxNodeIndex = 0;
     this._currentBlendMode = null;
     this._currentTexture = null;
-    this._lastReplayPass = null;
   }
 
   public render(sprite: NineSliceSprite): void {
@@ -431,36 +427,33 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
       const batchBytes = this._quadIndex * instanceStrideBytes;
       const needCount = this._maxNodeIndex + 1;
 
-      let active = backend._passCoordinator.acquirePass();
+      const coordinator = backend._passCoordinator;
+      let active = coordinator.acquirePass();
 
       this._instanceArena.syncPass(active);
 
       // A texture re-upload / resize lands on the queue timeline before the
       // deferred submit, retroactively changing draws already recorded into this
       // open pass. End (submit) the pass first so they capture the pre-mutation
-      // content, then reopen and re-upload into the fresh slice.
-      if (this._instanceArena.cursor > 0 && this._currentTexture !== null && backend._textureUploadWouldMutate(this._currentTexture)) {
-        backend._passCoordinator.endPass();
-        active = backend._passCoordinator.acquirePass();
-        this._instanceArena.resetPass();
-        this._instanceArena.syncPass(active);
+      // content, then reopen and re-upload into the fresh slice. The texture
+      // cache is shared and the pass survives a renderer switch, so the guard
+      // asks the coordinator whether ANY draw is recorded, not just our arena.
+      if (coordinator.passHasDraws && this._currentTexture !== null && backend._textureUploadWouldMutate(this._currentTexture)) {
+        active = this._reopenPass(coordinator);
       }
 
       // Resolving the transform storage may reallocate (and free) its GPU buffer;
-      // end the pass first when earlier batches in it still reference the old one.
-      if (this._instanceArena.cursor > 0 && backend._transformStorageWouldGrow(needCount)) {
-        backend._passCoordinator.endPass();
-        active = backend._passCoordinator.acquirePass();
-        this._instanceArena.resetPass();
-        this._instanceArena.syncPass(active);
+      // end the pass first when earlier batches in it still reference the old
+      // one — again from any renderer sharing this pass, not only ours.
+      if (coordinator.passHasDraws && backend._transformStorageWouldGrow(needCount)) {
+        active = this._reopenPass(coordinator);
       }
 
+      // The arena buffer is ours alone, so only our own batches in the pass
+      // reference the allocation `grow` is about to free.
       if (!this._instanceArena.fits(batchBytes)) {
         if (this._instanceArena.cursor > 0) {
-          backend._passCoordinator.endPass();
-          active = backend._passCoordinator.acquirePass();
-          this._instanceArena.resetPass();
-          this._instanceArena.syncPass(active);
+          active = this._reopenPass(coordinator);
         }
 
         this._instanceArena.grow(device, batchBytes);
@@ -486,6 +479,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
       pass.setIndexBuffer(this._indexBuffer!, 'uint16');
       pass.drawIndexed(indicesPerInstance, this._quadIndex, 0, 0, 0);
 
+      coordinator.markPassDraws();
       backend.stats.batches++;
       backend.stats.drawCalls++;
     } else if (backend.clearRequested) {
@@ -522,6 +516,18 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
 
   public destroy(): void {
     this.disconnect();
+  }
+
+  /** End (submit) the open pass and reopen a fresh one with an empty arena slice. */
+  private _reopenPass(coordinator: WebGpuPassCoordinator): WebGpuActiveRenderPass {
+    coordinator.endPass();
+
+    const active = coordinator.acquirePass();
+
+    this._instanceArena.resetPass();
+    this._instanceArena.syncPass(active);
+
+    return active;
   }
 
   private _getOrCreateTransformBindGroup(device: GPUDevice, uniformBuffer: GPUBuffer, storageBuffer: GPUBuffer): GPUBindGroup {
@@ -614,16 +620,14 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     }
 
     const coordinator = backend._passCoordinator;
-    let activePass = coordinator.activePass;
-    const passHasDraws =
-      activePass !== null && ((this._instanceArena.cursor > 0 && this._instanceArena.tracksPass(activePass)) || this._lastReplayPass === activePass);
 
     // Same-frame texture mutation guard: resolving the bindings below
     // re-uploads mutated content on the queue timeline BEFORE the deferred
     // submit, which would retroactively change draws already recorded into the
     // open pass. End (submit) the pass first so they keep the pre-mutation
-    // content.
-    if (passHasDraws) {
+    // content. The texture cache is shared and the pass survives a renderer
+    // switch, so any recorded draw is at risk, not just one of ours.
+    if (coordinator.passHasDraws) {
       for (const texture of payload.textures) {
         if (backend._textureUploadWouldMutate(texture)) {
           coordinator.endPass();
@@ -661,7 +665,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     }
 
     if (uboDirty) {
-      activePass = coordinator.activePass;
+      const activePass = coordinator.activePass;
 
       if (activePass !== null && bundle.drawsInPass === activePass) {
         // Rewriting the UBO would retroactively re-project this bundle's draws
@@ -689,7 +693,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     pass.drawIndexed(indicesPerInstance, payload.instanceCount, 0, 0, 0);
 
     bundle.drawsInPass = active;
-    this._lastReplayPass = active;
+    coordinator.markPassDraws();
     backend.stats.batches++;
     backend.stats.drawCalls++;
   }

--- a/src/rendering/webgpu/WebGpuPassCoordinator.ts
+++ b/src/rendering/webgpu/WebGpuPassCoordinator.ts
@@ -96,6 +96,7 @@ export class WebGpuPassCoordinator implements RenderPassCoordinator {
   private _stencilLoadOp: GPULoadOp = 'load';
   private _stencilRef = 0;
   private _active: WebGpuActiveRenderPass | null = null;
+  private _passHasDraws = false;
 
   public constructor(backend: WebGpuPassBackend) {
     this._backend = backend;
@@ -116,6 +117,35 @@ export class WebGpuPassCoordinator implements RenderPassCoordinator {
   /** The open GPU pass, or `null` when none is open. @internal */
   public get activePass(): WebGpuActiveRenderPass | null {
     return this._active;
+  }
+
+  /**
+   * Whether the open pass holds draws recorded by anyone — this renderer or
+   * another one. The pass survives a renderer switch, so a renderer's own
+   * cursors no longer answer "would mutating a resource now retroactively
+   * change a draw already in this pass": the draw may belong to a renderer that
+   * flushed earlier into the same pass.
+   *
+   * The contract deliberately stops at a boolean. Guards against a *shared*
+   * resource being mutated under recorded draws (the transform storage buffer,
+   * managed texture content) need only "does this pass hold any draw" — never
+   * "whose". Every "is it mine" question is answered locally, by comparing
+   * against {@link activePass} by identity.
+   * @internal
+   */
+  public get passHasDraws(): boolean {
+    return this._passHasDraws;
+  }
+
+  /**
+   * Record that a draw was encoded into the open pass. Called by every renderer
+   * at the site that bumps `stats.drawCalls`. A no-op with no pass open.
+   * @internal
+   */
+  public markPassDraws(): void {
+    if (this._active !== null) {
+      this._passHasDraws = true;
+    }
   }
 
   /**
@@ -158,6 +188,7 @@ export class WebGpuPassCoordinator implements RenderPassCoordinator {
     const encoder = backend.device.createCommandEncoder({ label: 'pass-coordinator:command-encoder' });
     const pass = encoder.beginRenderPass(descriptor);
 
+    this._passHasDraws = false;
     backend.stats.renderPasses++;
 
     const scissor = backend.getScissorRect();
@@ -194,6 +225,7 @@ export class WebGpuPassCoordinator implements RenderPassCoordinator {
     }
 
     this._active = null;
+    this._passHasDraws = false;
     active.pass.end();
     this._backend.submit(active.encoder.finish());
   }
@@ -258,6 +290,7 @@ export class WebGpuPassCoordinator implements RenderPassCoordinator {
 
     const active = this.acquirePass();
     this._stencil.draw(active.pass, active.targetFormat, true, shape, transform, active.view);
+    this.markPassDraws();
     this.endPass();
 
     this._stencilWriteInProgress = false;
@@ -288,6 +321,7 @@ export class WebGpuPassCoordinator implements RenderPassCoordinator {
 
     const active = this.acquirePass();
     this._stencil.draw(active.pass, active.targetFormat, false, entry.shape, entry.transform, active.view);
+    this.markPassDraws();
     this.endPass();
 
     this._stencilWriteInProgress = false;

--- a/src/rendering/webgpu/WebGpuPassCoordinator.ts
+++ b/src/rendering/webgpu/WebGpuPassCoordinator.ts
@@ -216,6 +216,25 @@ export class WebGpuPassCoordinator implements RenderPassCoordinator {
     return this._active;
   }
 
+  /**
+   * Drop the open pass WITHOUT ending or submitting it. For teardown paths only,
+   * where the recorded draws must not reach the queue at all: backend destroy,
+   * and device-loss teardown, where the encoder belongs to the dead device.
+   *
+   * Leaving `_active` set is the failure this exists to prevent. The coordinator
+   * instance outlives a device-loss recovery, and {@link acquirePass}
+   * short-circuits on an already-open pass — so a pass left open across the
+   * teardown would be handed back to the RESTORED device, which would then
+   * record every later frame into the dead device's encoder, silently and for
+   * the rest of the session. Operations on a lost device do not throw, so
+   * nothing would surface the breakage.
+   * @internal
+   */
+  public discardPass(): void {
+    this._active = null;
+    this._passHasDraws = false;
+  }
+
   /** End and submit the active GPU pass, if any. Idempotent. */
   public endPass(): void {
     const active = this._active;

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -15,7 +15,7 @@ import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
 import { WebGpuInstanceArena } from './WebGpuInstanceArena';
-import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
+import type { WebGpuActiveRenderPass, WebGpuPassCoordinator } from './WebGpuPassCoordinator';
 import {
   retainedGroupUniformBytes,
   type WebGpuRetainedBatchPayload,
@@ -319,7 +319,6 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
   // never marks the live projection "already staged").
   private readonly _recordTextureScratch: Array<Texture | RenderTexture | null> = [null];
   private readonly _stagedReplayGroupData = new Float32Array(16);
-  private _lastReplayPass: WebGpuActiveRenderPass | null = null;
 
   protected onConnect(backend: WebGpuBackend): void {
     if (this._device) return;
@@ -413,7 +412,6 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     this._currentModeY = null;
     this._currentPath = null;
     this._recordTextureScratch[0] = null;
-    this._lastReplayPass = null;
   }
 
   public render(sprite: RepeatingSprite): void {
@@ -616,36 +614,33 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
       const batchBytes = drawShader ? this._shaderQuadCount * shaderStrideBytes : this._geoQuadCount * geoStrideBytes;
       const needCount = this._maxNodeIndex + 1;
 
-      let active = backend._passCoordinator.acquirePass();
+      const coordinator = backend._passCoordinator;
+      let active = coordinator.acquirePass();
 
       this._instanceArena.syncPass(active);
 
       // A texture re-upload / resize lands on the queue timeline before the
       // deferred submit, retroactively changing draws already recorded into this
       // open pass. End (submit) the pass first so they capture the pre-mutation
-      // content, then reopen and re-upload into the fresh slice.
-      if (this._instanceArena.cursor > 0 && this._currentTexture !== null && backend._textureUploadWouldMutate(this._currentTexture)) {
-        backend._passCoordinator.endPass();
-        active = backend._passCoordinator.acquirePass();
-        this._instanceArena.resetPass();
-        this._instanceArena.syncPass(active);
+      // content, then reopen and re-upload into the fresh slice. The texture
+      // cache is shared and the pass survives a renderer switch, so the guard
+      // asks the coordinator whether ANY draw is recorded, not just our arena.
+      if (coordinator.passHasDraws && this._currentTexture !== null && backend._textureUploadWouldMutate(this._currentTexture)) {
+        active = this._reopenPass(coordinator);
       }
 
       // Resolving the transform storage may reallocate (and free) its GPU buffer;
-      // end the pass first when earlier batches in it still reference the old one.
-      if (this._instanceArena.cursor > 0 && backend._transformStorageWouldGrow(needCount)) {
-        backend._passCoordinator.endPass();
-        active = backend._passCoordinator.acquirePass();
-        this._instanceArena.resetPass();
-        this._instanceArena.syncPass(active);
+      // end the pass first when earlier batches in it still reference the old
+      // one — again from any renderer sharing this pass, not only ours.
+      if (coordinator.passHasDraws && backend._transformStorageWouldGrow(needCount)) {
+        active = this._reopenPass(coordinator);
       }
 
+      // The arena buffer is ours alone, so only our own batches in the pass
+      // reference the allocation `grow` is about to free.
       if (!this._instanceArena.fits(batchBytes)) {
         if (this._instanceArena.cursor > 0) {
-          backend._passCoordinator.endPass();
-          active = backend._passCoordinator.acquirePass();
-          this._instanceArena.resetPass();
-          this._instanceArena.syncPass(active);
+          active = this._reopenPass(coordinator);
         }
 
         this._instanceArena.grow(device, batchBytes);
@@ -707,6 +702,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     pass.setIndexBuffer(this._indexBuffer, 'uint16');
     pass.drawIndexed(indicesPerInstance, this._shaderQuadCount, 0, 0, 0);
 
+    backend._passCoordinator.markPassDraws();
     backend.stats.batches++;
     backend.stats.drawCalls++;
   }
@@ -745,6 +741,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     pass.setIndexBuffer(this._indexBuffer, 'uint16');
     pass.drawIndexed(indicesPerInstance, this._geoQuadCount, 0, 0, 0);
 
+    backend._passCoordinator.markPassDraws();
     backend.stats.batches++;
     backend.stats.drawCalls++;
 
@@ -833,16 +830,14 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     }
 
     const coordinator = backend._passCoordinator;
-    let activePass = coordinator.activePass;
-    const passHasDraws =
-      activePass !== null && ((this._instanceArena.cursor > 0 && this._instanceArena.tracksPass(activePass)) || this._lastReplayPass === activePass);
 
     // Same-frame texture mutation guard: resolving the bindings below re-
     // uploads mutated content on the queue timeline BEFORE the deferred
     // submit, which would retroactively change draws already recorded into
     // the open pass. End (submit) the pass first so they keep the
-    // pre-mutation content.
-    if (passHasDraws) {
+    // pre-mutation content. The texture cache is shared and the pass survives
+    // a renderer switch, so any recorded draw is at risk, not just one of ours.
+    if (coordinator.passHasDraws) {
       for (const texture of payload.textures) {
         if (backend._textureUploadWouldMutate(texture)) {
           coordinator.endPass();
@@ -882,7 +877,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     }
 
     if (uboDirty) {
-      activePass = coordinator.activePass;
+      const activePass = coordinator.activePass;
 
       if (activePass !== null && bundle.drawsInPass === activePass) {
         // Rewriting the UBO would retroactively re-project this bundle's
@@ -910,13 +905,25 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     pass.drawIndexed(indicesPerInstance, payload.instanceCount, 0, 0, 0);
 
     bundle.drawsInPass = active;
-    this._lastReplayPass = active;
+    coordinator.markPassDraws();
     backend.stats.batches++;
     backend.stats.drawCalls++;
   }
 
   public destroy(): void {
     this.disconnect();
+  }
+
+  /** End (submit) the open pass and reopen a fresh one with an empty arena slice. */
+  private _reopenPass(coordinator: WebGpuPassCoordinator): WebGpuActiveRenderPass {
+    coordinator.endPass();
+
+    const active = coordinator.acquirePass();
+
+    this._instanceArena.resetPass();
+    this._instanceArena.syncPass(active);
+
+    return active;
   }
 
   // -----------------------------------------------------------------------

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -351,9 +351,6 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
   private _writtenViewUpdateId = -1;
   private _hasWrittenProjection = false;
   private readonly _stagedGroupData = new Float32Array(16);
-  // The open pass replayed retained batches were last recorded into — feeds
-  // the "does the open pass already hold draws?" checks alongside the arena.
-  private _lastReplayPass: WebGpuActiveRenderPass | null = null;
 
   private _device: GPUDevice | null = null;
   private _shaderModule: GPUShaderModule | null = null;
@@ -528,7 +525,6 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     this._writtenView = null;
     this._writtenViewUpdateId = -1;
     this._hasWrittenProjection = false;
-    this._lastReplayPass = null;
     this._uniformBuffer = null;
     this._pipelineLayout = null;
     this._customBaseTextureLayout = null;
@@ -722,7 +718,8 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
 
       // Open the coordinator's pass (idempotent — consecutive flushes reuse it)
       // and reserve a fresh slice of the instance arena for this batch.
-      let active = backend._passCoordinator.acquirePass();
+      const coordinator = backend._passCoordinator;
+      let active = coordinator.acquirePass();
 
       this._instanceArena.syncPass(active);
       this._syncUniformHazardPass(active);
@@ -738,14 +735,17 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       // deferred submit, retroactively changing draws already recorded into this
       // open pass. End (submit) the pass first so those draws capture the
       // pre-mutation content, then reopen and re-upload into the fresh slice.
-      if (this._instanceArena.cursor > 0 && this._batchWouldMutateTexture(backend)) {
+      // The texture cache is shared, so the endangered draw need not be one of
+      // ours — the pass survives a renderer switch. Same for the storage guard
+      // below; both ask the coordinator, not this renderer's own cursor.
+      if (coordinator.passHasDraws && this._batchWouldMutateTexture(backend)) {
         active = this._reopenPass(backend);
       }
 
       // Resolving the transform storage may reallocate (and free) its GPU buffer;
       // earlier batches in this open pass still reference the old one, so end the
       // pass first when it already holds batches, then reopen with a fresh slice.
-      if (this._instanceArena.cursor > 0 && backend._transformStorageWouldGrow(needCount)) {
+      if (coordinator.passHasDraws && backend._transformStorageWouldGrow(needCount)) {
         active = this._reopenPass(backend);
       }
 
@@ -802,6 +802,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
         this._uniformBuffersInPass.add(customResources!.userUniformBuffer!);
       }
 
+      coordinator.markPassDraws();
       backend.stats.batches++;
       backend.stats.drawCalls++;
     } else if (backend.clearRequested) {
@@ -1062,17 +1063,16 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     }
 
     const coordinator = backend._passCoordinator;
-    let activePass = coordinator.activePass;
-    const passHasDraws =
-      activePass !== null && ((this._instanceArena.cursor > 0 && this._instanceArena.tracksPass(activePass)) || this._lastReplayPass === activePass);
 
     // Same-frame texture mutation guard: resolving the bindings below
     // re-uploads mutated content on the queue timeline BEFORE the deferred
     // submit, which would retroactively change draws already recorded into
     // the open pass. End (submit) the pass first so they keep the
     // pre-mutation content — the `_batchWouldMutateTexture` hazard, applied
-    // to the recorded texture list.
-    if (passHasDraws) {
+    // to the recorded texture list. The texture cache is shared and the pass
+    // survives a renderer switch, so any recorded draw is at risk, not just
+    // one of ours.
+    if (coordinator.passHasDraws) {
       for (const texture of payload.textures) {
         if (backend._textureUploadWouldMutate(texture)) {
           coordinator.endPass();
@@ -1109,7 +1109,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     }
 
     if (uboDirty) {
-      activePass = coordinator.activePass;
+      const activePass = coordinator.activePass;
 
       if (activePass !== null && bundle.drawsInPass === activePass) {
         // Rewriting the UBO would retroactively re-project this bundle's
@@ -1138,7 +1138,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     pass.drawIndexed(indicesPerSprite, payload.instanceCount, 0, 0, 0);
 
     bundle.drawsInPass = active;
-    this._lastReplayPass = active;
+    coordinator.markPassDraws();
     backend.stats.batches++;
     backend.stats.drawCalls++;
   }

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -582,9 +582,24 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     const stencil = backend._passCoordinator.stencilActive;
     const frameBindGroup = this._getFrameBindGroup(device);
 
+    const coordinator = backend._passCoordinator;
+
+    // The pass survives a renderer switch, so it can still hold another
+    // renderer's draws. Resolving an atlas bind group below syncs a dirty glyph
+    // page on the queue timeline, ahead of the deferred submit, which would
+    // retroactively change a recorded draw sampling that same atlas.
+    if (coordinator.passHasDraws) {
+      for (const batch of batches) {
+        if (backend._textureUploadWouldMutate(batch.atlasTexture)) {
+          coordinator.endPass();
+          break;
+        }
+      }
+    }
+
     // The coordinator owns the GPU pass (load/clear resolution, pass count and
     // scissor are applied there) and ends + submits it below.
-    const pass = backend._passCoordinator.acquirePass().pass;
+    const pass = coordinator.acquirePass().pass;
 
     pass.setVertexBuffer(0, this._vertexBuffer);
     pass.setIndexBuffer(this._indexBuffer!, 'uint16');
@@ -603,11 +618,12 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
         lastTexture = batch.atlasTexture;
       }
       pass.drawIndexed(batch.indexCount, 1, batch.firstIndex, 0, 0);
+      coordinator.markPassDraws();
       backend.stats.batches++;
       backend.stats.drawCalls++;
     }
 
-    backend._passCoordinator.endPass();
+    coordinator.endPass();
 
     this._resetFrameState();
   }
@@ -1217,6 +1233,15 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     // page — see `_tryRecordRetainedBatch`'s `[batch.atlasTexture]`), never a
     // `RenderTexture`; the payload's shared type is wider only because other
     // renderers can target one.
+    // Same-frame atlas-mutation guard: syncing a dirty glyph page below lands on
+    // the queue timeline ahead of the deferred submit, retroactively changing
+    // draws already recorded into the open pass — from any renderer, since the
+    // pass survives a renderer switch.
+    if (coordinator.passHasDraws && backend._textureUploadWouldMutate(payload.textures[0]!)) {
+      coordinator.endPass();
+      state.drawsInPass = null;
+    }
+
     const textureBindGroup = this._getTexBindGroup(device, backend, payload.textures[0]! as Texture);
     const frameBindGroup = this._getTextReplayBindGroup(state, device);
     const indexBuffer = this._ensureRetainedQuadIndexBuffer(device, data.quadCount);
@@ -1232,6 +1257,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     pass.drawIndexed(data.quadCount * 6, 1, 0, 0, 0);
 
     state.drawsInPass = active;
+    coordinator.markPassDraws();
     backend.stats.batches++;
     backend.stats.drawCalls++;
   }

--- a/test/rendering/browser/webgpu-single-submit.test.ts
+++ b/test/rendering/browser/webgpu-single-submit.test.ts
@@ -23,6 +23,7 @@ import type { Application } from '#core/Application';
 import { Color } from '#core/Color';
 import { Container } from '#rendering/Container';
 import { Geometry } from '#rendering/geometry/Geometry';
+import { Mesh } from '#rendering/mesh/Mesh';
 import { RenderingContext } from '#rendering/RenderingContext';
 import type { RenderNode } from '#rendering/RenderNode';
 import { Sprite } from '#rendering/sprite/Sprite';
@@ -173,6 +174,19 @@ const paletteColor = (index: number): string => {
 };
 const palette36 = Array.from({ length: 36 }, (_, i) => paletteColor(i));
 
+// `Mesh.colors` takes one packed-RGBA8 u32 per vertex. Building it through a
+// byte view keeps the channel order explicit rather than relying on a hand-rolled
+// shift expression matching the platform's endianness.
+const packRgbaPerVertex = (rgba: RgbaTuple, vertexCount: number): Uint32Array => {
+  const bytes = new Uint8Array(vertexCount * 4);
+
+  for (let i = 0; i < vertexCount; i++) {
+    bytes.set(rgba, i * 4);
+  }
+
+  return new Uint32Array(bytes.buffer);
+};
+
 // Parse a `#rrggbb` string to an opaque RGBA tuple (canvas alphaMode 'opaque').
 const hexToRgba = (hex: string): RgbaTuple => [parseInt(hex.slice(1, 3), 16), parseInt(hex.slice(3, 5), 16), parseInt(hex.slice(5, 7), 16), 255];
 
@@ -281,6 +295,100 @@ describe('WebGPU single-submit frame', () => {
     } finally {
       root.destroy();
       textures.forEach(texture => texture.destroy());
+      backend.destroy();
+    }
+  });
+
+  test('a sprite/mesh/sprite frame merges both renderers into ONE pass and ONE submit', async ctx => {
+    const backend = await setupBackend();
+    // Two sprites on the top row and one mesh on the bottom row, rendered
+    // sprite -> mesh -> sprite so the backend switches renderers twice. A
+    // renderer switch used to end (submit) the pass, and the mesh renderer
+    // additionally ended its own at the tail of every flush — so this frame cost
+    // a pass plus a submit per alternation, and the sprite flush after the mesh
+    // had to open a fresh pass. Both renderers write into the SHARED transform
+    // storage and share the texture cache, which is why merging them needs the
+    // coordinator-side `passHasDraws` knowledge rather than each renderer's own
+    // cursor.
+    //
+    // ONE mesh flush is the boundary of what this merges. `WebGpuMeshRenderer`
+    // rewrites its vertex / index / uniform buffers from offset 0 on every
+    // flush, so a SECOND mesh flush still has to end the pass holding the
+    // first's draws — the per-pass cursor discipline `drawInstancedBatch` uses
+    // has not been extended to the flush path.
+    const cell = 16;
+    const columns = [0, 24, 48];
+    const spriteColors = ['#ff0000', '#00ff00'];
+    const meshColor: RgbaTuple = [255, 255, 0, 255];
+    const spriteTextures = spriteColors.map(color => createSolidTexture(color, 8));
+    const sprites = spriteTextures.map((texture, i) => {
+      const sprite = new Sprite(texture);
+
+      sprite.setPosition(columns[i]!, 0);
+      sprite.width = cell;
+      sprite.height = cell;
+
+      return sprite;
+    });
+    // The mesh carries its colour in the vertex stream and samples the 1x1 white
+    // texture, so no extra texture bindings are involved.
+    const meshX = columns[2]!;
+    const meshY = 24;
+    const mesh = new Mesh({
+      vertices: new Float32Array([
+        meshX,
+        meshY,
+        meshX + cell,
+        meshY,
+        meshX + cell,
+        meshY + cell,
+        meshX,
+        meshY,
+        meshX + cell,
+        meshY + cell,
+        meshX,
+        meshY + cell,
+      ]),
+      uvs: new Float32Array([0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]),
+      colors: packRgbaPerVertex(meshColor, 6),
+    });
+
+    const renderInterleaved = (): void => {
+      backend.resetStats();
+      backend.clear(Color.black);
+
+      sprites[0]!.render(backend);
+      mesh.render(backend);
+      sprites[1]!.render(backend);
+
+      backend.flush();
+    };
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderGuarded(ctx, backend, renderInterleaved))) {
+          return;
+        }
+      }
+
+      const submits = countSubmits(backend, renderInterleaved);
+
+      expect(backend.stats.drawCalls).toBe(3);
+      expect(backend.stats.renderPasses).toBe(1);
+      expect(submits).toBe(1);
+
+      // Pixels are what actually guard the merge: a pass that keeps all three
+      // draws but lets one renderer's buffer write land under the other's
+      // recorded draws would still submit once, and paint the wrong cells.
+      const readPixel = readWebGpuPixels(backend, canvasSize);
+
+      expectPixelNear(readPixel(columns[0]! + 8, 8), hexToRgba(spriteColors[0]!));
+      expectPixelNear(readPixel(columns[1]! + 8, 8), hexToRgba(spriteColors[1]!));
+      expectPixelNear(readPixel(meshX + 8, meshY + 8), meshColor);
+    } finally {
+      mesh.destroy();
+      sprites.forEach(sprite => sprite.destroy());
+      spriteTextures.forEach(texture => texture.destroy());
       backend.destroy();
     }
   });

--- a/test/rendering/pass/web-gpu-pass-coordinator.test.ts
+++ b/test/rendering/pass/web-gpu-pass-coordinator.test.ts
@@ -297,6 +297,57 @@ describe('WebGpuPassCoordinator', () => {
     }
   });
 
+  test('passHasDraws tracks recorded draws for the lifetime of one pass', () => {
+    const root = new RenderTarget(64, 64, true);
+    const { backend } = createMockBackend(root);
+    const coordinator = new WebGpuPassCoordinator(backend);
+
+    try {
+      // No pass open: marking is a no-op rather than staging state for the pass
+      // that happens to open next.
+      coordinator.markPassDraws();
+      expect(coordinator.passHasDraws).toBe(false);
+
+      coordinator.acquirePass();
+      expect(coordinator.passHasDraws).toBe(false);
+
+      coordinator.markPassDraws();
+      expect(coordinator.passHasDraws).toBe(true);
+
+      // Ending clears it, and the next pass starts empty — this is what lets a
+      // renderer read "does the open pass hold anyone's draws" without knowing
+      // which renderer split it.
+      coordinator.endPass();
+      expect(coordinator.passHasDraws).toBe(false);
+
+      coordinator.acquirePass();
+      expect(coordinator.passHasDraws).toBe(false);
+    } finally {
+      coordinator.endPass();
+      root.destroy();
+    }
+  });
+
+  test('passHasDraws survives a redundant acquire of the already-open pass', () => {
+    const root = new RenderTarget(64, 64, true);
+    const { backend } = createMockBackend(root);
+    const coordinator = new WebGpuPassCoordinator(backend);
+
+    try {
+      coordinator.acquirePass();
+      coordinator.markPassDraws();
+
+      // acquirePass is idempotent; it must not reset the flag, or the very next
+      // renderer to open the pass would think it is empty and skip its guards.
+      coordinator.acquirePass();
+
+      expect(coordinator.passHasDraws).toBe(true);
+    } finally {
+      coordinator.endPass();
+      root.destroy();
+    }
+  });
+
   test('acquirePass applies the active scissor rect when non-empty', () => {
     const root = new RenderTarget(64, 64, true);
     const scissorRect = { x: 1, y: 2, width: 8, height: 4 };

--- a/test/rendering/pass/web-gpu-pass-coordinator.test.ts
+++ b/test/rendering/pass/web-gpu-pass-coordinator.test.ts
@@ -328,6 +328,33 @@ describe('WebGpuPassCoordinator', () => {
     }
   });
 
+  test('discardPass drops the open pass without ending or submitting it', () => {
+    const root = new RenderTarget(64, 64, true);
+    const { backend, passEncoder, submit } = createMockBackend(root);
+    const coordinator = new WebGpuPassCoordinator(backend);
+
+    try {
+      coordinator.acquirePass();
+      coordinator.markPassDraws();
+
+      coordinator.discardPass();
+
+      // Teardown semantics: the recorded draws must not reach the queue at all,
+      // which is what separates this from endPass().
+      expect(passEncoder.end).not.toHaveBeenCalled();
+      expect(submit).not.toHaveBeenCalled();
+      expect(coordinator.hasActivePass).toBe(false);
+      expect(coordinator.passHasDraws).toBe(false);
+
+      // Idempotent, and a later acquire opens a genuinely fresh pass.
+      coordinator.discardPass();
+      expect(coordinator.acquirePass()).not.toBeNull();
+    } finally {
+      coordinator.endPass();
+      root.destroy();
+    }
+  });
+
   test('passHasDraws survives a redundant acquire of the already-open pass', () => {
     const root = new RenderTarget(64, 64, true);
     const { backend } = createMockBackend(root);

--- a/test/rendering/webgpu-backend.test.ts
+++ b/test/rendering/webgpu-backend.test.ts
@@ -2343,6 +2343,84 @@ describe('WebGpuBackend', () => {
     }
   });
 
+  test('destroy drops an open render pass instead of leaving it on the coordinator', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const app = {
+        canvas: environment.canvas,
+        options: {
+          canvas: { width: 128, height: 128 },
+          clearColor: Color.black,
+        },
+      } as unknown as Application;
+      const manager = new WebGpuBackend(app);
+
+      installCoreAndParticleRenderers(manager);
+
+      await manager.initialize();
+
+      // A renderer switch no longer ends the pass, so destroy() can be reached
+      // with one open — which used to be impossible, because switching to a
+      // null renderer ended it.
+      manager._passCoordinator.acquirePass();
+
+      expect(manager._passCoordinator.hasActivePass).toBe(true);
+
+      manager.destroy();
+
+      expect(manager._passCoordinator.hasActivePass).toBe(false);
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('device-loss teardown drops the open pass so the restored device does not inherit it', async () => {
+    const environment = createMockWebGpuEnvironment();
+    let manager: WebGpuBackend | null = null;
+
+    try {
+      const app = {
+        canvas: environment.canvas,
+        options: {
+          canvas: { width: 128, height: 128 },
+          clearColor: Color.black,
+        },
+      } as unknown as Application;
+
+      manager = new WebGpuBackend(app);
+      installCoreAndParticleRenderers(manager);
+
+      await manager.initialize();
+
+      const restored = vi.fn();
+
+      manager.onDeviceRestored.add(restored);
+
+      const deadPass = manager._passCoordinator.acquirePass();
+
+      environment.simulateDeviceLost({ message: 'gpu removed' });
+      await Promise.resolve();
+
+      await vi.waitFor(
+        () => {
+          expect(restored).toHaveBeenCalledTimes(1);
+        },
+        { timeout: 5000, interval: 25 },
+      );
+
+      // The coordinator survives recovery and acquirePass short-circuits on an
+      // already-open pass. Inheriting the dead device's pass would record every
+      // later frame into an encoder that can never be submitted — silently,
+      // since operations on a lost device do not throw.
+      expect(manager._passCoordinator.hasActivePass).toBe(false);
+      expect(manager._passCoordinator.acquirePass()).not.toBe(deadPass);
+    } finally {
+      manager?.destroy();
+      environment.restore();
+    }
+  });
+
   test('exhausting all device-recovery attempts reports an aggregated error instead of failing silently', async () => {
     const environment = createMockWebGpuEnvironment();
 


### PR DESCRIPTION
Closes `NEU-O18` from the architecture-review track.

## The finding, re-counted at the code

The review scoped this to the `endPass` at the end of `WebGpuMeshRenderer.flush()`. That is the smaller half. The dominant cost sits one level up:

```ts
private _setActiveRenderer(renderer: Renderer | null): void {
  if (this._renderer !== renderer) {
    this._flushActiveRenderer();   // flush() AND _passCoordinator.endPass()
    this._renderer = renderer;
  }
}
```

Every sprite -> mesh -> sprite alternation cost a `queue.submit` plus a fresh pass, regardless of what the mesh renderer did internally.

## Why the pass end was load-bearing

Every renderer's hazard guards are keyed to its *own* draws in the open pass (`_instanceArena.cursor > 0`, `_instancedBatchPass === activePass`, `bundle.drawsInPass === activePass`). Two of the guarded resources are **shared**:

- the transform storage buffer — growth destroys the buffer earlier draws bind,
- managed texture content — a re-upload lands on the queue timeline ahead of the deferred submit.

With the pass surviving a switch, the endangered draw can belong to another renderer, which the per-renderer cursors cannot see.

That hazard was **already live** between the four renderers that never end their pass (sprite, nine-slice, repeating, tilemap replay) whenever the plan player's up-front `reserve()` under-reserves. The widened guards are a correctness fix independent of the merge.

## The contract

`WebGpuPassCoordinator` gained `passHasDraws` / `markPassDraws()`. Owner identity is deliberately **not** modelled: only the two shared-resource guards need the question, and there it reads "any recorded draw", never "whose". Every "is it mine" question is already answered locally by comparing against `activePass` by identity.

> A guard against a **shared** resource being mutated under recorded draws asks `coordinator.passHasDraws`. A guard against a **renderer-owned** buffer being rewritten or reallocated keeps its local cursor / pass-identity condition.

## Scope boundary

ONE mesh flush is what this merges. The mesh flush path still rewrites its vertex / index / uniform buffers from offset 0, so a second mesh flush ends the pass holding the first's draws. Text, tilemap and particles keep their trailing `endPass` — ending is always safe. Lifting the per-pass cursor discipline `drawInstancedBatch` got in #533 onto the flush path is tracked as `NEU-O20`.

## Measurements

New bench archetype `mixed-sprite-mesh`: one mesh leaf every 64 sprites, so frame cost tracks renderer switches rather than mesh node count. Single cells, headless Chromium, NVIDIA Blackwell, exojs/current.

| cell | before | after |
|---|---|---|
| WebGPU @25k frame | 6943 / 6833 ms | **78.8 / 78.4 ms** (88x) |
| WebGPU @25k CPU | 29.8 ms | 26.1 ms |
| WebGPU @5k | 2.91 CPU / 2.32 frame | 2.86 / 2.66 (flat) |
| WebGL2 @25k | 11.85 / 5.41 | 11.80 / 5.38 (flat) |

Draw calls unchanged (781 @25k, 80 @5k) — the same signature as the earlier pass-merge fixes. The cliff is per-submit cost at ~390 submits, not a per-node cost. No regression on `instanced-batch` (7.10 -> 7.08 frame) or `static-heavy` (9.44 -> 9.34 frame).

## Found in review, fixed here

`destroy()` and the device-loss teardown relied on the renderer switch ending the pass. The device-loss path is the sharper edge: the coordinator survives recovery and `acquirePass` short-circuits on an already-open pass, so the **restored** device inherited the dead device's pass and recorded every later frame into an encoder that can never be submitted — silently, since operations on a lost device do not throw. `discardPass()` drops it on both paths. Both new tests were confirmed to fail with the fix removed.

## Gates

`typecheck` · `lint` · `verify:quick` (11 gates) · `pnpm test` (9658) · `test:browser:webgpu` (315) · `test:browser:webgl` (281).

Browser gate: a sprite/mesh/sprite frame collapses to one render pass and one submit, with correct per-draw pixels and no validation error.

## Breaking

None to the public API. The pass-lifecycle change is internal, but a caller driving the raw `RenderingContext` across a renderer switch and reading the surface back without ending the frame now needs `context.backend.flush()` — the same contract #533 established for `drawBatch`.

https://claude.ai/code/session_01Q9BTMeWSga5Y2yxXZBK2Bo