### PR TITLE
fix(rendering): invalidate the view when its viewport is mutated in place, and guard particle draws against it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -483,6 +483,17 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   `updateId` exactly as `setViewport` does. A `Rectangle` mutated back to the
   value it already holds still notifies nobody, and `clone()` does not carry
   the callback over.
+- **Particles no longer render through a stale viewport on WebGPU.** A pass
+  carries the viewport it was opened with and cannot be given another one, so
+  moving a camera's viewport between two particle draws that shared a pass made
+  the second draw render into the first one's rectangle — visible in
+  split-screen, picture-in-picture and minimap scenes, where a view renders
+  into a sub-rectangle of the canvas. `WebGpuParticleRenderer` now ends the
+  pass when the view was invalidated after it was opened, as the sprite
+  renderers already did. Unlike their guard this one does not ask whether the
+  recorded draws are its own: the viewport belongs to the pass, so a pass
+  opened by any renderer already carries it. A frame that does not move its
+  camera keeps the same pass and submit counts as before.
 - **A paused voice is no longer the pool's preferred eviction victim.** A paused
   `SoundVoice` stays in the pool while its bookkeeping ages against the still
   running context clock, so `FirstInFirstOut` saw the oldest entry and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,6 +471,18 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
 
 ### Fixed
 
+- **Writing to `view.viewport` directly now invalidates the camera.**
+  `View.viewport` hands out the live `Rectangle`, but its setters only marked
+  the rectangle's own cached edge normals — so `view.viewport.x = 0.5` changed
+  what the backend reads when it opens a render pass while `View.updateId`
+  stood still, and every backend guard keyed on that counter was blind to it.
+  `Rectangle` now takes an optional owner notification, invoked from the single
+  internal point that both its position and its (now observable) size report
+  to; `View` hooks it, so direct writes, `viewport.set(…)`, a write one level
+  down such as `viewport.size.width = …`, and `View.reset()` all advance
+  `updateId` exactly as `setViewport` does. A `Rectangle` mutated back to the
+  value it already holds still notifies nobody, and `clone()` does not carry
+  the callback over.
 - **A paused voice is no longer the pool's preferred eviction victim.** A paused
   `SoundVoice` stays in the pool while its bookkeeping ages against the still
   running context clock, so `FirstInFirstOut` saw the oldest entry and

--- a/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
+++ b/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
@@ -482,6 +482,16 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
       return false;
     }
 
+    // The viewport is baked into the pass at `acquirePass` and cannot be
+    // rewritten on an open one, so a view invalidated since then would render
+    // this draw through the rectangle the pass was opened with. That makes it a
+    // PASS property rather than a resource of ours: whoever opened the pass —
+    // any renderer — carried the stale viewport into it, so unlike the cursor
+    // checks below this one asks nothing about who owns the recorded draws.
+    if (active.viewUpdateId !== backend.view.updateId) {
+      return true;
+    }
+
     // The rest are renderer-OWNED buffers, so they ask this renderer's own
     // cursors instead: only draws of ours read them. Re-writing the mode's
     // per-vertex geometry from 0 aliases the draws already bound to it, and

