### PR TITLE
fix(rendering): submit open WebGPU passes before destroying the buffers their draws bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -460,6 +460,14 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   `Container` itself — the paint-order snapshot skips the sort entirely while
   every sibling shares a `zIndex` — invalidated by each structural mutator, and
   by a child's `zIndex` write for the paint order alone.
+- **The retained-text quad-index buffer starts at 1024 quads, not 64.** 64
+  quads is roughly one short line of text, so effectively every real text
+  draw triggered several doubling steps to reach a usable size — each one a
+  fresh buffer allocation plus a CPU index fill (plus, since growth now ends
+  an open pass first, an extra submit). 1024 quads is 12 KiB and covers
+  normal text scenes in a single allocation, in both `WebGpuTextRenderer` and
+  `WebGl2TextRenderer`; the hard ceiling stays at 16384 quads (the `Uint16`
+  vertex-index limit).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -582,6 +582,15 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   check is now an always-on `invariant` throw, matching the existing
   ancestor-cycle guard, so a use-after-destroy attach fails the same way in
   every build instead of degrading quietly in production only.
+- **`WebGpuMeshRenderer.onDisconnect()` no longer destroys buffers a
+  still-open pass draws against.** Since the pass-cursor sweep, a mesh flush
+  no longer ends the WebGPU render pass; disconnecting the renderer on its
+  own (mid-frame, outside `WebGpuBackend.destroy()`/device loss, both of
+  which already drop the pass first) could leave its own draws recorded into
+  a pass that was still open and unsubmitted, then free the vertex, index,
+  uniform and instanced buffers they read — a destroyed-buffer validation
+  error whenever something later submitted that pass. `onDisconnect()` now
+  ends its own open pass first when it holds the renderer's draws.
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -591,6 +591,13 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   uniform and instanced buffers they read — a destroyed-buffer validation
   error whenever something later submitted that pass. `onDisconnect()` now
   ends its own open pass first when it holds the renderer's draws.
+- **`WebGpuTextRenderer`'s shared retained quad-index buffer no longer grows
+  out from under a still-open pass.** The grow branch of
+  `_ensureRetainedQuadIndexBuffer()` destroyed the current buffer
+  unconditionally; an earlier retained replay in the same still-open pass
+  could already have a draw bound to it, so freeing it invalidated the whole
+  merged command buffer at the next submit. Growth now ends the open pass
+  first when it already holds draws.
 
 ### Docs
 

--- a/src/rendering/webgl2/WebGl2TextRenderer.ts
+++ b/src/rendering/webgl2/WebGl2TextRenderer.ts
@@ -66,6 +66,11 @@ const vertexStrideWords = vertexStrideBytes / 4; // 5 floats per vertex
 const initialVertexCapacity = 256;
 const initialIndexCapacity = 384;
 const initialNodeCapacity = 32;
+// One short line of text is already ~64 quads, so that floor made almost
+// every real retained draw pay several doubling steps (a fresh GL buffer plus
+// a CPU index fill each). 1024 quads is 12 KiB and covers normal text scenes
+// in one allocation, well inside the 16384-quad Uint16 vertex-index ceiling.
+const initialRetainedQuadCapacity = 1024;
 
 type ShaderType = 'sdf' | 'msdf' | 'color';
 
@@ -860,7 +865,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       return this._retainedQuadIndexBuffer;
     }
 
