### PR TITLE
perf(rendering)!: batch multiple base textures per custom SpriteMaterial draw

### DIFF
--- a/packages/exojs-bench/src/rendering/adapters/exojs.ts
+++ b/packages/exojs-bench/src/rendering/adapters/exojs.ts
@@ -108,11 +108,10 @@ const materialFragmentGlsl = `#version 300 es
 precision mediump float;
 in vec2 v_texcoord;
 in vec4 v_color;
-uniform sampler2D u_texture;
 uniform vec4 u_userColor;
 out vec4 fragColor;
 void main() {
-  fragColor = texture(u_texture, v_texcoord) * v_color * u_userColor;
+  fragColor = sampleBase(v_textureSlot, v_texcoord) * v_color * u_userColor;
 }`;
 
 /** WGSL twin of {@link materialFragmentGlsl} so the same material also runs on the WebGPU backend. */
@@ -122,7 +121,7 @@ struct UserUniforms { color: vec4<f32> };
 
 @fragment
 fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
-  let base = textureSample(u_texture, u_sampler, input.texcoord);
+  let base = sampleBase(input.textureSlot, input.texcoord);
   return base * input.color * u_user.color;
 }
 `.trim();

--- a/src/rendering/sprite/spriteMaterialSources.ts
+++ b/src/rendering/sprite/spriteMaterialSources.ts
@@ -6,8 +6,9 @@
  * expansion, affine transform, UV unpacking) is owned by the renderer and stays
  * instancing-critical. The sprite renderers consume these constants directly:
  * `WebGl2SpriteRenderer` pairs {@link spriteVertexGlsl} with the material's
- * fragment (ignoring any author-supplied `glsl.vertex`), and
- * `WebGpuSpriteRenderer` prepends {@link spriteVertexWgsl} to the material's
+ * fragment (ignoring any author-supplied `glsl.vertex`) after splicing
+ * {@link spriteMaterialPrologueGlsl} into it, and `WebGpuSpriteRenderer`
+ * prepends {@link spriteMaterialPrologueWgsl} to the material's
  * fragment WGSL. Both pin the per-instance attribute locations and the
  * projection binding exactly as the default sprite path does, so a custom
  * material keeps the single `drawArraysInstanced` / `drawIndexed` batch.
@@ -18,11 +19,30 @@
  * WGSL path reads the `transforms` storage buffer (group(0) binding(1)) and
  * the `tints` packed-rgba8 storage buffer (group(0) binding(2)).
  *
- * A custom fragment receives the interpolated `v_texcoord` and premultiplied
- * `v_color`, plus the per-batch base texture bound as `u_texture` (WebGL2 unit 0
- * / WGSL group(1) binding 0). Material uniforms and additional textures bind on
- * top (WebGL2 units 1..N / WGSL group(2)).
+ * A custom fragment receives the interpolated `v_texcoord`, the premultiplied
+ * `v_color` and the flat per-instance base-texture slot. The base texture is
+ * NOT bound as a single sampler: like the default path, a custom batch rotates
+ * up to {@link spriteMaterialTextureSlots} base textures through the group(1)
+ * (WGSL) / unit 0..N-1 (WebGL2) slot table, and the fragment reads its own
+ * instance's texture through the engine-provided `sampleBase(slot, uv)` helper.
+ * Material uniforms and additional textures bind on top (WebGL2 units
+ * {@link spriteMaterialTextureSlots}..N / WGSL group(2)).
  */
+
+/**
+ * Base-texture batch slots a custom {@link SpriteMaterial} rotates through.
+ *
+ * Deliberately smaller than the default path's device-derived tier (WebGL2 16,
+ * WebGPU 8/16/32): the custom path additionally binds the material's own
+ * textures in the SAME fragment stage, and both backends only guarantee 16
+ * fragment-stage texture/sampler bindings (`MAX_TEXTURE_IMAGE_UNITS` >= 16;
+ * WebGPU's `maxSampledTexturesPerShaderStage` / `maxSamplersPerShaderStage`
+ * base limits of 16). 8 base slots + 7 material textures = 15 fits that floor
+ * on every conformant device, so exactly one prologue variant ships per backend
+ * and no bind-group layout depends on the granted limits.
+ * @internal
+ */
+export const spriteMaterialTextureSlots = 8;
 
 /**
  * GLSL ES 3.00 vertex shader for the custom sprite-material path. Identical
@@ -127,13 +147,98 @@ void main(void) {
 `;
 
 /**
- * WGSL vertex stage + shared bindings for the custom sprite-material path.
- * Prepend to a material's fragment WGSL: it declares the per-instance
- * `VertexInput` (locations 0, 3, 5, 6), the `VertexOutput` a custom
- * `@fragment` consumes, the group(0) projection uniform + shared transform
- * storage buffer, the group(1) base texture and sampler (`u_texture` /
- * `u_sampler`), and the `vertexMain` entry point. The fragment author adds their
- * group(2) bindings and a `fragmentMain` reading `VertexOutput`.
+ * GLSL ES 3.00 multi-texture slot table for `textureSlots` base textures:
+ * the `u_texture0..N-1` sampler declarations, the flat slot varying, and the
+ * `sampleBase(slot, uv)` dispatch a custom fragment reads its own instance's
+ * base texture through.
+ *
+ * The dispatch is an unrolled if/else chain, matching the default sprite
+ * fragment (`webgl2/glsl/sprite.frag`): GLSL ES 3.00 forbids indexing an array
+ * of samplers with a non-dynamically-uniform expression, which a per-instance
+ * slot is not.
+ * @internal
+ */
+export const buildSpriteMaterialSlotGlsl = (textureSlots: number): string => {
+  const samplers = Array.from({ length: textureSlots }, (_, slot) => `uniform sampler2D u_texture${slot};`).join('\n');
+  // The last slot is the else branch so every uint value maps to a texture.
+  const dispatch = Array.from({ length: textureSlots - 1 }, (_, slot) => `    if (slot == ${slot}u) return texture(u_texture${slot}, uv);`).join('\n');
+
+  // Every FLOAT-typed declaration carries an explicit precision qualifier: a
+  // GLSL ES 3.00 fragment shader has no default float precision, and the
+  // prologue is spliced ahead of whatever `precision` statement the author
+  // wrote, so an unqualified `vec4` here would not compile. `uint` and
+  // `sampler2D` do have fragment-stage defaults (mediump / lowp) and stay
+  // unqualified — the sampler precision matches the default sprite fragment.
+  return `${samplers}
+
+// Engine-owned base-texture varying: the slot this instance's texture occupies
+// in the batch's slot table. Custom fragments must not redeclare it.
+flat in uint v_textureSlot;
+
+// Sample this instance's base texture. \`slot\` is \`v_textureSlot\`; \`uv\` is
+// normally \`v_texcoord\` but may be any coordinate the effect derives from it.
+highp vec4 sampleBase(uint slot, highp vec2 uv) {
+${dispatch}
+    return texture(u_texture${textureSlots - 1}, uv);
+}`;
+};
+
+/**
+ * Engine-owned fragment prologue spliced into every custom sprite-material
+ * GLSL fragment (see {@link composeSpriteMaterialFragmentGlsl}).
+ * @internal
+ */
+export const spriteMaterialPrologueGlsl = buildSpriteMaterialSlotGlsl(spriteMaterialTextureSlots);
+
+/**
+ * Splice {@link spriteMaterialPrologueGlsl} into an author-supplied sprite
+ * material fragment.
+ *
+ * The prologue cannot simply be prepended: a GLSL ES 3.00 fragment starts with
+ * its own `#version` directive, which must be the first token in the unit.
+ * The insertion point is therefore after the run of leading directives and
+ * `precision` statements (plus blank lines and line comments) — after the
+ * author's defaults, and still before any declaration, which is where
+ * `#extension` requires to sit.
+ * @internal
+ */
+export const composeSpriteMaterialFragmentGlsl = (fragment: string): string => {
+  const lines = fragment.split('\n');
+  let insertAt = 0;
+
+  for (let index = 0; index < lines.length; index++) {
+    // In-bounds: index < lines.length via the loop guard.
+    const line = lines[index]!.trim();
+
+    if (line === '' || line.startsWith('//')) {
+      continue;
+    }
+
+    if (
+      line.startsWith('#version') ||
+      line.startsWith('#extension') ||
+      line.startsWith('#pragma') ||
+      line.startsWith('#line') ||
+      line.startsWith('precision ')
+    ) {
+      insertAt = index + 1;
+      continue;
+    }
+
+    break;
+  }
+
+  return [...lines.slice(0, insertAt), spriteMaterialPrologueGlsl, ...lines.slice(insertAt)].join('\n');
+};
+
+/**
+ * WGSL vertex stage for the custom sprite-material path. Declares the
+ * per-instance `VertexInput` (locations 0, 3, 5, 6), the `VertexOutput` a
+ * custom `@fragment` consumes, the group(0) projection uniform + shared
+ * transform storage buffers, and the `vertexMain` entry point.
+ *
+ * Not fed to `createShaderModule` on its own — {@link spriteMaterialPrologueWgsl}
+ * pairs it with the group(1) base-texture slot table.
  * @internal
  */
 export const spriteVertexWgsl = `
@@ -154,9 +259,6 @@ struct TransformSlot {
 // u32 per instance.
 @group(0) @binding(2) var<storage, read> tints: array<u32>;
 
-@group(1) @binding(0) var u_texture: texture_2d<f32>;
-@group(1) @binding(1) var u_sampler: sampler;
-
 struct VertexInput {
     @location(0) localBounds: vec4<f32>,
     @location(3) uvBounds: vec4<f32>,
@@ -168,6 +270,9 @@ struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) texcoord: vec2<f32>,
     @location(1) color: vec4<f32>,
+    // Slot this instance's base texture occupies in the batch's slot table;
+    // pass it to sampleBase() to read the base texture.
+    @location(2) @interpolate(flat) textureSlot: u32,
 };
 
 // Round one local boundary coordinate to the device grid along an axis whose
@@ -242,7 +347,73 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     output.texcoord = vec2<f32>(u, v);
 
     output.color = vec4<f32>(tint.rgb * tint.a, tint.a);
+    output.textureSlot = input.textureSlot;
 
     return output;
+}
+`;
+
+/**
+ * WGSL multi-texture slot table for `textureSlots` base textures on group(1):
+ * the texture bindings at [0, N), their samplers at [N, 2N), and the
+ * `sampleTexture` dispatch over the same slot range.
+ *
+ * The single generator behind BOTH the default sprite pipeline
+ * (`buildSpriteShaderSource`) and the custom-material prologue
+ * ({@link spriteMaterialPrologueWgsl}), so the two slot layouts cannot drift.
+ *
+ * `textureSampleGrad` (explicit derivatives) rather than `textureSample`:
+ * WGSL requires implicit-LOD sampling to run in uniform control flow, which
+ * multi-texture batching breaks because the slot varies per fragment. Explicit
+ * derivatives are valid regardless of control-flow uniformity while preserving
+ * mipmap-correct LOD.
+ * @internal
+ */
+export const buildSpriteTextureSlotWgsl = (textureSlots: number): string => {
+  const textureBindings = Array.from({ length: textureSlots }, (_, slot) => `@group(1) @binding(${slot})\nvar spriteTexture${slot}: texture_2d<f32>;`).join(
+    '\n',
+  );
+  const samplerBindings = Array.from(
+    { length: textureSlots },
+    (_, slot) => `@group(1) @binding(${textureSlots + slot})\nvar spriteSampler${slot}: sampler;`,
+  ).join('\n');
+  // The last slot is the switch default so every u32 value maps to a texture.
+  const sampleCases = Array.from({ length: textureSlots }, (_, slot) =>
+    slot < textureSlots - 1
+      ? `        case ${slot}u: {\n            return textureSampleGrad(spriteTexture${slot}, spriteSampler${slot}, uv, ddx, ddy);\n        }`
+      : `        default: {\n            return textureSampleGrad(spriteTexture${slot}, spriteSampler${slot}, uv, ddx, ddy);\n        }`,
+  ).join('\n');
+
+  return `${textureBindings}
+
+${samplerBindings}
+
+fn sampleTexture(slot: u32, uv: vec2<f32>, ddx: vec2<f32>, ddy: vec2<f32>) -> vec4<f32> {
+    switch slot {
+${sampleCases}
+    }
+}`;
+};
+
+/**
+ * Engine-owned WGSL prologue prepended to every custom sprite-material
+ * fragment: {@link spriteVertexWgsl} plus the group(1) base-texture slot table
+ * and the `sampleBase(slot, uv)` helper a custom fragment reads its own
+ * instance's base texture through.
+ *
+ * The author adds their group(2) bindings and a `fragmentMain` reading
+ * `VertexOutput`.
+ * @internal
+ */
+export const spriteMaterialPrologueWgsl = `${spriteVertexWgsl}
+${buildSpriteTextureSlotWgsl(spriteMaterialTextureSlots)}
+
+// Sample this instance's base texture. \`slot\` is \`input.textureSlot\`; \`uv\` is
+// normally \`input.texcoord\` but may be any coordinate the effect derives from
+// it. Derivatives are taken here, before the per-slot switch, because
+// multi-texture batching makes the slot non-uniform across a quad and
+// textureSampleGrad is the only sampling form valid in that control flow.
+fn sampleBase(slot: u32, uv: vec2<f32>) -> vec4<f32> {
+    return sampleTexture(slot, uv, dpdx(uv), dpdy(uv));
 }
 `;

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -3,7 +3,7 @@ import type { UniformValue } from '#rendering/material/Material';
 import type { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import { Shader } from '#rendering/shader/Shader';
 import type { Sprite } from '#rendering/sprite/Sprite';
-import { spriteVertexGlsl } from '#rendering/sprite/spriteMaterialSources';
+import { composeSpriteMaterialFragmentGlsl, spriteMaterialTextureSlots, spriteVertexGlsl } from '#rendering/sprite/spriteMaterialSources';
 import { RenderTexture } from '#rendering/texture/RenderTexture';
 import { Texture } from '#rendering/texture/Texture';
 import { BlendModes, BufferTypes, BufferUsage, RenderingPrimitives } from '#rendering/types';
@@ -50,10 +50,11 @@ import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './
  * rotate through `u_texture0..15`, selected per-instance via `a_textureSlot`,
  * so unrelated sprites merge into one draw. Sprites with a {@link SpriteMaterial}
  * take the custom path: the material's fragment program runs against the same
- * instance buffer, the single base texture binds to unit 0 as `u_texture`, and
- * material uniforms/textures bind once per batch (units 1..7). The custom path
- * keeps instancing but not the opportunistic 16-slot merge — a custom batch
- * breaks on material instance, base texture, blend mode, or buffer capacity.
+ * instance buffer, up to {@link spriteMaterialTextureSlots} base textures
+ * rotate through `u_texture0..7` behind the engine-spliced `sampleBase(slot,
+ * uv)` helper, and material uniforms/textures bind once per batch on the units
+ * above them. A custom batch breaks on material instance, blend mode, base
+ * slot exhaustion, or buffer capacity — no longer on every base-texture switch.
  */
 
 const identityGroupMat3 = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
@@ -69,12 +70,16 @@ const transformTextureUnit = 16;
 // sprite draw's shader is active, so units stay disjoint in practice, but this
 // still sits clear of it.
 const transformTintTextureUnit = 18;
-// Custom-material texture bindings (base texture on unit 0 + material textures
-// on units 1..7) keep the pre-16-slot cap: the material CONTRACT stays at 7
+// Material texture bindings occupy the units above the custom path's base-slot
+// table (spriteMaterialTextureSlots..+6). The material CONTRACT stays at 7
 // extra textures, matching WebGl2MeshRenderer and the WebGPU sprite renderer.
 // Deliberately decoupled from maxBatchTextures — bumping the default-path
-// batch capacity must not silently widen what materials may request.
-const maxCustomTextureSlots = 8;
+// batch capacity must not silently widen what materials may request. 8 base
+// slots + 7 material textures = 15 fragment units, inside the WebGL2
+// MAX_TEXTURE_IMAGE_UNITS >= 16 guarantee.
+const maxCustomTextureSlots = 7;
+// First texture unit a material's own textures may use.
+const customTextureUnitBase = spriteMaterialTextureSlots;
 const instanceStrideBytes = 32;
 const wordsPerInstance = instanceStrideBytes / Uint32Array.BYTES_PER_ELEMENT;
 
@@ -109,6 +114,10 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
   // MAX_TEXTURE_IMAGE_UNITS — a defensive floor that WebGL2's >= 16 guarantee
   // means should never actually reduce the batch below maxBatchTextures.
   private _maxTextureSlots = maxBatchTextures;
+  // Effective base-texture slot cap for the CUSTOM path. Smaller than
+  // _maxTextureSlots on purpose: a material's own textures share the fragment
+  // stage's unit budget (see maxCustomTextureSlots).
+  private _maxCustomTextureSlots = spriteMaterialTextureSlots;
 
   // Custom-material state. Compiled fragment programs are cached per material
   // instance; the current batch's material/base-texture decide when to flush.
@@ -120,7 +129,6 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
   private readonly _transformUnitScratch: Int32Array = new Int32Array([transformTextureUnit]);
   private readonly _tintUnitScratch: Int32Array = new Int32Array([transformTintTextureUnit]);
   private _currentMaterial: SpriteMaterial | null = null;
-  private _currentBaseTexture: Texture | RenderTexture | null = null;
   // Local bounds resolved for the sprite currently being packed. Geometry-mode
   // boundary snapping now happens in the vertex shader, so this is always the
   // sprite's logical local bounds; the field lets _packInstance read the value
@@ -232,15 +240,8 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
 
       backend._stageViewportUniform(shader);
 
-      // The single base texture binds to unit 0 as `u_texture`.
-      const baseTexture = this._currentBaseTexture;
-
-      if (baseTexture !== null && shader.uniforms.has('u_texture')) {
-        backend.bindTexture(baseTexture, 0);
-        // In-bounds: `_slotScratches` is pre-allocated with `maxBatchTextures` (>= 1) entries.
-        shader.getUniform('u_texture').setValue(this._slotScratches[0]!);
-      }
-
+      // Base textures are already bound to their slot units by _renderCustom;
+      // the sampler uniforms are pinned once when the program is compiled.
       this._bindCustomUniforms(shader, material, backend);
     }
 
