### PR TITLE
perf(rendering): stop opening render passes that draw nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -467,6 +467,13 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   closed in place, so a following flush (e.g. the sprite flush right after)
   appends into it rather than paying for a pass and a `queue.submit` of its
   own.
+- **A fully mask-clipped tile-chunk flush no longer opens (or counts) an
+  empty render pass.** `WebGpuTileChunkRenderer.flush()` called
+  `acquirePass()` unconditionally, so a flush whose quads were entirely
+  clipped away by the active mask still opened a pass — and counted it in
+  `stats.renderPasses` — even with nothing left to draw and no clear
+  pending. The pass is now only acquired when the flush will actually draw
+  or a clear is still pending.
 - **`Container` caches its paint order and child-index lookups.**
   `InteractionManager` re-sorted every container's children on every single
   hit-test call, and `getChildIndex()` did a linear `indexOf` scan on every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -459,6 +459,14 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   regardless of how many systems or flushes it contains. A capacity growth and
   a mid-frame edit to a mode's own vertex geometry still end the pass, since
   appending cannot cover either.
+- **A frame that ends on a mesh no longer pays an extra pass and submit for
+  the next frame's clear.** `WebGpuMeshRenderer.flush()` honored a pending
+  clear-with-nothing-to-draw by opening a render pass and ending it right
+  back — even though the very next renderer's flush in the same frame would
+  have reused an open one. That empty pass now stays open instead of being
+  closed in place, so a following flush (e.g. the sprite flush right after)
+  appends into it rather than paying for a pass and a `queue.submit` of its
+  own.
 - **`Container` caches its paint order and child-index lookups.**
   `InteractionManager` re-sorted every container's children on every single
   hit-test call, and `getChildIndex()` did a linear `indexOf` scan on every

--- a/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
@@ -490,37 +490,44 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
       device.queue.writeBuffer(uniformBuffer, 0, this._projectionData.buffer, this._projectionData.byteOffset, this._projectionData.byteLength);
     }
 
