### PR TITLE
fix(rendering): use uint32 glyph indices so large text flushes stop wrapping silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -470,13 +470,21 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   quads is roughly one short line of text, so effectively every real text
   draw triggered several doubling steps to reach a usable size — each one a
   fresh buffer allocation plus a CPU index fill (plus, since growth now ends
-  an open pass first, an extra submit). 1024 quads is 12 KiB and covers
+  an open pass first, an extra submit). 1024 quads is 24 KiB and covers
   normal text scenes in a single allocation, in both `WebGpuTextRenderer` and
-  `WebGl2TextRenderer`; the hard ceiling stays at 16384 quads (the `Uint16`
-  vertex-index limit).
+  `WebGl2TextRenderer`.
 
 ### Fixed
 
+- **Text draws past 16384 quads no longer silently corrupt.** `WebGpuTextRenderer`
+  and `WebGl2TextRenderer` computed glyph vertex indices as `quadIndex * 4` into a
+  `Uint16` index buffer, which wraps once a flush's cumulative quad count reaches
+  16384 — with no error and no warning, just wrong geometry (a later glyph's draw
+  silently reading an earlier glyph's vertex slot). The ceiling was tighter than it
+  looked in the WebGPU live path specifically, since one running vertex cursor
+  spans every batch of a flush, not just one draw. Both renderers' index buffers
+  (live and retained) now use `Uint32` (`'uint32'` in WebGPU, `UNSIGNED_INT` in
+  WebGL2 — both core, no extension), at the cost of doubling index-buffer memory.
 - **A paused voice is no longer the pool's preferred eviction victim.** A paused
   `SoundVoice` stays in the pool while its bookkeeping ages against the still
   running context clock, so `FirstInFirstOut` saw the oldest entry and

--- a/src/rendering/types.ts
+++ b/src/rendering/types.ts
@@ -164,6 +164,16 @@ export enum BufferUsage {
 }
 
 /**
+ * Element data type of an index buffer, used when calling `gl.drawElements` /
+ * `gl.drawElementsInstanced`. Values are WebGL2 GLenum constants; both are
+ * core WebGL2 (no `OES_element_index_uint` extension check needed, unlike WebGL1).
+ */
+export enum IndexElementTypes {
+  UnsignedShort = 0x1403,
+  UnsignedInt = 0x1405,
+}
+
+/**
  * GLSL primitive type tokens used to describe {@link ShaderAttribute} and {@link ShaderUniform} data types.
  * Values are WebGL2 GLenum constants returned by `gl.getActiveAttrib` / `gl.getActiveUniform`.
  */

--- a/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
+++ b/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
@@ -539,10 +539,14 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
             gl.vertexAttribDivisor(attribute.location, attribute.divisor);
           }
 
-          // Indexed batches (mesh opt-in) carry an index buffer; capturing its
-          // ELEMENT_ARRAY_BUFFER binding into this VAO is what lets replay use
-          // drawElementsInstanced. Sprite/nine-slice/repeating VAOs have no
-          // index buffer, so this is a no-op for them (drawArrays path).
+          // Indexed batches (mesh opt-in, and Text's static glyph-quad pattern)
+          // carry an index buffer; capturing its ELEMENT_ARRAY_BUFFER binding
+          // into this VAO is what lets replay use drawElements(Instanced).
+          // Sprite/nine-slice/repeating VAOs have no index buffer, so this is a
+          // no-op for them (drawArrays path). Each renderer's `addIndex` call
+          // stamps the matching element type (`vao.indexType`, read below) —
+          // mesh's Uint16 geometry and Text's Uint32 glyph pattern share this
+          // one runtime but never assume each other's width.
           vao.indexBuffer?.bind();
 
           appliedVersion = vao.version;