@@ -445,6 +446,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     const maxImageUnits = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS) as number;
 
     this._maxTextureSlots = Math.min(maxBatchTextures, maxImageUnits);
+    this._maxCustomTextureSlots = Math.min(spriteMaterialTextureSlots, this._maxTextureSlots);
 
     this._shader.connect(createWebGl2ShaderProgram(gl));
     this._connection = this._createConnection(gl);
@@ -484,7 +486,6 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
 
     this._customShaders.clear();
     this._currentMaterial = null;
-    this._currentBaseTexture = null;
     this._instanceBuffer?.destroy();
     this._instanceBuffer = null;
     this._vao?.destroy();
@@ -536,7 +537,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     this._instanceCount++;
   }
 
-  /** Custom-material path: single base texture on unit 0, instanced. */
+  /** Custom-material path: rotate the base texture through the material slot table, instanced. */
   private _renderCustom(sprite: Sprite, texture: Texture | RenderTexture, material: SpriteMaterial, backend: WebGl2Backend, nodeIndex: number): void {
     // The material owns its blend mode; the sprite's own blendMode overrides it
     // when set away from the default (Normal).
@@ -544,9 +545,9 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     const batchFull = this._instanceCount >= this._batchSize;
     const blendModeChanged = blendMode !== this._currentBlendMode;
     const materialChanged = material !== this._currentMaterial;
-    const textureChanged = texture !== this._currentBaseTexture;
+    const slotExhausted = !this._textureSlots.has(texture) && this._slotCount >= this._maxCustomTextureSlots;
 
-    if (this._instanceCount > 0 && (batchFull || blendModeChanged || materialChanged || textureChanged)) {
+    if (this._instanceCount > 0 && (batchFull || blendModeChanged || materialChanged || slotExhausted)) {
       this.flush();
     }
 
@@ -556,10 +557,19 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     }
 
     this._currentMaterial = material;
-    this._currentBaseTexture = texture;
 
-    // textureSlot word is unused by custom fragments (base binds to unit 0).
-    this._packInstance(sprite, texture, 0, nodeIndex);
+    // Resolve / assign texture slot, exactly as the default path does — the
+    // spliced prologue's sampleBase() dispatches over it per fragment.
+    let slot = this._textureSlots.get(texture);
+
+    if (slot === undefined) {
+      slot = this._slotCount++;
+      this._textureSlots.set(texture, slot);
+      this._activeTextures[slot] = texture;
+      backend.bindTexture(texture, slot);
+    }
+
+    this._packInstance(sprite, texture, slot, nodeIndex);
     this._instanceCount++;
   }
 
