### PR TITLE
fix(rendering): cache equivalent group transforms

### DIFF
--- a/packages/exojs-tilemap/src/webgl2/WebGl2TileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgl2/WebGl2TileChunkRenderer.ts
@@ -15,6 +15,7 @@ import {
   BufferTypes,
   BufferUsage,
   createWebGl2ShaderProgram,
+  packedGroupChanged,
   RenderingPrimitives,
   Shader,
   WebGl2RenderBuffer,
@@ -166,7 +167,8 @@ export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNod
   private _currentTexture: Texture | null = null;
   private _currentView: View | null = null;
   private _currentViewId = -1;
-  private _currentGroupTransformId = -1;
+  private _hasWrittenGroup = false;
+  private readonly _writtenGroupData = new Float32Array(9);
 
   private _instanceBuffer: WebGl2RenderBuffer | null = null;
   private _vao: WebGl2VertexArrayObject | null = null;
@@ -375,12 +377,13 @@ export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNod
       this._shader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
     }
 
-    if (this._currentGroupTransformId !== backend.renderGroupTransformId) {
-      this._currentGroupTransformId = backend.renderGroupTransformId;
+    const groupTransform = backend.renderGroupTransform;
+    const groupData = groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3;
 
-      const groupTransform = backend.renderGroupTransform;
-
-      this._shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
+    if (!this._hasWrittenGroup || packedGroupChanged(groupData, this._writtenGroupData, 0)) {
+      this._shader.getUniform('u_group').setValue(groupData);
+      this._writtenGroupData.set(groupData);
+      this._hasWrittenGroup = true;
     }
 
     backend._stageViewportUniform(this._shader);
@@ -545,7 +548,7 @@ export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNod
     this._currentTexture = null;
     this._currentView = null;
     this._currentViewId = -1;
-    this._currentGroupTransformId = -1;
+    this._hasWrittenGroup = false;
     this._quadIndex = 0;
     this._maxNodeIndex = 0;
   }

--- a/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
@@ -1,3 +1,4 @@
+import { packedGroupChanged } from '#rendering/affinePacking';
 import { Shader } from '#rendering/shader/Shader';
 import type { NineSliceQuad } from '#rendering/sprite/nineSlice';
 import type { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
@@ -168,7 +169,8 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
   private _currentTexture: Texture | RenderTexture | null = null;
   private _currentView: View | null = null;
   private _currentViewId = -1;
-  private _currentGroupTransformId = -1;
+  private _hasWrittenGroup = false;
+  private readonly _writtenGroupData = new Float32Array(9);
 
   private _instanceBuffer: WebGl2RenderBuffer | null = null;
   private _vao: WebGl2VertexArrayObject | null = null;
@@ -354,12 +356,15 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
       this._shader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
     }
 
-    if (this._shader.uniforms.has('u_group') && this._currentGroupTransformId !== backend.renderGroupTransformId) {
-      this._currentGroupTransformId = backend.renderGroupTransformId;
-
+    if (this._shader.uniforms.has('u_group')) {
       const groupTransform = backend.renderGroupTransform;
+      const groupData = groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3;
 
-      this._shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
+      if (!this._hasWrittenGroup || packedGroupChanged(groupData, this._writtenGroupData, 0)) {
+        this._shader.getUniform('u_group').setValue(groupData);
+        this._writtenGroupData.set(groupData);
+        this._hasWrittenGroup = true;
+      }
     }
 
     backend._stageViewportUniform(this._shader);
@@ -511,7 +516,7 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
     this._currentTexture = null;
     this._currentView = null;
     this._currentViewId = -1;
-    this._currentGroupTransformId = -1;
+    this._hasWrittenGroup = false;
     this._quadIndex = 0;
     this._maxNodeIndex = 0;
   }

