### PR TITLE
perf(rendering): append flushes at pass-scoped cursors across text, tilemap and particle renderers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,14 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
 
 ### Performance
 
+- **WebGPU text flushes share one render pass and one submit.** The WebGPU text
+  renderer rewrote its shared vertex, index and node-data buffers from offset 0
+  on every flush, and ended (submitted) the render pass at the tail of each one
+  to keep those writes from landing under draws already recorded. A frame that
+  alternates sprites and text therefore cost one pass and one submit per text
+  flush. Each flush now appends at pass-scoped cursors and adds the base at bind
+  time, so the whole frame collapses to a single pass again. A capacity growth
+  and a projection rewrite remain real pass boundaries.
 - **`Container` caches its paint order and child-index lookups.**
   `InteractionManager` re-sorted every container's children on every single
   hit-test call, and `getChildIndex()` did a linear `indexOf` scan on every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,15 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   flush. Each flush now appends at pass-scoped cursors and adds the base at bind
   time, so the whole frame collapses to a single pass again. A capacity growth
   and a projection rewrite remain real pass boundaries.
+- **WebGPU tile chunks cost one render pass per frame, not one per flush.** The
+  tile-chunk renderer rewrote its shared instance buffer from offset 0 and ended
+  (submitted) the render pass at the tail of every flush, so a frame that broke
+  the tile batch N times — a tileset change, a blend-mode change, an interleaved
+  actor — paid N render passes and N `queue.submit` calls. Each flush now appends
+  at a pass-scoped cursor and binds its own sub-range, so those flushes merge
+  into one pass and one submit. The pass still ends where it must: a capacity
+  growth, a projection rewrite, and the shared transform-storage / texture-upload
+  hazards.
 - **`Container` caches its paint order and child-index lookups.**
   `InteractionManager` re-sorted every container's children on every single
   hit-test call, and `getChildIndex()` did a linear `indexOf` scan on every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,6 +443,16 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   into one pass and one submit. The pass still ends where it must: a capacity
   growth, a projection rewrite, and the shared transform-storage / texture-upload
   hazards.