@@ -624,11 +634,31 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
 
     // The engine owns the vertex stage: pair the canonical sprite vertex shader
     // with the material's fragment so the corner-expansion / instancing
-    // contract is fixed regardless of the material author.
-    const shader = new Shader(spriteVertexGlsl, glsl.fragment);
+    // contract is fixed regardless of the material author. The fragment gets
+    // the engine's base-texture slot table spliced in, so `sampleBase` and the
+    // `u_texture0..N-1` samplers behind it exist without the author declaring
+    // them.
+    const shader = new Shader(spriteVertexGlsl, composeSpriteMaterialFragmentGlsl(glsl.fragment));
 
     shader.connect(createWebGl2ShaderProgram(gl));
+    // Links the program and populates `shader.uniforms`; the slot samplers can
+    // only be pinned once that table exists (same order as `onConnect`).
     shader.sync();
+
+    // Pin the slot samplers to units 0..N-1. Guarded by `has` (unlike the
+    // default program's strict pinning): a fragment that never calls
+    // `sampleBase` leaves every slot sampler unused, and the GLSL compiler
+    // then drops all of them from the linked program.
+    const samplerUnit = new Int32Array(1);
+
+    for (let i = 0; i < this._maxCustomTextureSlots; i++) {
+      const name = `u_texture${i}`;
+
+      if (shader.uniforms.has(name)) {
+        samplerUnit[0] = i;
+        shader.getUniform(name).setValue(samplerUnit);
+      }
+    }
 
     this._customShaders.set(material, shader);
 