--- a/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
@@ -1,3 +1,4 @@
+import { packedGroupChanged } from '#rendering/affinePacking';
 import { Shader } from '#rendering/shader/Shader';
 import type { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
 import { computeShaderTiling, type RepeatingSpriteQuad } from '#rendering/sprite/repeatingSpritePlan';
@@ -318,18 +319,19 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
 
   private readonly _transformUnitScratch = new Int32Array([transformTextureUnit]);
   private readonly _textureUnitScratch = new Int32Array([0]);
-  private _currentView: unknown = null;
-  private _currentViewId = -1;
-  private _currentGroupTransformId = -1;
+  private _shaderView: unknown = null;
+  private _shaderViewId = -1;
+  private _geoView: unknown = null;
+  private _geoViewId = -1;
+  private _hasWrittenShaderGroup = false;
+  private readonly _writtenShaderGroupData = new Float32Array(9);
+  private _hasWrittenGeoGroup = false;
+  private readonly _writtenGeoGroupData = new Float32Array(9);
 
-  // Retained-replay reusable scratch + dedicated view/group uniform tracking
-  // for the geo shader — kept SEPARATE from the live-flush state above so a
-  // replay never marks the live projection "already staged" and leaves the
-  // shader-path program holding a stale projection.
+  // Retained-replay reusable scratch. Uniform tracking follows the physical
+  // shader programs above: replay and live geometry draws share the geo state,
+  // while the shader path has its own state.
   private readonly _recordTextureScratch: Array<Texture | RenderTexture | null> = [null];
-  private _replayView: unknown = null;
-  private _replayViewId = -1;
-  private _replayGroupTransformId = -1;
 
   public constructor(batchSize: number) {
     super();
@@ -520,27 +522,31 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
 
     const view = backend.view;
 
-    if (this._currentView !== view || this._currentViewId !== view.updateId) {
-      this._currentView = view;
-      this._currentViewId = view.updateId;
-      const proj = view.getTransform().toArray(false);
-      this._shaderPathShader.getUniform('u_projection').setValue(proj);
-      this._geoPathShader.getUniform('u_projection').setValue(proj);
+    if (this._shaderView !== view || this._shaderViewId !== view.updateId) {
+      this._shaderView = view;
+      this._shaderViewId = view.updateId;
+      this._shaderPathShader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
     }
 
-    if (this._currentGroupTransformId !== backend.renderGroupTransformId) {
-      this._currentGroupTransformId = backend.renderGroupTransformId;
+    if (this._geoView !== view || this._geoViewId !== view.updateId) {
+      this._geoView = view;
+      this._geoViewId = view.updateId;
+      this._geoPathShader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
+    }
 
-      const groupTransform = backend.renderGroupTransform;
-      const groupArray = groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3;
+    const groupTransform = backend.renderGroupTransform;
+    const groupData = groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3;
 
-      if (this._shaderPathShader.uniforms.has('u_group')) {
-        this._shaderPathShader.getUniform('u_group').setValue(groupArray);
-      }
+    if (this._shaderPathShader.uniforms.has('u_group') && (!this._hasWrittenShaderGroup || packedGroupChanged(groupData, this._writtenShaderGroupData, 0))) {
+      this._shaderPathShader.getUniform('u_group').setValue(groupData);
+      this._writtenShaderGroupData.set(groupData);
+      this._hasWrittenShaderGroup = true;
+    }
 
-      if (this._geoPathShader.uniforms.has('u_group')) {
-        this._geoPathShader.getUniform('u_group').setValue(groupArray);
-      }
+    if (this._geoPathShader.uniforms.has('u_group') && (!this._hasWrittenGeoGroup || packedGroupChanged(groupData, this._writtenGeoGroupData, 0))) {
+      this._geoPathShader.getUniform('u_group').setValue(groupData);
+      this._writtenGeoGroupData.set(groupData);
+      this._hasWrittenGeoGroup = true;
     }
 
     // Staged unconditionally per flush (cheap vec4) so a viewport change without
@@ -738,25 +744,28 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
 
   /**
    * Stage `u_projection` (live view) and `u_group` (live composed group matrix)
-   * on the geometry-path shader for a retained replay. Dedicated view/group
-   * tracking (not the live-flush stamps) so a replay never suppresses the live
-   * flush's own projection write to the shader-path program.
+   * on the geometry-path shader for a retained replay. Tracking is shared with
+   * live geometry draws because both write the same physical program; the
+   * shader-path program keeps independent state.
    */
   private _stageGeoReplayUniforms(backend: WebGl2Backend): void {
     const view = backend.view;
 
-    if (this._replayView !== view || this._replayViewId !== view.updateId) {
-      this._replayView = view;
-      this._replayViewId = view.updateId;
+    if (this._geoView !== view || this._geoViewId !== view.updateId) {
+      this._geoView = view;
+      this._geoViewId = view.updateId;
       this._geoPathShader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
     }
 
-    if (this._geoPathShader.uniforms.has('u_group') && this._replayGroupTransformId !== backend.renderGroupTransformId) {
-      this._replayGroupTransformId = backend.renderGroupTransformId;
-
+    if (this._geoPathShader.uniforms.has('u_group')) {
       const groupTransform = backend.renderGroupTransform;
+      const groupData = groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3;
 
-      this._geoPathShader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
+      if (!this._hasWrittenGeoGroup || packedGroupChanged(groupData, this._writtenGeoGroupData, 0)) {
+        this._geoPathShader.getUniform('u_group').setValue(groupData);
+        this._writtenGeoGroupData.set(groupData);
+        this._hasWrittenGeoGroup = true;
+      }
     }
 
     backend._stageViewportUniform(this._geoPathShader);
@@ -852,12 +861,12 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     this._geoVao?.destroy();
     this._geoVao = null;
     this._connection = null;
-    this._currentView = null;
-    this._currentViewId = -1;
-    this._currentGroupTransformId = -1;
-    this._replayView = null;
-    this._replayViewId = -1;
-    this._replayGroupTransformId = -1;
+    this._shaderView = null;
+    this._shaderViewId = -1;
+    this._geoView = null;
+    this._geoViewId = -1;
+    this._hasWrittenShaderGroup = false;
+    this._hasWrittenGeoGroup = false;
     this._recordTextureScratch[0] = null;
     this._resetBatchState();
   }

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -1,4 +1,5 @@
 import type { ReadonlyRectangle } from '#math/Rectangle';
+import { packedGroupChanged } from '#rendering/affinePacking';
 import type { UniformValue } from '#rendering/material/Material';
 import type { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import { Shader } from '#rendering/shader/Shader';
@@ -142,7 +143,8 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
   private _currentBlendMode: BlendModes | null = null;
   private _currentView: View | null = null;
   private _currentViewId = -1;
-  private _currentGroupTransformId = -1;
+  private _hasWrittenGroup = false;
+  private readonly _writtenGroupData = new Float32Array(9);
 
   private _instanceBuffer: WebGl2RenderBuffer | null = null;
   private _vao: WebGl2VertexArrayObject | null = null;
@@ -304,12 +306,15 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
       this._shader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
     }
 
-    if (this._shader.uniforms.has('u_group') && this._currentGroupTransformId !== backend.renderGroupTransformId) {
-      this._currentGroupTransformId = backend.renderGroupTransformId;
-
+    if (this._shader.uniforms.has('u_group')) {
       const groupTransform = backend.renderGroupTransform;
+      const groupData = groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3;
 
-      this._shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
+      if (!this._hasWrittenGroup || packedGroupChanged(groupData, this._writtenGroupData, 0)) {
+        this._shader.getUniform('u_group').setValue(groupData);
+        this._writtenGroupData.set(groupData);
+        this._hasWrittenGroup = true;
+      }
     }
 
     backend._stageViewportUniform(this._shader);
@@ -494,7 +499,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     this._currentBlendMode = null;
     this._currentView = null;
     this._currentViewId = -1;
-    this._currentGroupTransformId = -1;
+    this._hasWrittenGroup = false;
     this._instanceCount = 0;
     this._maxNodeIndex = 0;
   }

--- a/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
@@ -1,7 +1,7 @@
 /// <reference types="@webgpu/types" />
 
 import { Matrix } from '#math/Matrix';
-import { packAffineMat4 } from '#rendering/affinePacking';
+import { affineMat4FloatCount, packAffineMat4, packedGroupChanged } from '#rendering/affinePacking';
 import type { NineSliceQuad } from '#rendering/sprite/nineSlice';
 import type { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
 import { DataTexture } from '#rendering/texture/DataTexture';
@@ -163,13 +163,13 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
 
   private readonly _projectionData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
   // Projection-uniform skip state: a matching (view identity, view.updateId,
-  // group-transform id) triple means the shared UBO already holds this flush's
-  // projection, so the 128-byte write is skipped — static frames issue zero
-  // projection uploads. Mirrors the sprite renderer's redundant-write skip.
+  // group-matrix content) triple means the shared UBO already holds this
+  // flush's projection, so the 128-byte write is skipped — static frames issue
+  // zero projection uploads. Mirrors the sprite renderer's redundant-write skip.
   private _writtenView: View | null = null;
   private _writtenViewUpdateId = -1;
-  private _writtenGroupTransformId = -1;
   private _hasWrittenProjection = false;
+  private readonly _stagedGroupData = new Float32Array(affineMat4FloatCount);
 
   private _device: GPUDevice | null = null;
   private _shaderModule: GPUShaderModule | null = null;
@@ -265,7 +265,6 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     this._textureBindGroups = new WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView; sampler: GPUSampler }>();
     this._writtenView = null;
     this._writtenViewUpdateId = -1;
-    this._writtenGroupTransformId = -1;
     this._hasWrittenProjection = false;
     this._uniformBuffer = null;
     this._pipelineLayout = null;
@@ -381,12 +380,13 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     // between merged flushes) would retroactively re-project them; end that pass
     // first. Guarded on the arena tracking the current active pass.
     const activePass = backend._passCoordinator.activePass;
+    const groupChanged = this._groupContentChanged(backend);
 
     if (
       activePass !== null &&
       this._instanceArena.cursor > 0 &&
       this._instanceArena.tracksPass(activePass) &&
-      (activePass.viewUpdateId !== backend.view.updateId || this._writtenGroupTransformId !== backend.renderGroupTransformId)
+      (activePass.viewUpdateId !== backend.view.updateId || groupChanged)
     ) {
       backend._passCoordinator.endPass();
       this._instanceArena.resetPass();
@@ -395,24 +395,17 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     // ProjectionUniforms layout: mat4x4 projection + mat4x4 group + vec4 snap
     // viewport, packed via the shared canonical (non-transposed) column order.
     // The write is skipped when the UBO already holds this exact (view,
-    // updateId, group-id, snap-rect) state — static frames then issue zero
+    // updateId, group bytes, snap-rect) state — static frames then issue zero
     // projection uploads.
     const view = backend.view;
     const viewportChanged = packSnapViewport(backend, this._projectionData, 32);
 
-    if (
-      !this._hasWrittenProjection ||
-      this._writtenView !== view ||
-      this._writtenViewUpdateId !== view.updateId ||
-      this._writtenGroupTransformId !== backend.renderGroupTransformId ||
-      viewportChanged
-    ) {
+    if (!this._hasWrittenProjection || this._writtenView !== view || this._writtenViewUpdateId !== view.updateId || groupChanged || viewportChanged) {
       packAffineMat4(view.getTransform(), this._projectionData, 0);
       packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, this._projectionData, 16);
 
       this._writtenView = view;
       this._writtenViewUpdateId = view.updateId;
-      this._writtenGroupTransformId = backend.renderGroupTransformId;
       this._hasWrittenProjection = true;
 
       device.queue.writeBuffer(uniformBuffer, 0, this._projectionData.buffer, this._projectionData.byteOffset, this._projectionData.byteLength);
@@ -512,6 +505,16 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
     this._maxNodeIndex = 0;
     this._currentBlendMode = null;
     this._currentTexture = null;
+  }
+
+  private _groupContentChanged(backend: WebGpuBackend): boolean {
+    packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, this._stagedGroupData, 0);
+
+    if (!this._hasWrittenProjection) {
+      return true;
+    }
+
+    return packedGroupChanged(this._stagedGroupData, this._projectionData, affineMat4FloatCount);
   }
 
   public destroy(): void {

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -1,7 +1,7 @@
 /// <reference types="@webgpu/types" />
 
 import { Matrix } from '#math/Matrix';
-import { packAffineMat4 } from '#rendering/affinePacking';
+import { affineMat4FloatCount, packAffineMat4, packedGroupChanged } from '#rendering/affinePacking';
 import type { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
 import { computeShaderTiling, type RepeatingSpriteQuad } from '#rendering/sprite/repeatingSpritePlan';
 import { DataTexture } from '#rendering/texture/DataTexture';
@@ -255,13 +255,13 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
 
   private readonly _projData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
   // Projection-uniform skip state: a matching (view identity, view.updateId,
-  // group-transform id) triple means the shared UBO already holds this flush's
-  // projection, so the 128-byte write is skipped — static frames issue zero
-  // projection uploads. Mirrors the sprite renderer's redundant-write skip.
+  // group-matrix content) triple means the shared UBO already holds this
+  // flush's projection, so the 128-byte write is skipped — static frames issue
+  // zero projection uploads. Mirrors the sprite renderer's redundant-write skip.
   private _writtenView: View | null = null;
   private _writtenViewUpdateId = -1;
-  private _writtenGroupTransformId = -1;
   private _hasWrittenProjection = false;
+  private readonly _stagedGroupData = new Float32Array(affineMat4FloatCount);
 
   // Shared GPU objects
   private _device: GPUDevice | null = null;
@@ -380,7 +380,6 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     this._textureBindGroups = new WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView; sampler: GPUSampler }>();
     this._writtenView = null;
     this._writtenViewUpdateId = -1;
-    this._writtenGroupTransformId = -1;
     this._hasWrittenProjection = false;
 
     this._indexBuffer = null;
@@ -565,12 +564,13 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     // between merged flushes) would retroactively re-project them; end that pass
     // first. Guarded on the arena tracking the current active pass.
     const activePass = backend._passCoordinator.activePass;
+    const groupChanged = this._groupContentChanged(backend);
 
     if (
       activePass !== null &&
       this._instanceArena.cursor > 0 &&
       this._instanceArena.tracksPass(activePass) &&
-      (activePass.viewUpdateId !== backend.view.updateId || this._writtenGroupTransformId !== backend.renderGroupTransformId)
+      (activePass.viewUpdateId !== backend.view.updateId || groupChanged)
     ) {
       backend._passCoordinator.endPass();
       this._instanceArena.resetPass();
@@ -579,24 +579,17 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     // ProjectionUniforms layout: mat4x4 projection + mat4x4 group + vec4 snap
     // viewport, packed via the shared canonical (non-transposed) column order.
     // The write is skipped when the UBO already holds this exact (view,
-    // updateId, group-id, snap-rect) state — static frames then issue zero
+    // updateId, group bytes, snap-rect) state — static frames then issue zero
     // projection uploads.
     const view = backend.view;
     const viewportChanged = packSnapViewport(backend, this._projData, 32);
 
-    if (
-      !this._hasWrittenProjection ||
-      this._writtenView !== view ||
-      this._writtenViewUpdateId !== view.updateId ||
-      this._writtenGroupTransformId !== backend.renderGroupTransformId ||
-      viewportChanged
-    ) {
+    if (!this._hasWrittenProjection || this._writtenView !== view || this._writtenViewUpdateId !== view.updateId || groupChanged || viewportChanged) {
       packAffineMat4(view.getTransform(), this._projData, 0);
       packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, this._projData, 16);
 
       this._writtenView = view;
       this._writtenViewUpdateId = view.updateId;
-      this._writtenGroupTransformId = backend.renderGroupTransformId;
       this._hasWrittenProjection = true;
 
       device.queue.writeBuffer(uniform, 0, this._projData.buffer, this._projData.byteOffset, this._projData.byteLength);
@@ -908,6 +901,16 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     coordinator.markPassDraws();
     backend.stats.batches++;
     backend.stats.drawCalls++;
+  }
+
+  private _groupContentChanged(backend: WebGpuBackend): boolean {
+    packAffineMat4(backend.renderGroupTransform ?? Matrix.identity, this._stagedGroupData, 0);
+
+    if (!this._hasWrittenProjection) {
+      return true;
+    }
+
+    return packedGroupChanged(this._stagedGroupData, this._projData, affineMat4FloatCount);
   }
 
   public destroy(): void {

--- a/test/rendering/browser/webgl2-group-content-caching.test.ts
+++ b/test/rendering/browser/webgl2-group-content-caching.test.ts
@@ -1,0 +1,245 @@
+/**
+ * WebGL2 group-uniform content caching gates.
+ *
+ * The backend's render-group id changes on every group boundary, even when the
+ * effective matrix bytes stay identical. Core sprite variants and the tilemap
+ * renderer must skip `u_group` uploads in that case; the retained repeating
+ * replay path keeps a separate cache and must do the same across frames.
+ *
+ * Run via:  pnpm test:browser:webgl
+ */
+
+import { TileMapNode } from '@codexo/exojs-tilemap';
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Matrix } from '#math/Matrix';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
+import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { TextureRegion } from '#rendering/texture/TextureRegion';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { readWebGl2Pixel } from './_backendSetup';
+import { wireCoreRenderers } from './_coreRenderers';
+import { expectPixelNear, type RgbaTuple } from './_pixels';
+import { singleTileMap, wireTilemapRenderers } from './_tilemapScene';
+
+const canvasSize = 64;
+const spriteSize = 12;
+const positions = [2, 20, 38] as const;
+const colors = [
+  [255, 0, 0, 255],
+  [0, 255, 0, 255],
+  [0, 0, 255, 255],
+] as const satisfies readonly RgbaTuple[];
+
+const createBackend = async (wire: (backend: WebGl2Backend) => void): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const app: Application = {
+    canvas,
+    options: {
+      clearColor: Color.black,
+      canvas: { width: canvasSize, height: canvasSize },
+      rendering: {
+        debug: false,
+        webglAttributes: {
+          alpha: false,
+          antialias: false,
+          premultipliedAlpha: false,
+          preserveDrawingBuffer: true,
+          stencil: false,
+          depth: false,
+        },
+      },
+    },
+  } as unknown as Application;
+
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wire(backend);
+
+  return backend;
+};
+
+const createSolidTexture = (color: string, size = 8): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const context = source.getContext('2d')!;
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+type VariantSprite = NineSliceSprite | RepeatingSprite | Sprite;
+
+const variantCases: ReadonlyArray<{ name: string; create: (texture: Texture) => VariantSprite }> = [
+  {
+    name: 'Sprite',
+    create: texture => {
+      const sprite = new Sprite(texture);
+
+      sprite.width = spriteSize;
+      sprite.height = spriteSize;
+
+      return sprite;
+    },
+  },
+  {
+    name: 'NineSliceSprite',
+    create: texture => new NineSliceSprite(texture, { slices: 2, border: 2, width: spriteSize, height: spriteSize }),
+  },
+  {
+    name: 'RepeatingSprite',
+    create: texture => new RepeatingSprite(texture, { width: spriteSize, height: spriteSize }),
+  },
+];
+
+describe('WebGL2 group uniform — content caching', () => {
+  test.each(variantCases)('$name skips uploads across identity-only group id changes', async ({ create }) => {
+    const backend = await createBackend(wireCoreRenderers);
+    const texture = createSolidTexture('#ffffff');
+    const variants = colors.map(([r, g, b], index) => {
+      const sprite = create(texture);
+
+      sprite.setPosition(positions[index]!, 2);
+      sprite.tint = new Color(r, g, b, 1);
+
+      return sprite;
+    });
+    const identityGroup = new Matrix();
+    const render = (): void => {
+      backend.resetStats();
+      backend.clear(Color.black);
+
+      variants[0]!.render(backend);
+      backend._setRenderGroupTransform(identityGroup);
+      variants[1]!.render(backend);
+      backend._setRenderGroupTransform(null);
+      variants[2]!.render(backend);
+      backend.flush();
+    };
+    const matrixUpload = vi.spyOn(backend.context, 'uniformMatrix3fv');
+
+    try {
+      render();
+      render();
+      matrixUpload.mockClear();
+
+      const groupIdBefore = backend.renderGroupTransformId;
+
+      render();
+
+      expect(backend.renderGroupTransformId - groupIdBefore).toBe(2);
+      expect(matrixUpload).not.toHaveBeenCalled();
+
+      for (let i = 0; i < variants.length; i++) {
+        expectPixelNear(readWebGl2Pixel(backend, positions[i]! + spriteSize / 2, 2 + spriteSize / 2), colors[i]!);
+      }
+    } finally {
+      matrixUpload.mockRestore();
+      variants.forEach(sprite => sprite.destroy());
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('TileMapNode skips uploads across identity-only group id changes', async () => {
+    const backend = await createBackend(wireTilemapRenderers);
+    const textures = ['#ff0000', '#00ff00', '#0000ff'].map(color => createSolidTexture(color, 16));
+    const nodes = textures.map((texture, index) => {
+      const node = new TileMapNode(singleTileMap(texture));
+
+      node.setPosition(positions[index]!, 20);
+
+      return node;
+    });
+    const identityGroup = new Matrix();
+    const render = (): void => {
+      backend.resetStats();
+      backend.clear(Color.black);
+
+      nodes[0]!.render(backend);
+      backend._setRenderGroupTransform(identityGroup);
+      nodes[1]!.render(backend);
+      backend._setRenderGroupTransform(null);
+      nodes[2]!.render(backend);
+      backend.flush();
+    };
+    const matrixUpload = vi.spyOn(backend.context, 'uniformMatrix3fv');
+
+    try {
+      render();
+      render();
+      matrixUpload.mockClear();
+
+      const groupIdBefore = backend.renderGroupTransformId;
+
+      render();
+
+      expect(backend.renderGroupTransformId - groupIdBefore).toBe(2);
+      expect(matrixUpload).not.toHaveBeenCalled();
+
+      for (let i = 0; i < nodes.length; i++) {
+        expectPixelNear(readWebGl2Pixel(backend, positions[i]! + 8, 28), colors[i]!);
+      }
+    } finally {
+      matrixUpload.mockRestore();
+      nodes.forEach(node => node.destroy());
+      textures.forEach(texture => texture.destroy());
+      backend.destroy();
+    }
+  });
+
+  test('retained RepeatingSprite replay skips an unchanged identity group upload', async () => {
+    const backend = await createBackend(wireCoreRenderers);
+    const texture = createSolidTexture('#ffffff', 16);
+    const region = new TextureRegion(texture, { x: 0, y: 0, width: 16, height: 16 });
+    const group = new RetainedContainer();
+    const repeating = new RepeatingSprite(region, { width: 16, height: 16, modeX: 'repeat', fitX: 'clip', modeY: 'stretch' });
+
+    repeating.setPosition(8, 8);
+    repeating.tint = new Color(255, 0, 0, 1);
+    group.addChild(repeating);
+
+    const render = (): void => {
+      backend.resetStats();
+      backend.clear(Color.black);
+      group.render(backend);
+      backend.flush();
+    };
+    const matrixUpload = vi.spyOn(backend.context, 'uniformMatrix3fv');
+
+    try {
+      render();
+      render();
+      render();
+      matrixUpload.mockClear();
+
+      const replay = vi.spyOn(backend, '_replayRetainedBatch');
+
+      render();
+
+      expect(replay).toHaveBeenCalled();
+      expect(matrixUpload).not.toHaveBeenCalled();
+      expectPixelNear(readWebGl2Pixel(backend, 16, 16), [255, 0, 0, 255]);
+    } finally {
+      matrixUpload.mockRestore();
+      group.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgl2-video.test.ts
+++ b/test/rendering/browser/webgl2-video.test.ts
@@ -16,7 +16,9 @@
  * `requestVideoFrameCallback` — empirically, in this headless Chromium
  * configuration `requestVideoFrameCallback` never fires (even with the video
  * attached to the DOM and a `requestAnimationFrame` pump kept alive for the
- * full test), while polling resolves reliably in ~60-100ms. A *second*,
+ * full test). The bounded wait starts before `video.play()`: under full-lane
+ * load that promise can stay pending indefinitely even though isolated runs
+ * decode in under a second. A *second*,
  * dynamic scenario — repainting the source canvas after the first decoded
  * frame and asserting the video texture picks up the new colour — was
  * prototyped and found NOT to be reliably observable within a bounded window
@@ -113,16 +115,35 @@ const createSolidColorVideo = async (color: string, size = 16): Promise<HTMLVide
   video.playsInline = true;
   video.srcObject = stream;
 
-  await video.play();
-
   await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(
-      () => reject(new Error(`timed out waiting for decoded video frame (videoWidth=${video.videoWidth}, readyState=${video.readyState})`)),
-      5000,
-    );
+    let settled = false;
+
+    const cleanupFailedPlayback = (): void => {
+      video.pause();
+      stream.getTracks().forEach(track => track.stop());
+      video.srcObject = null;
+    };
+    const fail = (error: unknown): void => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeout);
+      cleanupFailedPlayback();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    };
+    const timeout = setTimeout(() => {
+      fail(new Error(`timed out waiting for video.play() / decoded frame (videoWidth=${video.videoWidth}, readyState=${video.readyState})`));
+    }, 5000);
 
     const poll = (): void => {
+      if (settled) {
+        return;
+      }
+
       if (video.videoWidth > 0 && video.videoHeight > 0 && video.readyState >= 2) {
+        settled = true;
         clearTimeout(timeout);
         resolve();
       } else {
@@ -130,6 +151,10 @@ const createSolidColorVideo = async (color: string, size = 16): Promise<HTMLVide
       }
     };
 
+    // `play()` may stay pending indefinitely under a fully loaded browser lane,
+    // so its promise must live inside the same bounded wait as first-frame
+    // readiness. Polling can still succeed before the play promise settles.
+    void video.play().catch(fail);
     poll();
   });
 

--- a/test/rendering/browser/webgpu-sprite-variants-single-pass.test.ts
+++ b/test/rendering/browser/webgpu-sprite-variants-single-pass.test.ts
@@ -1,0 +1,195 @@
+/**
+ * WebGPU sprite-variant group-content gates.
+ *
+ * NineSliceSprite and RepeatingSprite keep one shared projection UBO per
+ * renderer. Entering and leaving an identity render group advances the
+ * backend's group id twice but restores byte-identical matrix content. Those
+ * boundaries must therefore neither rewrite the UBO nor split the open pass.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Matrix } from '#math/Matrix';
+import { NineSliceSprite } from '#rendering/sprite/NineSliceSprite';
+import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { readWebGpuPixels } from './_backendSetup';
+import { wireCoreRenderers } from './_coreRenderers';
+import { expectPixelNear, type RgbaTuple } from './_pixels';
+import { getBackendDevice } from './webgpu-test-helpers';
+
+const canvasSize = 64;
+const spriteSize = 12;
+const positions = [2, 20, 38] as const;
+const colors = [
+  [255, 0, 0, 255],
+  [0, 255, 0, 255],
+  [0, 0, 255, 255],
+] as const satisfies readonly RgbaTuple[];
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: canvasSize, height: canvasSize },
+      clearColor: Color.black,
+    },
+  }) as unknown as Application;
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+const createSolidTexture = (color: string, size = 8): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = size;
+  source.height = size;
+
+  const context = source.getContext('2d')!;
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, size, size);
+
+  return new Texture(source);
+};
+
+const isDeviceLoss = (error: unknown): boolean => error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError');
+
+const renderGuarded = async (ctx: { skip: (reason: string) => void }, backend: WebGpuBackend, body: () => void): Promise<boolean> => {
+  const device = getBackendDevice(backend);
+
+  device.pushErrorScope('validation');
+
+  let validationError: GPUError | null;
+
+  try {
+    body();
+    validationError = await device.popErrorScope();
+  } catch (error) {
+    if (isDeviceLoss(error)) {
+      ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+      return false;
+    }
+
+    throw error;
+  }
+
+  expect(validationError).toBeNull();
+
+  return true;
+};
+
+const countSubmits = (backend: WebGpuBackend, body: () => void): number => {
+  const queue = getBackendDevice(backend).queue;
+  const real = queue.submit.bind(queue);
+  let count = 0;
+
+  queue.submit = ((buffers: Iterable<GPUCommandBuffer>): undefined => {
+    count++;
+
+    return real(buffers);
+  }) as GPUQueue['submit'];
+
+  try {
+    body();
+  } finally {
+    queue.submit = real;
+  }
+
+  return count;
+};
+
+type VariantSprite = NineSliceSprite | RepeatingSprite;
+
+const verifyIdentityGroupKeepsSinglePass = async (
+  ctx: { skip: (reason: string) => void },
+  createVariant: (texture: Texture) => VariantSprite,
+): Promise<void> => {
+  const backend = await setupBackend();
+  const white = createSolidTexture('#ffffff');
+  const trailingTexture = createSolidTexture('#ff00ff');
+  const variants = colors.map(([r, g, b], index) => {
+    const sprite = createVariant(white);
+
+    sprite.setPosition(positions[index]!, 2);
+    sprite.tint = new Color(r, g, b, 1);
+
+    return sprite;
+  });
+  const trailing = new Sprite(trailingTexture);
+
+  trailing.setPosition(54, 2);
+  trailing.width = 8;
+  trailing.height = 8;
+
+  const identityGroup = new Matrix();
+  const render = (): void => {
+    backend.resetStats();
+    backend.clear(Color.black);
+
+    variants[0]!.render(backend);
+    backend._setRenderGroupTransform(identityGroup);
+    variants[1]!.render(backend);
+    backend._setRenderGroupTransform(null);
+    variants[2]!.render(backend);
+    trailing.render(backend);
+    backend.flush();
+  };
+
+  try {
+    for (let frame = 0; frame < 3; frame++) {
+      if (!(await renderGuarded(ctx, backend, render))) {
+        return;
+      }
+    }
+
+    const groupIdBefore = backend.renderGroupTransformId;
+    const submits = countSubmits(backend, render);
+
+    expect(backend.renderGroupTransformId - groupIdBefore).toBe(2);
+    expect(backend.stats.drawCalls).toBe(variants.length + 1);
+    expect(backend.stats.renderPasses).toBe(1);
+    expect(submits).toBe(1);
+
+    const readPixel = readWebGpuPixels(backend, canvasSize);
+
+    for (let i = 0; i < variants.length; i++) {
+      expectPixelNear(readPixel(positions[i]! + spriteSize / 2, 2 + spriteSize / 2), colors[i]!);
+    }
+
+    expectPixelNear(readPixel(58, 6), [255, 0, 255, 255]);
+  } finally {
+    variants.forEach(sprite => sprite.destroy());
+    trailing.destroy();
+    white.destroy();
+    trailingTexture.destroy();
+    backend.destroy();
+  }
+};
+
+describe('WebGPU sprite variants — group content keeps a single pass', () => {
+  test('NineSliceSprite ignores identity-only group id changes', async ctx => {
+    await verifyIdentityGroupKeepsSinglePass(ctx, texture => new NineSliceSprite(texture, { slices: 2, border: 2, width: spriteSize, height: spriteSize }));
+  });
+
+  test('RepeatingSprite ignores identity-only group id changes', async ctx => {
+    await verifyIdentityGroupKeepsSinglePass(ctx, texture => new RepeatingSprite(texture, { width: spriteSize, height: spriteSize }));
+  });
+});

--- a/test/rendering/browser/webgpu-video.test.ts
+++ b/test/rendering/browser/webgpu-video.test.ts
@@ -17,7 +17,9 @@
  * `requestVideoFrameCallback` — empirically, in this headless Chromium
  * configuration `requestVideoFrameCallback` never fires (even with the video
  * attached to the DOM and a `requestAnimationFrame` pump kept alive for the
- * full test), while polling resolves reliably in ~60-100ms. A *second*,
+ * full test). The bounded wait starts before `video.play()`: under full-lane
+ * load that promise can stay pending indefinitely even though isolated runs
+ * decode in under a second. A *second*,
  * dynamic scenario — repainting the source canvas after the first decoded
  * frame and asserting the video texture picks up the new colour — was
  * prototyped and found NOT to be reliably observable within a bounded window
@@ -101,16 +103,35 @@ const createSolidColorVideo = async (color: string, size = 16): Promise<HTMLVide
   video.playsInline = true;
   video.srcObject = stream;
 
-  await video.play();
-
   await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(
-      () => reject(new Error(`timed out waiting for decoded video frame (videoWidth=${video.videoWidth}, readyState=${video.readyState})`)),
-      5000,
-    );
+    let settled = false;
+
+    const cleanupFailedPlayback = (): void => {
+      video.pause();
+      stream.getTracks().forEach(track => track.stop());
+      video.srcObject = null;
+    };
+    const fail = (error: unknown): void => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      clearTimeout(timeout);
+      cleanupFailedPlayback();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    };
+    const timeout = setTimeout(() => {
+      fail(new Error(`timed out waiting for video.play() / decoded frame (videoWidth=${video.videoWidth}, readyState=${video.readyState})`));
+    }, 5000);
 
     const poll = (): void => {
+      if (settled) {
+        return;
+      }
+
       if (video.videoWidth > 0 && video.videoHeight > 0 && video.readyState >= 2) {
+        settled = true;
         clearTimeout(timeout);
         resolve();
       } else {
@@ -118,6 +139,10 @@ const createSolidColorVideo = async (color: string, size = 16): Promise<HTMLVide
       }
     };
 
+    // `play()` may stay pending indefinitely under a fully loaded browser lane,
+    // so its promise must live inside the same bounded wait as first-frame
+    // readiness. Polling can still succeed before the play promise settles.
+    void video.play().catch(fail);
     poll();
   });
 


### PR DESCRIPTION
## Summary

- compare composed group matrices by content across WebGL2 sprite variants and tile chunks
- avoid redundant WebGPU projection uploads and pass splits for equivalent group transforms
- bound video playback and first-frame readiness under full browser-lane load

## Verification

- pnpm format:check
- pnpm typecheck
- targeted WebGL2 browser tests: 7/7
- targeted WebGPU browser tests: 4/4
- full WebGL2 Chromium lane: 288/288
- full WebGPU Chromium lane: 332/332