### PR TITLE
refactor(rendering): rename WebGpuInstanceArena to WebGpuPassArena and export it from renderer-sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,12 @@ state, claims, inFlight, background }` — for diagnostics and support bundles.
 
 ### Changed
 
+- **`WebGpuInstanceArena` renamed `WebGpuPassArena` and exported from
+  `renderer-sdk`.** The class stages bytes against a cursor bound to the open
+  render pass and knows nothing about instances — the name described its first
+  caller, not what it does. Package renderers previously had to hand-rebuild the
+  cursor/grow/reset discipline, which is subtle enough that every copy is a
+  chance to get it wrong.
 - **BREAKING — `SceneManager` renamed `SceneDirector`, `app.scene` renamed
   `app.scenes`.**
 - **BREAKING — scene construction and navigation are constructor- or

--- a/src/renderer-sdk.ts
+++ b/src/renderer-sdk.ts
@@ -51,6 +51,7 @@ export type { ComputeBindGroupEntry, ComputeBinding } from '#rendering/webgpu/co
 export { reflectComputeBindings, WebGpuComputePipeline, WebGpuStorageBuffer, WebGpuUniformBuffer } from '#rendering/webgpu/compute/index';
 export { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 export { getWebGpuBlendState } from '#rendering/webgpu/WebGpuBlendState';
+export { WebGpuPassArena } from '#rendering/webgpu/WebGpuPassArena';
 export type { WebGpuActiveRenderPass } from '#rendering/webgpu/WebGpuPassCoordinator';
 export {
   retainedGroupUniformBytes,

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -1116,7 +1116,7 @@ export class WebGpuBackend implements RenderBackend {
     // so it happens only at genuine boundaries (render-target / view / scissor /
     // stencil change, compositor, execute, plan / frame end), NOT once per batch
     // flush and not on a renderer switch. Instanced renderers record consecutive
-    // batch flushes into the same open pass (via WebGpuInstanceArena) and no
+    // batch flushes into the same open pass (via WebGpuPassArena) and no
     // longer end it themselves, collapsing thousands of per-draw submits into
     // one per frame.
     this._passCoordinatorInstance?.endPass();

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -16,7 +16,7 @@ import type { View } from '#rendering/View';
 import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
-import { WebGpuInstanceArena } from './WebGpuInstanceArena';
+import { WebGpuPassArena } from './WebGpuPassArena';
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
 import type {
   WebGpuRetainedBatchPayload,
@@ -393,7 +393,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
   // than a single rewritten buffer, because several batches now share one open
   // pass and `queue.writeBuffer` is ordered against the submit, not against the
   // individual draws inside it.
-  private readonly _instancedAttributeArena = new WebGpuInstanceArena('mesh:instanced-attribute-buffer', 0);
+  private readonly _instancedAttributeArena = new WebGpuPassArena('mesh:instanced-attribute-buffer', 0);
   // ── Immediate-batch pass scope ────────────────────────────────────────────
   // `drawInstancedBatch` records into the coordinator's open pass and no longer
   // ends it, so consecutive `drawBatch` calls land in ONE pass and ONE submit.

--- a/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
@@ -13,7 +13,7 @@ import type { View } from '#rendering/View';
 import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
-import { WebGpuInstanceArena } from './WebGpuInstanceArena';
+import { WebGpuPassArena } from './WebGpuPassArena';
 import type { WebGpuActiveRenderPass, WebGpuPassCoordinator } from './WebGpuPassCoordinator';
 import {
   retainedGroupUniformBytes,
@@ -182,7 +182,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
   private _indexBuffer: GPUBuffer | null = null;
   // Frame-scoped append arena: consecutive batch flushes accumulate into one
   // open pass at distinct byte offsets so the frame submits once.
-  private readonly _instanceArena = new WebGpuInstanceArena('nine-slice:instance-buffer', initialBatchCapacity * instanceStrideBytes);
+  private readonly _instanceArena = new WebGpuPassArena('nine-slice:instance-buffer', initialBatchCapacity * instanceStrideBytes);
   private _instanceCapacity = 0;
   private _instanceData: ArrayBuffer = new ArrayBuffer(0);
   private _instanceFloat32 = new Float32Array(this._instanceData);

--- a/src/rendering/webgpu/WebGpuPassArena.ts
+++ b/src/rendering/webgpu/WebGpuPassArena.ts
@@ -3,23 +3,25 @@
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
 
 /**
- * A frame-scoped, append-only GPU vertex buffer shared across the multiple batch
- * flushes an instanced renderer records into a single open render pass.
+ * A pass-scoped, append-only GPU buffer shared across the multiple batch flushes
+ * a renderer records into a single open render pass.
  *
  * WebGPU's `queue.writeBuffer` writes land on the queue timeline BEFORE the
- * submit that consumes them, so a renderer that keeps one reused instance buffer
- * and rewrites it at offset 0 on every flush would have every `drawIndexed` in a
- * merged submit read the LAST batch's bytes (aliasing). This arena hands each
- * batch a fresh byte offset within one buffer so all batches in a submit keep
- * their own data. The cursor resets whenever a new pass begins (tracked by the
- * identity of the coordinator's active pass), and capacity only grows.
+ * submit that consumes them, so a renderer that keeps one reused buffer and
+ * rewrites it at offset 0 on every flush would have every draw in a merged
+ * submit read the LAST batch's bytes (aliasing). This arena hands each batch a
+ * fresh byte offset within one buffer so all batches in a submit keep their own
+ * data. The cursor resets whenever a new pass begins (tracked by the identity of
+ * the coordinator's active pass), and capacity only grows.
+ *
+ * The arena is agnostic about what it stages — instance attributes, vertices or
+ * indices all work, as long as the caller keeps its own stride bookkeeping.
  *
  * Growth reallocates the underlying buffer, which must not orphan draws already
  * recorded into the open pass — the caller is responsible for ending (submitting)
  * the pass before {@link grow} whenever {@link cursor} is non-zero.
- * @internal
  */
-export class WebGpuInstanceArena {
+export class WebGpuPassArena {
   private readonly _label: string;
   private readonly _initialBytes: number;
   private _buffer: GPUBuffer | null = null;
@@ -27,6 +29,12 @@ export class WebGpuInstanceArena {
   private _cursorBytes = 0;
   private _pass: WebGpuActiveRenderPass | null = null;
 
+  /**
+   * @param label Debug label for the backing buffer, surfaced in GPU error messages.
+   * @param initialBytes Capacity the first {@link grow} allocates at minimum. Sized
+   *   so a typical frame never reallocates, since growth forces the caller to end
+   *   the open pass.
+   */
   public constructor(label: string, initialBytes: number) {
     this._label = label;
     this._initialBytes = initialBytes;
@@ -101,6 +109,12 @@ export class WebGpuInstanceArena {
     return offset;
   }
 
+  /**
+   * Release the backing buffer and reset the arena to its pre-{@link grow} state.
+   *
+   * Destroys a buffer that draws in an open pass may still bind, so the caller
+   * must have submitted or discarded that pass first.
+   */
   public destroy(): void {
     this._buffer?.destroy();
     this._buffer = null;

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -14,7 +14,7 @@ import type { View } from '#rendering/View';
 import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
-import { WebGpuInstanceArena } from './WebGpuInstanceArena';
+import { WebGpuPassArena } from './WebGpuPassArena';
 import type { WebGpuActiveRenderPass, WebGpuPassCoordinator } from './WebGpuPassCoordinator';
 import {
   retainedGroupUniformBytes,
@@ -288,7 +288,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
   // flushes accumulate into one open pass at distinct byte offsets — the frame
   // submits once instead of once per flush. CPU staging stays per-path (the two
   // layouts differ in stride).
-  private readonly _instanceArena = new WebGpuInstanceArena('repeating-sprite:instance-buffer', initialBatchCapacity * shaderStrideBytes);
+  private readonly _instanceArena = new WebGpuPassArena('repeating-sprite:instance-buffer', initialBatchCapacity * shaderStrideBytes);
 
   // Shader-path CPU staging
   private _shaderInstCapacity = 0;

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -15,7 +15,7 @@ import type { View } from '#rendering/View';
 import { AbstractWebGpuRenderer } from './AbstractWebGpuRenderer';
 import type { WebGpuBackend } from './WebGpuBackend';
 import { getWebGpuBlendState } from './WebGpuBlendState';
-import { WebGpuInstanceArena } from './WebGpuInstanceArena';
+import { WebGpuPassArena } from './WebGpuPassArena';
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
 import {
   retainedGroupUniformBytes,
@@ -367,7 +367,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
   // Frame-scoped append arena for the per-batch instance stream: consecutive
   // batch flushes accumulate into one open pass at distinct byte offsets, so the
   // whole frame submits once instead of once per flush.
-  private readonly _instanceArena = new WebGpuInstanceArena('sprite:instance-buffer', initialBatchCapacity * instanceStrideBytes);
+  private readonly _instanceArena = new WebGpuPassArena('sprite:instance-buffer', initialBatchCapacity * instanceStrideBytes);
   // CPU staging for the batch currently being packed (one batch at a time).
   private _instanceCapacity = 0;
   private _instanceData: ArrayBuffer = new ArrayBuffer(0);

--- a/test/rendering/webgpu-pass-arena.test.ts
+++ b/test/rendering/webgpu-pass-arena.test.ts
@@ -1,6 +1,6 @@
 import type { MockInstance } from 'vitest';
 
-import { WebGpuInstanceArena } from '#rendering/webgpu/WebGpuInstanceArena';
+import { WebGpuPassArena } from '#rendering/webgpu/WebGpuPassArena';
 import type { WebGpuActiveRenderPass } from '#rendering/webgpu/WebGpuPassCoordinator';
 
 // Minimal WebGPU device mock sufficient for arena buffer creation/destruction.
@@ -59,7 +59,7 @@ const setupGpuBufferUsage = (): (() => void) => {
 // A distinct pass identity — the arena only compares object references.
 const makePass = (): WebGpuActiveRenderPass => ({}) as unknown as WebGpuActiveRenderPass;
 
-describe('WebGpuInstanceArena', () => {
+describe('WebGpuPassArena', () => {
   let restore: () => void;
 
   beforeEach(() => {
@@ -72,7 +72,7 @@ describe('WebGpuInstanceArena', () => {
   });
 
   test('has no buffer and does not fit anything before the first grow', () => {
-    const arena = new WebGpuInstanceArena('test', 64);
+    const arena = new WebGpuPassArena('test', 64);
 
     expect(arena.buffer).toBeNull();
     expect(arena.cursor).toBe(0);
@@ -82,7 +82,7 @@ describe('WebGpuInstanceArena', () => {
 
   test('take() hands out distinct, monotonically increasing offsets within a pass', () => {
     const device = createMockDevice();
-    const arena = new WebGpuInstanceArena('test', 256);
+    const arena = new WebGpuPassArena('test', 256);
     const pass = makePass();
 
     arena.grow(device as unknown as GPUDevice, 256);
@@ -103,7 +103,7 @@ describe('WebGpuInstanceArena', () => {
 
   test('fits() is true up to capacity and false once a batch would overflow', () => {
     const device = createMockDevice();
-    const arena = new WebGpuInstanceArena('test', 64);
+    const arena = new WebGpuPassArena('test', 64);
     const pass = makePass();
 
     arena.grow(device as unknown as GPUDevice, 64);
@@ -121,7 +121,7 @@ describe('WebGpuInstanceArena', () => {
 
   test('grow() doubles capacity (or jumps to the request) and destroys the old buffer', () => {
     const device = createMockDevice();
-    const arena = new WebGpuInstanceArena('test', 16);
+    const arena = new WebGpuPassArena('test', 16);
 
     arena.grow(device as unknown as GPUDevice, 10);
 
@@ -147,7 +147,7 @@ describe('WebGpuInstanceArena', () => {
 
   test('grow() preserves the append invariant: a fresh larger buffer, cursor untouched', () => {
     const device = createMockDevice();
-    const arena = new WebGpuInstanceArena('test', 32);
+    const arena = new WebGpuPassArena('test', 32);
     const pass = makePass();
 
     arena.grow(device as unknown as GPUDevice, 32);
@@ -164,7 +164,7 @@ describe('WebGpuInstanceArena', () => {
 
   test('syncPass() resets the cursor when a different pass opens (per-frame reset)', () => {
     const device = createMockDevice();
-    const arena = new WebGpuInstanceArena('test', 256);
+    const arena = new WebGpuPassArena('test', 256);
     const passA = makePass();
     const passB = makePass();
 
@@ -188,7 +188,7 @@ describe('WebGpuInstanceArena', () => {
 
   test('resetPass() drops the pass association so the next syncPass restarts', () => {
     const device = createMockDevice();
-    const arena = new WebGpuInstanceArena('test', 128);
+    const arena = new WebGpuPassArena('test', 128);
     const pass = makePass();
 
     arena.grow(device as unknown as GPUDevice, 128);
@@ -209,7 +209,7 @@ describe('WebGpuInstanceArena', () => {
 
   test('destroy() releases the buffer and clears state', () => {
     const device = createMockDevice();
-    const arena = new WebGpuInstanceArena('test', 64);
+    const arena = new WebGpuPassArena('test', 64);
     const pass = makePass();
 
     arena.grow(device as unknown as GPUDevice, 64);


### PR DESCRIPTION
`WebGpuInstanceArena` holds a label, a byte capacity, a cursor and the identity
of the render pass that cursor belongs to. Nothing about it is instance-specific
— the name described its first caller, not what the class does. Text staging
would put vertices and indices through it just as well.

Renamed to `WebGpuPassArena` and exported from `renderer-sdk`, so package
renderers can use the cursor/grow/reset discipline instead of hand-rebuilding
it. That discipline is subtle enough (the ratchet trap around growth
invalidating draws in an open pass) that every hand-built copy is a chance to
get it wrong.

The rename lands together with the export deliberately: doing it afterwards
would be a breaking change to public surface.

Docs for the class were rewritten for its new audience — the `@internal` marker
is gone, the wording no longer assumes instance data, and constructor and
`destroy` gained the notes a public API needs (in particular that `destroy`
frees a buffer open-pass draws may still bind).

### Verification

- `verify:quick` — all 11 gates
- `test/rendering/webgpu-pass-arena.test.ts` — 8/8