-    let capacity = Math.max(this._retainedQuadCapacity, 64);
+    let capacity = Math.max(this._retainedQuadCapacity, initialRetainedQuadCapacity);
 
     while (capacity < quadCount) capacity *= 2;
 

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -1286,6 +1286,18 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
 
   protected onDisconnect(): void {
     this.flush();
+
+    // The teardown below destroys the very buffers a draw of ours left in the
+    // open pass still binds, and the pass no longer ends at the tail of a
+    // flush. Submit it first so those draws reach the queue against live
+    // buffers. Backend destroy and device loss drop the pass before disconnecting
+    // renderers, so this only fires when a renderer is disconnected on its own.
+    const coordinator = this._backend?._passCoordinator ?? null;
+
+    if (coordinator !== null && this._ownDrawsPass !== null && this._ownDrawsPass === coordinator.activePass) {
+      coordinator.endPass();
+    }
+
     this._vertexBuffer?.destroy();
     this._indexBuffer?.destroy();
     this._uniformBuffer?.destroy();

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -62,6 +62,12 @@ const alignIndexBytes = (indexCount: number): number => (indexCount * Uint16Arra
 const initialVertexCapacity = 256;
 const initialIndexCapacity = 384;
 const initialNodeCapacity = 32;
+// One short line of text is already ~64 quads, so that floor made almost
+// every real retained draw pay several doubling steps (createBuffer + a CPU
+// index fill + writeBuffer each, plus — since the pass-open growth guard —
+// an extra submit). 1024 quads is 12 KiB and covers normal text scenes in
+// one allocation, well inside the 16384-quad Uint16 vertex-index ceiling.
+const initialRetainedQuadCapacity = 1024;
 
 // FrameUniforms: 7 × vec4<f32> = 112 bytes (projection + group mat3x3,
 // column-major, + device-pixel snap viewport rect)
@@ -1524,7 +1530,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       coordinator.endPass();
     }
 
-    let capacity = Math.max(this._retainedQuadIndexCapacity, 64);
+    let capacity = Math.max(this._retainedQuadIndexCapacity, initialRetainedQuadCapacity);
 
     while (capacity < quadCount) capacity *= 2;
 

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -1365,7 +1365,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
 
     const textureBindGroup = this._getTexBindGroup(device, backend, payload.textures[0]! as Texture);
     const frameBindGroup = this._getTextReplayBindGroup(state, device);
-    const indexBuffer = this._ensureRetainedQuadIndexBuffer(device, data.quadCount);
+    const indexBuffer = this._ensureRetainedQuadIndexBuffer(device, data.quadCount, coordinator);
 
     const active = coordinator.acquirePass();
     const pass = active.pass;
@@ -1511,9 +1511,17 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
    * renderer, exactly like `WebGpuNineSliceSpriteRenderer`'s static per-quad
    * index buffer serves every nine-slice instance.
    */
-  private _ensureRetainedQuadIndexBuffer(device: GPUDevice, quadCount: number): GPUBuffer {
+  private _ensureRetainedQuadIndexBuffer(device: GPUDevice, quadCount: number, coordinator: WebGpuBackend['_passCoordinator']): GPUBuffer {
     if (this._retainedQuadIndexBuffer !== null && this._retainedQuadIndexCapacity >= quadCount) {
       return this._retainedQuadIndexBuffer;
+    }
+
+    // Growing below destroys the current buffer. An earlier retained replay
+    // in this same still-open pass may still have a draw bound to it, and
+    // the pass no longer ends at the tail of a replay call — end it first so
+    // that draw reaches the queue against a live buffer.
+    if (this._retainedQuadIndexBuffer !== null && coordinator.passHasDraws) {
+      coordinator.endPass();
     }
 
     let capacity = Math.max(this._retainedQuadIndexCapacity, 64);

--- a/test/rendering/browser/webgpu-mesh-disconnect-open-pass.test.ts
+++ b/test/rendering/browser/webgpu-mesh-disconnect-open-pass.test.ts
@@ -1,0 +1,175 @@
+/**
+ * WebGPU mesh-renderer mid-frame disconnect browser test.
+ *
+ * Since the pass-cursor sweep, the WebGPU render pass survives a renderer
+ * switch and is only ended (submitted) at genuine frame boundaries — a mesh
+ * flush no longer ends it. `WebGpuMeshRenderer.onDisconnect` used to destroy
+ * `_vertexBuffer` / `_indexBuffer` / `_uniformBuffer` (and the instanced
+ * counterparts) right after its own `flush()`, with no regard for whether
+ * that flush's draws had already been recorded into a pass that is STILL
+ * OPEN and not yet submitted. A renderer disconnected on its own — outside
+ * `WebGpuBackend.destroy()` / device loss, both of which drop the pass first
+ * — left those draws bound to now-destroyed buffers sitting in the pass;
+ * whatever later ends it submits a command buffer that reads freed GPU
+ * memory, a WebGPU validation error.
+ *
+ * `onDisconnect` now ends its own open pass before destroying its buffers, so
+ * the draws reach the queue against live buffers first.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Geometry } from '#rendering/geometry/Geometry';
+import { Mesh } from '#rendering/mesh/Mesh';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+const canvasSize = 32;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: { canvas: { width: canvasSize, height: canvasSize }, clearColor: Color.black },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+const createSolidTexture = (color: string, size = 16): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+/** A 16x16 textured quad geometry (usage 'static' by default). */
+const createQuadGeometry = (): Geometry => {
+  const stride = 16; // vec2 position (8) + vec2 texcoord (8)
+  const buffer = new ArrayBuffer(4 * stride);
+  const view = new DataView(buffer);
+  const verts = [
+    { x: 0, y: 0, u: 0, v: 0 },
+    { x: 16, y: 0, u: 1, v: 0 },
+    { x: 16, y: 16, u: 1, v: 1 },
+    { x: 0, y: 16, u: 0, v: 1 },
+  ];
+
+  verts.forEach((vert, i) => {
+    const base = i * stride;
+
+    view.setFloat32(base + 0, vert.x, true);
+    view.setFloat32(base + 4, vert.y, true);
+    view.setFloat32(base + 8, vert.u, true);
+    view.setFloat32(base + 12, vert.v, true);
+  });
+
+  return new Geometry({
+    attributes: [
+      { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+      { name: 'a_texcoord', size: 2, type: 'f32', normalized: false, offset: 8 },
+    ],
+    vertexData: buffer,
+    stride,
+    indices: new Uint16Array([0, 1, 2, 0, 2, 3]),
+  });
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+/** Run `body` inside a validation error scope; returns false on a device-loss skip. */
+const runGuarded = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, body: () => void): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    body();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+describe('WebGPU mesh renderer mid-frame disconnect', () => {
+  test('disconnecting the mesh renderer while its draw sits in the still-open pass submits it first — no destroyed-buffer usage', async ctx => {
+    const backend = await setupBackend();
+    const meshTexture = createSolidTexture('#ff0000');
+    const geometry = createQuadGeometry();
+    const mesh = new Mesh({ geometry, texture: meshTexture });
+    const spriteTexture = createSolidTexture('#00ff00', 8);
+    const sprite = new Sprite(spriteTexture);
+
+    sprite.setPosition(16, 16);
+    sprite.width = 8;
+    sprite.height = 8;
+
+    try {
+      await runGuarded(ctx, backend, () => {
+        backend.resetStats();
+        backend.clear(Color.black);
+        // Buffers the mesh draw call (mesh renderer becomes the active renderer).
+        mesh.render(backend);
+        // Renderer switch: flushes the mesh renderer, recording its draw into
+        // the coordinator's pass — which stays OPEN, not submitted — then
+        // buffers the sprite draw on the new active renderer.
+        sprite.render(backend);
+
+        // Disconnect the mesh renderer directly and mid-frame (not through
+        // `backend.destroy()`, which would drop the open pass first): its own
+        // draw above is still sitting, unsubmitted, in the pass the sprite
+        // renderer is about to append to.
+        backend.rendererRegistry.resolve(mesh).disconnect();
+
+        // Ends (submits) whatever pass remains open.
+        backend.flush();
+      });
+    } finally {
+      mesh.destroy();
+      meshTexture.destroy();
+      geometry.destroy();
+      sprite.destroy();
+      spriteTexture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-text-retained-quad-index-growth.test.ts
+++ b/test/rendering/browser/webgpu-text-retained-quad-index-growth.test.ts
@@ -1,0 +1,169 @@
+/**
+ * WebGPU retained-text quad-index buffer growth browser test.
+ *
+ * `WebGpuTextRenderer` shares ONE grow-only quad-index buffer across every
+ * retained Text batch on the renderer (see `_ensureRetainedQuadIndexBuffer`).
+ * Growing it destroys the current buffer before allocating the larger one.
+ * Since the pass-cursor sweep, the WebGPU render pass survives a renderer
+ * switch and a retained replay no longer ends it — so an EARLIER retained
+ * replay in the SAME still-open pass can have a draw bound to the buffer
+ * being destroyed. Freeing it under that draw invalidates the whole merged
+ * command buffer at the next submit: a WebGPU validation error.
+ *
+ * `_ensureRetainedQuadIndexBuffer` now ends the open pass before growing
+ * whenever it already holds draws, so the earlier replay's draw reaches the
+ * queue against the buffer it was actually bound to.
+ *
+ * Two retained groups reproduce this deterministically: a small one whose
+ * replay creates the shared buffer at its initial (small) capacity, and a
+ * much larger one — rendered after it in the same tree, so its replay lands
+ * in the same open pass — whose quad count forces a growth.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { readWebGpuPixels } from './_backendSetup';
+import { wireCoreRenderers } from './_coreRenderers';
+import { expectPixelNear, type RgbaTuple } from './_pixels';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+const canvasSize = 48;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: { canvas: { width: canvasSize, height: canvasSize }, clearColor: Color.black },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+/** Render `body` inside a validation error scope; returns false on a device-loss skip. */
+const renderGuarded = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, body: () => void): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    body();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+const renderFrame = (backend: WebGpuBackend, root: RenderNode): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  root.render(backend);
+  backend.flush();
+};
+
+describe('WebGPU retained text quad-index buffer growth', () => {
+  beforeEach(() => resetDefaultGlyphAtlasPool());
+  afterEach(() => resetDefaultGlyphAtlasPool());
+
+  test('growing the shared quad-index buffer while an earlier replay in the pass still binds it submits that replay first', async ctx => {
+    const backend = await setupBackend();
+    const root = new Container();
+
+    // A small retained group: its replay is what first creates the shared
+    // quad-index buffer, at whatever the renderer's initial (small) capacity
+    // is — the exact number doesn't matter, only that it is far below the
+    // second group's quad count below.
+    const groupA = new RetainedContainer();
+    const textA = new Text('M', { fillColor: Color.white, fontSize: 16 });
+
+    textA.setPosition(2, 2);
+    groupA.addChild(textA);
+    groupA.setPosition(0, 0);
+    root.addChild(groupA);
+
+    try {
+      // F1 capture, F2 record, F3 replay: group A's replay creates the
+      // shared quad-index buffer.
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderGuarded(ctx, backend, () => renderFrame(backend, root)))) {
+          return;
+        }
+      }
+
+      const readBeforeGrowth = readWebGpuPixels(backend, canvasSize);
+      const inkBeforeGrowth: RgbaTuple = readBeforeGrowth(3, 10);
+
+      // Sanity: group A actually painted something before group B exists.
+      expect(inkBeforeGrowth).not.toEqual([0, 0, 0, 255]);
+
+      // A large retained group, added AFTER group A in the tree so its replay
+      // is recorded into the pass AFTER group A's — well beyond any plausible
+      // initial quad-index capacity, so its first replay forces a growth
+      // while group A's own replay draw from this same frame still sits,
+      // unsubmitted, in the open pass.
+      const groupB = new RetainedContainer();
+      const textB = new Text('M'.repeat(1200), { fillColor: Color.white, fontSize: 8 });
+
+      textB.setPosition(0, 40);
+      groupB.addChild(textB);
+      groupB.setPosition(0, 0);
+      root.addChild(groupB);
+
+      // F1 capture, F2 record for group B — group A keeps replaying normally
+      // (no growth: its own quad count never exceeds the existing buffer).
+      for (let frame = 0; frame < 2; frame++) {
+        if (!(await renderGuarded(ctx, backend, () => renderFrame(backend, root)))) {
+          return;
+        }
+      }
+
+      // F3: group B's first replay. Group A's replay draw (recorded earlier
+      // in THIS frame, into the still-open pass) is what makes the guard's
+      // `coordinator.passHasDraws` check load-bearing.
+      if (!(await renderGuarded(ctx, backend, () => renderFrame(backend, root)))) {
+        return;
+      }
+
+      const readAfterGrowth = readWebGpuPixels(backend, canvasSize);
+
+      // Group A's content survived the growth — the fix submits its replay
+      // draw against the buffer it was actually bound to, not the grown one.
+      expectPixelNear(readAfterGrowth(3, 10), inkBeforeGrowth);
+    } finally {
+      root.destroy();
+      backend.destroy();
+    }
+  });
+});


### PR DESCRIPTION
Two defects of the same class, both first reachable after the pass-cursor sweep
(#536) made `flush()` keep the render pass open: a `GPUBuffer` is destroyed while
a draw recorded into a still-open, not-yet-submitted pass binds it.

- `WebGpuMeshRenderer.onDisconnect` destroyed its vertex/index/uniform/node-index
  buffers and the attribute arena right after `flush()`. It now ends its own open
  pass first, mirroring the guard `WebGpuTileChunkRenderer.onDisconnect` already
  had. Only reachable via a direct `renderer.disconnect()` mid-frame — backend
  destroy and device loss call `discardPass()` beforehand.
- `WebGpuTextRenderer._ensureRetainedQuadIndexBuffer` destroyed the old buffer in
  its grow branch. It now ends the pass via `coordinator.passHasDraws` first.
  Chosen over the full pass-cursor treatment because the buffer only grows, and
  never again after warm-up.

Also raises the retained quad-index buffer's initial capacity from 64 to 1024
quads in both backends. 64 quads is about one short line of text, so effectively
every real text draw triggered several doubling steps, each one a `createBuffer`
plus a CPU index fill plus a `writeBuffer` — and, with the new growth guard, an
extra submit. 1024 quads is 12 KiB and covers normal text scenes in a single
allocation, well inside the unchanged 16384-quad ceiling of the `Uint16` vertex
index.

### Verification

Both regression tests were confirmed to fail without their fix
(`expected GPUValidationError{} to be null`) and pass with it.

- `verify:quick` — all 11 gates
- `test:browser:webgpu` — 322/322