@@ -645,10 +675,11 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
   }
 
   private _bindCustomUniforms(shader: Shader, material: SpriteMaterial, backend: WebGl2Backend): void {
-    // Texture bindings take consecutive units starting at 1 (unit 0 belongs to
-    // the sprite's own base texture). Texture-valued uniforms bind first, then
-    // the entries of the material's dedicated `textures` map.
-    let textureSlot = 1;
+    // Texture bindings take consecutive units above the base-texture slot table
+    // (units 0..spriteMaterialTextureSlots-1 belong to the sprites' own base
+    // textures). Texture-valued uniforms bind first, then the entries of the
+    // material's dedicated `textures` map.
+    let textureSlot = customTextureUnitBase;
 
     const uniforms = material.uniforms;
 
@@ -662,13 +693,14 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
       const uniform = shader.getUniform(name);
 
       if (value instanceof Texture || value instanceof RenderTexture) {
-        if (textureSlot >= maxCustomTextureSlots) {
-          throw new Error(`SpriteMaterial requested more than ${maxCustomTextureSlots - 1} texture bindings.`);
+        if (textureSlot >= customTextureUnitBase + maxCustomTextureSlots) {
+          throw new Error(`SpriteMaterial requested more than ${maxCustomTextureSlots} texture bindings.`);
         }
 
         backend.bindTexture(value, textureSlot);
-        // In-bounds: `textureSlot < maxCustomTextureSlots <= maxBatchTextures`
-        // (guarded) and `_slotScratches` has `maxBatchTextures` entries.
+        // In-bounds: `textureSlot < customTextureUnitBase + maxCustomTextureSlots
+        // <= maxBatchTextures` (guarded) and `_slotScratches` has
+        // `maxBatchTextures` entries.
         uniform.setValue(this._slotScratches[textureSlot]!);
         textureSlot++;
       } else {
@@ -683,8 +715,8 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
         continue;
       }
 
-      if (textureSlot >= maxCustomTextureSlots) {
-        throw new Error(`SpriteMaterial requested more than ${maxCustomTextureSlots - 1} texture bindings.`);
+      if (textureSlot >= customTextureUnitBase + maxCustomTextureSlots) {
+        throw new Error(`SpriteMaterial requested more than ${maxCustomTextureSlots} texture bindings.`);
       }
 
       // `name` iterates own keys of `textures`, so the lookup is defined.

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -5,7 +5,7 @@ import type { ReadonlyRectangle } from '#math/Rectangle';
 import { affineMat4FloatCount, packAffineMat4, packedGroupChanged } from '#rendering/affinePacking';
 import type { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import type { Sprite } from '#rendering/sprite/Sprite';
-import { spriteVertexWgsl } from '#rendering/sprite/spriteMaterialSources';
+import { buildSpriteTextureSlotWgsl, spriteMaterialPrologueWgsl, spriteMaterialTextureSlots } from '#rendering/sprite/spriteMaterialSources';
 import { DataTexture } from '#rendering/texture/DataTexture';
 import { RenderTexture } from '#rendering/texture/RenderTexture';
 import { Texture } from '#rendering/texture/Texture';
@@ -115,20 +115,6 @@ export const resolveSpriteBatchTextureSlots = (device: GPUDevice): number => {
  * @internal
  */
 export const buildSpriteShaderSource = (textureSlots: number): string => {
-  const textureBindings = Array.from({ length: textureSlots }, (_, slot) => `@group(1) @binding(${slot})\nvar spriteTexture${slot}: texture_2d<f32>;`).join(
-    '\n',
-  );
-  const samplerBindings = Array.from(
-    { length: textureSlots },
-    (_, slot) => `@group(1) @binding(${textureSlots + slot})\nvar spriteSampler${slot}: sampler;`,
-  ).join('\n');
-  // The last slot is the switch default so every u32 value maps to a texture.
-  const sampleCases = Array.from({ length: textureSlots }, (_, slot) =>
-    slot < textureSlots - 1
-      ? `        case ${slot}u: {\n            return textureSampleGrad(spriteTexture${slot}, spriteSampler${slot}, uv, ddx, ddy);\n        }`
-      : `        default: {\n            return textureSampleGrad(spriteTexture${slot}, spriteSampler${slot}, uv, ddx, ddy);\n        }`,
-  ).join('\n');
-
   return `
 struct ProjectionUniforms {
     matrix: mat4x4<f32>,
@@ -150,9 +136,7 @@ var<storage, read> transforms: array<TransformSlot>;
 @group(0) @binding(2)
 var<storage, read> tints: array<u32>;
 
-${textureBindings}
-
-${samplerBindings}
+${buildSpriteTextureSlotWgsl(textureSlots)}
 
 // Per-instance vertex layout (32 bytes per sprite). The four corners
 // of the quad are derived from @builtin(vertex_index) 0..3 inside the
@@ -255,20 +239,11 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     return output;
 }
 
-fn sampleTexture(slot: u32, uv: vec2<f32>, ddx: vec2<f32>, ddy: vec2<f32>) -> vec4<f32> {
-    switch slot {
-${sampleCases}
-    }
-}
-
 @fragment
 fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
     // Compute screen-space derivatives in uniform control flow before the
-    // per-slot switch. WGSL requires textureSample (implicit LOD) to run in
-    // uniform control flow, which multi-texture batching breaks because the
-    // slot varies per fragment. textureSampleGrad takes explicit derivatives
-    // and is valid regardless of control-flow uniformity, while preserving
-    // mipmap-correct LOD when sprites use mipmapped textures.
+    // per-slot switch (see buildSpriteTextureSlotWgsl for why sampling takes
+    // explicit derivatives).
     let ddx = dpdx(input.texcoord);
     let ddy = dpdy(input.texcoord);
     let sample = sampleTexture(input.textureSlot, input.texcoord, ddx, ddy);
@@ -287,6 +262,9 @@ const initialBatchCapacity = 32;
 // Deliberately decoupled from the multi-texture batch slot count — bumping the
 // default-path batch tiers must not silently widen the custom-material
 // contract (mirrors the WebGL2 renderer's maxCustomTextureSlots convention).
+// Together with spriteMaterialTextureSlots (8) this keeps a custom pipeline at
+// 15 sampled textures / 15 samplers per fragment stage, inside WebGPU's base
+// limit of 16.
 const maxCustomTextureSlots = 7; // user texture uniforms; group(2) binding 1..N
 const indicesPerSprite = 6;
 // Static index buffer: two triangles forming a quad, vertex IDs 0..3 in
@@ -318,8 +296,8 @@ const maxTextureSetsPerAnchor = 8;
 /**
  * Per-material GPU resources for the custom sprite path, cached against the
  * material instance and released when the material's `_onDispose` fires.
- * group(0) reuses the shared projection UBO; group(1) is the single base
- * texture; group(2) is the user UBO + texture/sampler pairs.
+ * group(0) reuses the shared projection UBO; group(1) is the base-texture slot
+ * table; group(2) is the user UBO + texture/sampler pairs.
  */
 interface CustomSpriteResources {
   shaderModule: GPUShaderModule;
@@ -332,7 +310,9 @@ interface CustomSpriteResources {
   // re-uploaded/rebuilt only when the material's uniform values or bound
   // texture views actually change.
   userUniform: UserUniformState;
-  baseTextureBindGroups: WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView }>;
+  // Base-texture slot count the cached shader module and pipeline layout were
+  // generated for. Fixed for the custom path, so this only ever asserts.
+  textureSlots: number;
 }
 
 export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> implements WebGpuRetainedBatchReplayer {
@@ -385,6 +365,10 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
   // GPU bind groups across long sessions). Rebuilt when the backend hands out
   // a new view for any slot; dropped wholesale on disconnect / device loss.
   private _textureSetBindGroups = new WeakMap<Texture | RenderTexture, TextureSetBindGroupEntry[]>();
+  // Same cache, for the custom path's narrower slot table (group(1) laid out
+  // for spriteMaterialTextureSlots instead of the device tier). Kept separate
+  // because the cached bind groups are built against a different layout.
+  private _customTextureSetBindGroups = new WeakMap<Texture | RenderTexture, TextureSetBindGroupEntry[]>();
   private readonly _textureSlots = new Map<Texture | RenderTexture, number>();
   private _slotCount = 0;
   private _instanceCount = 0;
@@ -396,9 +380,8 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
   // Custom-material state. Per-material pipelines/bind groups are cached; the
   // current batch's material/base-texture decide when to flush.
   private readonly _customMaterials = new Map<SpriteMaterial, CustomSpriteResources>();
-  private _customBaseTextureLayout: GPUBindGroupLayout | null = null;
+  private _customTextureBindGroupLayout: GPUBindGroupLayout | null = null;
   private _currentMaterial: SpriteMaterial | null = null;
-  private _currentBaseTexture: Texture | RenderTexture | null = null;
   // Material uniform buffers a draw already recorded into the currently open
   // pass reads from. A batch about to rewrite one of them has to end that pass
   // first — see the hazard checks in flush(). Keyed to the pass identity so a
@@ -422,6 +405,18 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     // resolved once per connection — before the shader module and the
     // group(1) layout are built from it.
     this._maxBatchTextures = resolveSpriteBatchTextureSlots(this._device);
+
+    // The custom-material prologue is generated for a FIXED slot count, so its
+    // group(1) layout must fit inside what the default path already proved
+    // bindable. Every tier resolveSpriteBatchTextureSlots can return is >= it;
+    // this asserts that invariant instead of silently generating a layout the
+    // device cannot satisfy.
+    if (this._maxBatchTextures < spriteMaterialTextureSlots) {
+      throw new Error(
+        `WebGpuSpriteRenderer: device grants only ${this._maxBatchTextures} sprite batch texture slots, below the ${spriteMaterialTextureSlots} the custom-material path requires.`,
+      );
+    }
+
     this._activeTextures = new Array<Texture | RenderTexture | null>(this._maxBatchTextures).fill(null);
     this._shaderModule = this._device.createShaderModule({ label: 'sprite:shader', code: buildSpriteShaderSource(this._maxBatchTextures) });
 
@@ -474,12 +469,25 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       label: 'sprite:pipeline-layout',
       bindGroupLayouts: [this._uniformBindGroupLayout, this._textureBindGroupLayout],
     });
-    // Single base-texture layout for the custom-material path (group 1).
-    this._customBaseTextureLayout = this._device.createBindGroupLayout({
-      label: 'sprite:bind-group-layout:custom-base-texture',
+    // Base-texture slot table for the custom-material path (group 1). Same
+    // shape as the default layout above, sized to the fixed custom slot count.
+    this._customTextureBindGroupLayout = this._device.createBindGroupLayout({
+      label: 'sprite:bind-group-layout:custom-texture',
       entries: [
-        { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float' } },
-        { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
+        ...Array.from({ length: spriteMaterialTextureSlots }, (_, index) => ({
+          binding: index,
+          visibility: GPUShaderStage.FRAGMENT,
+          texture: {
+            sampleType: 'float' as const,
+          },
+        })),
+        ...Array.from({ length: spriteMaterialTextureSlots }, (_, index) => ({
+          binding: spriteMaterialTextureSlots + index,
+          visibility: GPUShaderStage.FRAGMENT,
+          sampler: {
+            type: 'filtering' as const,
+          },
+        })),
       ],
     });
     this._uniformBuffer = this._device.createBuffer({
@@ -522,12 +530,13 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     // Bind groups and the projection UBO belong to the (possibly lost) device;
     // drop the caches so reconnect rebuilds them against the fresh device.
     this._textureSetBindGroups = new WeakMap<Texture | RenderTexture, TextureSetBindGroupEntry[]>();
+    this._customTextureSetBindGroups = new WeakMap<Texture | RenderTexture, TextureSetBindGroupEntry[]>();
     this._writtenView = null;
     this._writtenViewUpdateId = -1;
     this._hasWrittenProjection = false;
     this._uniformBuffer = null;
     this._pipelineLayout = null;
-    this._customBaseTextureLayout = null;
+    this._customTextureBindGroupLayout = null;
     this._textureBindGroupLayout = null;
     this._uniformBindGroupLayout = null;
     this._shaderModule = null;
@@ -541,7 +550,6 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     this._maxNodeIndex = 0;
     this._currentBlendMode = null;
     this._currentMaterial = null;
-    this._currentBaseTexture = null;
     this._resetSlots();
     this._maxBatchTextures = fallbackSpriteBatchTextureSlots;
     this._activeTextures = new Array<Texture | RenderTexture | null>(fallbackSpriteBatchTextureSlots).fill(null);
@@ -629,7 +637,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     this._instanceCount++;
   }
 
-  /** Custom-material path: single base texture on group(1), instanced. */
+  /** Custom-material path: rotate the base texture through the material slot table on group(1), instanced. */
   private _renderCustom(sprite: Sprite, texture: Texture | RenderTexture, material: SpriteMaterial, backend: WebGpuBackend, nodeIndex: number): void {
     if (material.shader.wgsl === null) {
       throw new Error('SpriteMaterial shader has no `wgsl` source; cannot render through the WebGPU backend.');
@@ -640,21 +648,29 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     const blendMode = sprite.blendMode === BlendModes.Normal ? material.blendMode : sprite.blendMode;
     const blendModeChanged = this._currentBlendMode !== null && blendMode !== this._currentBlendMode;
     const materialChanged = this._currentMaterial !== null && material !== this._currentMaterial;
-    const textureChanged = this._currentBaseTexture !== null && texture !== this._currentBaseTexture;
+    const slotExhausted = !this._textureSlots.has(texture) && this._slotCount >= spriteMaterialTextureSlots;
     const modeSwitch = this._currentMaterial === null && this._instanceCount > 0;
 
-    if (blendModeChanged || materialChanged || textureChanged || modeSwitch) {
+    if (blendModeChanged || materialChanged || slotExhausted || modeSwitch) {
       this.flush();
     }
 
     this._currentBlendMode = blendMode;
     this._currentMaterial = material;
-    this._currentBaseTexture = texture;
     backend.setBlendMode(blendMode);
 
-    // textureSlot word is unused by custom fragments (base binds to group(1)).
+    // Resolve / assign texture slot, exactly as the default path does — the
+    // fragment dispatches over the slot via the prologue's sampleBase().
+    let slot = this._textureSlots.get(texture);
+
+    if (slot === undefined) {
+      slot = this._slotCount++;
+      this._textureSlots.set(texture, slot);
+      this._activeTextures[slot] = texture;
+    }
+
     this._ensureInstanceCapacity(this._instanceCount + 1);
-    this._packInstance(sprite, texture, 0, nodeIndex);
+    this._packInstance(sprite, texture, slot, nodeIndex);
     this._instanceCount++;
   }
 
@@ -842,7 +858,6 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     this._resetSlots();
     this._currentBlendMode = null;
     this._currentMaterial = null;
-    this._currentBaseTexture = null;
   }
 
   /**
@@ -886,14 +901,10 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
 
   /**
    * Whether any texture the pending batch binds would be re-uploaded or resized
-   * when synced (see {@link WebGpuBackend._textureUploadWouldMutate}). Checks the
-   * custom base texture on the custom path, else every active multi-texture slot.
+   * when synced (see {@link WebGpuBackend._textureUploadWouldMutate}). Both paths
+   * rotate their base textures through the slot table, so the check is the same.
    */
   private _batchWouldMutateTexture(backend: WebGpuBackend): boolean {
-    if (this._currentMaterial !== null) {
-      return this._currentBaseTexture !== null && backend._textureUploadWouldMutate(this._currentBaseTexture);
-    }
-
     for (let i = 0; i < this._slotCount; i++) {
       const texture = this._activeTextures[i];
 
@@ -1294,6 +1305,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     device: GPUDevice,
     backend: WebGpuBackend,
     textures: ReadonlyArray<Texture | RenderTexture | null | undefined>,
+    custom = false,
   ): GPUBindGroup {
     // Slots beyond the active count get the slot-0 texture as a filler so
     // the bind-group layout always sees N valid texture views and samplers.
@@ -1307,7 +1319,10 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     // Bindings are resolved BEFORE the cache lookup on purpose: resolving is
     // what syncs a dirty/mutated texture's content to the GPU, so it must run
     // every flush even when the bind group itself is served from cache.
-    const slotCapacity = this._maxBatchTextures;
+    //
+    // `custom` selects the custom-material slot table (fixed capacity, its own
+    // group(1) layout) instead of the device-tier default one.
+    const slotCapacity = custom ? spriteMaterialTextureSlots : this._maxBatchTextures;
     const fallbackTexture = textures[0] ?? Texture.empty;
     const fallbackBinding = backend.getTextureBinding(fallbackTexture);
     const resolvedTextures = new Array<Texture | RenderTexture>(slotCapacity);
@@ -1324,11 +1339,12 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     // when the full ordered texture set is identical; its bind group is reused
     // while every backend-resolved view is unchanged, and refreshed in place
     // when the backend recreated any slot's GPU texture (new view identity).
-    let entries = this._textureSetBindGroups.get(fallbackTexture);
+    const cache = custom ? this._customTextureSetBindGroups : this._textureSetBindGroups;
+    let entries = cache.get(fallbackTexture);
 
     if (entries === undefined) {
       entries = [];
-      this._textureSetBindGroups.set(fallbackTexture, entries);
+      cache.set(fallbackTexture, entries);
     }
 
     for (const entry of entries) {
@@ -1360,13 +1376,13 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       if (!bindingsMatch) {
         entry.views = resolvedBindings.map(binding => binding.view);
         entry.samplers = resolvedBindings.map(binding => binding.sampler);
-        entry.group = this._buildTextureBindGroup(device, resolvedBindings);
+        entry.group = this._buildTextureBindGroup(device, resolvedBindings, custom);
       }
 
       return entry.group;
     }
 
-    const group = this._buildTextureBindGroup(device, resolvedBindings);
+    const group = this._buildTextureBindGroup(device, resolvedBindings, custom);
 
     entries.push({
       textures: resolvedTextures,
@@ -1382,8 +1398,12 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     return group;
   }
 
-  private _buildTextureBindGroup(device: GPUDevice, resolvedBindings: ReadonlyArray<ReturnType<WebGpuBackend['getTextureBinding']>>): GPUBindGroup {
-    const slotCapacity = this._maxBatchTextures;
+  private _buildTextureBindGroup(
+    device: GPUDevice,
+    resolvedBindings: ReadonlyArray<ReturnType<WebGpuBackend['getTextureBinding']>>,
+    custom: boolean,
+  ): GPUBindGroup {
+    const slotCapacity = custom ? spriteMaterialTextureSlots : this._maxBatchTextures;
     const entries: GPUBindGroupEntry[] = [];
 
     // resolvedBindings always holds one fully-resolved binding per batch slot.
@@ -1402,8 +1422,8 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     }
 
     return device.createBindGroup({
-      label: 'sprite:texture-bind-group',
-      layout: this._textureBindGroupLayout!,
+      label: custom ? 'sprite:material-texture-bind-group' : 'sprite:texture-bind-group',
+      layout: (custom ? this._customTextureBindGroupLayout : this._textureBindGroupLayout)!,
       entries,
     });
   }
@@ -1506,8 +1526,6 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     instanceBuffer: GPUBuffer,
     instanceByteOffset: number,
   ): void {
-    const baseTexture = this._currentBaseTexture ?? Texture.empty;
-
     // Planned before the pass was settled; the write only happens when the
     // material's values actually changed since its last upload.
     applyUserUniformUpload(uniformUpload, resources, device);
@@ -1516,7 +1534,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
 
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, transformBindGroup);
-    pass.setBindGroup(1, this._getCustomBaseTextureBindGroup(resources, backend, baseTexture, device));
+    pass.setBindGroup(1, this._getOrCreateTextureBindGroup(device, backend, this._activeTextures, true));
     pass.setBindGroup(2, this._getUserBindGroup(material, resources, backend, device));
     pass.setVertexBuffer(0, instanceBuffer, instanceByteOffset);
     pass.setIndexBuffer(this._indexBuffer!, 'uint16');
@@ -1527,6 +1545,15 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     const existing = this._customMaterials.get(material);
 
     if (existing !== undefined) {
+      // The slot count is device-derived and fixed per connection (the cache is
+      // dropped on disconnect), so this can only ever hold — it guards against a
+      // future device-dependent slot count silently reusing a stale layout.
+      if (existing.textureSlots !== spriteMaterialTextureSlots) {
+        throw new Error(
+          `WebGpuSpriteRenderer: cached material resources were built for ${existing.textureSlots} base-texture slots, but the pipeline now needs ${spriteMaterialTextureSlots}.`,
+        );
+      }
+
       return existing;
     }
 
@@ -1536,16 +1563,16 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       throw new Error('SpriteMaterial shader has no `wgsl` source; cannot render through the WebGPU backend.');
     }
 
-    // The engine owns the vertex stage: prepend the canonical sprite vertex
-    // module (VertexInput/VertexOutput, group(0) projection + transform storage,
-    // group(1) base texture + sampler) to the material's fragment WGSL.
-    // Routed through the backend so WGSL compilation errors in user-supplied
-    // material shaders surface via backend.onRenderError.
-    const shaderModule = this.getBackend()._createShaderModule(`${spriteVertexWgsl}\n${wgsl}`, 'sprite:material-shader');
+    // The engine owns the vertex stage: prepend the canonical sprite material
+    // prologue (VertexInput/VertexOutput, group(0) projection + transform
+    // storage, the group(1) base-texture slot table and sampleBase) to the
+    // material's fragment WGSL. Routed through the backend so WGSL compilation
+    // errors in user-supplied material shaders surface via backend.onRenderError.
+    const shaderModule = this.getBackend()._createShaderModule(`${spriteMaterialPrologueWgsl}\n${wgsl}`, 'sprite:material-shader');
     const userLayout = this._buildUserBindGroupLayout(device, material);
     const pipelineLayout = device.createPipelineLayout({
       label: 'sprite:material-pipeline-layout',
-      bindGroupLayouts: [this._uniformBindGroupLayout!, this._customBaseTextureLayout!, userLayout],
+      bindGroupLayouts: [this._uniformBindGroupLayout!, this._customTextureBindGroupLayout!, userLayout],
     });
 
     const resources: CustomSpriteResources = {
@@ -1556,7 +1583,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       userUniformBuffer: null,
       userUniformBufferCapacity: 0,
       userUniform: createUserUniformState(),
-      baseTextureBindGroups: new WeakMap(),
+      textureSlots: spriteMaterialTextureSlots,
     };
 
     this._customMaterials.set(material, resources);
@@ -1633,36 +1660,6 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     return pipeline;
   }
 
-  private _getCustomBaseTextureBindGroup(
-    resources: CustomSpriteResources,
-    backend: WebGpuBackend,
-    texture: Texture | RenderTexture,
-    device: GPUDevice,
-  ): GPUBindGroup {
-    // Resolve the binding every call so a mutable base texture uploads its
-    // dirty region before sampling; reuse the cached group only while the
-    // underlying view is unchanged (the backend swaps it on texture resize).
-    const binding = backend.getTextureBinding(texture);
-    const existing = resources.baseTextureBindGroups.get(texture);
-
-    if (existing?.view === binding.view) {
-      return existing.group;
-    }
-
-    const group = device.createBindGroup({
-      label: 'sprite:material-base-texture-bind-group',
-      layout: this._customBaseTextureLayout!,
-      entries: [
-        { binding: 0, resource: binding.view },
-        { binding: 1, resource: binding.sampler },
-      ],
-    });
-
-    resources.baseTextureBindGroups.set(texture, { group, view: binding.view });
-
-    return group;
-  }
-
   private _buildUserBindGroupLayout(device: GPUDevice, material: SpriteMaterial): GPUBindGroupLayout {
     const entries: GPUBindGroupLayoutEntry[] = [];
 
@@ -1710,6 +1707,5 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     resources.userUniformBuffer = null;
     resources.userUniformBufferCapacity = 0;
     resetUserUniformState(resources.userUniform);
-    resources.baseTextureBindGroups = new WeakMap();
   }
 }

--- a/test/rendering/browser/webgl2-custom-sprite-material.test.ts
+++ b/test/rendering/browser/webgl2-custom-sprite-material.test.ts
@@ -5,7 +5,7 @@ import { ShaderSource } from '#rendering/material/ShaderSource';
 import { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import type { RenderNode } from '#rendering/RenderNode';
 import { Sprite } from '#rendering/sprite/Sprite';
-import { spriteVertexGlsl } from '#rendering/sprite/spriteMaterialSources';
+import { spriteMaterialTextureSlots, spriteVertexGlsl } from '#rendering/sprite/spriteMaterialSources';
 import { Texture } from '#rendering/texture/Texture';
 import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
 
@@ -85,26 +85,25 @@ const createSolidTexture = (r: number, g: number, b: number, a = 255, size = 16)
   return new Texture(source);
 };
 
-// Custom fragment: samples the per-batch base texture (u_texture, unit 0) and
-// modulates it by a user vec4 uniform.
+// Custom fragment: samples this instance's base texture through the engine's
+// spliced `sampleBase` helper and modulates it by a user vec4 uniform.
 const tintFragment = `#version 300 es
 precision mediump float;
 in vec2 v_texcoord;
 in vec4 v_color;
-uniform sampler2D u_texture;
 uniform vec4 u_userColor;
 out vec4 fragColor;
 void main() {
-  vec4 base = texture(u_texture, v_texcoord);
+  vec4 base = sampleBase(v_textureSlot, v_texcoord);
   fragColor = vec4(base.rgb * u_userColor.rgb, 1.0);
 }`;
 
-// Custom fragment: ignores the base texture and outputs a material texture
-// bound on unit 1 — proves material-texture binding is independent of the base.
+// Custom fragment: never calls sampleBase and outputs a material texture
+// instead — proves material-texture binding is independent of the base slot
+// table, and that a program with every slot sampler optimised out still links.
 const patternFragment = `#version 300 es
 precision mediump float;
 in vec2 v_texcoord;
-uniform sampler2D u_texture;
 uniform sampler2D u_pattern;
 out vec4 fragColor;
 void main() {
@@ -167,7 +166,7 @@ describe('custom SpriteMaterial WebGL2 browser', () => {
     }
   });
 
-  test('binds a material texture on unit 1 independent of the base texture', async () => {
+  test('binds a material texture independent of the base slot table', async () => {
     const backend = await createBackend();
     const base = createSolidTexture(255, 0, 0);
     const pattern = createSolidTexture(0, 255, 0);
@@ -219,22 +218,55 @@ describe('custom SpriteMaterial WebGL2 browser', () => {
     }
   });
 
-  test('a base-texture switch breaks the custom-material batch', async () => {
+  // Multi-texture batching gate for the custom path. Before base textures
+  // rotated through the material slot table this frame cost one draw per
+  // sprite; it must now collapse to the plateau of a single instanced draw.
+  test('four distinct base textures under one material collapse to a single draw', async () => {
     const backend = await createBackend();
-    const textureA = createSolidTexture(200, 0, 0);
-    const textureB = createSolidTexture(0, 0, 200);
+    const textures = [createSolidTexture(200, 0, 0), createSolidTexture(0, 200, 0), createSolidTexture(0, 0, 200), createSolidTexture(200, 200, 0)];
     const material = createTintMaterial([1, 1, 1, 1]);
     const root = new Container();
-    const spriteA = new Sprite(textureA);
-    const spriteB = new Sprite(textureB);
 
     try {
-      spriteA.material = material;
-      spriteB.material = material;
-      spriteA.setPosition(8, 16);
-      spriteB.setPosition(36, 16);
-      root.addChild(spriteA);
-      root.addChild(spriteB);
+      textures.forEach((texture, index) => {
+        const sprite = new Sprite(texture);
+
+        sprite.material = material;
+        sprite.setPosition(4 + index * 14, 16);
+        root.addChild(sprite);
+      });
+
+      render(backend, root);
+
+      expect(backend.stats.drawCalls).toBe(1);
+      // Each sprite still samples ITS OWN texture, not slot 0's.
+      expectPixelNear(readWebGl2Pixel(backend, 8, 20), [200, 0, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 22, 20), [0, 200, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 36, 20), [0, 0, 200, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 50, 20), [200, 200, 0, 255]);
+    } finally {
+      root.destroy();
+      material.destroy();
+      textures.forEach(texture => texture.destroy());
+      backend.destroy();
+    }
+  });
+
+  test('base-slot exhaustion breaks the custom-material batch', async () => {
+    // One more distinct base texture than the custom path's slot table holds.
+    const backend = await createBackend();
+    const textures = Array.from({ length: spriteMaterialTextureSlots + 1 }, (_, index) => createSolidTexture(16 * (index + 1), 0, 0));
+    const material = createTintMaterial([1, 1, 1, 1]);
+    const root = new Container();
+
+    try {
+      textures.forEach((texture, index) => {
+        const sprite = new Sprite(texture);
+
+        sprite.material = material;
+        sprite.setPosition(2 + index * 6, 16);
+        root.addChild(sprite);
+      });
 
       render(backend, root);
 
@@ -242,8 +274,7 @@ describe('custom SpriteMaterial WebGL2 browser', () => {
     } finally {
       root.destroy();
       material.destroy();
-      textureA.destroy();
-      textureB.destroy();
+      textures.forEach(texture => texture.destroy());
       backend.destroy();
     }
   });

--- a/test/rendering/browser/webgl2-pixel-snap-gpu.test.ts
+++ b/test/rendering/browser/webgl2-pixel-snap-gpu.test.ts
@@ -192,9 +192,8 @@ describe('WebGL2 GPU pixel snapping — Sprite position mode', () => {
           fragment: `#version 300 es
 precision mediump float;
 in vec2 v_texcoord;
-uniform sampler2D u_texture;
 out vec4 fragColor;
-void main() { fragColor = texture(u_texture, v_texcoord); }`,
+void main() { fragColor = sampleBase(v_textureSlot, v_texcoord); }`,
         },
       }),
     });

--- a/test/rendering/browser/webgpu-custom-sprite-material.test.ts
+++ b/test/rendering/browser/webgpu-custom-sprite-material.test.ts
@@ -5,7 +5,7 @@
  * against Mesa lavapipe), so this test drives a
  * custom {@link SpriteMaterial} (user uniform) through the real
  * {@link WebGpuSpriteRenderer} and asserts the custom path (group 0 projection +
- * shared transform storage, group 1 base texture, group 2 user UBO) issues an
+ * shared transform storage, group 1 base-texture slot table, group 2 user UBO) issues an
  * instanced draw without raising a GPU validation error, while keeping the
  * 32-byte instance buffer (transform and tint fetched from storage by nodeIndex).
  *
@@ -18,23 +18,25 @@ import { Container } from '#rendering/Container';
 import { ShaderSource } from '#rendering/material/ShaderSource';
 import { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import { Sprite } from '#rendering/sprite/Sprite';
+import { spriteMaterialTextureSlots } from '#rendering/sprite/spriteMaterialSources';
 import { Texture } from '#rendering/texture/Texture';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
 import { getBackendDevice } from './webgpu-test-helpers';
 
-// Fragment-only WGSL: the engine prepends the canonical sprite vertex module
-// (spriteVertexWgsl), which declares VertexOutput, the group(0) projection, and
-// the group(1) base texture (`u_texture`/`u_sampler`). The author adds the
-// group(2) user UBO and the fragment entry point.
+// Fragment-only WGSL: the engine prepends the canonical sprite material
+// prologue (spriteMaterialPrologueWgsl), which declares VertexOutput, the
+// group(0) projection, the group(1) base-texture slot table and the
+// `sampleBase(slot, uv)` helper. The author adds the group(2) user UBO and the
+// fragment entry point.
 const customFragmentWgsl = `
 struct UserUniforms { color: vec4<f32> };
 @group(2) @binding(0) var<uniform> u_user: UserUniforms;
 
 @fragment
 fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
-  let base = textureSample(u_texture, u_sampler, input.texcoord);
+  let base = sampleBase(input.textureSlot, input.texcoord);
   return vec4<f32>(base.rgb * u_user.color.rgb, 1.0);
 }
 `.trim();
@@ -133,6 +135,132 @@ describe('custom SpriteMaterial WebGPU browser', () => {
       material.destroy();
       texture.destroy();
       backend.destroy();
+    }
+  });
+
+  // Multi-texture batching gate for the custom path. Before base textures
+  // rotated through the material slot table this frame cost one draw per
+  // sprite; it must now collapse to the plateau of a single instanced draw.
+  test('four distinct base textures under one material collapse to a single draw', async ctx => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+
+    const backend = new WebGpuBackend(makeApp(canvas));
+
+    await backend.initialize();
+    wireCoreRenderers(backend);
+
+    const device = getBackendDevice(backend);
+
+    const textures = [createSolidTexture(200, 0, 0), createSolidTexture(0, 200, 0), createSolidTexture(0, 0, 200), createSolidTexture(200, 200, 0)];
+    const material = createMaterial();
+    const root = new Container();
+
+    textures.forEach((texture, index) => {
+      const sprite = new Sprite(texture);
+
+      sprite.material = material;
+      sprite.setPosition(4 + index * 14, 16);
+      root.addChild(sprite);
+    });
+
+    const cleanup = (): void => {
+      root.destroy();
+      material.destroy();
+      textures.forEach(texture => texture.destroy());
+      backend.destroy();
+    };
+
+    device.pushErrorScope('validation');
+
+    let validationError: GPUError | null;
+
+    try {
+      backend.resetStats();
+      backend.clear(Color.black);
+      root.render(backend);
+      backend.flush();
+      validationError = await device.popErrorScope();
+    } catch (error) {
+      if (error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError')) {
+        cleanup();
+        // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
+        ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+        return;
+      }
+
+      throw error;
+    }
+
+    try {
+      expect(validationError).toBeNull();
+      expect(backend.stats.drawCalls).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test('base-slot exhaustion breaks the custom-material batch', async ctx => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+
+    const backend = new WebGpuBackend(makeApp(canvas));
+
+    await backend.initialize();
+    wireCoreRenderers(backend);
+
+    const device = getBackendDevice(backend);
+
+    // One more distinct base texture than the custom path's slot table holds.
+    const textures = Array.from({ length: spriteMaterialTextureSlots + 1 }, (_, index) => createSolidTexture(16 * (index + 1), 0, 0));
+    const material = createMaterial();
+    const root = new Container();
+
+    textures.forEach((texture, index) => {
+      const sprite = new Sprite(texture);
+
+      sprite.material = material;
+      sprite.setPosition(2 + index * 6, 16);
+      root.addChild(sprite);
+    });
+
+    const cleanup = (): void => {
+      root.destroy();
+      material.destroy();
+      textures.forEach(texture => texture.destroy());
+      backend.destroy();
+    };
+
+    device.pushErrorScope('validation');
+
+    let validationError: GPUError | null;
+
+    try {
+      backend.resetStats();
+      backend.clear(Color.black);
+      root.render(backend);
+      backend.flush();
+      validationError = await device.popErrorScope();
+    } catch (error) {
+      if (error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError')) {
+        cleanup();
+        // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
+        ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+        return;
+      }
+
+      throw error;
+    }
+
+    try {
+      expect(validationError).toBeNull();
+      expect(backend.stats.drawCalls).toBe(2);
+    } finally {
+      cleanup();
     }
   });
 });

--- a/test/rendering/browser/webgpu-pixel-snap-gpu.test.ts
+++ b/test/rendering/browser/webgpu-pixel-snap-gpu.test.ts
@@ -213,7 +213,7 @@ describe('WebGPU GPU pixel snapping — Sprite position mode', () => {
 
   // -------------------------------------------------------------------------
   // Case 1b: a CUSTOM SpriteMaterial snaps identically. A custom material owns
-  // only the fragment stage; the engine prepends `spriteVertexWgsl`, which runs
+  // only the fragment stage; the engine prepends `spriteMaterialPrologueWgsl`, which runs
   // the same origin snap. Before that snap block was ported into the custom
   // vertex module (and `viewport` added to its ProjectionUniforms), custom-
   // material sprites silently lost position snapping once the CPU seam was
@@ -230,7 +230,7 @@ describe('WebGPU GPU pixel snapping — Sprite position mode', () => {
         wgsl: `
 @fragment
 fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
-  return textureSample(u_texture, u_sampler, input.texcoord);
+  return sampleBase(input.textureSlot, input.texcoord);
 }
 `.trim(),
       }),

--- a/test/rendering/browser/webgpu-shader-compile.test.ts
+++ b/test/rendering/browser/webgpu-shader-compile.test.ts
@@ -26,8 +26,8 @@
  *  - `WebGpuSpriteRenderer`'s custom-material path and
  *    `WebGpuMeshRenderer._getOrCreateCustomShaderResources` compile
  *    user-authored `material.shader.wgsl` at runtime — there is no
- *    engine-owned fixed string to assert against. `spriteVertexWgsl`, the
- *    fixed prelude those custom-material shaders are prepended with, IS
+ *    engine-owned fixed string to assert against. `spriteMaterialPrologueWgsl`,
+ *    the fixed prelude those custom-material shaders are prepended with, IS
  *    covered below.
  *
  * CI guarantees a real WebGPU adapter (the required Chromium-WebGPU lane runs
@@ -35,7 +35,7 @@
  * device mid-test. Run via: pnpm test:browser:webgpu
  */
 
-import { spriteVertexWgsl } from '#rendering/sprite/spriteMaterialSources';
+import { spriteMaterialPrologueWgsl } from '#rendering/sprite/spriteMaterialSources';
 import { compositorShaderSource as backdropBlendCompositorWgsl } from '#rendering/webgpu/WebGpuBackdropBlendCompositor';
 import { mipmapWgsl } from '#rendering/webgpu/WebGpuBackend';
 import { compositorShaderSource as maskCompositorWgsl } from '#rendering/webgpu/WebGpuMaskCompositor';
@@ -66,7 +66,7 @@ const shaders: readonly ShaderEntry[] = [
   ...spriteBatchTextureSlotTiers.map(tier => ({ name: `WebGpuSpriteRenderer (${tier} texture slots)`, source: buildSpriteShaderSource(tier) })),
   { name: 'WebGpuStencilClipper', source: stencilWriteShaderSource },
   { name: 'WebGpuTextRenderer', source: textShaderSource },
-  { name: 'spriteMaterialSources spriteVertexWgsl (custom-material vertex prelude)', source: spriteVertexWgsl },
+  { name: 'spriteMaterialSources spriteMaterialPrologueWgsl (custom-material prelude)', source: spriteMaterialPrologueWgsl },
 ];
 
 // On the software (swiftshader / lavapipe) adapter the WebGPU device can drop

--- a/test/rendering/browser/webgpu-stencil-clip.test.ts
+++ b/test/rendering/browser/webgpu-stencil-clip.test.ts
@@ -159,8 +159,8 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
 `;
 
 // Custom SpriteMaterial fragment WGSL (the engine prepends the canonical sprite
-// vertex module exposing VertexOutput, the group(1) base texture `u_texture` /
-// `u_sampler`). Compiled for real now that a custom-material Sprite is supported
+// material prologue exposing VertexOutput, the group(1) base-texture slot table
+// and `sampleBase`). Compiled for real now that a custom-material Sprite is supported
 // under a Geometry stencil clip — it tints the white base texture by the user
 // `color` uniform so the clipped/visible pixels are checkable.
 const customSpriteWgsl = `
@@ -169,7 +169,7 @@ struct UserUniforms { color: vec4<f32> };
 
 @fragment
 fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
-  let base = textureSample(u_texture, u_sampler, input.texcoord);
+  let base = sampleBase(input.textureSlot, input.texcoord);
   return vec4<f32>(base.rgb * u_user.color.rgb, 1.0);
 }
 `.trim();

--- a/test/rendering/render-plan-grouping-key-audit.test.ts
+++ b/test/rendering/render-plan-grouping-key-audit.test.ts
@@ -28,7 +28,9 @@
  *    bindKey encodes the material's own extra textures (material.textures /
  *    texture-valued uniforms), NOT the sprite's base texture (sprite.texture).
  *    Two custom-material sprites sharing a material instance get the same
- *    groupIndex regardless of their base texture.
+ *    groupIndex regardless of their base texture — and the custom path now
+ *    rotates base textures through its own slot table, so that also costs no
+ *    flush until the table is exhausted.
  *
  * 5. The z-split in _assignGroupIndices serves mesh static-batch draw order:
  *    meshes at different z must not coalesce. For sprite renderers the split
@@ -461,9 +463,9 @@ describe('render plan grouping key audit', () => {
       // bindKey regardless of their base texture, so the optimizer gives them
       // the same groupIndex.
       //
-      // The sprite renderer flushes on base-texture change via its own state
-      // machine (_currentBaseTexture tracking) — this boundary is
-      // renderer-owned, not optimizer-owned.
+      // The sprite renderer absorbs a base-texture change into one of its
+      // custom-path slots and only flushes on slot exhaustion — that boundary
+      // is renderer-owned, not optimizer-owned.
       const { backend, destroy } = createBuildBackend();
 
       try {

--- a/test/rendering/webgpu-custom-material-render-passes.test.ts
+++ b/test/rendering/webgpu-custom-material-render-passes.test.ts
@@ -23,6 +23,7 @@ import { ShaderSource } from '#rendering/material/ShaderSource';
 import { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import type { RenderNode } from '#rendering/RenderNode';
 import { Sprite } from '#rendering/sprite/Sprite';
+import { BlendModes } from '#rendering/types';
 import type { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { createCanvasTexture, createMockBackend, createMockWebGpuEnvironment } from './webgpuMockEnvironment';
@@ -45,7 +46,7 @@ struct UserUniforms { color: vec4<f32> };
 
 @fragment
 fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
-  let base = textureSample(u_texture, u_sampler, input.texcoord);
+  let base = sampleBase(input.textureSlot, input.texcoord);
   return vec4<f32>(base.rgb * u_user.color.rgb, 1.0);
 }
 `.trim();
@@ -57,7 +58,7 @@ const createMaterial = (color: Float32Array): SpriteMaterial =>
   });
 
 describe('WebGPU custom-material batches and render passes', () => {
-  test('sprites on distinct base textures flush separately but stay in one render pass', async () => {
+  test('sprites on distinct base textures merge into one draw in one render pass', async () => {
     const environment = createMockWebGpuEnvironment();
 
     try {
@@ -76,11 +77,10 @@ describe('WebGPU custom-material batches and render passes', () => {
 
       renderFrame(backend, nodes);
 
-      // The custom path binds one base texture, so three textures are still
-      // three batches — that part is the separate multi-texture question.
-      expect(environment.drawIndexedCount()).toBe(drawMark + 3);
-      // But nothing wrote a buffer an earlier draw reads, so one pass carries
-      // all three.
+      // The custom path rotates base textures through its slot table, so three
+      // distinct textures collapse into a single instanced draw.
+      expect(environment.drawIndexedCount()).toBe(drawMark + 1);
+      // And nothing wrote a buffer an earlier draw reads, so one pass carries it.
       expect(backend.stats.renderPasses).toBe(1);
 
       backend.destroy();
@@ -147,19 +147,27 @@ describe('WebGPU custom-material batches and render passes', () => {
     try {
       const backend = await createMockBackend(environment);
       const material = createMaterial(new Float32Array([1, 0, 0, 1]));
-      const nodes = [new Sprite(createCanvasTexture()), new Sprite(createCanvasTexture()), new Sprite(createCanvasTexture())];
+      const texture = createCanvasTexture();
+      const nodes = [new Sprite(texture), new Sprite(texture), new Sprite(texture)];
+
+      // Distinct blend modes, so each sprite starts a new batch of the SAME
+      // material — a base-texture change no longer does that now that the
+      // custom path rotates base textures through its slot table.
+      nodes[0]!.blendMode = BlendModes.Normal;
+      nodes[1]!.blendMode = BlendModes.Additive;
+      nodes[2]!.blendMode = BlendModes.Multiply;
 
       for (const sprite of nodes) {
         sprite.material = material;
       }
 
-      // Warmup, so the lazy texture uploads are not what splits the pass below.
+      // Warmup, so the lazy texture upload is not what splits the pass below.
       renderFrame(backend, nodes);
 
-      // Each sprite has its own base texture, so rendering the next one flushes
-      // the previous batch. Mutating the uniforms between the second and third
-      // render means the flush of the SECOND batch rewrites the very buffer the
-      // FIRST batch's draw — already recorded into the open pass — reads.
+      // Rendering the next sprite flushes the previous batch. Mutating the
+      // uniforms between the second and third render means the flush of the
+      // SECOND batch rewrites the very buffer the FIRST batch's draw — already
+      // recorded into the open pass — reads.
       backend.resetStats();
       backend.clear(Color.black);
       nodes[0]!.render(backend);

--- a/test/rendering/webgpu-custom-material-uniform-caching.test.ts
+++ b/test/rendering/webgpu-custom-material-uniform-caching.test.ts
@@ -38,14 +38,14 @@ const renderFrame = (backend: WebGpuBackend, nodes: readonly RenderNode[]): void
   backend.flush();
 };
 
-// Fragment-only WGSL: the engine prepends the canonical sprite vertex module.
+// Fragment-only WGSL: the engine prepends the canonical sprite material prologue.
 const spriteFragmentWgsl = `
 struct UserUniforms { color: vec4<f32> };
 @group(2) @binding(0) var<uniform> u_user: UserUniforms;
 
 @fragment
 fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
-  let base = textureSample(u_texture, u_sampler, input.texcoord);
+  let base = sampleBase(input.textureSlot, input.texcoord);
   return vec4<f32>(base.rgb * u_user.color.rgb, 1.0);
 }
 `.trim();


### PR DESCRIPTION
Review point NEU-O10, which is also cause (a) of NEU-O33.

## Problem

The custom-material path bound exactly one base texture per batch and flushed whenever the texture changed — `WebGpuSpriteRenderer._renderCustom` (one view on `group(1) @binding(0)`) and `WebGl2SpriteRenderer._renderCustom` (one texture on unit 0). The default path meanwhile rotates N slots and dispatches in-shader over a per-instance slot word. So any scene whose custom materials span more than one base texture paid one draw call per sprite.

Measured in `@codexo/exojs-bench` (25k nodes, WebGPU, `retained`), which isolates it cleanly because the three cells differ in exactly one dimension each:

| Cell | CPU | Draws |
|---|---|---|
| `mixed-blend` (no materials) | 1.285 ms | 782 |
| `mixed-material-atlased` (materials, 1 texture) | 15.873 ms | 782 |
| `mixed-material` (materials, 4 textures) | 92.443 ms | 25000 |

This change is the 15.9 -> 92.4 ms step. (The 1.3 -> 15.9 ms step is a separate cause — custom-material batches poison the retained capture — and is tracked on its own.)

## BREAKING: custom fragments no longer sample the base texture directly

`u_texture` / `u_sampler` leave the author-visible surface on both backends. The engine-owned prologue now provides a helper:

```glsl
// before
fragColor = texture(u_texture, v_texcoord) * v_color * u_userColor;
// after
fragColor = sampleBase(v_textureSlot, v_texcoord) * v_color * u_userColor;
```
```wgsl
// before
let base = textureSample(u_texture, u_sampler, input.texcoord);
// after
let base = sampleBase(input.textureSlot, input.texcoord);
```

Author uniforms and author-supplied textures are unaffected; they keep their reserved space (WGSL `group(2)`, WebGL2 units 8..14 — moved up from 1..7 to make room for the base slots).

The helper takes the slot explicitly rather than reading it implicitly. WGSL cannot expose an entry-point interpolant to a module-scope function, so a one-argument form would require the engine to own `@fragment fn fragmentMain` and rename the author's function — or to diverge from the GLSL signature. Passing the slot keeps one shape on both backends.

Pre-1.0 policy is clean breaks without shims: a permanent opt-in flag would keep the single-bind pipeline alive forever.

## Implementation

The WGSL slot-table generator is now shared between the default pipeline and the material prologue (`buildSpriteTextureSlotWgsl`) so the two cannot drift. `spriteVertexWgsl` gained the `textureSlot` interpolant on `VertexOutput` — the vertex *input* already carried it, the output did not. `_renderCustom` on both backends now acquires slots exactly like `_renderDefault` and flushes on slot exhaustion instead of on texture change.

Also corrected: `WebGl2SpriteRenderer.maxCustomTextureSlots` was `8` but used as an exclusive bound over slots starting at 1, so it meant 7 — and its error messages printed `maxCustomTextureSlots - 1`. WebGPU's identically named constant meant 7 literally. Both are 7 now.

## Draw counts

| Frame | before | after |
|---|---|---|
| 4 distinct base textures, 1 material | 4 | **1** |
| 9 distinct base textures (slot table + 1) | 9 | **2** |

Both numbers on both backends. Node-lane mock device: 3 textures, 3 `drawIndexed` calls, now 1.

Gates proven to have teeth by capping the custom slot table at 1, which reproduced exactly the pre-change numbers on both lanes (`expected 4 to be 1`, `expected 9 to be 2`) before being restored.

Single-texture pixel identity is held by the pre-existing probes, unchanged: the `webgl2-custom-sprite-material` base-texture-times-uniform case and Case 1b of both `*-pixel-snap-gpu` specs, which compare the custom path pixel-for-pixel against the default path. The new 4-texture gate additionally probes each sprite's own colour, so a batch that collapsed onto slot 0 would fail.

## Verification

- `pnpm verify:quick` — all 11 gates
- Node lanes — 388 files, 6661 tests
- `browser-webgpu` 330/330, `browser-webgl` 283/283