-    const active = coordinator.acquirePass();
-    const pass = active.pass;
+    // A flush whose quads are entirely clipped away by the mask draws nothing,
+    // so it only needs a pass at all when a clear is still pending — opened
+    // here so `createColorAttachment` consumes the clear-state once. With no
+    // clear pending, skip `acquirePass` entirely rather than open (and count)
+    // a pass no draw will land in.
+    if (willDraw || backend.clearRequested) {
+      const active = coordinator.acquirePass();
+      const pass = active.pass;
 
-    if (willDraw) {
-      const instanceBuffer = this._ensureInstanceBufferCapacity(device, targetInstanceBytes);
-      const instanceByteOffset = this._instancePassBytes;
+      if (willDraw) {
+        const instanceBuffer = this._ensureInstanceBufferCapacity(device, targetInstanceBytes);
+        const instanceByteOffset = this._instancePassBytes;
 
-      device.queue.writeBuffer(instanceBuffer, instanceByteOffset, this._instanceData, 0, flushBytes);
+        device.queue.writeBuffer(instanceBuffer, instanceByteOffset, this._instanceData, 0, flushBytes);
 
-      const storage = backend.getTransformStorageBuffer(this._maxNodeIndex + 1);
-      const transformBindGroup = this._getOrCreateTransformBindGroup(device, uniformBuffer, storage.buffer);
-      const textureBindGroup = this._getOrCreateTextureBindGroup(device, backend, texture);
+        const storage = backend.getTransformStorageBuffer(this._maxNodeIndex + 1);
+        const transformBindGroup = this._getOrCreateTransformBindGroup(device, uniformBuffer, storage.buffer);
+        const textureBindGroup = this._getOrCreateTextureBindGroup(device, backend, texture);
 
-      const stencil = coordinator.stencilActive;
-      const pipeline = this._getPipeline(blendMode, backend.renderTargetFormat, stencil);
+        const stencil = coordinator.stencilActive;
+        const pipeline = this._getPipeline(blendMode, backend.renderTargetFormat, stencil);
 
-      pass.setPipeline(pipeline);
-      pass.setBindGroup(0, transformBindGroup);
-      pass.setBindGroup(1, textureBindGroup);
-      pass.setVertexBuffer(0, instanceBuffer, instanceByteOffset);
-      pass.setIndexBuffer(indexBuffer, 'uint16');
-      pass.drawIndexed(indicesPerInstance, this._quadIndex, 0, 0, 0);
+        pass.setPipeline(pipeline);
+        pass.setBindGroup(0, transformBindGroup);
+        pass.setBindGroup(1, textureBindGroup);
+        pass.setVertexBuffer(0, instanceBuffer, instanceByteOffset);
+        pass.setIndexBuffer(indexBuffer, 'uint16');
+        pass.drawIndexed(indicesPerInstance, this._quadIndex, 0, 0, 0);
 
-      // The pass stays open; the cursor carries this flush's consumption forward
-      // so the next flush in the same pass appends AFTER the slice these draws
-      // read instead of overwriting it.
-      this._instancePassBytes = instanceByteOffset + flushBytes;
-      this._passDraws = active;
-      coordinator.markPassDraws();
-      backend.stats.batches++;
-      backend.stats.drawCalls++;
+        // The pass stays open; the cursor carries this flush's consumption forward
+        // so the next flush in the same pass appends AFTER the slice these draws
+        // read instead of overwriting it.
+        this._instancePassBytes = instanceByteOffset + flushBytes;
+        this._passDraws = active;
+        coordinator.markPassDraws();
+        backend.stats.batches++;
+        backend.stats.drawCalls++;
+      }
     }
 
     // Retained capture: while a capture window is active, additionally stage

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -728,12 +728,13 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     const maskClipsAll = scissor !== null && (scissor.width <= 0 || scissor.height <= 0);
 
     if (this._drawCallCount === 0 || maskClipsAll) {
-      // Honor a pending clear with an empty pass so createColorAttachment
-      // consumes the clear-state once.
+      // No drawable content but a clear is pending: open the coordinator's
+      // pass so createColorAttachment consumes the clear-state once, but
+      // leave it open (not ended) so a following renderer's flush in the same
+      // frame — e.g. the sprite flush right after this one — can append its
+      // draws into it instead of paying for an extra pass and submit.
       if (backend.clearRequested) {
         backend._passCoordinator.acquirePass();
-        backend._passCoordinator.endPass();
-        this._resetInstancedBatchPass();
       }
       this._resetFrame();
       return;

--- a/test/rendering/browser/webgpu-single-submit.test.ts
+++ b/test/rendering/browser/webgpu-single-submit.test.ts
@@ -388,6 +388,85 @@ describe('WebGPU single-submit frame', () => {
     }
   });
 
+  test('a frame ending on a mesh costs no extra pass/submit consuming the following clear', async ctx => {
+    const backend = await setupBackend();
+    // Sprite first, mesh last, every frame: `_setActiveRenderer` flushes the
+    // PREVIOUS frame's still-active renderer (the mesh, now holding zero draw
+    // calls) the instant this frame's first sprite draw switches away from it.
+    // That flush used to open an empty pass purely to consume the pending
+    // clear and close it immediately, even though the sprite flush right
+    // after would have consumed the SAME open pass — costing an extra pass
+    // and submit on every frame that ends on a mesh. Measuring a *steady-state*
+    // repetition of this exact frame (not just its first run) is what exposes
+    // the defect: it only fires once the previous frame really did end on the
+    // mesh renderer.
+    const cell = 12;
+    const spriteColor = '#ff0000';
+    const meshColor: RgbaTuple = [255, 255, 0, 255];
+    const spriteTexture = createSolidTexture(spriteColor, 8);
+    const sprite = new Sprite(spriteTexture);
+
+    sprite.setPosition(0, 0);
+    sprite.width = cell;
+    sprite.height = cell;
+
+    const meshX = 24;
+    const meshY = 24;
+    const mesh = new Mesh({
+      vertices: new Float32Array([
+        meshX,
+        meshY,
+        meshX + cell,
+        meshY,
+        meshX + cell,
+        meshY + cell,
+        meshX,
+        meshY,
+        meshX + cell,
+        meshY + cell,
+        meshX,
+        meshY + cell,
+      ]),
+      uvs: new Float32Array([0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]),
+      colors: packRgbaPerVertex(meshColor, 6),
+    });
+
+    const renderFrameEndingOnMesh = (): void => {
+      backend.resetStats();
+      backend.clear(Color.black);
+      sprite.render(backend);
+      mesh.render(backend);
+      backend.flush();
+    };
+
+    try {
+      // Warm up in the SAME shape as the measured frame so `_renderer` already
+      // points at the mesh renderer (from the previous iteration's tail) by
+      // the time the measured call's first sprite draw runs.
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderGuarded(ctx, backend, renderFrameEndingOnMesh))) {
+          return;
+        }
+      }
+
+      const submits = countSubmits(backend, renderFrameEndingOnMesh);
+
+      expect(backend.stats.drawCalls).toBe(2);
+      expect(backend.stats.renderPasses).toBe(1);
+      expect(submits).toBe(1);
+
+      const readPixel = readWebGpuPixels(backend, canvasSize);
+
+      expectPixelNear(readPixel(4, 4), hexToRgba(spriteColor));
+      expectPixelNear(readPixel(meshX + 4, meshY + 4), meshColor);
+    } finally {
+      mesh.destroy();
+      sprite.destroy();
+      spriteTexture.destroy();
+      backend.destroy();
+    }
+  });
+
   test('many sprite/mesh alternations still cost ONE pass and ONE submit, with per-flush mesh pixels correct', async ctx => {
     const backend = await setupBackend();
     // Each alternation switches the active renderer, so this frame contains N

--- a/test/rendering/browser/webgpu-tilechunk-single-pass.test.ts
+++ b/test/rendering/browser/webgpu-tilechunk-single-pass.test.ts
@@ -23,6 +23,8 @@ import { TileMapNode } from '@codexo/exojs-tilemap';
 
 import type { Application } from '#core/Application';
 import { Color } from '#core/Color';
+import { Rectangle } from '#math/Rectangle';
+import { Container } from '#rendering/Container';
 import { Sprite } from '#rendering/sprite/Sprite';
 import type { Texture } from '#rendering/texture/Texture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
@@ -191,6 +193,74 @@ describe('WebGPU tile-chunk single pass', () => {
       nodes.forEach(node => node.destroy());
       tileTextures.forEach(texture => texture.destroy());
       trailingSprite.destroy();
+      spriteTexture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('a fully mask-clipped tile-chunk flush does not open or count an extra pass', async ctx => {
+    const backend = await setupBackend();
+    // A sprite drawn first consumes the frame's pending clear and leaves a
+    // pass open holding its draw. The tile node is wrapped in a container
+    // clipped to a rectangle entirely off-canvas: `pushScissorRect` (which
+    // ends the sprite's open pass — a genuine boundary) resolves the clip to
+    // zero pixels, so the tile chunk's quads accumulate during `render()` but
+    // the mask clips all of them by the time `flush()` observes the scissor.
+    // With no clear pending at that point, `flush()` must not open (and count)
+    // a pass no draw lands in.
+    const spriteColor = '#ff00ff';
+    const spriteTexture = createSolidTexture(spriteColor, 8);
+    const sprite = new Sprite(spriteTexture);
+
+    sprite.setPosition(0, 0);
+    sprite.width = 8;
+    sprite.height = 8;
+
+    const tileColor = '#ff0000';
+    const tileTexture = createSolidTexture(tileColor, tileSize);
+    const node = new TileMapNode(singleTileMap(tileTexture));
+
+    node.setPosition(32, 32);
+
+    const clipped = new Container();
+
+    clipped.clip = true;
+    clipped.clipShape = new Rectangle(1000, 1000, 8, 8); // positive size, entirely off-canvas
+    clipped.addChild(node);
+
+    const renderScene = (): void => {
+      backend.resetStats();
+      backend.clear(Color.black);
+      sprite.render(backend);
+      clipped.render(backend);
+      backend.flush();
+    };
+
+    try {
+      for (let frame = 0; frame < 3; frame++) {
+        if (!(await renderGuarded(ctx, backend, renderScene))) {
+          return;
+        }
+      }
+
+      const submits = countSubmits(backend, renderScene);
+
+      // Only the sprite actually draws; the tile chunk's quads were all
+      // clipped away.
+      expect(backend.stats.drawCalls).toBe(1);
+      expect(backend.stats.renderPasses).toBe(1);
+      expect(submits).toBe(1);
+
+      const readPixel = readWebGpuPixels(backend, canvasSize);
+
+      expectPixelNear(readPixel(4, 4), hexToRgba(spriteColor));
+      // The clipped tile never drew: its cell stays at the black clear.
+      expectPixelNear(readPixel(32 + tileSize / 2, 32 + tileSize / 2), [0, 0, 0, 255]);
+    } finally {
+      clipped.destroy();
+      (clipped.clipShape as Rectangle).destroy();
+      tileTexture.destroy();
+      sprite.destroy();
       spriteTexture.destroy();
       backend.destroy();
     }


### PR DESCRIPTION
Two renderers opened a render pass that drew nothing, each costing one pass and
one submit per frame — constantly, not proportionally, which is why neither was
a blocker.

`WebGpuMeshRenderer.flush()` honoured a pending clear by calling `acquirePass()`
and then `endPass()` right away, even though the next renderer's flush in the
same frame would have consumed that pass. It now leaves the pass open, matching
the pattern `WebGpuSpriteRenderer` already uses for the same situation. The clear
is still consumed exactly once inside `createColorAttachment`.

`WebGpuTileChunkRenderer.flush()` called `acquirePass()` unconditionally, so a
flush whose quads were entirely clipped away by a mask opened an empty pass and
counted it in `stats.renderPasses`. The acquire is now gated on whether anything
will actually be drawn (or a clear is pending). The hazard-boundary logic —
projection rewrite, capacity growth, shared transform storage, texture upload —
is untouched, so real boundaries still fire.

### Verification

Each fix was reverted individually and its test confirmed red
(`expected 2 to be 1` on `stats.renderPasses` in both cases), then restored.

No existing test needed adjusting. The pre-existing sprite/mesh alternation test
deliberately ends on a trailing sprite to sidestep the mesh case; that workaround
is now unnecessary but was left in place and still passes unchanged.

- `verify:quick` — all 11 gates
- `test:browser:webgpu` — 326/326