+- **WebGPU particle draws share one render pass and one submit.**
+  `WebGpuParticleRenderer` opened a render pass, recorded one draw call and
+  ended (submitted) it again — per particle system, because every system
+  rewrote the render mode's shared vertex buffer and the system uniform buffer
+  from offset 0. Each draw call now appends at pass-scoped cursors (a byte
+  offset into the mode's vertex buffer, a slot in a uniform ring) and adds the
+  base at bind time, so a frame's particle draws cost one pass and one submit
+  regardless of how many systems or flushes it contains. A capacity growth and
+  a mid-frame edit to a mode's own vertex geometry still end the pass, since
+  appending cannot cover either.
 - **`Container` caches its paint order and child-index lookups.**
   `InteractionManager` re-sorted every container's children on every single
   hit-test call, and `getChildIndex()` did a linear `indexOf` scan on every

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1041,10 +1041,17 @@ export default defineConfig([
   },
 
   {
-    files: ['src/rendering/webgpu/WebGpuBackend.ts', 'src/rendering/webgpu/WebGpuMeshRenderer.ts', 'src/rendering/webgpu/WebGpuSpriteRenderer.ts'],
+    files: [
+      'src/rendering/webgpu/WebGpuBackend.ts',
+      'src/rendering/webgpu/WebGpuMeshRenderer.ts',
+      'src/rendering/webgpu/WebGpuSpriteRenderer.ts',
+      'src/rendering/webgpu/WebGpuTextRenderer.ts',
+    ],
     rules: {
       // Cohesive WebGPU backend/renderer surface; each file is a single
-      // tightly-coupled unit (device/pipeline state, draw submission).
+      // tightly-coupled unit (device/pipeline state, draw submission), and the
+      // text renderer additionally carries its whole WGSL module as one
+      // template literal that cannot be split the way `max-lines` assumes.
       // Splitting would scatter that state across files for no readability
       // gain. Known deviation, candidate for a later extraction.
       'max-lines': 'off',

--- a/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
+++ b/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
@@ -2,7 +2,7 @@
 
 import type { GeometryAttribute, Material } from '@codexo/exojs';
 import type { BlendModes } from '@codexo/exojs/renderer-sdk';
-import type { WebGpuBackend } from '@codexo/exojs/renderer-sdk';
+import type { WebGpuActiveRenderPass, WebGpuBackend } from '@codexo/exojs/renderer-sdk';
 import { DataTexture } from '@codexo/exojs/renderer-sdk';
 import { Texture } from '@codexo/exojs/renderer-sdk';
 import { AbstractWebGpuRenderer } from '@codexo/exojs/renderer-sdk';
@@ -14,6 +14,13 @@ import { assertVertexGeometryCompatible } from '#renderModes/ParticleBufferLayou
 import type { ParticleRenderMode } from '#renderModes/ParticleRenderMode';
 
 const uniformByteLength = 176;
+/**
+ * Stride of one draw call's slot in the uniform ring. `setBindGroup`'s dynamic
+ * offset must be a multiple of the device's `minUniformBufferOffsetAlignment`,
+ * whose spec-mandated maximum is 256 — so a fixed 256 is valid on every device
+ * and needs no limit query.
+ */
+const uniformSlotStride = 256;
 
 /**
  * WebGPU vertex formats by `<n?><type>x<size>` key, where the leading `n`
@@ -83,6 +90,17 @@ interface ParticleModeResources {
   readonly pipelines: Map<string, GPURenderPipeline>;
   vertexBuffer: GPUBuffer | null;
   vertexBufferByteLength: number;
+  /**
+   * The render pass {@link vertexPassBytes} is scoped to, compared by identity
+   * against the coordinator's active pass. Anything else (a different pass, or
+   * none open) means this mode holds no draws in the open pass and its cursor
+   * restarts at 0. The mode's buffers are renderer-owned, so this is the local
+   * answer to "would writing them now alias a draw already recorded" — the
+   * coordinator's `passHasDraws` answers that only for SHARED resources.
+   */
+  passRef: WebGpuActiveRenderPass | null;
+  /** Bytes of {@link vertexBuffer} the open pass has consumed. */
+  vertexPassBytes: number;
 }
 
 interface WebGpuParticleDrawCall {
@@ -136,6 +154,17 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
   private _pipelineLayout: GPUPipelineLayout | null = null;
   private _uniformBuffer: GPUBuffer | null = null;
   private _uniformBindGroup: GPUBindGroup | null = null;
+  private _uniformBufferCapacity = 0;
+  /**
+   * Slots of the uniform ring the open pass has consumed, and the pass they are
+   * scoped to. One draw call takes one slot; the base is added as the bind
+   * group's dynamic offset, so consecutive flushes append instead of all
+   * rewriting slot 0. Same identity-comparison rule as
+   * {@link ParticleModeResources.passRef}, one level up: the ring is shared by
+   * every mode this renderer draws.
+   */
+  private _uniformPassSlots = 0;
+  private _ownDrawsPass: WebGpuActiveRenderPass | null = null;
   private readonly _resources = new Map<Material, ParticleModeResources>();
   /**
    * Materials this renderer already registered a dispose listener on.
@@ -185,10 +214,8 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
   public flush(): void {
     const backend = this._backend;
     const device = this._device;
-    const uniformBuffer = this._uniformBuffer;
-    const uniformBindGroup = this._uniformBindGroup;
 
-    if (!backend || !device || !uniformBuffer || !uniformBindGroup) {
+    if (!backend || !device || this._uniformBuffer === null || this._uniformBindGroup === null) {
       return;
     }
 
@@ -211,108 +238,22 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
       return;
     }
 
-    // One command encoder / pass per drawcall. Each particle system's
-    // queue.writeBuffer calls target offset 0 of the mode's vertex and the
-    // uniform buffer — a single pass with multiple systems would see all
-    // writeBuffers serialize before submit, leaving only the last
-    // system's data in those buffers and making every earlier draw read
-    // the wrong data. Also: _ensureCapacity may destroy and recreate the
-    // vertex buffer on growth; keeping one drawcall per pass means
-    // that destroy happens strictly between submits, so no pass holds a
-    // reference to a buffer that has since been destroyed.
+    // Every draw call APPENDS at the cursors the open pass has reached — a byte
+    // offset into the mode's vertex buffer, a slot in the uniform ring — and
+    // adds the base at bind time, so N particle draws cost ONE pass and ONE
+    // submit instead of N of each. Rewriting either buffer from offset 0 (which
+    // this loop used to do, hence its pass per draw call) cannot work with the
+    // pass left open: `queue.writeBuffer` is ordered against the submit, not
+    // against the individual draws inside it, so draw k+1's write would land
+    // under draw k's already-recorded read of the same bytes.
     for (let drawCallIndex = 0; drawCallIndex < this._drawCallCount; drawCallIndex++) {
       const drawCall = this._drawCalls[drawCallIndex]!;
-      const system = drawCall.system;
-      const particleCount = system.liveCount;
 
-      if (particleCount === 0) {
+      if (drawCall.system.liveCount === 0) {
         continue;
       }
 
-      const mode = system.renderMode;
-      const resources = this._getOrCreateResources(mode, device);
-      const coordinator = backend._passCoordinator;
-
-      // The pass survives a renderer switch, so it can still hold another
-      // renderer's draws. Resolving the texture binding below syncs dirty
-      // content on the queue timeline, ahead of the deferred submit, which
-      // would retroactively change a recorded draw sampling that same texture.
-      if (coordinator.passHasDraws && backend._textureUploadWouldMutate(drawCall.texture)) {
-        coordinator.endPass();
-      }
-
-      const pipeline = this._getPipeline(resources, drawCall.blendMode, backend.renderTargetFormat, coordinator.stencilActive);
-      const textureBinding = backend.getTextureBinding(drawCall.texture);
-      const textureBindGroup = device.createBindGroup({
-        layout: this._textureBindGroupLayout!,
-        entries: [
-          {
-            binding: 0,
-            resource: textureBinding.view,
-          },
-          {
-            binding: 1,
-            resource: textureBinding.sampler,
-          },
-        ],
-      });
-
-      this._writeUniformData(backend, system, drawCall.texture);
-
-      // GPU mode: the system's compute pipeline already wrote the
-      // interleaved instance data into its own buffer. Bind it
-      // directly — no CPU build, no writeBuffer for instance data.
-      // CPU mode: the mode builds from CPU SoA into its scratch buffer,
-      // which is uploaded into the buffer this renderer owns for it.
-      let drawCount = particleCount;
-      const vertexBuffer = ((): GPUBuffer => {
-        if (system.gpuMode && system.gpuState !== null) {
-          return system.gpuState.instanceBuffer;
-        }
-
-        mode.build(system);
-        drawCount = mode.count;
-
-        const buffer = this._ensureCapacity(device, resources, drawCount);
-
-        device.queue.writeBuffer(buffer, 0, mode.data, 0, drawCount * resources.stride);
-
-        return buffer;
-      })();
-
-      device.queue.writeBuffer(uniformBuffer, 0, this._uniformData.buffer, this._uniformData.byteOffset, this._uniformData.byteLength);
-
-      // One coordinator-owned pass per drawcall: each system's writeBuffers
-      // target offset 0, so the pass must be submitted before the next system
-      // overwrites those buffers. acquirePass/endPass preserve that 1:1 ratio.
-      const pass = coordinator.acquirePass().pass;
-
-      pass.setBindGroup(0, uniformBindGroup);
-      pass.setPipeline(pipeline);
-      pass.setBindGroup(1, textureBindGroup);
-      pass.setVertexBuffer(0, vertexBuffer);
-
-      if (resources.meshBuffer !== null) {
-        this._syncMeshBuffer(device, resources, mode);
-        pass.setVertexBuffer(1, resources.meshBuffer);
-      }
-
-      // `mode.count` is instance count for an instanced mode and vertex count
-      // otherwise, so it drives exactly one of the two draw arguments.
-      const instanceCount = resources.instanced ? drawCount : 1;
-
-      if (resources.indexBuffer !== null) {
-        pass.setIndexBuffer(resources.indexBuffer, resources.indexFormat);
-        pass.drawIndexed(resources.indexCount, instanceCount, 0, 0, 0);
-      } else {
-        pass.draw(resources.instanced ? resources.indexCount : drawCount, instanceCount, 0, 0);
-      }
-
-      coordinator.markPassDraws();
-      backend.stats.batches++;
-      backend.stats.drawCalls++;
-
-      coordinator.endPass();
+      this._drawSystem(backend, device, drawCall);
     }
 
     this._drawCallCount = 0;
@@ -330,8 +271,10 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
         {
           binding: 0,
           visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+          // One ring slot per draw call, selected by the dynamic offset.
           buffer: {
             type: 'uniform',
+            hasDynamicOffset: true,
           },
         },
       ],
@@ -357,21 +300,7 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
     this._pipelineLayout = this._device.createPipelineLayout({
       bindGroupLayouts: [this._uniformBindGroupLayout, this._textureBindGroupLayout],
     });
-    this._uniformBuffer = this._device.createBuffer({
-      size: uniformByteLength,
-      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-    });
-    this._uniformBindGroup = this._device.createBindGroup({
-      layout: this._uniformBindGroupLayout,
-      entries: [
-        {
-          binding: 0,
-          resource: {
-            buffer: this._uniformBuffer,
-          },
-        },
-      ],
-    });
+    this._createUniformResources(this._device, uniformSlotStride);
   }
 
   protected onDisconnect(): void {
@@ -386,12 +315,216 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
 
     this._uniformBindGroup = null;
     this._uniformBuffer = null;
+    this._uniformBufferCapacity = 0;
+    this._uniformPassSlots = 0;
+    this._ownDrawsPass = null;
     this._pipelineLayout = null;
     this._textureBindGroupLayout = null;
     this._uniformBindGroupLayout = null;
     this._device = null;
     this._backend = null;
     this._drawCallCount = 0;
+  }
+
+  /**
+   * Append one system's draw at the open pass's cursors and record it, leaving
+   * the pass open. Ends (submits) the pass first only where appending cannot
+   * cover the hazard — see {@link _appendWouldAlias}.
+   */
+  private _drawSystem(backend: WebGpuBackend, device: GPUDevice, drawCall: WebGpuParticleDrawCall): void {
+    const system = drawCall.system;
+    const mode = system.renderMode;
+    const resources = this._getOrCreateResources(mode, device);
+    const coordinator = backend._passCoordinator;
+
+    // GPU mode: the system's compute pipeline already wrote the interleaved
+    // instance data into its own buffer — from its own encoder and its own
+    // submit, in the system's update, so that compute pass is finished and
+    // ordered ahead of this render pass no matter when the render pass ends.
+    // Bind it directly: no CPU build, no writeBuffer, no cursor, since the
+    // buffer belongs to that one system and is never appended to.
+    // CPU mode: the mode builds from CPU SoA into its scratch buffer, which is
+    // uploaded into the buffer this renderer owns for the mode — shared by every
+    // system drawing that mode, so that one takes the cursor. The build is pure
+    // CPU work, so it runs up front and gives the checks below the byte count
+    // this draw will append.
+    const gpuState = system.gpuMode ? system.gpuState : null;
+    let drawCount = system.liveCount;
+    let appendBytes = 0;
+
+    if (gpuState === null) {
+      mode.build(system);
+      drawCount = mode.count;
+      // At least one stride, so a zero-element build still leaves the cursor on
+      // the 4-byte boundary `setVertexBuffer` and `writeBuffer` require.
+      appendBytes = Math.max(drawCount, 1) * resources.stride;
+    }
+
+    const meshGeometry = mode.vertexGeometry;
+    const meshSyncRequired = resources.meshBuffer !== null && meshGeometry !== null && resources.meshVersion !== meshGeometry.version;
+
+    // Pass totals appending would reach, resolved BEFORE the split below. They
+    // size the buffers even when the split does happen: sizing to the lone draw
+    // that remains after it would peg both buffers at one draw forever — the
+    // split shrinks the requirement back, the capacity never ratchets, and every
+    // draw call opens its own pass again, which is the state this discipline
+    // exists to remove.
+    const targetVertexBytes = this._modePassBytes(coordinator.activePass, resources) + appendBytes;
+    const targetUniformSlots = this._uniformPassBase(coordinator.activePass) + 1;
+
+    if (this._appendWouldAlias(backend, drawCall, resources, meshSyncRequired, targetVertexBytes, targetUniformSlots)) {
+      coordinator.endPass();
+    }
+
+    // Re-resolved after the split: an ended pass restarts every cursor at 0,
+    // while the draws it held keep reading the bytes already written at their
+    // own base offsets.
+    const vertexByteOffset = this._modePassBytes(coordinator.activePass, resources);
+    const uniformSlot = this._uniformPassBase(coordinator.activePass);
+
+    // Sized to the pre-split pass totals, not to what remains after it.
+    this._ensureUniformCapacity(device, targetUniformSlots);
+
+    const pipeline = this._getPipeline(resources, drawCall.blendMode, backend.renderTargetFormat, coordinator.stencilActive);
+    const textureBinding = backend.getTextureBinding(drawCall.texture);
+    const textureBindGroup = device.createBindGroup({
+      layout: this._textureBindGroupLayout!,
+      entries: [
+        {
+          binding: 0,
+          resource: textureBinding.view,
+        },
+        {
+          binding: 1,
+          resource: textureBinding.sampler,
+        },
+      ],
+    });
+
+    this._writeUniformData(backend, system, drawCall.texture);
+
+    const vertexBuffer = gpuState !== null ? gpuState.instanceBuffer : this._uploadModeData(device, resources, mode, targetVertexBytes, vertexByteOffset, drawCount);
+
+    device.queue.writeBuffer(
+      this._uniformBuffer!,
+      uniformSlot * uniformSlotStride,
+      this._uniformData.buffer,
+      this._uniformData.byteOffset,
+      this._uniformData.byteLength,
+    );
+
+    if (meshSyncRequired) {
+      this._syncMeshBuffer(device, resources, mode);
+    }
+
+    const active = coordinator.acquirePass();
+    const pass = active.pass;
+
+    pass.setBindGroup(0, this._uniformBindGroup, [uniformSlot * uniformSlotStride]);
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(1, textureBindGroup);
+    pass.setVertexBuffer(0, vertexBuffer, gpuState !== null ? 0 : vertexByteOffset);
+
+    if (resources.meshBuffer !== null) {
+      pass.setVertexBuffer(1, resources.meshBuffer);
+    }
+
+    // `mode.count` is instance count for an instanced mode and vertex count
+    // otherwise, so it drives exactly one of the two draw arguments.
+    const instanceCount = resources.instanced ? drawCount : 1;
+
+    if (resources.indexBuffer !== null) {
+      pass.setIndexBuffer(resources.indexBuffer, resources.indexFormat);
+      pass.drawIndexed(resources.indexCount, instanceCount, 0, 0, 0);
+    } else {
+      pass.draw(resources.instanced ? resources.indexCount : drawCount, instanceCount, 0, 0);
+    }
+
+    coordinator.markPassDraws();
+    backend.stats.batches++;
+    backend.stats.drawCalls++;
+
+    // The pass stays open. Its cursors carry this draw's consumption forward so
+    // the next draw — this flush's or a later one's — appends AFTER the slices
+    // this one reads instead of overwriting them. The backend ends the pass at
+    // the frame boundary and at every genuine boundary in between.
+    this._ownDrawsPass = active;
+    this._uniformPassSlots = uniformSlot + 1;
+    resources.passRef = active;
+    resources.vertexPassBytes = vertexByteOffset + appendBytes;
+  }
+
+  /**
+   * Whether appending this draw would retroactively change what a draw already
+   * recorded into the open pass reads — in which case the caller ends (submits)
+   * that pass first, which restarts every cursor at 0.
+   */
+  private _appendWouldAlias(
+    backend: WebGpuBackend,
+    drawCall: WebGpuParticleDrawCall,
+    resources: ParticleModeResources,
+    meshSyncRequired: boolean,
+    targetVertexBytes: number,
+    targetUniformSlots: number,
+  ): boolean {
+    const coordinator = backend._passCoordinator;
+    const active = coordinator.activePass;
+
+    // The texture cache is SHARED, and resolving the binding syncs dirty content
+    // on the queue timeline ahead of the deferred submit. The pass survives a
+    // renderer switch, so the endangered draw need not be one of ours — hence
+    // the coordinator-side question rather than a local cursor.
+    if (coordinator.passHasDraws && backend._textureUploadWouldMutate(drawCall.texture)) {
+      return true;
+    }
+
+    if (active === null) {
+      return false;
+    }
+
+    // The rest are renderer-OWNED buffers, so they ask this renderer's own
+    // cursors instead: only draws of ours read them. Re-writing the mode's
+    // per-vertex geometry from 0 aliases the draws already bound to it, and
+    // growing either the mode's vertex buffer or the uniform ring frees the
+    // buffer those draws read. Appending covers neither.
+    if (resources.passRef === active && (meshSyncRequired || targetVertexBytes > resources.vertexBufferByteLength)) {
+      return true;
+    }
+
+    return this._ownDrawsPass === active && targetUniformSlots * uniformSlotStride > this._uniformBufferCapacity;
+  }
+
+  /**
+   * Bytes of the mode's vertex buffer `active` has consumed, or 0 when it holds
+   * none of that mode's draws (a different pass, or none open).
+   */
+  private _modePassBytes(active: WebGpuActiveRenderPass | null, resources: ParticleModeResources): number {
+    return active !== null && resources.passRef === active ? resources.vertexPassBytes : 0;
+  }
+
+  /** Uniform ring slots `active` has consumed, or 0 when it holds no draws of ours. */
+  private _uniformPassBase(active: WebGpuActiveRenderPass | null): number {
+    return active !== null && this._ownDrawsPass === active ? this._uniformPassSlots : 0;
+  }
+
+  /**
+   * Upload what the mode just built into this draw's sub-range of the mode's
+   * vertex buffer, growing it to the pass total first. Returns the buffer to
+   * bind, since growth replaces it.
+   */
+  private _uploadModeData(
+    device: GPUDevice,
+    resources: ParticleModeResources,
+    mode: ParticleRenderMode,
+    targetByteLength: number,
+    byteOffset: number,
+    elementCount: number,
+  ): GPUBuffer {
+    const buffer = this._ensureCapacity(device, resources, targetByteLength);
+
+    device.queue.writeBuffer(buffer, byteOffset, mode.data, 0, elementCount * resources.stride);
+
+    return buffer;
   }
 
   private _getOrCreateResources(mode: ParticleRenderMode, device: GPUDevice): ParticleModeResources {
@@ -519,6 +652,8 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
       pipelines: new Map<string, GPURenderPipeline>(),
       vertexBuffer: null,
       vertexBufferByteLength: 0,
+      passRef: null,
+      vertexPassBytes: 0,
     };
   }
 
@@ -547,25 +682,28 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
     resources.vertexBuffer = null;
     resources.meshBuffer = null;
     resources.vertexBufferByteLength = 0;
+    resources.passRef = null;
+    resources.vertexPassBytes = 0;
   }
 
   /**
-   * Grow the mode's vertex buffer to hold `elementCount` elements of its
-   * stride. Grow-only and doubling, matching the mode's own scratch-buffer
-   * policy; the returned buffer is the one this draw must bind, since growth
-   * replaces it.
+   * Grow the mode's vertex buffer to `requiredByteLength`, which is the whole
+   * open pass's consumption of it (this draw's append plus everything already
+   * written for the draws it holds), not just this draw's own bytes. Grow-only
+   * and doubling, matching the mode's own scratch-buffer policy; the returned
+   * buffer is the one this draw must bind, since growth replaces it.
    */
-  private _ensureCapacity(device: GPUDevice, resources: ParticleModeResources, elementCount: number): GPUBuffer {
+  private _ensureCapacity(device: GPUDevice, resources: ParticleModeResources, requiredByteLength: number): GPUBuffer {
     const stride = resources.stride;
-    const requiredByteLength = Math.max(elementCount, 1) * stride;
+    const required = Math.max(requiredByteLength, stride);
 
-    if (resources.vertexBuffer !== null && requiredByteLength <= resources.vertexBufferByteLength) {
+    if (resources.vertexBuffer !== null && required <= resources.vertexBufferByteLength) {
       return resources.vertexBuffer;
     }
 
     let byteLength = resources.vertexBufferByteLength || stride;
 
-    while (byteLength < requiredByteLength) {
+    while (byteLength < required) {
       byteLength *= 2;
     }
 
@@ -577,6 +715,48 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
     resources.vertexBufferByteLength = byteLength;
 
     return resources.vertexBuffer;
+  }
+
+  /**
+   * Grow the uniform ring to `slots` draw-call slots — again the open pass's
+   * total, not this draw's one slot. Doubling and grow-only; growth frees the
+   * current buffer, so the caller must have ended any pass holding draws of
+   * ours that read it.
+   */
+  private _ensureUniformCapacity(device: GPUDevice, slots: number): void {
+    const requiredBytes = slots * uniformSlotStride;
+
+    if (requiredBytes <= this._uniformBufferCapacity) {
+      return;
+    }
+
+    this._uniformBuffer?.destroy();
+    this._createUniformResources(device, Math.max(requiredBytes, this._uniformBufferCapacity * 2));
+  }
+
+  /** (Re-)create the uniform ring and its bind group at `capacityBytes`. */
+  private _createUniformResources(device: GPUDevice, capacityBytes: number): void {
+    this._uniformBufferCapacity = capacityBytes;
+    this._uniformBuffer = device.createBuffer({
+      label: 'particles:uniform-ring',
+      size: capacityBytes,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    this._uniformBindGroup = device.createBindGroup({
+      label: 'particles:uniform-bind-group',
+      layout: this._uniformBindGroupLayout!,
+      entries: [
+        {
+          binding: 0,
+          // Explicit size: the dynamic offset addresses one slot, so the binding
+          // must span one slot's worth of uniforms rather than the whole ring.
+          resource: {
+            buffer: this._uniformBuffer,
+            size: uniformByteLength,
+          },
+        },
+      ],
+    });
   }
 
   private _writeUniformData(backend: WebGpuBackend, system: ParticleSystem, texture: Texture): void {

--- a/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
@@ -3,6 +3,7 @@
 import { Matrix } from '@codexo/exojs';
 import type {
   RenderTexture,
+  WebGpuActiveRenderPass,
   WebGpuRetainedBatchPayload,
   WebGpuRetainedBatchReplayer,
   WebGpuRetainedNodeIndexRange,
@@ -164,7 +165,11 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
   private _transformStorageBuffer: GPUBuffer | null = null;
   private _indexBuffer: GPUBuffer | null = null;
   private _instanceBuffer: GPUBuffer | null = null;
-  private _instanceCapacity = 0;
+  // Capacity of the GPU instance buffer, in BYTES: it carries every flush the
+  // open pass has taken, not just the pending one. The CPU staging array is
+  // sized separately (in instances) because it only ever holds one flush.
+  private _instanceBufferCapacity = 0;
+  private _instanceStagingCapacity = 0;
   private _instanceData: ArrayBuffer = new ArrayBuffer(0);
   private _instanceFloat32 = new Float32Array(this._instanceData);
   private _instanceUint32 = new Uint32Array(this._instanceData);
@@ -179,6 +184,22 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
   private _maxNodeIndex = 0;
   private _currentBlendMode: BlendModes | null = null;
   private _currentTexture: Texture | null = null;
+
+  // ── Pass-scoped write cursor ──────────────────────────────────────────────
+  // `flush()` no longer ends the pass, so consecutive flushes record into ONE
+  // open pass and ONE submit. Everything written into the shared instance
+  // buffer is therefore scoped to that pass, not to a single flush: a flush
+  // that rewrote the buffer from offset 0 would have the earlier flushes' draws
+  // read this flush's bytes, because `queue.writeBuffer` is ordered against the
+  // submit and not against the individual draws inside it. Each flush appends
+  // at `_instancePassBytes` instead and adds the base at bind time.
+  //
+  // `_passDraws` is the open pass this renderer has actually RECORDED draws
+  // into. Pass identity is the key: the coordinator builds a fresh active-pass
+  // object on every acquire, so a pass ended by anyone else (a target switch, a
+  // stencil clip, another renderer) is distinguished automatically.
+  private _passDraws: WebGpuActiveRenderPass | null = null;
+  private _instancePassBytes = 0;
 
   // ── Retained-batch replay state ───────────────────────────────────────────
   private readonly _stagedReplayGroupData = new Float32Array(16);
@@ -225,6 +246,17 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
   }
 
   protected onDisconnect(): void {
+    // The teardown below destroys the very buffers a draw of ours left in the
+    // open pass still binds, and the pass no longer ends at the tail of a
+    // flush. Submit it first so those draws reach the queue against live
+    // buffers. Backend destroy and device loss drop the pass before disconnecting
+    // renderers, so this only fires when a renderer is disconnected on its own.
+    const coordinator = this._backend?._passCoordinator ?? null;
+
+    if (coordinator !== null && this._passDraws !== null && this._passDraws === coordinator.activePass) {
+      coordinator.endPass();
+    }
+
     this._instanceBuffer?.destroy();
     this._indexBuffer?.destroy();
     this._uniformBuffer?.destroy();
@@ -243,10 +275,13 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     this._shaderModule = null;
     this._device = null;
     this._backend = null;
-    this._instanceCapacity = 0;
+    this._instanceBufferCapacity = 0;
+    this._instanceStagingCapacity = 0;
     this._instanceData = new ArrayBuffer(0);
     this._instanceFloat32 = new Float32Array(this._instanceData);
     this._instanceUint32 = new Uint32Array(this._instanceData);
+    this._passDraws = null;
+    this._instancePassBytes = 0;
     this._quadIndex = 0;
     this._maxNodeIndex = 0;
     this._currentBlendMode = null;
@@ -308,7 +343,11 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
 
     const blendModeChanged = this._currentBlendMode !== null && blendMode !== this._currentBlendMode;
     const textureChanged = this._currentTexture !== null && texture !== this._currentTexture;
-    const willExceed = this._quadIndex + quads.length > this._instanceCapacity && this._instanceCapacity > 0;
+    // Overflowing the CPU staging array flushes the accumulated run rather than
+    // growing it. The GPU buffer is NOT what this asks about: it now carries
+    // every flush in the pass, so flushing frees no room there — its capacity is
+    // resolved in `flush()` against the pass total.
+    const willExceed = this._quadIndex + quads.length > this._instanceStagingCapacity && this._instanceStagingCapacity > 0;
 
     if ((blendModeChanged || textureChanged || willExceed) && this._quadIndex > 0) {
       this.flush();
@@ -318,7 +357,7 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     this._currentTexture = texture;
     backend.setBlendMode(blendMode);
 
-    this._ensureInstanceCapacity(this._quadIndex + quads.length);
+    this._ensureStagingCapacity(this._quadIndex + quads.length);
 
     const f32 = this._instanceFloat32;
     const u32 = this._instanceUint32;
@@ -386,14 +425,60 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     // (view, updateId, group-id, snap-rect) state.
     const view = backend.view;
     const viewportChanged = packSnapViewport(backend, this._projectionData, 32);
-
-    if (
+    const projectionChanged =
       !this._hasWrittenProjection ||
       this._writtenView !== view ||
       this._writtenViewUpdateId !== view.updateId ||
       this._writtenGroupTransformId !== backend.renderGroupTransformId ||
-      viewportChanged
+      viewportChanged;
+
+    const scissor = backend.getScissorRect();
+    const maskClipsAll = scissor !== null && (scissor.width <= 0 || scissor.height <= 0);
+
+    const coordinator = backend._passCoordinator;
+    // Aliased as consts so the `willDraw` predicate narrows them for the draw
+    // block below (the same narrowing the inlined condition used to provide).
+    const texture = this._currentTexture;
+    const blendMode = this._currentBlendMode;
+    const indexBuffer = this._indexBuffer;
+    const willDraw = this._quadIndex > 0 && !maskClipsAll && texture !== null && blendMode !== null && indexBuffer !== null;
+
+    const flushBytes = this._quadIndex * instanceStrideBytes;
+    // Sized for everything this pass has taken SO FAR plus this flush, captured
+    // BEFORE the guard below may reset the cursor — and used to size the buffer
+    // even when it does split. Sizing to the lone flush that remains after a
+    // split would peg the buffer at one flush forever: the guard would split,
+    // the split would shrink the requirement back, the capacity would never
+    // ratchet, and every flush would open its own pass again.
+    const targetInstanceBytes = this._instancePassBytes + flushBytes;
+    const ownDrawsInPass = this._passDraws !== null && this._passDraws === coordinator.activePass;
+
+    // Two predicates, deliberately different. The first gates the hazards
+    // against resources only THIS renderer binds — the projection UBO (rewritten
+    // at offset 0, which would retroactively re-project our earlier draws) and
+    // the instance buffer (whose reallocation frees what those draws read) — so
+    // it asks this renderer's own cursor. The second gates the two SHARED ones
+    // (transform storage, managed texture content), which the pass may hold
+    // another renderer's draws against, so it asks the coordinator. Both land on
+    // the queue timeline ahead of the deferred submit, and both are answered by
+    // ending (submitting) the pass first.
+    if (
+      (ownDrawsInPass && (projectionChanged || (willDraw && targetInstanceBytes > this._instanceBufferCapacity))) ||
+      (willDraw &&
+        coordinator.passHasDraws &&
+        (backend._textureUploadWouldMutate(texture) || backend._transformStorageWouldGrow(this._maxNodeIndex + 1)))
     ) {
+      coordinator.endPass();
+    }
+
+    // Any boundary above — or one another renderer hit since our last flush —
+    // means the open pass no longer holds our draws, so the cursor restarts.
+    if (this._passDraws !== coordinator.activePass) {
+      this._passDraws = null;
+      this._instancePassBytes = 0;
+    }
+
+    if (projectionChanged) {
       packAffineMat4(view.getTransform(), this._projectionData, 0);
       packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, this._projectionData, 16);
 
@@ -405,49 +490,34 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
       device.queue.writeBuffer(uniformBuffer, 0, this._projectionData.buffer, this._projectionData.byteOffset, this._projectionData.byteLength);
     }
 
-    const scissor = backend.getScissorRect();
-    const maskClipsAll = scissor !== null && (scissor.width <= 0 || scissor.height <= 0);
+    const active = coordinator.acquirePass();
+    const pass = active.pass;
 
-    const coordinator = backend._passCoordinator;
+    if (willDraw) {
+      const instanceBuffer = this._ensureInstanceBufferCapacity(device, targetInstanceBytes);
+      const instanceByteOffset = this._instancePassBytes;
 
-    // The pass survives a renderer switch, so it can hold ANOTHER renderer's
-    // draws by the time this flush runs. Resolving the shared transform storage
-    // below may free the buffer those draws bind, and syncing the tileset
-    // texture may re-upload content they sample — both land on the queue
-    // timeline ahead of the deferred submit. End (submit) the pass first so
-    // they keep what they were recorded against. Only the conditions this check
-    // actually needs are repeated from the draw condition below: hoisting the
-    // whole predicate into a boolean would cost the narrowing the draw block
-    // relies on.
-    if (
-      this._quadIndex > 0 &&
-      !maskClipsAll &&
-      this._currentTexture !== null &&
-      coordinator.passHasDraws &&
-      (backend._textureUploadWouldMutate(this._currentTexture) || backend._transformStorageWouldGrow(this._maxNodeIndex + 1))
-    ) {
-      coordinator.endPass();
-    }
-
-    const pass = coordinator.acquirePass().pass;
-
-    if (this._quadIndex > 0 && !maskClipsAll && this._instanceBuffer !== null && this._indexBuffer !== null && this._currentBlendMode !== null && this._currentTexture !== null) {
-      device.queue.writeBuffer(this._instanceBuffer, 0, this._instanceData, 0, this._quadIndex * instanceStrideBytes);
+      device.queue.writeBuffer(instanceBuffer, instanceByteOffset, this._instanceData, 0, flushBytes);
 
       const storage = backend.getTransformStorageBuffer(this._maxNodeIndex + 1);
       const transformBindGroup = this._getOrCreateTransformBindGroup(device, uniformBuffer, storage.buffer);
-      const textureBindGroup = this._getOrCreateTextureBindGroup(device, backend, this._currentTexture);
+      const textureBindGroup = this._getOrCreateTextureBindGroup(device, backend, texture);
 
-      const stencil = backend._passCoordinator.stencilActive;
-      const pipeline = this._getPipeline(this._currentBlendMode, backend.renderTargetFormat, stencil);
+      const stencil = coordinator.stencilActive;
+      const pipeline = this._getPipeline(blendMode, backend.renderTargetFormat, stencil);
 
       pass.setPipeline(pipeline);
       pass.setBindGroup(0, transformBindGroup);
       pass.setBindGroup(1, textureBindGroup);
-      pass.setVertexBuffer(0, this._instanceBuffer);
-      pass.setIndexBuffer(this._indexBuffer, 'uint16');
+      pass.setVertexBuffer(0, instanceBuffer, instanceByteOffset);
+      pass.setIndexBuffer(indexBuffer, 'uint16');
       pass.drawIndexed(indicesPerInstance, this._quadIndex, 0, 0, 0);
 
+      // The pass stays open; the cursor carries this flush's consumption forward
+      // so the next flush in the same pass appends AFTER the slice these draws
+      // read instead of overwriting it.
+      this._instancePassBytes = instanceByteOffset + flushBytes;
+      this._passDraws = active;
       coordinator.markPassDraws();
       backend.stats.batches++;
       backend.stats.drawCalls++;
@@ -460,21 +530,15 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     // scissor), since visibility is re-evaluated live at replay. A batch
     // always binds a single tileset texture (slot 0); a pixel-snapped node
     // already poisoned the capture in render().
-    if (this._quadIndex > 0 && backend._retainedCaptureActive && this._currentBlendMode !== null && this._currentTexture !== null) {
-      this._recordTextures[0] = this._currentTexture;
-      backend._recordRetainedBatch(
-        this,
-        this._instanceData,
-        this._quadIndex * instanceStrideBytes,
-        this._quadIndex,
-        this._currentBlendMode,
-        this._recordTextures,
-        1,
-      );
+    if (this._quadIndex > 0 && backend._retainedCaptureActive && blendMode !== null && texture !== null) {
+      this._recordTextures[0] = texture;
+      backend._recordRetainedBatch(this, this._instanceData, flushBytes, this._quadIndex, blendMode, this._recordTextures, 1);
     }
 
-    coordinator.endPass();
-
+    // The pass is deliberately left OPEN. It ends at genuine boundaries only
+    // (the backend's frame/plan end, a target or view switch, a stencil clip)
+    // and at the hazard splits above, so N tile-chunk flushes in a frame cost
+    // one pass and one submit rather than N.
     this._quadIndex = 0;
     this._maxNodeIndex = 0;
     this._currentBlendMode = null;
@@ -739,12 +803,17 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     return pipeline;
   }
 
-  private _ensureInstanceCapacity(instanceCount: number): void {
-    if (!this._device || instanceCount <= this._instanceCapacity) {
+  /**
+   * Grow the CPU staging array to hold `instanceCount` instances, carrying the
+   * quads packed so far. Flush-local: the array only ever holds the pending
+   * batch, so it is sized independently of the pass-scoped GPU buffer.
+   */
+  private _ensureStagingCapacity(instanceCount: number): void {
+    if (instanceCount <= this._instanceStagingCapacity) {
       return;
     }
 
-    let nextCapacity = Math.max(this._instanceCapacity, initialBatchCapacity);
+    let nextCapacity = Math.max(this._instanceStagingCapacity, initialBatchCapacity);
 
     while (nextCapacity < instanceCount) {
       nextCapacity *= 2;
@@ -758,17 +827,38 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
       new Uint8Array(instanceData).set(new Uint8Array(oldData, 0, carryBytes));
     }
 
-    const instanceBuffer = this._device.createBuffer({
-      size: instanceData.byteLength,
-      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
-    });
-
-    this._instanceBuffer?.destroy();
-
-    this._instanceCapacity = nextCapacity;
+    this._instanceStagingCapacity = nextCapacity;
     this._instanceData = instanceData;
     this._instanceFloat32 = new Float32Array(instanceData);
     this._instanceUint32 = new Uint32Array(instanceData);
+  }
+
+  /**
+   * Resolve the GPU instance buffer for `requiredBytes` — the total this pass
+   * would reach by appending, not this flush's own bytes. Reallocation frees the
+   * buffer earlier draws in the open pass read, so the caller must have ended
+   * that pass (and restarted the cursor) before a growing call. Capacity
+   * doubles, so the split a growth costs converges away within a frame or two.
+   */
+  private _ensureInstanceBufferCapacity(device: GPUDevice, requiredBytes: number): GPUBuffer {
+    const existing = this._instanceBuffer;
+
+    if (existing !== null && requiredBytes <= this._instanceBufferCapacity) {
+      return existing;
+    }
+
+    const nextCapacity = Math.max(this._instanceBufferCapacity * 2, requiredBytes, initialBatchCapacity * instanceStrideBytes);
+    const instanceBuffer = device.createBuffer({
+      label: 'tile-chunk:instance-buffer',
+      size: nextCapacity,
+      usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+    });
+
+    existing?.destroy();
+
+    this._instanceBufferCapacity = nextCapacity;
     this._instanceBuffer = instanceBuffer;
+
+    return instanceBuffer;
   }
 }

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -48,6 +48,16 @@ const nodeFloats = nodeTexels * 4;
 // Per-vertex layout (20 bytes): pos f32x2 + uv f32x2 + nodeIndex f32
 const vertexStrideBytes = 20;
 const vertexStrideWords = vertexStrideBytes / 4;
+// Word offset of the per-vertex node index within one vertex.
+const nodeIndexWord = 4;
+
+/**
+ * Byte size of `indexCount` uint16 indices, rounded up to 4. `GPUQueue.writeBuffer`
+ * rejects byte counts and offsets that are not a multiple of 4, so index sub-ranges
+ * within the shared buffer are laid out on 4-byte boundaries — which also satisfies
+ * `setIndexBuffer`'s weaker 2-byte offset requirement.
+ */
+const alignIndexBytes = (indexCount: number): number => (indexCount * Uint16Array.BYTES_PER_ELEMENT + 3) & ~3;
 
 const initialVertexCapacity = 256;
 const initialIndexCapacity = 384;
@@ -407,6 +417,21 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
   private _frameBindGroup: GPUBindGroup | null = null;
   private _frameBindGroupDirty = true;
 
+  // The pass this renderer's live-path draws were last recorded into, plus the
+  // write cursors scoped to it. The pass survives a renderer switch, so several
+  // `flush()` calls now record into ONE pass and ONE submit: a flush that
+  // rewrote the shared vertex / index / node buffers from offset 0 would have
+  // the earlier flush's draws read the later flush's bytes, because
+  // `queue.writeBuffer` is ordered against the submit and not against the
+  // individual draws inside it. Each flush therefore APPENDS at these cursors
+  // and adds the base at bind time. The coordinator builds a fresh active-pass
+  // object per acquire, so reference identity also covers a pass ended by
+  // someone else entirely (target switch, stencil clip, another renderer).
+  private _ownDrawsPass: WebGpuActiveRenderPass | null = null;
+  private _vertexPassBytes = 0;
+  private _indexPassBytes = 0;
+  private _nodePassCount = 0;
+
   // FrameUniforms (projection + group) skip state: a matching (view identity,
   // view.updateId, group-transform id) triple means the proj UBO already holds
   // this flush's transform, so the 96-byte write is skipped. Per-node style
@@ -469,34 +494,22 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       return (this._textureKeyMap.get(a.atlasTexture) ?? 0) - (this._textureKeyMap.get(b.atlasTexture) ?? 0);
     });
 
-    // Upload FrameUniforms: projection + group as vec4-padded mat3x3 columns
+    // Stage FrameUniforms: projection + group as vec4-padded mat3x3 columns
     // plus the device-pixel snap viewport rect, packed via the shared canonical
     // (non-transposed) column order. The write is skipped when the UBO already
     // holds this exact (view, updateId, group-id, snap-rect) state — static
-    // text then issues zero projection uploads.
+    // text then issues zero projection uploads. Whether it changes is decided
+    // here but applied below, because a rewrite of this single-slot UBO would
+    // retroactively re-project draws of ours already recorded into the open
+    // pass: appending cannot cover it, so it is a pass boundary.
     const view = backend.view;
     const viewportChanged = packSnapViewport(backend, this._projData, 24);
-
-    if (
+    const projectionChanged =
       !this._hasWrittenProjection ||
       this._writtenView !== view ||
       this._writtenViewUpdateId !== view.updateId ||
       this._writtenGroupTransformId !== backend.renderGroupTransformId ||
-      viewportChanged
-    ) {
-      packAffineMat3Std140(view.getTransform(), this._projData, 0);
-      packAffineMat3Std140(backend.renderGroupTransform ?? Matrix.identity, this._projData, 12);
-
-      this._writtenView = view;
-      this._writtenViewUpdateId = view.updateId;
-      this._writtenGroupTransformId = backend.renderGroupTransformId;
-      this._hasWrittenProjection = true;
-
-      device.queue.writeBuffer(this._projBuffer!, 0, this._projData.buffer, 0, projectionBytes);
-    }
-
-    // Upload per-node style data (may reallocate the storage buffer)
-    this._uploadNodeBuffer(device);
+      viewportChanged;
 
     // Build interleaved vertex/index data for all batches in one pass
     const quads = this._pendingQuads;
@@ -568,26 +581,98 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       qi = qj;
     }
 
-    // Upload vertex/index buffers (reallocate GPU side when needed)
-    this._ensureGpuVertexBuffer(device, packedV);
-    this._ensureGpuIndexBuffer(device, packedI);
-    device.queue.writeBuffer(this._vertexBuffer!, 0, this._vertexData, 0, packedV * vertexStrideBytes);
-    device.queue.writeBuffer(this._indexBuffer!, 0, this._indexData.buffer, 0, packedI * 2);
-
+    // The recording carries this flush's OWN dense, 0-based node indices, so it
+    // has to take its copy of the staged vertex bytes before they are rebased
+    // onto the pass cursor below.
     if (backend._retainedCaptureActive) {
       this._tryRecordRetainedBatch(backend, batches);
     }
 
+    const coordinator = backend._passCoordinator;
+    const flushVertexBytes = packedV * vertexStrideBytes;
+    const flushIndexBytes = alignIndexBytes(packedI);
+
+    // The writes below land in the shared vertex / index / node buffers and may
+    // reallocate them. Draws of OURS left in the open pass — from an earlier
+    // flush — still read those exact buffers, and `queue.writeBuffer` lands
+    // ahead of the whole submit, so this flush APPENDS at the pass cursors
+    // rather than rewriting from offset 0. Ending the pass is the fallback for
+    // the two cases appending cannot cover: a reallocation (which frees the
+    // buffer those draws read) and a projection rewrite (a single-slot UBO
+    // every draw of ours reads). Another renderer's draws in the pass are not
+    // at risk: none of these buffers is shared, and the pass survives a
+    // renderer switch precisely so they can stay.
+    const ownDrawsInPass = this._ownDrawsPass !== null && this._ownDrawsPass === coordinator.activePass;
+    // Sized for everything this pass has taken SO FAR plus this flush, captured
+    // BEFORE the guard below may reset the cursors — and used to size the
+    // buffers even when it does split. Sizing to the lone flush that remains
+    // after a split would peg every buffer at one flush forever: the guard
+    // would split, the split would shrink the requirement back, the capacity
+    // would never ratchet, and every flush would open its own pass.
+    const targetVertexBytes = this._vertexPassBytes + flushVertexBytes;
+    const targetIndexBytes = this._indexPassBytes + flushIndexBytes;
+    const targetNodeCount = this._nodePassCount + this._nodeCount;
+
+    if (ownDrawsInPass && (projectionChanged || this._flushAppendWouldGrow(targetVertexBytes, targetIndexBytes, targetNodeCount))) {
+      coordinator.endPass();
+      this._resetPassCursors();
+    } else if (!ownDrawsInPass) {
+      // No draws of ours are held by the open pass (it was ended by a boundary,
+      // or never opened), so every cursor restarts.
+      this._resetPassCursors();
+    }
+
+    const vertexBase = this._vertexPassBytes;
+    const indexBase = this._indexPassBytes;
+    const nodeBase = this._nodePassCount;
+
+    if (projectionChanged) {
+      packAffineMat3Std140(view.getTransform(), this._projData, 0);
+      packAffineMat3Std140(backend.renderGroupTransform ?? Matrix.identity, this._projData, 12);
+
+      this._writtenView = view;
+      this._writtenViewUpdateId = view.updateId;
+      this._writtenGroupTransformId = backend.renderGroupTransformId;
+      this._hasWrittenProjection = true;
+
+      device.queue.writeBuffer(this._projBuffer!, 0, this._projData.buffer, 0, projectionBytes);
+    }
+
+    // Upload per-node style data at this flush's sub-range of the pass, and
+    // shift the staged per-vertex node indices to match: the storage binding
+    // covers the whole buffer (no dynamic offset), so the rebase has to travel
+    // in the vertex attribute the shader indexes with.
+    this._uploadNodeBuffer(device, nodeBase, targetNodeCount);
+
+    if (nodeBase > 0) {
+      for (let v = 0; v < packedV; v++) {
+        const w = v * vertexStrideWords + nodeIndexWord;
+
+        this._float32View[w] = this._float32View[w]! + nodeBase;
+      }
+    }
+
+    // Upload vertex/index buffers (reallocate GPU side when needed), sized to
+    // the pass totals and written at this flush's base offsets.
+    this._ensureGpuVertexBuffer(device, targetVertexBytes);
+    this._ensureGpuIndexBuffer(device, targetIndexBytes);
+    device.queue.writeBuffer(this._vertexBuffer!, vertexBase, this._vertexData, 0, flushVertexBytes);
+    device.queue.writeBuffer(this._indexBuffer!, indexBase, this._indexData.buffer, 0, flushIndexBytes);
+
     const format = backend.renderTargetFormat;
-    const stencil = backend._passCoordinator.stencilActive;
+    const stencil = coordinator.stencilActive;
     const frameBindGroup = this._getFrameBindGroup(device);
 
-    const coordinator = backend._passCoordinator;
-
     // The pass survives a renderer switch, so it can still hold another
-    // renderer's draws. Resolving an atlas bind group below syncs a dirty glyph
-    // page on the queue timeline, ahead of the deferred submit, which would
-    // retroactively change a recorded draw sampling that same atlas.
+    // renderer's draws — or an earlier flush of ours this one appended after.
+    // Resolving an atlas bind group below syncs a dirty glyph page on the queue
+    // timeline, ahead of the deferred submit, which would retroactively change
+    // a recorded draw sampling that same atlas.
+    //
+    // Ending the pass here does NOT rewind the cursors: this flush's bytes are
+    // already written at the base offsets, and its draws (recorded below into
+    // the freshly opened pass) still read them there. Rewinding would let a
+    // later append overwrite bytes those draws read.
     if (coordinator.passHasDraws) {
       for (const batch of batches) {
         if (backend._textureUploadWouldMutate(batch.atlasTexture)) {
@@ -598,11 +683,13 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     }
 
     // The coordinator owns the GPU pass (load/clear resolution, pass count and
-    // scissor are applied there) and ends + submits it below.
-    const pass = coordinator.acquirePass().pass;
+    // scissor are applied there). It stays OPEN afterwards so a following flush,
+    // or another renderer, merges into the same submit.
+    const active = coordinator.acquirePass();
+    const pass = active.pass;
 
-    pass.setVertexBuffer(0, this._vertexBuffer);
-    pass.setIndexBuffer(this._indexBuffer!, 'uint16');
+    pass.setVertexBuffer(0, this._vertexBuffer, vertexBase);
+    pass.setIndexBuffer(this._indexBuffer!, 'uint16', indexBase);
 
     let lastShaderType: ShaderType | null = null;
     let lastTexture: Texture | null = null;
@@ -623,7 +710,13 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       backend.stats.drawCalls++;
     }
 
-    coordinator.endPass();
+    // Carry this flush's consumption forward so a following flush in the same
+    // pass appends AFTER these draws' slices instead of overwriting the bytes
+    // they read.
+    this._ownDrawsPass = active;
+    this._vertexPassBytes = vertexBase + flushVertexBytes;
+    this._indexPassBytes = indexBase + flushIndexBytes;
+    this._nodePassCount = nodeBase + this._nodeCount;
 
     this._resetFrameState();
   }
@@ -767,6 +860,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     this._writtenViewUpdateId = -1;
     this._writtenGroupTransformId = -1;
     this._hasWrittenProjection = false;
+    this._resetPassCursors();
 
     this._pipelines.clear();
     this._texBindGroups = new WeakMap<Texture, { group: GPUBindGroup; view: GPUTextureView }>();
@@ -900,8 +994,14 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
 
   // ── GPU resource helpers ─────────────────────────────────────────────────
 
-  private _uploadNodeBuffer(device: GPUDevice): void {
-    const requiredBytes = this._nodeCount * nodeFloats * 4;
+  /**
+   * Upload this flush's per-node style data into the pass-wide node buffer at
+   * node `base`, sizing the buffer for `passNodeCount` nodes. Staging holds only
+   * this flush's nodes; the buffer must also keep the rows earlier draws in the
+   * open pass still read.
+   */
+  private _uploadNodeBuffer(device: GPUDevice, base: number, passNodeCount: number): void {
+    const requiredBytes = passNodeCount * nodeFloats * 4;
 
     if (requiredBytes > this._nodeBufferCapacity) {
       let newCap = this._nodeBufferCapacity;
@@ -916,15 +1016,18 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       this._frameBindGroupDirty = true;
     }
 
-    device.queue.writeBuffer(this._nodeBuffer!, 0, this._nodeDataArray.buffer, 0, requiredBytes);
+    const flushBytes = this._nodeCount * nodeFloats * 4;
+
+    if (flushBytes > 0) {
+      device.queue.writeBuffer(this._nodeBuffer!, base * nodeFloats * 4, this._nodeDataArray.buffer, 0, flushBytes);
+    }
   }
 
-  private _ensureGpuVertexBuffer(device: GPUDevice, vertexCount: number): void {
-    const required = vertexCount * vertexStrideBytes;
-    if (required <= this._vertexBufferCapacity) return;
+  private _ensureGpuVertexBuffer(device: GPUDevice, requiredBytes: number): void {
+    if (requiredBytes <= this._vertexBufferCapacity) return;
 
     let newCap = this._vertexBufferCapacity;
-    while (newCap < required) newCap *= 2;
+    while (newCap < requiredBytes) newCap *= 2;
     this._vertexBuffer?.destroy();
     this._vertexBuffer = device.createBuffer({
       label: 'WebGpuTextRenderer/vertices',
@@ -934,12 +1037,11 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     this._vertexBufferCapacity = newCap;
   }
 
-  private _ensureGpuIndexBuffer(device: GPUDevice, indexCount: number): void {
-    const required = indexCount * 2;
-    if (required <= this._indexBufferCapacity) return;
+  private _ensureGpuIndexBuffer(device: GPUDevice, requiredBytes: number): void {
+    if (requiredBytes <= this._indexBufferCapacity) return;
 
     let newCap = this._indexBufferCapacity;
-    while (newCap < required) newCap *= 2;
+    while (newCap < requiredBytes) newCap *= 2;
     this._indexBuffer?.destroy();
     this._indexBuffer = device.createBuffer({
       label: 'WebGpuTextRenderer/indices',
@@ -947,6 +1049,25 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       usage: GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
     });
     this._indexBufferCapacity = newCap;
+  }
+
+  /**
+   * Whether sizing the shared buffers to the pass totals a flush would reach by
+   * appending reallocates any of them. Reallocation destroys the buffer the draws
+   * already recorded into the open pass read, so the caller must end that pass
+   * (which zeroes the cursors) instead of appending. All arguments are pass
+   * totals, not this flush's deltas.
+   */
+  private _flushAppendWouldGrow(vertexBytes: number, indexBytes: number, nodeCount: number): boolean {
+    return vertexBytes > this._vertexBufferCapacity || indexBytes > this._indexBufferCapacity || nodeCount * nodeFloats * 4 > this._nodeBufferCapacity;
+  }
+
+  /** Drop the pass association so the next flush restarts every cursor. */
+  private _resetPassCursors(): void {
+    this._ownDrawsPass = null;
+    this._vertexPassBytes = 0;
+    this._indexPassBytes = 0;
+    this._nodePassCount = 0;
   }
 
   private _getFrameBindGroup(device: GPUDevice): GPUBindGroup {

--- a/test/rendering/browser/webgpu-particles-single-pass.test.ts
+++ b/test/rendering/browser/webgpu-particles-single-pass.test.ts
@@ -1,0 +1,345 @@
+/**
+ * WebGPU particle single-pass browser tests.
+ *
+ * `WebGpuParticleRenderer` used to open a coordinator pass, record one draw call
+ * into it and end (submit) it again — per draw call. It had to: every particle
+ * system rewrote the mode's shared vertex buffer and the system uniform buffer
+ * from offset 0, and `queue.writeBuffer` is ordered against the submit rather
+ * than against the individual draws inside it, so leaving the pass open would
+ * have made every earlier draw read the last system's bytes. A frame that
+ * alternates sprites and particle systems therefore cost one pass and one submit
+ * PER ALTERNATION.
+ *
+ * The renderer now appends at pass-scoped cursors (a byte offset into the mode's
+ * vertex buffer, a slot in the uniform ring) and adds the base at bind time, so
+ * the whole frame collapses to one pass and one submit again.
+ *
+ * These tests spy on `device.queue.submit` for exactly one rendered frame and
+ * additionally probe a pixel per flush: a change that merges the passes but
+ * corrupts the offsets paints the wrong colour (vertex buffer aliased) or leaves
+ * a cell at the clear colour (uniform ring aliased, so every system draws at the
+ * last one's position), and fails here rather than passing as a win.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Time } from '#core/Time';
+import { materializeRendererBindings } from '#extensions/materialize';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { ApplyForce, particlesExtension, ParticleSystem } from '../../../packages/exojs-particles/src/index';
+import { readWebGpuPixels } from './_backendSetup';
+import { wireCoreRenderers } from './_coreRenderers';
+import { expectPixelNear, type RgbaTuple } from './_pixels';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+const canvasSize = 64;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  wireCoreRenderers(backend);
+  await backend.initialize();
+  // The particle renderer is not part of the core renderer bindings — the
+  // `@codexo/exojs-particles` package materialises it itself via its Extension
+  // descriptor, and these tests build a bare backend without an Application.
+  materializeRendererBindings(backend, particlesExtension.renderers);
+
+  return backend;
+};
+
+const createSolidTexture = (color: string, size = 8): Texture => {
+  const src = document.createElement('canvas');
+
+  src.width = size;
+  src.height = size;
+
+  const ctx = src.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, size, size);
+
+  return new Texture(src);
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+/** Render `body` inside a validation error scope; returns false on a device-loss skip. */
+const renderGuarded = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, body: () => void): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    body();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+/** Count `device.queue.submit` calls for exactly one invocation of `body`. */
+const countSubmits = (backend: WebGpuBackend, body: () => void): number => {
+  const queue = getBackendDevice(backend).queue;
+  const real = queue.submit.bind(queue);
+  let count = 0;
+
+  queue.submit = ((buffers: Iterable<GPUCommandBuffer>): undefined => {
+    count++;
+
+    return real(buffers);
+  }) as GPUQueue['submit'];
+
+  try {
+    body();
+  } finally {
+    queue.submit = real;
+  }
+
+  return count;
+};
+
+// Fully saturated, mutually distant colours: any two differ by 255 in at least
+// one channel, far above the probe tolerance, and none of them is the black
+// clear colour.
+const particleColors: readonly RgbaTuple[] = [
+  [255, 0, 0, 255],
+  [0, 255, 0, 255],
+  [0, 0, 255, 255],
+  [255, 255, 0, 255],
+  [0, 255, 255, 255],
+  [255, 0, 255, 255],
+];
+
+/**
+ * A one-particle system tinted `color` and placed at (`x`, `y`). The particle
+ * itself sits at the system's local origin, so its screen position comes from
+ * the system transform (the per-draw UNIFORM slot) while its colour comes from
+ * the built instance record (the per-draw VERTEX sub-range) — one probe
+ * therefore covers both cursors.
+ *
+ * Deterministic by construction: spawn modules are bypassed and the SoA slot is
+ * written directly, and `update()` is never called, so `elapsed` stays at 0 and
+ * the particle cannot expire.
+ */
+const createTintedSystem = (texture: Texture, color: RgbaTuple, x: number, y: number): ParticleSystem => {
+  const system = new ParticleSystem(texture, { capacity: 4 });
+  const slot = system.spawn();
+
+  system.posX[slot] = 0;
+  system.posY[slot] = 0;
+  system.scaleX[slot] = 1;
+  system.scaleY[slot] = 1;
+  system.rotations[slot] = 0;
+  system.color[slot] = new Color(color[0], color[1], color[2]).toRgba();
+  system.lifetime[slot] = 1;
+  system.setPosition(x, y);
+
+  return system;
+};
+
+describe('WebGPU particle single-pass frame', () => {
+  test('many sprite/particle alternations cost ONE pass and ONE submit, with per-flush particle pixels correct', async ctx => {
+    const backend = await setupBackend();
+    // Each alternation switches the active renderer, so this frame contains N
+    // separate particle flushes. All systems run the SHARED default render mode,
+    // whose vertex buffer the renderer caches against the mode's material — so
+    // they all append into one buffer, which is exactly the aliasing this
+    // guards.
+    const alternations = particleColors.length;
+    const cell = 8;
+    const spriteRow = 0;
+    const particleRow = 40;
+    const texture = createSolidTexture('#ffffff', cell);
+    const sprites: Sprite[] = [];
+    const systems: ParticleSystem[] = [];
+
+    for (let i = 0; i < alternations; i++) {
+      const sprite = new Sprite(texture);
+
+      sprite.setPosition(i * 10, spriteRow);
+      sprite.width = cell;
+      sprite.height = cell;
+      sprites.push(sprite);
+
+      // Centres 10px apart with a ±4px quad: 2px of clear colour between cells.
+      systems.push(createTintedSystem(texture, particleColors[i]!, 5 + i * 10, particleRow));
+    }
+
+    // Closing on a sprite keeps the frame boundary out of the measurement: with
+    // a particle system last, the NEXT frame's pending clear is consumed by an
+    // empty pass the particle renderer opens for it, which adds a pass unrelated
+    // to what this test measures.
+    const trailingSprite = new Sprite(texture);
+
+    trailingSprite.setPosition(0, canvasSize - cell);
+    trailingSprite.width = cell;
+    trailingSprite.height = cell;
+
+    const renderAlternating = (): void => {
+      backend.resetStats();
+      backend.clear(Color.black);
+
+      for (let i = 0; i < alternations; i++) {
+        sprites[i]!.render(backend);
+        systems[i]!.render(backend);
+      }
+
+      trailingSprite.render(backend);
+      backend.flush();
+    };
+
+    try {
+      // Warm up so pipelines are compiled and the shared buffers have ratcheted
+      // up to the frame's total: a capacity growth legitimately splits the pass,
+      // and sizing to the post-split draw would peg them at one draw forever.
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderGuarded(ctx, backend, renderAlternating))) {
+          return;
+        }
+      }
+
+      const submits = countSubmits(backend, renderAlternating);
+
+      // One draw call per sprite flush and per particle flush, plus the trailing sprite.
+      expect(backend.stats.drawCalls).toBe(alternations * 2 + 1);
+      expect(backend.stats.renderPasses).toBe(1);
+      expect(submits).toBe(1);
+
+      const readPixel = readWebGpuPixels(backend, canvasSize);
+
+      for (let i = 0; i < alternations; i++) {
+        expectPixelNear(readPixel(5 + i * 10, particleRow), particleColors[i]!);
+      }
+
+      // The gap between two systems: a frame that drew every system at one
+      // position would leave the cells empty rather than the gaps.
+      expectPixelNear(readPixel(10, particleRow), [0, 0, 0, 255]);
+      expectPixelNear(readPixel(30, particleRow), [0, 0, 0, 255]);
+    } finally {
+      systems.forEach(system => system.destroy());
+      sprites.forEach(sprite => sprite.destroy());
+      trailingSprite.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('a GPU-compute system alternating with a CPU one still costs ONE pass and ONE submit', async ctx => {
+    const backend = await setupBackend();
+    // The compute simulation runs from the system's OWN encoder and submit, in
+    // `update()` — a compute pass, never nested in the render pass — and writes
+    // an instance buffer owned by that one system. So it neither shares a cursor
+    // with the CPU path nor forces a render-pass boundary here; the only thing
+    // the render side does differently is bind that buffer at offset 0. This
+    // pins both halves of that: the compute system's pixels stay correct while
+    // the frame keeps merging.
+    const cell = 8;
+    const texture = createSolidTexture('#ffffff', cell);
+    const gpuSystem = new ParticleSystem(texture, { capacity: 4, device: getBackendDevice(backend) });
+    const cpuSystem = createTintedSystem(texture, particleColors[1]!, 45, 40);
+    const sprite = new Sprite(texture);
+    const trailingSprite = new Sprite(texture);
+
+    sprite.setPosition(0, 0);
+    sprite.width = cell;
+    sprite.height = cell;
+    trailingSprite.setPosition(0, canvasSize - cell);
+    trailingSprite.width = cell;
+    trailingSprite.height = cell;
+
+    const renderFrame = (): void => {
+      backend.resetStats();
+      backend.clear(Color.black);
+      sprite.render(backend);
+      gpuSystem.render(backend);
+      cpuSystem.render(backend);
+      // A second flush of the same renderer pair, so the merge is measured
+      // across a renderer switch rather than within one flush.
+      trailingSprite.render(backend);
+      backend.flush();
+    };
+
+    try {
+      gpuSystem.addUpdateModule(new ApplyForce(0, 0));
+
+      const slot = gpuSystem.spawn();
+
+      gpuSystem.posX[slot] = 0;
+      gpuSystem.posY[slot] = 0;
+      gpuSystem.scaleX[slot] = 1;
+      gpuSystem.scaleY[slot] = 1;
+      gpuSystem.rotations[slot] = 0;
+      gpuSystem.color[slot] = new Color(particleColors[0]![0], particleColors[0]![1], particleColors[0]![2]).toRgba();
+      gpuSystem.lifetime[slot] = 100;
+      gpuSystem.setPosition(15, 40);
+
+      // The system tears its GPU state down the first time it sees a backend it
+      // has not been collected against, so the first frame is always the CPU
+      // path. Render once to bind the backend, then update — that update is the
+      // one that compiles the compute pipeline.
+      if (!(await renderGuarded(ctx, backend, renderFrame))) {
+        return;
+      }
+
+      gpuSystem.update(Time.zero.clone().set(16));
+
+      expect(gpuSystem.gpuMode).toBe(true);
+
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderGuarded(ctx, backend, renderFrame))) {
+          return;
+        }
+      }
+
+      const submits = countSubmits(backend, renderFrame);
+
+      expect(backend.stats.renderPasses).toBe(1);
+      expect(submits).toBe(1);
+
+      const readPixel = readWebGpuPixels(backend, canvasSize);
+
+      // The compute-fed system and the CPU-fed one keep their own colour and
+      // their own position, which a shared uniform slot would collapse.
+      expectPixelNear(readPixel(15, 40), particleColors[0]!);
+      expectPixelNear(readPixel(45, 40), particleColors[1]!);
+    } finally {
+      gpuSystem.destroy();
+      cpuSystem.destroy();
+      sprite.destroy();
+      trailingSprite.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-particles-single-pass.test.ts
+++ b/test/rendering/browser/webgpu-particles-single-pass.test.ts
@@ -61,7 +61,13 @@ const setupBackend = async (): Promise<WebGpuBackend> => {
   // The particle renderer is not part of the core renderer bindings — the
   // `@codexo/exojs-particles` package materialises it itself via its Extension
   // descriptor, and these tests build a bare backend without an Application.
-  materializeRendererBindings(backend, particlesExtension.renderers);
+  const { renderers } = particlesExtension;
+
+  if (!renderers) {
+    throw new Error('particlesExtension exposes no renderer bindings');
+  }
+
+  materializeRendererBindings(backend, renderers);
 
   return backend;
 };

--- a/test/rendering/browser/webgpu-text-single-pass.test.ts
+++ b/test/rendering/browser/webgpu-text-single-pass.test.ts
@@ -1,0 +1,257 @@
+/**
+ * WebGPU text single-pass browser test.
+ *
+ * The WebGPU render pass survives a renderer switch, so a frame that alternates
+ * sprites and text contains SEVERAL text flushes inside one pass. The text
+ * renderer used to rewrite its shared vertex / index / node-data buffers from
+ * offset 0 on every flush — `queue.writeBuffer` is ordered against the submit,
+ * not against the individual draws inside the pass, so flush k+1's bytes would
+ * land under the draws flush k had already recorded — and it ended (submitted)
+ * the pass unconditionally at the tail of every flush to paper over that. Cost:
+ * one pass and one submit PER TEXT FLUSH, i.e. linear in the alternation count.
+ *
+ * The flush path now appends at pass-scoped cursors (vertex bytes, index bytes,
+ * node rows) and adds the base at bind time, so the whole frame collapses to one
+ * pass and one submit again.
+ *
+ * Distinct fill colours AND distinct rows per text node are what make an
+ * aliasing regression visible: a flush whose vertex bytes or node rows were
+ * overwritten by a later one paints the later node's colour — or nothing at all,
+ * leaving its band at the black clear. Collapsing the passes while corrupting the
+ * offsets therefore fails the probes, not just the counters.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { readWebGpuFrame } from './_backendSetup';
+import { wireCoreRenderers } from './_coreRenderers';
+import { expectPixelNear, type RgbaTuple } from './_pixels';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+const canvasSize = 128;
+// One horizontal band per text flush, with the sprite column parked to the right
+// of `textProbeWidth` so the probe scan only ever sees glyph pixels.
+const flushes = 4;
+const bandHeight = canvasSize / flushes;
+const textProbeWidth = 96;
+const spriteColumn = 112;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+const createSolidTexture = (color: string, size = 8): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const ctx = source.getContext('2d')!;
+
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+/** Render `body` inside a validation error scope; returns false on a device-loss skip. */
+const renderGuarded = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, body: () => void): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    body();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+/**
+ * Count `device.queue.submit` calls for exactly one invocation of `body`.
+ * Restores the real method afterwards.
+ */
+const countSubmits = (backend: WebGpuBackend, body: () => void): number => {
+  const queue = getBackendDevice(backend).queue;
+  const real = queue.submit.bind(queue);
+  let count = 0;
+
+  queue.submit = ((buffers: Iterable<GPUCommandBuffer>): undefined => {
+    count++;
+
+    return real(buffers);
+  }) as GPUQueue['submit'];
+
+  try {
+    body();
+  } finally {
+    queue.submit = real;
+  }
+
+  return count;
+};
+
+/**
+ * The most strongly covered glyph pixel inside one band. Glyph edges are
+ * antialiased, so the fill colour is only reproduced exactly where coverage
+ * saturates — the brightest pixel of a thick stem. Returns `null` for a band
+ * that holds no ink at all (which is itself a failure: the flush was dropped or
+ * drew somewhere else).
+ */
+const strongestBandPixel = (frame: ArrayLike<number>, band: number): RgbaTuple | null => {
+  let best: RgbaTuple | null = null;
+  let bestTotal = 0;
+
+  for (let y = band * bandHeight; y < (band + 1) * bandHeight; y++) {
+    for (let x = 0; x < textProbeWidth; x++) {
+      const i = (y * canvasSize + x) * 4;
+      const total = frame[i]! + frame[i + 1]! + frame[i + 2]!;
+
+      if (total > bestTotal) {
+        bestTotal = total;
+        best = [frame[i]!, frame[i + 1]!, frame[i + 2]!, frame[i + 3]!];
+      }
+    }
+  }
+
+  // A saturated stem pixel of any palette entry sums to at least 255; anything
+  // dimmer is edge antialiasing, not a readable sample.
+  return bestTotal >= 240 ? best : null;
+};
+
+describe('WebGPU text single-pass frame', () => {
+  beforeEach(() => resetDefaultGlyphAtlasPool());
+  afterEach(() => resetDefaultGlyphAtlasPool());
+
+  test('many sprite/text alternations cost ONE pass and ONE submit, with per-flush text pixels correct', async ctx => {
+    const backend = await setupBackend();
+    // Fully saturated primaries plus yellow: any two differ by 255 in some
+    // channel, so a band painted by the wrong flush's node row is unmissable.
+    const fillColors: readonly RgbaTuple[] = [
+      [255, 0, 0, 255],
+      [0, 255, 0, 255],
+      [0, 0, 255, 255],
+      [255, 255, 0, 255],
+    ];
+    const texture = createSolidTexture('#ffffff', 8);
+    const sprites: Sprite[] = [];
+    const texts: Text[] = [];
+
+    for (let i = 0; i < flushes; i++) {
+      const sprite = new Sprite(texture);
+
+      sprite.setPosition(spriteColumn, i * bandHeight + 4);
+      sprite.width = 8;
+      sprite.height = 8;
+      sprites.push(sprite);
+
+      // 'M' is wide and solid, so every band has a thick stem whose centre
+      // pixels reach full coverage.
+      const [r, g, b] = fillColors[i]!;
+      const text = new Text('M', { fontSize: 24, fillColor: new Color(r, g, b, 1) });
+
+      text.setPosition(6, i * bandHeight + 4);
+      texts.push(text);
+    }
+
+    // Closing on a sprite keeps the frame boundary out of the measurement: with
+    // text last, the NEXT frame's pending clear is consumed by the text
+    // renderer's empty-clear pass, which adds a pass unrelated to what this test
+    // measures.
+    const trailingSprite = new Sprite(texture);
+
+    trailingSprite.setPosition(spriteColumn, canvasSize - 12);
+    trailingSprite.width = 8;
+    trailingSprite.height = 8;
+
+    const renderAlternating = (): void => {
+      backend.resetStats();
+      backend.clear(Color.black);
+
+      for (let i = 0; i < flushes; i++) {
+        sprites[i]!.render(backend);
+        texts[i]!.render(backend);
+      }
+
+      trailingSprite.render(backend);
+      backend.flush();
+    };
+
+    try {
+      // Warm up so pipelines are compiled, the glyph atlas holds 'M' (a dirty
+      // atlas page legitimately splits the pass), and the shared buffers have
+      // ratcheted up to the frame's total: a capacity growth also splits, and
+      // sizing to the post-split flush would peg them at one flush forever.
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderGuarded(ctx, backend, renderAlternating))) {
+          return;
+        }
+      }
+
+      const submits = countSubmits(backend, renderAlternating);
+
+      // One draw call per sprite flush and per text flush, plus the trailing
+      // sprite — so the text renderer really did flush `flushes` times.
+      expect(backend.stats.drawCalls).toBe(flushes * 2 + 1);
+      expect(backend.stats.renderPasses).toBe(1);
+      expect(submits).toBe(1);
+
+      const frame = readWebGpuFrame(backend, canvasSize);
+
+      for (let i = 0; i < flushes; i++) {
+        const sample = strongestBandPixel(frame, i);
+
+        expect(sample, `band ${i} holds no glyph ink`).not.toBeNull();
+        expectPixelNear(sample!, fillColors[i]!);
+      }
+    } finally {
+      texts.forEach(text => text.destroy());
+      sprites.forEach(sprite => sprite.destroy());
+      trailingSprite.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-tilechunk-single-pass.test.ts
+++ b/test/rendering/browser/webgpu-tilechunk-single-pass.test.ts
@@ -1,0 +1,198 @@
+/**
+ * WebGPU tile-chunk single-pass browser test.
+ *
+ * `WebGpuTileChunkRenderer` used to write its shared instance buffer from offset
+ * 0 on every flush and end (submit) the pass at the tail of each one. Since the
+ * render pass survives a renderer switch, flush k+1's write would otherwise land
+ * under the draws flush k had already recorded into the still-open pass —
+ * `queue.writeBuffer` is ordered against the submit, not against the individual
+ * draws inside it — so the unconditional pass end was load-bearing. A frame with
+ * N tile-chunk flushes therefore cost N passes and N submits.
+ *
+ * The flush path now appends at a pass-scoped cursor and adds the base offset at
+ * bind time, so the whole frame collapses to ONE pass and ONE submit. Distinct
+ * tileset colours AND distinct positions per flush are what makes an aliasing
+ * regression visible: a flush whose bytes were overwritten by a later one paints
+ * the later tile's colour at the later tile's coordinates, leaving its own cell
+ * at the black clear.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import { TileMapNode } from '@codexo/exojs-tilemap';
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Sprite } from '#rendering/sprite/Sprite';
+import type { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { readWebGpuPixels } from './_backendSetup';
+import { wireCoreRenderers } from './_coreRenderers';
+import { expectPixelNear, type RgbaTuple } from './_pixels';
+import { createSolidTexture, singleTileMap, wireTilemapRenderers } from './_tilemapScene';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+const canvasSize = 64;
+const tileSize = 16;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: { canvas: { width: canvasSize, height: canvasSize }, clearColor: Color.black },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  // Both bindings: the tilemap renderer draws the chunks, and the sprite
+  // renderer closes the frame (see the trailing-sprite note below).
+  wireTilemapRenderers(backend);
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+/** Render `body` inside a validation error scope; returns false on a device-loss skip. */
+const renderGuarded = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, body: () => void): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    body();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+/** Count `device.queue.submit` calls for exactly one invocation of `body`. */
+const countSubmits = (backend: WebGpuBackend, body: () => void): number => {
+  const queue = getBackendDevice(backend).queue;
+  const real = queue.submit.bind(queue);
+  let count = 0;
+
+  queue.submit = ((buffers: Iterable<GPUCommandBuffer>): undefined => {
+    count++;
+
+    return real(buffers);
+  }) as GPUQueue['submit'];
+
+  try {
+    body();
+  } finally {
+    queue.submit = real;
+  }
+
+  return count;
+};
+
+const hexToRgba = (hex: string): RgbaTuple => [parseInt(hex.slice(1, 3), 16), parseInt(hex.slice(3, 5), 16), parseInt(hex.slice(5, 7), 16), 255];
+
+// One 16x16 tile per node, each on its OWN tileset texture: a texture change is
+// what breaks the tile-chunk batch, so rendering these back to back produces one
+// flush per node.
+const tileColors = ['#ff0000', '#00ff00', '#0000ff', '#ffff00'] as const;
+// Laid out across the top two rows of the 64x64 canvas, clear of the trailing
+// sprite below.
+const tilePositions = [
+  [0, 0],
+  [tileSize, 0],
+  [0, tileSize],
+  [tileSize, tileSize],
+] as const;
+
+describe('WebGPU tile-chunk single pass', () => {
+  test('many tile-chunk flushes cost ONE pass and ONE submit, with per-flush pixels correct', async ctx => {
+    const backend = await setupBackend();
+    const tileTextures: Texture[] = tileColors.map(color => createSolidTexture(color, tileSize));
+    const nodes = tileTextures.map((texture, i) => {
+      const node = new TileMapNode(singleTileMap(texture));
+      const [x, y] = tilePositions[i]!;
+
+      node.setPosition(x, y);
+
+      return node;
+    });
+
+    // Closing the frame on a SPRITE keeps the frame boundary out of the
+    // measurement: with a tile chunk last, the NEXT frame's pending clear is
+    // consumed by an empty pass of the tilemap renderer, which adds a pass
+    // unrelated to what this test measures.
+    const spriteColor = '#ff00ff';
+    const spriteTexture = createSolidTexture(spriteColor, 8);
+    const trailingSprite = new Sprite(spriteTexture);
+
+    trailingSprite.setPosition(0, 48);
+    trailingSprite.width = 8;
+    trailingSprite.height = 8;
+
+    const renderScene = (): void => {
+      backend.resetStats();
+      backend.clear(Color.black);
+
+      for (const node of nodes) {
+        node.render(backend);
+      }
+
+      trailingSprite.render(backend);
+      backend.flush();
+    };
+
+    try {
+      // Warm up so pipelines are compiled, textures are uploaded and the shared
+      // instance buffer has ratcheted up to the frame's total: a capacity growth
+      // legitimately splits the pass, and sizing it to the post-split flush
+      // would peg it at one flush forever.
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderGuarded(ctx, backend, renderScene))) {
+          return;
+        }
+      }
+
+      const submits = countSubmits(backend, renderScene);
+
+      // One draw call per tile-chunk flush, plus the trailing sprite.
+      expect(backend.stats.drawCalls).toBe(tileColors.length + 1);
+      expect(backend.stats.renderPasses).toBe(1);
+      expect(submits).toBe(1);
+
+      const readPixel = readWebGpuPixels(backend, canvasSize);
+
+      for (let i = 0; i < tileColors.length; i++) {
+        const [x, y] = tilePositions[i]!;
+
+        expectPixelNear(readPixel(x + tileSize / 2, y + tileSize / 2), hexToRgba(tileColors[i]!));
+      }
+
+      expectPixelNear(readPixel(4, 52), hexToRgba(spriteColor));
+    } finally {
+      nodes.forEach(node => node.destroy());
+      tileTextures.forEach(texture => texture.destroy());
+      trailingSprite.destroy();
+      spriteTexture.destroy();
+      backend.destroy();
+    }
+  });
+});


### PR DESCRIPTION
Extends the pass-scoped cursor pattern established for meshes to the remaining
WebGPU renderers. Each of them previously started a fresh render pass (and its
own submit) per flush; they now append draws at a pass-scoped cursor and keep a
single pass open for the whole scene.

| Renderer  | Before               | After |
|-----------|----------------------|-------|
| Text      | 5 passes / 5 submits | 1 / 1 |
| TileChunk | 5 / 5                | 1 / 1 |
| Particles | 7 / 7                | 1 / 1 |

Particles additionally: compute + CPU system + 2 sprites goes from 3/3 to 1/1.

### Renderer-specific deviations from the mesh pattern

- **Text** passes the instance base through the `nodeIndex` attribute, because
  the node storage buffer has no dynamic offset.
- **Tilemap** required separating staging capacity (instances) from buffer
  capacity (bytes).
- **Particles** turned the uniform buffer into a ring with `hasDynamicOffset`.

The compute path does not force a render pass boundary: `dispatch()` runs from
its own encoder with its own submit, so it is never nested inside a render pass.

### Verification

- `browser-webgpu` 320/320, `browser-webgl` 281/281
- `verify:quick` — all 11 gates