@@ -553,14 +557,14 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
       },
       draw: (vao, size, start, type): void => {
         if (vao.indexBuffer !== null) {
-          gl.drawElements(type, size, gl.UNSIGNED_SHORT, start);
+          gl.drawElements(type, size, vao.indexType, start);
         } else {
           gl.drawArrays(type, start, size);
         }
       },
       drawInstanced: (vao, count, start, instanceCount, type): void => {
         if (vao.indexBuffer !== null) {
-          gl.drawElementsInstanced(type, count, gl.UNSIGNED_SHORT, start, instanceCount);
+          gl.drawElementsInstanced(type, count, vao.indexType, start, instanceCount);
         } else {
           gl.drawArraysInstanced(type, start, count, instanceCount);
         }

--- a/src/rendering/webgl2/WebGl2TextRenderer.ts
+++ b/src/rendering/webgl2/WebGl2TextRenderer.ts
@@ -7,7 +7,7 @@ import type { TextPageQuads } from '#rendering/text/Text';
 import { Text } from '#rendering/text/Text';
 import { DataTexture } from '#rendering/texture/DataTexture';
 import type { Texture } from '#rendering/texture/Texture';
-import { BlendModes, BufferTypes, BufferUsage, RenderingPrimitives, TextureFormat } from '#rendering/types';
+import { BlendModes, BufferTypes, BufferUsage, IndexElementTypes, RenderingPrimitives, TextureFormat } from '#rendering/types';
 
 import { AbstractWebGl2Renderer } from './AbstractWebGl2Renderer';
 import textVertSource from './glsl/text.vert';
@@ -68,8 +68,8 @@ const initialIndexCapacity = 384;
 const initialNodeCapacity = 32;
 // One short line of text is already ~64 quads, so that floor made almost
 // every real retained draw pay several doubling steps (a fresh GL buffer plus
-// a CPU index fill each). 1024 quads is 12 KiB and covers normal text scenes
-// in one allocation, well inside the 16384-quad Uint16 vertex-index ceiling.
+// a CPU index fill each). 1024 quads is 24 KiB (uint32 indices) and covers
+// normal text scenes in one allocation.
 const initialRetainedQuadCapacity = 1024;
 
 type ShaderType = 'sdf' | 'msdf' | 'color';
@@ -184,7 +184,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
   private _vertexData: ArrayBuffer = new ArrayBuffer(initialVertexCapacity * vertexStrideBytes);
   private _float32View: Float32Array = new Float32Array(this._vertexData);
   private _uint32View: Uint32Array = new Uint32Array(this._vertexData);
-  private _indexData: Uint16Array = new Uint16Array(initialIndexCapacity);
+  private _indexData: Uint32Array = new Uint32Array(initialIndexCapacity);
 
   // Retained-batch state: the renderer-owned, grow-only quad-index buffer (the
   // standard `0,1,2, 0,2,3` glyph pattern shared by every recorded batch) and
@@ -264,7 +264,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     if (vaoHandle === null) throw new Error('WebGl2TextRenderer: could not create VAO.');
 
     const vao = new WebGl2VertexArrayObject()
-      .addIndex(indexBuffer)
+      .addIndex(indexBuffer, IndexElementTypes.UnsignedInt)
       .addAttribute(vertexBuffer, this._sdfShader.getAttribute('a_position'), gl.FLOAT, false, vertexStrideBytes, 0)
       .addAttribute(vertexBuffer, this._sdfShader.getAttribute('a_texcoord'), gl.FLOAT, false, vertexStrideBytes, 8)
       .addAttribute(vertexBuffer, this._sdfShader.getAttribute('a_nodeIndex'), gl.FLOAT, false, vertexStrideBytes, 16);
@@ -702,7 +702,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     const indexBuffer = this._ensureRetainedQuadIndexBuffer(data.quadCount);
 
     vao
-      .addIndex(indexBuffer)
+      .addIndex(indexBuffer, IndexElementTypes.UnsignedInt)
       .addAttribute(buffer, shader.getAttribute('a_position'), gl.FLOAT, false, vertexStrideBytes, base + 0)
       .addAttribute(buffer, shader.getAttribute('a_texcoord'), gl.FLOAT, false, vertexStrideBytes, base + 8)
       .addAttribute(buffer, shader.getAttribute('a_nodeIndex'), gl.FLOAT, false, vertexStrideBytes, base + 16);
@@ -869,7 +869,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
 
     while (capacity < quadCount) capacity *= 2;
 
-    const indices = new Uint16Array(capacity * 6);
+    const indices = new Uint32Array(capacity * 6);
 
     for (let q = 0; q < capacity; q++) {
       const baseV = q * 4;
@@ -918,7 +918,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
   private _ensureIndexCapacity(indexCount: number): void {
     if (indexCount <= this._indexCapacity) return;
     while (this._indexCapacity < indexCount) this._indexCapacity *= 2;
-    this._indexData = new Uint16Array(this._indexCapacity);
+    this._indexData = new Uint32Array(this._indexCapacity);
   }
 
   private _ensureNodeCapacity(nodeCount: number): void {
@@ -1004,7 +1004,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       },
       draw: (vao, size, start, type): void => {
         if (vao.indexBuffer) {
-          gl.drawElements(type, size, gl.UNSIGNED_SHORT, start);
+          gl.drawElements(type, size, vao.indexType, start);
         } else {
           gl.drawArrays(type, start, size);
         }

--- a/src/rendering/webgl2/WebGl2VertexArrayObject.ts
+++ b/src/rendering/webgl2/WebGl2VertexArrayObject.ts
@@ -1,5 +1,5 @@
 import type { ShaderAttribute } from '#rendering/shader/ShaderAttribute';
-import { RenderingPrimitives, ShaderPrimitives } from '#rendering/types';
+import { IndexElementTypes, RenderingPrimitives, ShaderPrimitives } from '#rendering/types';
 
 import type { WebGl2RenderBuffer } from './WebGl2RenderBuffer';
 
@@ -45,6 +45,7 @@ export interface WebGl2VertexArrayObjectRuntime {
 export class WebGl2VertexArrayObject {
   private readonly _attributes: VaoAttribute[] = [];
   private _indexBuffer: WebGl2RenderBuffer | null = null;
+  private _indexType: IndexElementTypes = IndexElementTypes.UnsignedShort;
   private _drawMode: RenderingPrimitives;
   private _runtime: WebGl2VertexArrayObjectRuntime | null = null;
   private _version = 0;
@@ -59,6 +60,11 @@ export class WebGl2VertexArrayObject {
 
   public get indexBuffer(): WebGl2RenderBuffer | null {
     return this._indexBuffer;
+  }
+
+  /** GLenum element type of {@link indexBuffer}'s contents (`gl.drawElements`'s `type` argument). */
+  public get indexType(): IndexElementTypes {
+    return this._indexType;
   }
 
   public get drawMode(): RenderingPrimitives {
@@ -111,8 +117,9 @@ export class WebGl2VertexArrayObject {
     return this;
   }
 
-  public addIndex(buffer: WebGl2RenderBuffer): this {
+  public addIndex(buffer: WebGl2RenderBuffer, type: IndexElementTypes = IndexElementTypes.UnsignedShort): this {
     this._indexBuffer = buffer;
+    this._indexType = type;
     this._version++;
 
     return this;
@@ -121,6 +128,7 @@ export class WebGl2VertexArrayObject {
   public clear(): this {
     this._attributes.length = 0;
     this._indexBuffer = null;
+    this._indexType = IndexElementTypes.UnsignedShort;
     this._version++;
 
     return this;

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -52,12 +52,13 @@ const vertexStrideWords = vertexStrideBytes / 4;
 const nodeIndexWord = 4;
 
 /**
- * Byte size of `indexCount` uint16 indices, rounded up to 4. `GPUQueue.writeBuffer`
- * rejects byte counts and offsets that are not a multiple of 4, so index sub-ranges
- * within the shared buffer are laid out on 4-byte boundaries — which also satisfies
- * `setIndexBuffer`'s weaker 2-byte offset requirement.
+ * Byte size of `indexCount` uint32 indices. `GPUQueue.writeBuffer` rejects byte
+ * counts and offsets that are not a multiple of 4 — with 4-byte indices every
+ * index count already lands on a 4-byte boundary, so no rounding is needed
+ * (unlike the uint16 index type this renderer used before: 16-bit indices
+ * needed an explicit round-up to satisfy that same constraint).
  */
-const alignIndexBytes = (indexCount: number): number => (indexCount * Uint16Array.BYTES_PER_ELEMENT + 3) & ~3;
+const alignIndexBytes = (indexCount: number): number => indexCount * Uint32Array.BYTES_PER_ELEMENT;
 
 const initialVertexCapacity = 256;
 const initialIndexCapacity = 384;
@@ -65,8 +66,8 @@ const initialNodeCapacity = 32;
 // One short line of text is already ~64 quads, so that floor made almost
 // every real retained draw pay several doubling steps (createBuffer + a CPU
 // index fill + writeBuffer each, plus — since the pass-open growth guard —
-// an extra submit). 1024 quads is 12 KiB and covers normal text scenes in
-// one allocation, well inside the 16384-quad Uint16 vertex-index ceiling.
+// an extra submit). 1024 quads is 24 KiB (uint32 indices) and covers normal
+// text scenes in one allocation.
 const initialRetainedQuadCapacity = 1024;
 
 // FrameUniforms: 7 × vec4<f32> = 112 bytes (projection + group mat3x3,
@@ -453,7 +454,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
   private _indexCapacity = initialIndexCapacity;
   private _vertexData: ArrayBuffer = new ArrayBuffer(initialVertexCapacity * vertexStrideBytes);
   private _float32View: Float32Array = new Float32Array(this._vertexData);
-  private _indexData: Uint16Array = new Uint16Array(initialIndexCapacity);
+  private _indexData: Uint32Array = new Uint32Array(initialIndexCapacity);
   private _projData: Float32Array = new Float32Array(projectionBytes / 4);
 
   private _nodeDataArray: Float32Array = new Float32Array(initialNodeCapacity * nodeFloats);
@@ -695,7 +696,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     const pass = active.pass;
 
     pass.setVertexBuffer(0, this._vertexBuffer, vertexBase);
-    pass.setIndexBuffer(this._indexBuffer!, 'uint16', indexBase);
+    pass.setIndexBuffer(this._indexBuffer!, 'uint32', indexBase);
 
     let lastShaderType: ShaderType | null = null;
     let lastTexture: Texture | null = null;
@@ -832,7 +833,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     });
     this._vertexBufferCapacity = vertexBytes;
 
-    const indexBytes = initialIndexCapacity * 2;
+    const indexBytes = initialIndexCapacity * Uint32Array.BYTES_PER_ELEMENT;
     this._indexBuffer = device.createBuffer({
       label: 'WebGpuTextRenderer/indices',
       size: indexBytes,
@@ -1188,7 +1189,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
   private _ensureIndexCapacity(indexCount: number): void {
     if (indexCount <= this._indexCapacity) return;
     while (this._indexCapacity < indexCount) this._indexCapacity *= 2;
-    this._indexData = new Uint16Array(this._indexCapacity);
+    this._indexData = new Uint32Array(this._indexCapacity);
   }
 
   private _ensureNodeCapacity(nodeCount: number): void {
@@ -1380,7 +1381,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     pass.setBindGroup(0, frameBindGroup);
     pass.setBindGroup(1, textureBindGroup);
     pass.setVertexBuffer(0, bundle.instanceBuffer, payload.byteOffset);
-    pass.setIndexBuffer(indexBuffer, 'uint16');
+    pass.setIndexBuffer(indexBuffer, 'uint32');
     pass.drawIndexed(data.quadCount * 6, 1, 0, 0, 0);
 
     state.drawsInPass = active;
@@ -1534,7 +1535,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
 
     while (capacity < quadCount) capacity *= 2;
 
-    const indices = new Uint16Array(capacity * 6);
+    const indices = new Uint32Array(capacity * 6);
 
     for (let i = 0; i < capacity; i++) {
       const baseV = i * 4;

--- a/test/rendering/browser/webgl2-text-quad-index-overflow.test.ts
+++ b/test/rendering/browser/webgl2-text-quad-index-overflow.test.ts
@@ -1,0 +1,71 @@
+/**
+ * WebGL2 counterpart to `webgpu-text-quad-index-overflow.test.ts` — same
+ * live-path quad-index overflow, against `WebGl2TextRenderer`'s shared
+ * per-flush vertex/index staging (`_drawBatches`). See that file's header
+ * for the full mechanism.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+
+import { createWebGl2TestBackend, readWebGl2Pixel, renderWebGl2Once } from './_backendSetup';
+
+const canvasSize = 48;
+
+// 5 * 4000 = 20000 filler quads precede the marker — comfortably past the old
+// 16384-quad ceiling — while each individual node's 4000 glyphs stay well
+// under it (a single node with >16384 glyphs would also trip the separate
+// per-node `Uint16Array` ceiling in `buildTextPageQuads`).
+const fillerNodeCount = 5;
+const fillerGlyphsPerNode = 4000;
+
+describe('WebGL2: a live text flush past the old 16384-quad index ceiling still renders', () => {
+  beforeEach(() => resetDefaultGlyphAtlasPool());
+  afterEach(() => resetDefaultGlyphAtlasPool());
+
+  test('a marker glyph flushed after >16384 accumulated quads paints at its own position', async () => {
+    const backend = await createWebGl2TestBackend(canvasSize);
+    const root = new Container();
+    const style = { fillColor: Color.white, fontSize: 16 } as const;
+
+    // Filler nodes: same glyph/style as the marker, so they share one atlas
+    // page and batch — positioned far off-canvas so their own (correctly
+    // indexed) geometry never paints a visible pixel. `cullable = false`
+    // keeps the view-frustum cull (`RenderNode._collect` / `SceneNode.inView`)
+    // from dropping them before they ever reach the renderer — an off-canvas
+    // node is exactly what that cull exists to skip, which would otherwise
+    // silently defeat this test (the fillers never accumulate onto the
+    // renderer's cursor at all). Only their share of the shared vertex/index
+    // buffer's cursor matters here.
+    for (let i = 0; i < fillerNodeCount; i++) {
+      const filler = new Text('M'.repeat(fillerGlyphsPerNode), style);
+
+      filler.cullable = false;
+      filler.setPosition(500, 500 + i * 20);
+      root.addChild(filler);
+    }
+
+    // Added last, so its quads are appended last within the flush (all
+    // fillers + marker share one (shaderType, atlasTexture) batch, and equal
+    // sort keys preserve insertion order — Array.prototype.sort is stable).
+    const marker = new Text('M', style);
+
+    marker.setPosition(2, 2);
+    root.addChild(marker);
+
+    try {
+      renderWebGl2Once(backend, root);
+
+      const ink = readWebGl2Pixel(backend, 3, 10);
+
+      expect(ink, `marker glyph did not paint at its own position — got ${JSON.stringify(ink)}`).not.toEqual([0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-text-quad-index-overflow.test.ts
+++ b/test/rendering/browser/webgpu-text-quad-index-overflow.test.ts
@@ -1,0 +1,90 @@
+/**
+ * WebGPU live-path text quad-index overflow regression.
+ *
+ * `WebGpuTextRenderer`'s live flush packs every pending glyph quad from the
+ * whole frame into ONE shared vertex/index buffer, with a running vertex
+ * cursor (`packedV`) that never resets between batches within a flush (see
+ * `flush()`). Before the index buffer moved to `uint32`, that cursor fed a
+ * `Uint16Array`: `baseV = quadIndex * 4` silently wraps (`& 0xFFFF`) once
+ * `quadIndex` reaches 16384 (`16384 * 4 - 1 === 65535`, the last value a
+ * `Uint16` can hold), with no error and no warning — a draw past that point
+ * reads an EARLIER quad's vertex slot instead of its own.
+ *
+ * This reproduces that ceiling directly: several filler `Text` nodes sharing
+ * one glyph/atlas page push the flush's cumulative quad count past 16384,
+ * then one more "marker" glyph is flushed after them. Under the bug, the
+ * marker's index wraps to an earlier filler's vertex slot — same glyph
+ * shape, but that filler's off-canvas transform, so nothing paints at the
+ * marker's own on-canvas position. Fixed, the marker paints normally.
+ *
+ * Each filler node's OWN glyph count is kept far below 16384 on purpose:
+ * `buildTextPageQuads` (`TextLayout.ts`) packs one node's placements into its
+ * own `Uint16Array` index range, a separate ceiling from the renderer-level
+ * one under test here — a single node with >16384 glyphs would trip both at
+ * once and no longer isolate this fix.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+
+import { createWebGpuTestBackend, readWebGpuPixels, renderWebGpuOnce } from './_backendSetup';
+
+const canvasSize = 48;
+
+// 5 * 4000 = 20000 filler quads precede the marker — comfortably past the old
+// 16384-quad ceiling — while each individual node's 4000 glyphs stay well
+// under it.
+const fillerNodeCount = 5;
+const fillerGlyphsPerNode = 4000;
+
+describe('WebGPU: a live text flush past the old 16384-quad index ceiling still renders', () => {
+  beforeEach(() => resetDefaultGlyphAtlasPool());
+  afterEach(() => resetDefaultGlyphAtlasPool());
+
+  test('a marker glyph flushed after >16384 accumulated quads paints at its own position', async ctx => {
+    const backend = await createWebGpuTestBackend(canvasSize);
+    const root = new Container();
+    const style = { fillColor: Color.white, fontSize: 16 } as const;
+
+    // Filler nodes: same glyph/style as the marker, so they share one atlas
+    // page and batch — positioned far off-canvas so their own (correctly
+    // indexed) geometry never paints a visible pixel. `cullable = false`
+    // keeps the view-frustum cull (`RenderNode._collect` / `SceneNode.inView`)
+    // from dropping them before they ever reach the renderer — an off-canvas
+    // node is exactly what that cull exists to skip, which would otherwise
+    // silently defeat this test (the fillers never accumulate onto the
+    // renderer's cursor at all). Only their share of the shared vertex/index
+    // buffer's cursor matters here.
+    for (let i = 0; i < fillerNodeCount; i++) {
+      const filler = new Text('M'.repeat(fillerGlyphsPerNode), style);
+
+      filler.cullable = false;
+      filler.setPosition(500, 500 + i * 20);
+      root.addChild(filler);
+    }
+
+    // Added last, so its quads are appended last within the flush (all
+    // fillers + marker share one (shaderType, atlasTexture) batch, and equal
+    // sort keys preserve insertion order — Array.prototype.sort is stable).
+    const marker = new Text('M', style);
+
+    marker.setPosition(2, 2);
+    root.addChild(marker);
+
+    try {
+      if (!(await renderWebGpuOnce(ctx, backend, root))) return;
+
+      const read = readWebGpuPixels(backend, canvasSize);
+      const ink = read(3, 10);
+
+      expect(ink, `marker glyph did not paint at its own position — got ${JSON.stringify(ink)}`).not.toEqual([0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      backend.destroy();
+    }
+  });
+});


### PR DESCRIPTION
Glyph indices in both text renderers were `Uint16`, and vertex indices are
computed as `baseV = quadIndex * 4`, which capped a draw at 16384 quads. Nothing
guarded that limit — the index silently wrapped and produced wrong geometry with
no error and no warning.

In the live path the ceiling was tighter than it looked: `packedV` keeps running
across all batches of a flush instead of resetting per batch, so the limit
applied per flush across every atlas page and shader type, not per draw.

Switched to `Uint32` rather than adding batch splitting. A split would be
stateful control flow that has to work exactly when nobody is looking, while a
type change introduces no new path. `'uint32'` is core WebGPU with no feature
flag, `UNSIGNED_INT` is core WebGL2. Index memory doubles (12 → 24 KiB at the
current initial capacity) and the ceiling moves past a billion quads. Alignment
got simpler, not harder: `alignIndexBytes` only rounded up to 4 because
`writeBuffer` demands it, which 4-byte elements satisfy by construction.

One change beyond the obvious scope was required. The retained-batch VAO draw
runtime is shared between `WebGl2MeshRenderer` (still `Uint16`) and
`WebGl2TextRenderer` (now `Uint32`) and hardcoded `gl.UNSIGNED_SHORT`. It now
carries a per-VAO index element type set through `addIndex`, so the shared
runtime reads the real element width instead of assuming one. Mesh's default is
unchanged.

### Verification

Both new browser tests were confirmed to fail without the fix — the marker glyph
past the old ceiling did not paint, identically in the WebGPU and WebGL lanes.

- `verify:quick` — all 11 gates
- `test:browser:webgpu` 323 passed, `test:browser:webgl` 282 passed

### Found in passing, deliberately not fixed here

`buildTextPageQuads` packs a single node's glyph placements into a `Uint16Array`
with the same 16384 ceiling, reachable when one node alone has more than 16384
visible glyphs on one atlas page. Distinct bug, outside this change's file
scope; the regression tests spread glyphs across several nodes specifically to
isolate the renderer-level fix from it. `WebGpuMeshRenderer` has a structurally
identical `Uint16` index path that was left untouched.