--- a/site/src/content/api/rectangle.json
+++ b/site/src/content/api/rectangle.json
@@ -1,6 +1,6 @@
 {
   "title": "Rectangle",
-  "description": "Mutable axis-aligned rectangle defined by a top-left origin `(x, y)` and dimensions `(width, height)`. Implements ShapeLike with full SAT collision response for rectangles and polygons, and specialised algorithms for circle and ellipse intersections. `Rectangle.temp` is a shared scratch instance. Edge normals are lazily computed and cached; they are invalidated when position or size mutates. See ReadonlyRectangle for the read-only view engine APIs hand out when they return a live internal rectangle.",
+  "description": "Mutable axis-aligned rectangle defined by a top-left origin `(x, y)` and dimensions `(width, height)`. Implements ShapeLike with full SAT collision response for rectangles and polygons, and specialised algorithms for circle and ellipse intersections. `Rectangle.temp` is a shared scratch instance. Edge normals are lazily computed and cached; they are invalidated when position or size mutates. Position and size are reactive components, so EVERY mutation — the accessors here, `set`/`copy`, and a write one level down such as `rect.size.width = 5` — funnels through a single internal notification. Pass `onChange` to be told about all of them: an owner that hands out its live rectangle uses it to run whatever invalidation a direct write implies — a camera's viewport rectangle bumps the camera's update counter this way. clone deliberately does not carry the callback over — a copy is a value, not a second owner. See ReadonlyRectangle for the read-only view engine APIs hand out when they return a live internal rectangle.",
   "symbol": "Rectangle",
   "kind": "class",
   "subsystem": "math",
@@ -21,6 +21,7 @@
       "paragraphs": [
         "Mutable axis-aligned rectangle defined by a top-left origin `(x, y)` and dimensions `(width, height)`. Implements ShapeLike with full SAT collision response for rectangles and polygons, and specialised algorithms for circle and ellipse intersections.",
         "`Rectangle.temp` is a shared scratch instance. Edge normals are lazily computed and cached; they are invalidated when position or size mutates.",
+        "Position and size are reactive components, so EVERY mutation — the accessors here, `set`/`copy`, and a write one level down such as `rect.size.width = 5` — funnels through a single internal notification. Pass `onChange` to be told about all of them: an owner that hands out its live rectangle uses it to run whatever invalidation a direct write implies — a camera's viewport rectangle bumps the camera's update counter this way. clone deliberately does not carry the callback over — a copy is a value, not a second owner.",
         "See ReadonlyRectangle for the read-only view engine APIs hand out when they return a live internal rectangle."
       ],
       "importLine": "import { Rectangle } from '@codexo/exojs'",
@@ -32,7 +33,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(x: number, y: number, width: number, height: number): Rectangle",
+          "signature": "new(x: number, y: number, width: number, height: number, onChange: () => void | null): Rectangle",
           "signatureTokens": [
             {
               "text": "new",
@@ -103,6 +104,38 @@
               "kind": "keyword"
             },
             {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "onChange",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ") => ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -134,6 +167,11 @@
             {
               "name": "height",
               "type": "number",
+              "optional": false
+            },
+            {
+              "name": "onChange",
+              "type": "() => void | null",
               "optional": false
             }
           ],

--- a/site/src/content/api/view.json
+++ b/site/src/content/api/view.json
@@ -1953,7 +1953,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
+          "description": "The normalized (0..1) viewport rectangle this camera renders into. Returns the LIVE rectangle, and writing to it directly — view.viewport.x = 0.5, view.viewport.set(…), view.viewport.size.width = … — is a supported way to move the viewport: the rectangle reports every mutation back here, so updateId advances exactly as it does for setViewport. Backends key their \"may I keep the open pass\" decision on that counter, and a viewport is a property of the pass as a whole."
         },
         {
           "name": "width",

--- a/src/math/Rectangle.ts
+++ b/src/math/Rectangle.ts
@@ -18,11 +18,12 @@ import type { Ellipse } from './Ellipse';
 import { Interval } from './Interval';
 import type { Line } from './Line';
 import type { Matrix } from './Matrix';
+import { ObservableSize } from './ObservableSize';
 import { ObservableVector, type ObservableVectorOwner } from './ObservableVector';
 import type { Polygon } from './Polygon';
 import type { RectangleLike } from './RectangleLike';
 import type { ShapeLike } from './ShapeLike';
-import { Size } from './Size';
+import type { Size } from './Size';
 import { inRange } from './utils';
 import { Vector } from './Vector';
 
@@ -74,6 +75,14 @@ export interface ReadonlyRectangle extends Collidable {
  * `Rectangle.temp` is a shared scratch instance. Edge normals are lazily
  * computed and cached; they are invalidated when position or size mutates.
  *
+ * Position and size are reactive components, so EVERY mutation — the accessors
+ * here, `set`/`copy`, and a write one level down such as `rect.size.width = 5`
+ * — funnels through a single internal notification. Pass `onChange` to be told
+ * about all of them: an owner that hands out its live rectangle uses it to run
+ * whatever invalidation a direct write implies — a camera's viewport rectangle
+ * bumps the camera's update counter this way. {@link clone} deliberately does
+ * not carry the callback over — a copy is a value, not a second owner.
+ *
  * See {@link ReadonlyRectangle} for the read-only view engine APIs hand out
  * when they return a live internal rectangle.
  */
@@ -81,21 +90,35 @@ export class Rectangle implements ShapeLike, ObservableVectorOwner, ReadonlyRect
   public readonly collisionType: CollisionType = CollisionType.Rectangle;
 
   private readonly _position: ObservableVector;
-  private readonly _size: Size;
+  private readonly _size: ObservableSize;
   private _normals: Vector[] | null = null;
   private _normalsDirty = false;
+  private _onChange: (() => void) | null;
 
-  public constructor(x = 0, y = x, width = 0, height = width) {
+  /**
+   * @param x        - Left edge.
+   * @param y        - Top edge. Defaults to `x`.
+   * @param width    - Horizontal extent.
+   * @param height   - Vertical extent. Defaults to `width`.
+   * @param onChange - Owner notification invoked after any mutation. Defaults to `null`.
+   */
+  public constructor(x = 0, y = x, width = 0, height = width, onChange: (() => void) | null = null) {
     this._position = new ObservableVector(this, 0, x, y);
-    this._size = new Size(width, height);
+    this._size = new ObservableSize(this._onObservableChange.bind(this), width, height);
+    this._onChange = onChange;
   }
 
   /**
-   * Receives change notifications from `_position`; marks the cached edge
-   * normals stale so the next {@link getNormals} recomputes them. @internal
+   * The one point every mutation of this rectangle reaches: `_position` and
+   * `_size` both report here. Marks the cached edge normals stale so the next
+   * {@link getNormals} recomputes them, then forwards to the owner callback.
+   *
+   * The reactive components only report on an ACTUAL change, so writing a
+   * component its current value notifies nobody. @internal
    */
   public _onObservableChange(): void {
     this._normalsDirty = true;
+    this._onChange?.();
   }
 
   public get position(): AbstractVector {
@@ -112,7 +135,6 @@ export class Rectangle implements ShapeLike, ObservableVectorOwner, ReadonlyRect
 
   public set x(x: number) {
     this._position.x = x;
-    this._normalsDirty = true;
   }
 
   public get y(): number {
@@ -121,7 +143,6 @@ export class Rectangle implements ShapeLike, ObservableVectorOwner, ReadonlyRect
 
   public set y(y: number) {
     this._position.y = y;
-    this._normalsDirty = true;
   }
 
   public get size(): Size {
@@ -130,7 +151,6 @@ export class Rectangle implements ShapeLike, ObservableVectorOwner, ReadonlyRect
 
   public set size(size: Size) {
     this._size.copy(size);
-    this._normalsDirty = true;
   }
 
   public get width(): number {
@@ -139,7 +159,6 @@ export class Rectangle implements ShapeLike, ObservableVectorOwner, ReadonlyRect
 
   public set width(width: number) {
     this._size.width = width;
-    this._normalsDirty = true;
   }
 
   public get height(): number {
@@ -148,7 +167,6 @@ export class Rectangle implements ShapeLike, ObservableVectorOwner, ReadonlyRect
 
   public set height(height: number) {
     this._size.height = height;
-    this._normalsDirty = true;
   }
 
   public get left(): number {
@@ -169,14 +187,12 @@ export class Rectangle implements ShapeLike, ObservableVectorOwner, ReadonlyRect
 
   public setPosition(x: number, y: number): this {
     this._position.set(x, y);
-    this._normalsDirty = true;
 
     return this;
   }
 
   public setSize(width: number, height: number): this {
     this._size.set(width, height);
-    this._normalsDirty = true;
 
     return this;
   }
@@ -323,6 +339,9 @@ export class Rectangle implements ShapeLike, ObservableVectorOwner, ReadonlyRect
   public destroy(): void {
     this._position.destroy();
     this._size.destroy();
+    // Drop the owner notification along with the reactive components, so a
+    // rectangle retained past its owner's teardown cannot invalidate it again.
+    this._onChange = null;
 
     if (this._normals) {
       this._normals = null;

--- a/src/rendering/View.ts
+++ b/src/rendering/View.ts
@@ -73,7 +73,7 @@ export interface ViewOptions {
 export class View implements ObservableVectorOwner {
   private readonly _center: ObservableVector;
   private readonly _size: ObservableSize;
-  private readonly _viewport: Rectangle = new Rectangle(0, 0, 1, 1);
+  private readonly _viewport: Rectangle;
   private readonly _transform: Matrix = new Matrix();
   private readonly _inverseTransform: Matrix = new Matrix();
   private readonly _bounds: Bounds = new Bounds();
@@ -103,6 +103,7 @@ export class View implements ObservableVectorOwner {
   public constructor(centerX: number, centerY: number, width: number, height: number) {
     this._center = new ObservableVector(this, 0, centerX, centerY);
     this._size = new ObservableSize(this._setScalingDirty.bind(this), width, height);
+    this._viewport = new Rectangle(0, 0, 1, 1, this._setDirty.bind(this));
     this._zoomBaseWidth = width;
     this._zoomBaseHeight = height;
     this._flags.addMask(ViewFlags.Transform | ViewFlags.TransformInverse | ViewFlags.BoundingBox);
@@ -181,15 +182,22 @@ export class View implements ObservableVectorOwner {
     this.setRotation(rotation);
   }
 
+  /**
+   * The normalized (0..1) viewport rectangle this camera renders into.
+   *
+   * Returns the LIVE rectangle, and writing to it directly — `view.viewport.x =
+   * 0.5`, `view.viewport.set(…)`, `view.viewport.size.width = …` — is a
+   * supported way to move the viewport: the rectangle reports every mutation
+   * back here, so {@link updateId} advances exactly as it does for
+   * {@link setViewport}. Backends key their "may I keep the open pass" decision
+   * on that counter, and a viewport is a property of the pass as a whole.
+   */
   public get viewport(): Rectangle {
     return this._viewport;
   }
 
   public set viewport(viewport: Rectangle) {
-    if (!this._viewport.equals(viewport)) {
-      this._viewport.copy(viewport);
-      this._setDirty();
-    }
+    this._viewport.copy(viewport);
   }
 
   /**
@@ -254,10 +262,7 @@ export class View implements ObservableVectorOwner {
    * @param height - Height as a fraction of the canvas height.
    */
   public setViewport(x: number, y: number, width: number, height: number): this {
-    if (this._viewport.x !== x || this._viewport.y !== y || this._viewport.width !== width || this._viewport.height !== height) {
-      this._viewport.set(x, y, width, height);
-      this._setDirty();
-    }
+    this._viewport.set(x, y, width, height);
 
     return this;
   }

--- a/test/math/rectangle.test.ts
+++ b/test/math/rectangle.test.ts
@@ -513,6 +513,91 @@ describe('Rectangle', () => {
     });
   });
 
+  describe('onChange owner callback', () => {
+    // Every mutating path is enumerated on purpose. The callback exists so an
+    // owner that hands out its live rectangle can invalidate on a direct write;
+    // a path that skips the notification is a silent hole, and the only way to
+    // pin "there is exactly ONE funnel" is to walk them all.
+    const mutations: ReadonlyArray<[string, (rectangle: Rectangle) => void]> = [
+      ['x', rectangle => (rectangle.x = 5)],
+      ['y', rectangle => (rectangle.y = 5)],
+      ['width', rectangle => (rectangle.width = 5)],
+      ['height', rectangle => (rectangle.height = 5)],
+      ['position', rectangle => (rectangle.position = new Vector(5, 5))],
+      ['size', rectangle => (rectangle.size = new Size(5, 5))],
+      ['setPosition', rectangle => rectangle.setPosition(5, 5)],
+      ['setSize', rectangle => rectangle.setSize(5, 5)],
+      ['set', rectangle => rectangle.set(5, 5, 5, 5)],
+      ['copy', rectangle => rectangle.copy(new Rectangle(5, 5, 5, 5))],
+      ['transform (in place)', rectangle => rectangle.transform(new Matrix().translate(5, 5))],
+      // One level down: the components are reactive too, so a write that
+      // bypasses the accessors above still reaches the owner.
+      ['position.x', rectangle => (rectangle.position.x = 5)],
+      ['size.width', rectangle => (rectangle.size.width = 5)],
+      ['size.set', rectangle => rectangle.size.set(5, 5)],
+    ];
+
+    test.each(mutations)('%s notifies the owner', (_name, mutate) => {
+      const onChange = vi.fn();
+      const rectangle = new Rectangle(0, 0, 1, 1, onChange);
+
+      mutate(rectangle);
+
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    test('defaults to no callback and leaves an unowned rectangle silent', () => {
+      const rectangle = new Rectangle(0, 0, 1, 1);
+
+      expect(() => rectangle.set(2, 3, 4, 5)).not.toThrow();
+    });
+
+    test('writing a component its current value notifies nobody', () => {
+      const onChange = vi.fn();
+      const rectangle = new Rectangle(1, 2, 3, 4, onChange);
+
+      rectangle.x = 1;
+      rectangle.width = 3;
+      rectangle.set(1, 2, 3, 4);
+      rectangle.size.height = 4;
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    test('clone() does not carry the callback over to the copy', () => {
+      const onChange = vi.fn();
+      const clone = new Rectangle(0, 0, 1, 1, onChange).clone();
+
+      clone.set(2, 3, 4, 5);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    test('a rectangle copied INTO keeps its own callback and does not inherit the source one', () => {
+      const sourceChange = vi.fn();
+      const targetChange = vi.fn();
+      const source = new Rectangle(1, 2, 3, 4, sourceChange);
+      const target = new Rectangle(0, 0, 0, 0, targetChange);
+
+      target.copy(source);
+      sourceChange.mockClear();
+      target.set(9, 9, 9, 9);
+
+      expect(targetChange).toHaveBeenCalled();
+      expect(sourceChange).not.toHaveBeenCalled();
+    });
+
+    test('destroy() drops the callback so a retained rectangle cannot invalidate a torn-down owner', () => {
+      const onChange = vi.fn();
+      const rectangle = new Rectangle(0, 0, 1, 1, onChange);
+
+      rectangle.destroy();
+      rectangle.set(2, 3, 4, 5);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
   describe('static temp', () => {
     test('lazily allocates and returns the same instance on subsequent calls', () => {
       const first = Rectangle.temp;

--- a/test/rendering/browser/webgpu-particles-single-pass.test.ts
+++ b/test/rendering/browser/webgpu-particles-single-pass.test.ts
@@ -20,6 +20,9 @@
  * a cell at the clear colour (uniform ring aliased, so every system draws at the
  * last one's position), and fails here rather than passing as a win.
  *
+ * The last describe covers the other half of that contract — the one hazard
+ * appending CANNOT cover, so the renderer has to end the pass after all.
+ *
  * Run via:  pnpm test:browser:webgpu
  */
 
@@ -29,6 +32,7 @@ import { Time } from '#core/Time';
 import { materializeRendererBindings } from '#extensions/materialize';
 import { Sprite } from '#rendering/sprite/Sprite';
 import { Texture } from '#rendering/texture/Texture';
+import { View } from '#rendering/View';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { ApplyForce, particlesExtension, ParticleSystem } from '../../../packages/exojs-particles/src/index';
@@ -344,6 +348,88 @@ describe('WebGPU particle single-pass frame', () => {
       cpuSystem.destroy();
       sprite.destroy();
       trailingSprite.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});
+
+describe('WebGPU particle viewport invalidation', () => {
+  test('a viewport moved between two particle flushes does NOT let the second draw render through the first viewport', async ctx => {
+    const backend = await setupBackend();
+    const texture = createSolidTexture('#ffffff', 8);
+    // ONE camera object for the whole frame — the viewport moves by mutating it
+    // in place. A `setView` to a different View would end the pass on its own
+    // and prove nothing about the renderer's guard.
+    const view = new View(canvasSize / 2, canvasSize / 2, canvasSize, canvasSize);
+    // Both systems sit at the camera centre, so each lands in the middle of
+    // whichever viewport rectangle its own pass carries: the left half's centre
+    // for the first, the right half's for the second. The viewport is applied
+    // when the pass OPENS and cannot be rewritten on an open one, so a second
+    // draw appended to the first pass paints the left cell instead.
+    const first = createTintedSystem(texture, particleColors[0]!, canvasSize / 2, canvasSize / 2);
+    const second = createTintedSystem(texture, particleColors[1]!, canvasSize / 2, canvasSize / 2);
+    // Present only to switch the active renderer, which flushes the first
+    // particle draw into the pass while the viewport is still the left half.
+    // Parked in a corner, clear of both probes.
+    const switcher = new Sprite(texture);
+
+    switcher.setPosition(8, 8);
+    switcher.width = 8;
+    switcher.height = 8;
+
+    const leftCellX = canvasSize / 4;
+    const rightCellX = (canvasSize * 3) / 4;
+    const cellY = canvasSize / 2;
+
+    const renderFrame = (): void => {
+      backend.resetStats();
+      backend.clear(Color.black);
+      backend.setView(view);
+      view.viewport.set(0, 0, 0.5, 1);
+
+      first.render(backend);
+      // Renderer switch: flushes the first particle draw into the open pass
+      // under the left viewport, then queues the sprite.
+      switcher.render(backend);
+      // Switch back: flushes the sprite into that same pass, queues the second
+      // particle draw.
+      second.render(backend);
+      // The move lands with the second draw queued but not yet recorded, and
+      // with no other renderer left to flush after it — so nothing except the
+      // particle renderer's own guard can end the pass here.
+      view.viewport.set(0.5, 0, 0.5, 1);
+      backend.flush();
+    };
+
+    try {
+      // Warm up so pipelines are compiled and the shared buffers have ratcheted
+      // to the frame's total: a capacity growth ends the pass for its own
+      // reasons and would answer a different question than the one asked here.
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderGuarded(ctx, backend, renderFrame))) {
+          return;
+        }
+      }
+
+      const submits = countSubmits(backend, renderFrame);
+      const readPixel = readWebGpuPixels(backend, canvasSize);
+
+      // Asserted before the counts, so a regression reports the rendered result
+      // rather than the mechanism that produced it. The second draw landing in
+      // the RIGHT cell is the whole point; the first draw still owning the LEFT
+      // one rules out "it just painted everything".
+      expectPixelNear(readPixel(rightCellX, cellY), particleColors[1]!);
+      expectPixelNear(readPixel(leftCellX, cellY), particleColors[0]!);
+
+      // Exactly one extra boundary: the viewport move, and nothing else.
+      expect(backend.stats.renderPasses).toBe(2);
+      expect(submits).toBe(2);
+    } finally {
+      first.destroy();
+      second.destroy();
+      switcher.destroy();
+      view.destroy();
       texture.destroy();
       backend.destroy();
     }

--- a/test/rendering/view.test.ts
+++ b/test/rendering/view.test.ts
@@ -102,6 +102,76 @@ describe('View.setViewport', () => {
   });
 });
 
+describe('View.viewport — invalidation on direct mutation', () => {
+  // `get viewport` hands out the LIVE rectangle, so a direct write changes what
+  // a backend reads when it opens a render pass. Every backend guard against
+  // "this pass was opened with a different viewport" is keyed on updateId, so a
+  // mutation that leaves updateId alone is invisible to all of them — the write
+  // lands, the guard never fires, and the draw renders through the previous
+  // viewport. These pin that every route to the rectangle moves the counter.
+  const mutations: ReadonlyArray<[string, (view: View) => void]> = [
+    ['viewport.x', view => (view.viewport.x = 0.5)],
+    ['viewport.y', view => (view.viewport.y = 0.5)],
+    ['viewport.width', view => (view.viewport.width = 0.5)],
+    ['viewport.height', view => (view.viewport.height = 0.5)],
+    ['viewport.set', view => view.viewport.set(0.5, 0, 0.5, 1)],
+    ['viewport.copy', view => view.viewport.copy(new Rectangle(0.5, 0, 0.5, 1))],
+    ['viewport.setPosition', view => view.viewport.setPosition(0.5, 0)],
+    ['viewport.setSize', view => view.viewport.setSize(0.5, 1)],
+    // One level down — the leak the accessors above cannot see.
+    ['viewport.position.x', view => (view.viewport.position.x = 0.5)],
+    ['viewport.size.width', view => (view.viewport.size.width = 0.5)],
+    // The API routes, for symmetry.
+    ['setViewport', view => view.setViewport(0.5, 0, 0.5, 1)],
+    ['viewport setter', view => (view.viewport = new Rectangle(0.5, 0, 0.5, 1))],
+  ];
+
+  test.each(mutations)('%s bumps updateId', (_name, mutate) => {
+    const view = new View(0, 0, 100, 100);
+    const before = view.updateId;
+
+    mutate(view);
+
+    expect(view.updateId).not.toBe(before);
+
+    view.destroy();
+  });
+
+  test('a write that changes nothing leaves updateId alone', () => {
+    const view = new View(0, 0, 100, 100);
+
+    view.setViewport(0.5, 0, 0.5, 1);
+
+    const before = view.updateId;
+
+    view.viewport.x = 0.5;
+    view.viewport.set(0.5, 0, 0.5, 1);
+    view.viewport.size.width = 0.5;
+    view.setViewport(0.5, 0, 0.5, 1);
+
+    expect(view.updateId).toBe(before);
+
+    view.destroy();
+  });
+
+  test('reset() restores the full-canvas viewport and bumps updateId even when nothing else changes', () => {
+    const view = new View(10, 20, 100, 200);
+
+    view.setViewport(0.5, 0, 0.5, 1);
+
+    // Same centre and same size, so neither of those reports a change: the
+    // viewport reset is the only mutation left to invalidate on.
+    const before = view.updateId;
+
+    view.reset(10, 20, 100, 200);
+
+    expect(view.viewport.equals(new Rectangle(0, 0, 1, 1))).toBe(true);
+    expect(view.updateId).not.toBe(before);
+
+    view.destroy();
+  });
+});
+
 describe('View — coordinate conversion', () => {
   // Centered camera over an 800×600 design space, matching the default camera.
   const centered = (): View => new View(400, 300, 800, 600);


### PR DESCRIPTION
The WebGPU render pass fixes its viewport when it opens. If a `View`'s
normalized viewport changes between two draws that merged into one pass, the
second draw renders through the first draw's viewport. Two separate causes had
to be fixed for that hole to actually close.

### `Rectangle` — one invalidation funnel

`View.get viewport()` hands out the live mutable `Rectangle`, and its setters
only marked `_normalsDirty` — the view was never told. `view.viewport.x = 0.5`
therefore changed what the pass coordinator reads while `View._updateId` stayed
put, defeating any `updateId`-keyed guard.

`Rectangle._size` is now an `ObservableSize` reporting to the same
`_onObservableChange` point `_position` already used, and that point forwards to
an optional owner callback. The per-setter `_normalsDirty` assignments are gone —
redundant once both components report, and their removal makes the single funnel
literal instead of aspirational. This also closes `rect.size.width = 5`, which
bypassed the `Rectangle` setters one level down.

`View` builds `_viewport` with a callback into `_setDirty`. `View.reset` — which
previously wrote the viewport without any invalidation at all — now invalidates
on its own.

The getter deliberately still returns `Rectangle`, not a read-only view: direct
mutation stays legal, this is not an API break.

### `WebGpuParticleRenderer` — the guard

One clause in `_appendWouldAlias`, ending the pass when the view moved since it
was opened. It gates on `active !== null` alone rather than copying the sprite
renderers' `tracksPass` ownership gate: their hazard is overwriting their own
projection UBO, whereas the viewport is a pass-level property that another
renderer may have baked in before particles touched the pass.

Measured cost: none. `view.updateId` is bumped from exactly one place
(`View._setDirty`), and every path there runs in `preUpdate`/`update` or a
`ResizeObserver` callback — never in the draw phase. The two pre-existing
single-pass tests still assert one pass and one submit, unchanged.

Mesh, Text and TileChunk have the same missing guard and are deliberately out of
scope here.

### Verification

Both fixes were confirmed to fail without them. With the guard disabled the new
particle test reports the right-half cell as black — the second draw rendered
through the first viewport — and with the `Rectangle` change reverted, 26 of 107
math/view tests fail. Notably `setViewport` and the `viewport` setter stayed
green while reverted, since those already called `_setDirty()` explicitly; only
the direct-mutation routes and `reset` were holes.

- `verify:quick` — all 11 gates
- `pnpm test` — 9680 passed
- `test:browser:webgpu` 321 passed, `test:browser:webgl` 281 passed
