### PR TITLE
perf(rendering)!: retain live materials and batch text atlases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,12 @@ state, claims, inFlight, background }` — for diagnostics and support bundles.
 
 ### Changed
 
+- **BREAKING — `Material.sampler` is now a real base-texture binding override.**
+  It contains only `scaleMode` and `wrapMode`, applies to the drawable's base
+  texture across WebGPU and WebGL2 (including particle materials), and leaves
+  additional material textures on their own sampler state. `null` continues to
+  inherit the texture sampler. Sampler changes now affect `bindKey`, not
+  `pipelineKey`, and in-place changes are resolved live during retained replay.
 - **BREAKING — `Material` binding schemas are fixed at construction.** Declare
   every scalar and texture slot through the constructor's `uniforms`/`textures`
   options. Existing values and texture identities remain live and replaceable,
@@ -438,6 +444,11 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
 
 ### Performance
 
+- **Text batches can span up to eight atlas textures per draw.** WebGPU and
+  WebGL2 now assign compatible atlas pages to a small texture-slot table instead
+  of ending the batch at every texture change. Mixed-font text with the same
+  shader/page class therefore keeps one draw (and remains retained-recordable)
+  until the eight-slot capacity is exhausted.
 - **WebGPU text flushes share one render pass and one submit.** The WebGPU text
   renderer rewrote its shared vertex, index and node-data buffers from offset 0
   on every flush, and ended (submitted) the render pass at the tail of each one
@@ -497,6 +508,11 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
 
 ### Fixed
 
+- **Custom WebGPU `SpriteMaterial` shaders now honour
+  `Texture.premultiplyAlpha`.** The engine carries the per-texture flag through
+  the opaque value passed to `sampleBase()`, so custom materials match the stock
+  sprite shader and WebGL2 even when one batch mixes textures with different
+  upload-alpha modes.
 - **Retained `SpriteMaterial` batches now keep live uniforms and material
   textures on WebGPU and WebGL2.** Retained groups record instance/transform
   data while resolving material state at replay, deduplicated once per material

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,12 @@ state, claims, inFlight, background }` — for diagnostics and support bundles.
 
 ### Changed
 
+- **BREAKING — `Material` binding schemas are fixed at construction.** Declare
+  every scalar and texture slot through the constructor's `uniforms`/`textures`
+  options. Existing values and texture identities remain live and replaceable,
+  including in-place typed-array mutation; adding/deleting a key or changing a
+  slot between scalar and texture now fails immediately instead of leaving a
+  stale WebGPU bind-group layout.
 - **`WebGpuInstanceArena` renamed `WebGpuPassArena` and exported from
   `renderer-sdk`.** The class stages bytes against a cursor bound to the open
   render pass and knows nothing about instances — the name described its first
@@ -491,6 +497,12 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
 
 ### Fixed
 
+- **Retained `SpriteMaterial` batches now keep live uniforms and material
+  textures on WebGPU and WebGL2.** Retained groups record instance/transform
+  data while resolving material state at replay, deduplicated once per material
+  and render plan. Uniform or texture-value changes stay on the O(batches)
+  instruction tier; blend/sampler structure changes preflight-invalidate the
+  set, entry-replays once with live material keys, and records a replacement.
 - **Text draws past 16384 quads no longer silently corrupt.** `WebGpuTextRenderer`
   and `WebGl2TextRenderer` computed glyph vertex indices as `quadIndex * 4` into a
   `Uint16` index buffer, which wraps once a flush's cumulative quad count reaches

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     },
     {
       "path": "dist/exo.iife.min.js",
-      "limit": "250 KB",
+      "limit": "255 KB",
       "gzip": true
     },
     {

--- a/packages/exojs-particles/src/renderers/WebGl2ParticleRenderer.ts
+++ b/packages/exojs-particles/src/renderers/WebGl2ParticleRenderer.ts
@@ -221,10 +221,20 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
 
     resources.vertexBuffer.upload(this._resolveUpload(mode, resources));
 
+    const sampler = mode.material.sampler;
+
+    if (sampler !== null) {
+      backend.bindMaterialSampler(sampler, 0);
+    }
+
     if (resources.instanced) {
       resources.vao.drawInstanced(resources.indexCount, 0, this._drawCount, resources.primitive);
     } else {
       resources.vao.draw(resources.indexBuffer !== null ? resources.indexCount : this._drawCount, 0, resources.primitive);
+    }
+
+    if (sampler !== null) {
+      backend.unbindMaterialSampler(0);
     }
 
     backend.stats.batches++;

--- a/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
+++ b/packages/exojs-particles/src/renderers/WebGpuParticleRenderer.ts
@@ -386,7 +386,7 @@ export class WebGpuParticleRenderer extends AbstractWebGpuRenderer<ParticleSyste
     this._ensureUniformCapacity(device, targetUniformSlots);
 
     const pipeline = this._getPipeline(resources, drawCall.blendMode, backend.renderTargetFormat, coordinator.stencilActive);
-    const textureBinding = backend.getTextureBinding(drawCall.texture);
+    const textureBinding = backend.getTextureBinding(drawCall.texture, mode.material.sampler);
     const textureBindGroup = device.createBindGroup({
       layout: this._textureBindGroupLayout!,
       entries: [

--- a/site/src/content/api/material-options.json
+++ b/site/src/content/api/material-options.json
@@ -56,7 +56,7 @@
         },
         {
           "name": "sampler",
-          "signature": "sampler?: SamplerOptions | null",
+          "signature": "sampler?: MaterialSamplerOptions | null",
           "signatureTokens": [
             {
               "text": "sampler",
@@ -71,7 +71,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "SamplerOptions",
+              "text": "MaterialSamplerOptions",
               "kind": "type"
             },
             {
@@ -85,7 +85,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Backend-agnostic sampling state descriptor, or null to inherit the backend/texture default. Defaults to null."
+          "description": "Filter/wrap override for the drawable's base texture, or null to inherit that texture's sampler. Additional material textures keep their own sampler state. Defaults to null."
         },
         {
           "name": "shader",
@@ -159,7 +159,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Named texture bindings claimed in addition to the drawable's own texture."
+          "description": "Declared texture slots claimed in addition to the drawable's own texture."
         },
         {
           "name": "uniforms",
@@ -204,7 +204,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Initial uniform values; mutate per frame via Material.uniforms."
+          "description": "Declared uniform slots and their initial values. Names and scalar/texture kinds form a fixed construction-time schema; values remain mutable."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/material-sampler-options.json
+++ b/site/src/content/api/material-sampler-options.json
@@ -1,0 +1,92 @@
+{
+  "title": "MaterialSamplerOptions",
+  "description": "Sampling state a material can override for the drawable's base texture. Upload state remains owned by the texture because one texture may be drawn through several materials in the same frame.",
+  "symbol": "MaterialSamplerOptions",
+  "kind": "interface",
+  "subsystem": "rendering",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 2,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 2,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Sampling state a material can override for the drawable's base texture. Upload state remains owned by the texture because one texture may be drawn through several materials in the same frame."
+      ],
+      "importLine": "import { MaterialSamplerOptions } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "scaleMode",
+          "signature": "scaleMode: ScaleModes",
+          "signatureTokens": [
+            {
+              "text": "scaleMode",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ScaleModes",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Minification and magnification filter applied when sampling the base texture."
+        },
+        {
+          "name": "wrapMode",
+          "signature": "wrapMode: WrapModes",
+          "signatureTokens": [
+            {
+              "text": "wrapMode",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "WrapModes",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Behaviour when base-texture UV coordinates exceed [0, 1]."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/rendering/material/Material.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/material/Material.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/rendering/material/Material.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/rendering/material/Material.ts"
+}

--- a/site/src/content/api/material.json
+++ b/site/src/content/api/material.json
@@ -189,7 +189,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Bind a named texture. Equivalent to material.textures[name] = texture, returned this for chaining."
+          "description": "Replace the texture behind a declared slot, returning this for chaining."
         },
         {
           "name": "setUniform",
@@ -257,7 +257,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set a uniform value. Equivalent to material.uniforms[name] = value, returned this for chaining."
+          "description": "Replace a declared uniform value, returning this for chaining. Unknown names and scalar↔texture kind changes are rejected."
         }
       ],
       "paragraphs": [],
@@ -291,7 +291,7 @@
         },
         {
           "name": "sampler",
-          "signature": "sampler: SamplerOptions | null",
+          "signature": "sampler: MaterialSamplerOptions | null",
           "signatureTokens": [
             {
               "text": "sampler",
@@ -302,7 +302,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "SamplerOptions",
+              "text": "MaterialSamplerOptions",
               "kind": "type"
             },
             {
@@ -316,7 +316,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Backend-agnostic sampling state descriptor, or null for the default."
+          "description": "Filter/wrap override for the drawable's base texture, or null to inherit it."
         },
         {
           "name": "shader",
@@ -377,6 +377,48 @@
           "description": "Which drawable class this material can serve; renderers check compatibility."
         },
         {
+          "name": "bindKey",
+          "signature": "bindKey: number",
+          "signatureTokens": [
+            {
+              "text": "bindKey",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Stable bind key: identical ⇒ same bindings (textures unchanged). Derived from this material's identity, base-texture sampler override, and the identities of its bound textures. Changes when a texture is swapped or sampler state changes; drives bind-group/slot reuse."
+        },
+        {
+          "name": "pipelineKey",
+          "signature": "pipelineKey: number",
+          "signatureTokens": [
+            {
+              "text": "pipelineKey",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Stable pipeline key: identical ⇒ same GPU pipeline/program can be used. Derived from shader identity and blend mode, and is independent of the owning material instance so identically configured materials share a pipeline. Drives grouping and the pipeline cache."
+        },
+        {
           "name": "textures",
           "signature": "textures: Record<string, Texture | RenderTexture>",
           "signatureTokens": [
@@ -423,7 +465,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Named texture bindings claimed in addition to the drawable's own texture."
+          "description": "Live identities behind the fixed named texture slots."
         },
         {
           "name": "uniforms",
@@ -464,49 +506,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Mutable user uniform values. Mutate between frames to drive animated effects; the renderer reads from this map every draw. material.uniforms.u_time = performance.now() / 1000; material.uniforms.u_color = [1, 0.5, 0, 1];"
-        },
-        {
-          "name": "bindKey",
-          "signature": "bindKey: number",
-          "signatureTokens": [
-            {
-              "text": "bindKey",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Stable bind key: identical ⇒ same bindings (textures unchanged). Derived from this material's identity and the identities of its bound textures. Changes when a texture is swapped; drives bind-group/slot reuse."
-        },
-        {
-          "name": "pipelineKey",
-          "signature": "pipelineKey: number",
-          "signatureTokens": [
-            {
-              "text": "pipelineKey",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Stable pipeline key: identical ⇒ same GPU pipeline/program can be used. Derived from shader identity, blend mode, and sampler state, and is independent of the owning material instance so identically configured materials share a pipeline. Drives grouping and the pipeline cache."
+          "description": "Live user uniform values. Construction declares the fixed set of names and each name's scalar/texture kind; existing values can be replaced between frames and typed arrays can be mutated in place. material.uniforms.u_time = performance.now() / 1000; material.uniforms.u_color = [1, 0.5, 0, 1];"
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/mesh-material.json
+++ b/site/src/content/api/mesh-material.json
@@ -188,7 +188,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Bind a named texture. Equivalent to material.textures[name] = texture, returned this for chaining."
+          "description": "Replace the texture behind a declared slot, returning this for chaining."
         },
         {
           "name": "setUniform",
@@ -256,7 +256,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set a uniform value. Equivalent to material.uniforms[name] = value, returned this for chaining."
+          "description": "Replace a declared uniform value, returning this for chaining. Unknown names and scalar↔texture kind changes are rejected."
         },
         {
           "name": "from",
@@ -583,7 +583,7 @@
         },
         {
           "name": "sampler",
-          "signature": "sampler: SamplerOptions | null",
+          "signature": "sampler: MaterialSamplerOptions | null",
           "signatureTokens": [
             {
               "text": "sampler",
@@ -594,7 +594,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "SamplerOptions",
+              "text": "MaterialSamplerOptions",
               "kind": "type"
             },
             {
@@ -608,7 +608,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Backend-agnostic sampling state descriptor, or null for the default."
+          "description": "Filter/wrap override for the drawable's base texture, or null to inherit it."
         },
         {
           "name": "shader",
@@ -651,6 +651,48 @@
           "params": [],
           "returnType": null,
           "description": "Which drawable class this material can serve; renderers check compatibility."
+        },
+        {
+          "name": "bindKey",
+          "signature": "bindKey: number",
+          "signatureTokens": [
+            {
+              "text": "bindKey",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Stable bind key: identical ⇒ same bindings (textures unchanged). Derived from this material's identity, base-texture sampler override, and the identities of its bound textures. Changes when a texture is swapped or sampler state changes; drives bind-group/slot reuse."
+        },
+        {
+          "name": "pipelineKey",
+          "signature": "pipelineKey: number",
+          "signatureTokens": [
+            {
+              "text": "pipelineKey",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Stable pipeline key: identical ⇒ same GPU pipeline/program can be used. Derived from shader identity and blend mode, and is independent of the owning material instance so identically configured materials share a pipeline. Drives grouping and the pipeline cache."
         },
         {
           "name": "textures",
@@ -699,7 +741,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Named texture bindings claimed in addition to the drawable's own texture."
+          "description": "Live identities behind the fixed named texture slots."
         },
         {
           "name": "uniforms",
@@ -740,49 +782,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Mutable user uniform values. Mutate between frames to drive animated effects; the renderer reads from this map every draw. material.uniforms.u_time = performance.now() / 1000; material.uniforms.u_color = [1, 0.5, 0, 1];"
-        },
-        {
-          "name": "bindKey",
-          "signature": "bindKey: number",
-          "signatureTokens": [
-            {
-              "text": "bindKey",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Stable bind key: identical ⇒ same bindings (textures unchanged). Derived from this material's identity and the identities of its bound textures. Changes when a texture is swapped; drives bind-group/slot reuse."
-        },
-        {
-          "name": "pipelineKey",
-          "signature": "pipelineKey: number",
-          "signatureTokens": [
-            {
-              "text": "pipelineKey",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Stable pipeline key: identical ⇒ same GPU pipeline/program can be used. Derived from shader identity, blend mode, and sampler state, and is independent of the owning material instance so identically configured materials share a pipeline. Drives grouping and the pipeline cache."
+          "description": "Live user uniform values. Construction declares the fixed set of names and each name's scalar/texture kind; existing values can be replaced between frames and typed arrays can be mutated in place. material.uniforms.u_time = performance.now() / 1000; material.uniforms.u_color = [1, 0.5, 0, 1];"
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/particle-material.json
+++ b/site/src/content/api/particle-material.json
@@ -189,7 +189,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Bind a named texture. Equivalent to material.textures[name] = texture, returned this for chaining."
+          "description": "Replace the texture behind a declared slot, returning this for chaining."
         },
         {
           "name": "setUniform",
@@ -257,7 +257,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set a uniform value. Equivalent to material.uniforms[name] = value, returned this for chaining."
+          "description": "Replace a declared uniform value, returning this for chaining. Unknown names and scalar↔texture kind changes are rejected."
         }
       ],
       "paragraphs": [],
@@ -291,7 +291,7 @@
         },
         {
           "name": "sampler",
-          "signature": "sampler: SamplerOptions | null",
+          "signature": "sampler: MaterialSamplerOptions | null",
           "signatureTokens": [
             {
               "text": "sampler",
@@ -302,7 +302,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "SamplerOptions",
+              "text": "MaterialSamplerOptions",
               "kind": "type"
             },
             {
@@ -316,7 +316,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Backend-agnostic sampling state descriptor, or null for the default."
+          "description": "Filter/wrap override for the drawable's base texture, or null to inherit it."
         },
         {
           "name": "shader",
@@ -359,6 +359,48 @@
           "params": [],
           "returnType": null,
           "description": "Which drawable class this material can serve; renderers check compatibility."
+        },
+        {
+          "name": "bindKey",
+          "signature": "bindKey: number",
+          "signatureTokens": [
+            {
+              "text": "bindKey",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Stable bind key: identical ⇒ same bindings (textures unchanged). Derived from this material's identity, base-texture sampler override, and the identities of its bound textures. Changes when a texture is swapped or sampler state changes; drives bind-group/slot reuse."
+        },
+        {
+          "name": "pipelineKey",
+          "signature": "pipelineKey: number",
+          "signatureTokens": [
+            {
+              "text": "pipelineKey",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Stable pipeline key: identical ⇒ same GPU pipeline/program can be used. Derived from shader identity and blend mode, and is independent of the owning material instance so identically configured materials share a pipeline. Drives grouping and the pipeline cache."
         },
         {
           "name": "textures",
@@ -407,7 +449,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Named texture bindings claimed in addition to the drawable's own texture."
+          "description": "Live identities behind the fixed named texture slots."
         },
         {
           "name": "uniforms",
@@ -448,49 +490,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Mutable user uniform values. Mutate between frames to drive animated effects; the renderer reads from this map every draw. material.uniforms.u_time = performance.now() / 1000; material.uniforms.u_color = [1, 0.5, 0, 1];"
-        },
-        {
-          "name": "bindKey",
-          "signature": "bindKey: number",
-          "signatureTokens": [
-            {
-              "text": "bindKey",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Stable bind key: identical ⇒ same bindings (textures unchanged). Derived from this material's identity and the identities of its bound textures. Changes when a texture is swapped; drives bind-group/slot reuse."
-        },
-        {
-          "name": "pipelineKey",
-          "signature": "pipelineKey: number",
-          "signatureTokens": [
-            {
-              "text": "pipelineKey",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Stable pipeline key: identical ⇒ same GPU pipeline/program can be used. Derived from shader identity, blend mode, and sampler state, and is independent of the owning material instance so identically configured materials share a pipeline. Drives grouping and the pipeline cache."
+          "description": "Live user uniform values. Construction declares the fixed set of names and each name's scalar/texture kind; existing values can be replaced between frames and typed arrays can be mutated in place. material.uniforms.u_time = performance.now() / 1000; material.uniforms.u_color = [1, 0.5, 0, 1];"
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/sprite-material.json
+++ b/site/src/content/api/sprite-material.json
@@ -1,6 +1,6 @@
 {
   "title": "SpriteMaterial",
-  "description": "Material specialization for Sprite drawables. API shell for the sprite custom-material path; the renderer integration and instancing contract are added in a later phase. The base texture stays on the sprite — this material supplies the fragment program, uniforms, and additional texture bindings.",
+  "description": "Material specialization for Sprite drawables. The base texture stays on the sprite and is sampled through the engine's `sampleBase(slot, uv)` helper, which preserves batching and resolves the backend's premultiplied-alpha convention. The material supplies the custom fragment program, uniforms, additional texture bindings, and blend mode.",
   "symbol": "SpriteMaterial",
   "kind": "class",
   "subsystem": "rendering",
@@ -20,7 +20,7 @@
       "members": [],
       "paragraphs": [
         "Material specialization for Sprite drawables.",
-        "API shell for the sprite custom-material path; the renderer integration and instancing contract are added in a later phase. The base texture stays on the sprite — this material supplies the fragment program, uniforms, and additional texture bindings."
+        "The base texture stays on the sprite and is sampled through the engine's `sampleBase(slot, uv)` helper, which preserves batching and resolves the backend's premultiplied-alpha convention. The material supplies the custom fragment program, uniforms, additional texture bindings, and blend mode."
       ],
       "importLine": "import { SpriteMaterial } from '@codexo/exojs'",
       "sourceLink": null
@@ -188,7 +188,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Bind a named texture. Equivalent to material.textures[name] = texture, returned this for chaining."
+          "description": "Replace the texture behind a declared slot, returning this for chaining."
         },
         {
           "name": "setUniform",
@@ -256,7 +256,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set a uniform value. Equivalent to material.uniforms[name] = value, returned this for chaining."
+          "description": "Replace a declared uniform value, returning this for chaining. Unknown names and scalar↔texture kind changes are rejected."
         },
         {
           "name": "from",
@@ -583,7 +583,7 @@
         },
         {
           "name": "sampler",
-          "signature": "sampler: SamplerOptions | null",
+          "signature": "sampler: MaterialSamplerOptions | null",
           "signatureTokens": [
             {
               "text": "sampler",
@@ -594,7 +594,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "SamplerOptions",
+              "text": "MaterialSamplerOptions",
               "kind": "type"
             },
             {
@@ -608,7 +608,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Backend-agnostic sampling state descriptor, or null for the default."
+          "description": "Filter/wrap override for the drawable's base texture, or null to inherit it."
         },
         {
           "name": "shader",
@@ -651,6 +651,48 @@
           "params": [],
           "returnType": null,
           "description": "Which drawable class this material can serve; renderers check compatibility."
+        },
+        {
+          "name": "bindKey",
+          "signature": "bindKey: number",
+          "signatureTokens": [
+            {
+              "text": "bindKey",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Stable bind key: identical ⇒ same bindings (textures unchanged). Derived from this material's identity, base-texture sampler override, and the identities of its bound textures. Changes when a texture is swapped or sampler state changes; drives bind-group/slot reuse."
+        },
+        {
+          "name": "pipelineKey",
+          "signature": "pipelineKey: number",
+          "signatureTokens": [
+            {
+              "text": "pipelineKey",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Stable pipeline key: identical ⇒ same GPU pipeline/program can be used. Derived from shader identity and blend mode, and is independent of the owning material instance so identically configured materials share a pipeline. Drives grouping and the pipeline cache."
         },
         {
           "name": "textures",
@@ -699,7 +741,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Named texture bindings claimed in addition to the drawable's own texture."
+          "description": "Live identities behind the fixed named texture slots."
         },
         {
           "name": "uniforms",
@@ -740,49 +782,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Mutable user uniform values. Mutate between frames to drive animated effects; the renderer reads from this map every draw. material.uniforms.u_time = performance.now() / 1000; material.uniforms.u_color = [1, 0.5, 0, 1];"
-        },
-        {
-          "name": "bindKey",
-          "signature": "bindKey: number",
-          "signatureTokens": [
-            {
-              "text": "bindKey",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Stable bind key: identical ⇒ same bindings (textures unchanged). Derived from this material's identity and the identities of its bound textures. Changes when a texture is swapped; drives bind-group/slot reuse."
-        },
-        {
-          "name": "pipelineKey",
-          "signature": "pipelineKey: number",
-          "signatureTokens": [
-            {
-              "text": "pipelineKey",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": "Stable pipeline key: identical ⇒ same GPU pipeline/program can be used. Derived from shader identity, blend mode, and sampler state, and is independent of the owning material instance so identically configured materials share a pipeline. Drives grouping and the pipeline cache."
+          "description": "Live user uniform values. Construction declares the fixed set of names and each name's scalar/texture kind; existing values can be replaced between frames and typed arrays can be mutated in place. material.uniforms.u_time = performance.now() / 1000; material.uniforms.u_color = [1, 0.5, 0, 1];"
         }
       ],
       "paragraphs": [],

--- a/src/rendering/material/Material.ts
+++ b/src/rendering/material/Material.ts
@@ -1,7 +1,6 @@
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
-import type { SamplerOptions } from '#rendering/texture/Sampler';
 import type { Texture } from '#rendering/texture/Texture';
-import { BlendModes } from '#rendering/types';
+import { BlendModes, type ScaleModes, type WrapModes } from '#rendering/types';
 
 import { deriveBindKey, derivePipelineKey } from './MaterialKey';
 import type { ShaderSource } from './ShaderSource';
@@ -22,6 +21,18 @@ export type UniformValue =
   | Int32Array
   | Texture
   | RenderTexture;
+
+/**
+ * Sampling state a material can override for the drawable's base texture.
+ * Upload state remains owned by the texture because one texture may be drawn
+ * through several materials in the same frame.
+ */
+export interface MaterialSamplerOptions {
+  /** Minification and magnification filter applied when sampling the base texture. */
+  scaleMode: ScaleModes;
+  /** Behaviour when base-texture UV coordinates exceed [0, 1]. */
+  wrapMode: WrapModes;
+}
 
 /** Whether a material-uniform value occupies a texture binding. @internal */
 export const isTextureUniformValue = (value: UniformValue): value is Texture | RenderTexture =>
@@ -62,10 +73,11 @@ export interface MaterialOptions {
   readonly blendMode?: BlendModes;
 
   /**
-   * Backend-agnostic sampling state descriptor, or `null` to inherit the
-   * backend/texture default. Defaults to `null`.
+   * Filter/wrap override for the drawable's base texture, or `null` to inherit
+   * that texture's sampler. Additional material textures keep their own
+   * sampler state. Defaults to `null`.
    */
-  readonly sampler?: SamplerOptions | null;
+  readonly sampler?: MaterialSamplerOptions | null;
 }
 
 let nextMaterialId = 1;
@@ -111,8 +123,8 @@ export abstract class Material {
   /** Compositing blend mode applied when drawing with this material. */
   public blendMode: BlendModes;
 
-  /** Backend-agnostic sampling state descriptor, or `null` for the default. */
-  public sampler: SamplerOptions | null;
+  /** Filter/wrap override for the drawable's base texture, or `null` to inherit it. */
+  public sampler: MaterialSamplerOptions | null;
 
   /** Which drawable class this material can serve; renderers check compatibility. */
   public abstract readonly target: 'mesh' | 'sprite' | 'particle';
@@ -168,21 +180,22 @@ export abstract class Material {
 
   /**
    * Stable pipeline key: identical ⇒ same GPU pipeline/program can be used.
-   * Derived from shader identity, blend mode, and sampler state, and is
+   * Derived from shader identity and blend mode, and is
    * independent of the owning material instance so identically configured
    * materials share a pipeline. Drives grouping and the pipeline cache.
    */
   public get pipelineKey(): number {
-    return derivePipelineKey(this.shader.id, this.blendMode, this.sampler);
+    return derivePipelineKey(this.shader.id, this.blendMode);
   }
 
   /**
    * Stable bind key: identical ⇒ same bindings (textures unchanged). Derived
-   * from this material's identity and the identities of its bound textures.
-   * Changes when a texture is swapped; drives bind-group/slot reuse.
+   * from this material's identity, base-texture sampler override, and the
+   * identities of its bound textures. Changes when a texture is swapped or
+   * sampler state changes; drives bind-group/slot reuse.
    */
   public get bindKey(): number {
-    return deriveBindKey(this._id, this._uniformValues, this._textureValues);
+    return deriveBindKey(this._id, this._uniformValues, this._textureValues, this.sampler);
   }
 
   /**

--- a/src/rendering/material/Material.ts
+++ b/src/rendering/material/Material.ts
@@ -23,6 +23,21 @@ export type UniformValue =
   | Texture
   | RenderTexture;
 
+/** Whether a material-uniform value occupies a texture binding. @internal */
+export const isTextureUniformValue = (value: UniformValue): value is Texture | RenderTexture =>
+  typeof value === 'object' && value !== null && !Array.isArray(value) && !ArrayBuffer.isView(value);
+
+/**
+ * Immutable binding layout captured when a material is constructed. Values
+ * behind these names stay live; only the name/order/kind contract is fixed.
+ * @internal
+ */
+export interface MaterialBindingSchema {
+  readonly scalarUniformNames: readonly string[];
+  readonly textureUniformNames: readonly string[];
+  readonly textureNames: readonly string[];
+}
+
 /**
  * Construction options shared by every {@link Material}.
  *
@@ -34,10 +49,13 @@ export interface MaterialOptions {
   /** GLSL/WGSL source pair backing this material. */
   readonly shader: ShaderSource;
 
-  /** Initial uniform values; mutate per frame via {@link Material.uniforms}. */
+  /**
+   * Declared uniform slots and their initial values. Names and scalar/texture
+   * kinds form a fixed construction-time schema; values remain mutable.
+   */
   readonly uniforms?: Record<string, UniformValue>;
 
-  /** Named texture bindings claimed in addition to the drawable's own texture. */
+  /** Declared texture slots claimed in addition to the drawable's own texture. */
   readonly textures?: Record<string, Texture | RenderTexture>;
 
   /** Compositing blend mode; defaults to {@link BlendModes.Normal}. */
@@ -74,16 +92,21 @@ export abstract class Material {
   public readonly shader: ShaderSource;
 
   /**
-   * Mutable user uniform values. Mutate between frames to drive animated
-   * effects; the renderer reads from this map every draw.
+   * Live user uniform values. Construction declares the fixed set of names and
+   * each name's scalar/texture kind; existing values can be replaced between
+   * frames and typed arrays can be mutated in place.
    *
    *   material.uniforms.u_time = performance.now() / 1000;
    *   material.uniforms.u_color = [1, 0.5, 0, 1];
    */
-  public uniforms: Record<string, UniformValue>;
+  public get uniforms(): Record<string, UniformValue> {
+    return this._uniformView;
+  }
 
-  /** Named texture bindings claimed in addition to the drawable's own texture. */
-  public textures: Record<string, Texture | RenderTexture>;
+  /** Live identities behind the fixed named texture slots. */
+  public get textures(): Record<string, Texture | RenderTexture> {
+    return this._textureView;
+  }
 
   /** Compositing blend mode applied when drawing with this material. */
   public blendMode: BlendModes;
@@ -96,6 +119,12 @@ export abstract class Material {
 
   private readonly _id: number;
   private readonly _disposeCallbacks = new Set<() => void>();
+  private readonly _uniformValues: Record<string, UniformValue>;
+  private readonly _textureValues: Record<string, Texture | RenderTexture>;
+  private readonly _uniformView: Record<string, UniformValue>;
+  private readonly _textureView: Record<string, Texture | RenderTexture>;
+  /** Fixed construction-time binding schema used by both backends. @internal */
+  public readonly _bindingSchema: MaterialBindingSchema;
 
   protected constructor(options: MaterialOptions) {
     if (options.shader === undefined || options.shader === null) {
@@ -103,8 +132,35 @@ export abstract class Material {
     }
 
     this.shader = options.shader;
-    this.uniforms = { ...(options.uniforms ?? {}) };
-    this.textures = { ...(options.textures ?? {}) };
+    this._uniformValues = { ...(options.uniforms ?? {}) };
+    this._textureValues = { ...(options.textures ?? {}) };
+    this._uniformView = this._createUniformView();
+    this._textureView = this._createTextureView();
+
+    const scalarUniformNames: string[] = [];
+    const textureUniformNames: string[] = [];
+
+    for (const name of Object.keys(this._uniformValues)) {
+      if (isTextureUniformValue(this._uniformValues[name]!)) {
+        textureUniformNames.push(name);
+      } else {
+        scalarUniformNames.push(name);
+      }
+    }
+
+    const textureNames = Object.keys(this._textureValues);
+
+    for (const name of textureNames) {
+      if (Object.prototype.hasOwnProperty.call(this._uniformValues, name)) {
+        throw new Error(`Material binding \`${name}\` is declared in both \`uniforms\` and \`textures\`.`);
+      }
+    }
+
+    this._bindingSchema = Object.freeze({
+      scalarUniformNames: Object.freeze(scalarUniformNames),
+      textureUniformNames: Object.freeze(textureUniformNames),
+      textureNames: Object.freeze(textureNames),
+    });
     this.blendMode = options.blendMode ?? BlendModes.Normal;
     this.sampler = options.sampler ?? null;
     this._id = nextMaterialId++;
@@ -126,25 +182,32 @@ export abstract class Material {
    * Changes when a texture is swapped; drives bind-group/slot reuse.
    */
   public get bindKey(): number {
-    return deriveBindKey(this._id, this.uniforms, this.textures);
+    return deriveBindKey(this._id, this._uniformValues, this._textureValues);
   }
 
   /**
-   * Set a uniform value. Equivalent to `material.uniforms[name] = value`,
-   * returned `this` for chaining.
+   * Replace a declared uniform value, returning `this` for chaining. Unknown
+   * names and scalar↔texture kind changes are rejected.
    */
   public setUniform(name: string, value: UniformValue): this {
-    this.uniforms[name] = value;
+    if (!Object.prototype.hasOwnProperty.call(this._uniformView, name)) {
+      throw new Error(`Material uniform \`${name}\` is not part of this material's fixed binding schema.`);
+    }
+
+    this._uniformView[name] = value;
 
     return this;
   }
 
   /**
-   * Bind a named texture. Equivalent to `material.textures[name] = texture`,
-   * returned `this` for chaining.
+   * Replace the texture behind a declared slot, returning `this` for chaining.
    */
   public setTexture(name: string, texture: Texture | RenderTexture): this {
-    this.textures[name] = texture;
+    if (!Object.prototype.hasOwnProperty.call(this._textureView, name)) {
+      throw new Error(`Material texture \`${name}\` is not part of this material's fixed binding schema.`);
+    }
+
+    this._textureView[name] = texture;
 
     return this;
   }
@@ -173,5 +236,61 @@ export abstract class Material {
    */
   public _onDispose(callback: () => void): void {
     this._disposeCallbacks.add(callback);
+  }
+
+  /** Read a declared uniform without crossing the public guarded view. @internal */
+  public _getUniformValue(name: string): UniformValue {
+    return this._uniformValues[name]!;
+  }
+
+  /** Read a declared texture without crossing the public guarded view. @internal */
+  public _getTextureValue(name: string): Texture | RenderTexture {
+    return this._textureValues[name]!;
+  }
+
+  private _createUniformView(): Record<string, UniformValue> {
+    const view: Record<string, UniformValue> = {};
+
+    for (const name of Object.keys(this._uniformValues)) {
+      const textureSlot = isTextureUniformValue(this._uniformValues[name]!);
+
+      Object.defineProperty(view, name, {
+        enumerable: true,
+        configurable: false,
+        get: () => this._uniformValues[name]!,
+        set: (value: UniformValue) => {
+          if (isTextureUniformValue(value) !== textureSlot) {
+            throw new Error(
+              `Material uniform \`${name}\` cannot change binding kind from ${textureSlot ? 'texture' : 'scalar'} to ${textureSlot ? 'scalar' : 'texture'}.`,
+            );
+          }
+
+          this._uniformValues[name] = value;
+        },
+      });
+    }
+
+    return Object.preventExtensions(view);
+  }
+
+  private _createTextureView(): Record<string, Texture | RenderTexture> {
+    const view: Record<string, Texture | RenderTexture> = {};
+
+    for (const name of Object.keys(this._textureValues)) {
+      Object.defineProperty(view, name, {
+        enumerable: true,
+        configurable: false,
+        get: () => this._textureValues[name]!,
+        set: (value: Texture | RenderTexture) => {
+          if (!isTextureUniformValue(value)) {
+            throw new Error(`Material texture \`${name}\` must remain a texture binding.`);
+          }
+
+          this._textureValues[name] = value;
+        },
+      });
+    }
+
+    return Object.preventExtensions(view);
   }
 }

--- a/src/rendering/material/MaterialKey.ts
+++ b/src/rendering/material/MaterialKey.ts
@@ -1,9 +1,8 @@
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
-import type { SamplerOptions } from '#rendering/texture/Sampler';
 import type { Texture } from '#rendering/texture/Texture';
 import type { BlendModes } from '#rendering/types';
 
-import type { UniformValue } from './Material';
+import type { MaterialSamplerOptions, UniformValue } from './Material';
 
 /**
  * @internal
@@ -16,11 +15,12 @@ import type { UniformValue } from './Material';
  * `JSON.stringify` over objects with unstable key order.
  *
  * Two key spaces:
- * - {@link derivePipelineKey}: shader identity + blend + sampler state.
+ * - {@link derivePipelineKey}: shader identity + blend state.
  *   Drives GPU pipeline/program reuse and material grouping. Independent of
  *   the owning material instance, so identically configured materials share
  *   a pipeline key.
- * - {@link deriveBindKey}: material identity + bound texture identities.
+ * - {@link deriveBindKey}: material identity + base sampler override + bound
+ *   texture identities.
  *   Drives bind-group/slot reuse; changes when a material swaps a texture.
  */
 
@@ -59,23 +59,23 @@ const intern = (registry: Map<string, number>, descriptor: string, allocate: () 
   return key;
 };
 
-const samplerDescriptor = (sampler: SamplerOptions | null): string => {
+const samplerDescriptor = (sampler: MaterialSamplerOptions | null): string => {
   if (sampler === null) {
     return '-';
   }
 
-  return [sampler.scaleMode, sampler.wrapMode, sampler.premultiplyAlpha ? 1 : 0, sampler.generateMipMap ? 1 : 0, sampler.flipY ? 1 : 0].join(':');
+  return `${sampler.scaleMode}:${sampler.wrapMode}`;
 };
 
 const isTextureBinding = (value: UniformValue): value is Texture | RenderTexture =>
   typeof value === 'object' && value !== null && !Array.isArray(value) && !ArrayBuffer.isView(value);
 
 /**
- * Pipeline key from shader identity, blend mode, and sampler state.
+ * Pipeline key from shader identity and blend mode.
  * @internal
  */
-export const derivePipelineKey = (shaderId: number, blendMode: BlendModes, sampler: SamplerOptions | null): number => {
-  const descriptor = `${shaderId}|${blendMode}|${samplerDescriptor(sampler)}`;
+export const derivePipelineKey = (shaderId: number, blendMode: BlendModes): number => {
+  const descriptor = `${shaderId}|${blendMode}`;
 
   return intern(pipelineKeyRegistry, descriptor, () => nextPipelineKey++);
 };
@@ -87,7 +87,12 @@ export const derivePipelineKey = (shaderId: number, blendMode: BlendModes, sampl
  * descriptor is independent of insertion order.
  * @internal
  */
-export const deriveBindKey = (materialId: number, uniforms: Record<string, UniformValue>, textures: Record<string, Texture | RenderTexture>): number => {
+export const deriveBindKey = (
+  materialId: number,
+  uniforms: Record<string, UniformValue>,
+  textures: Record<string, Texture | RenderTexture>,
+  sampler: MaterialSamplerOptions | null,
+): number => {
   const entries: string[] = [];
 
   for (const name of Object.keys(textures)) {
@@ -106,7 +111,7 @@ export const deriveBindKey = (materialId: number, uniforms: Record<string, Unifo
 
   entries.sort();
 
-  const descriptor = `${materialId}|${entries.join(',')}`;
+  const descriptor = `${materialId}|${samplerDescriptor(sampler)}|${entries.join(',')}`;
 
   return intern(bindKeyRegistry, descriptor, () => nextBindKey++);
 };

--- a/src/rendering/material/RetainedMaterialState.ts
+++ b/src/rendering/material/RetainedMaterialState.ts
@@ -1,0 +1,33 @@
+import type { Material, MaterialBindingSchema } from './Material';
+
+/** Renderer-private discriminator carried through retained batch payloads. */
+const retainedMaterialStateKind = 'exojs:retained-material-state';
+
+/**
+ * Live-material handle recorded beside retained geometry. The material itself
+ * remains authoritative for values and texture identities; the stamps cover
+ * state that can change batching or the GPU layout.
+ * @internal
+ */
+export interface RetainedMaterialState<M extends Material = Material> {
+  readonly kind: typeof retainedMaterialStateKind;
+  readonly material: M;
+  readonly bindingSchema: MaterialBindingSchema;
+  readonly pipelineKey: number;
+}
+
+/** Capture the structural stamps for one material batch. @internal */
+export const createRetainedMaterialState = <M extends Material>(material: M): RetainedMaterialState<M> => ({
+  kind: retainedMaterialStateKind,
+  material,
+  bindingSchema: material._bindingSchema,
+  pipelineKey: material.pipelineKey,
+});
+
+/** Narrow an opaque renderer payload to a retained material descriptor. @internal */
+export const isRetainedMaterialState = (value: unknown): value is RetainedMaterialState =>
+  typeof value === 'object' && value !== null && (value as Partial<RetainedMaterialState>).kind === retainedMaterialStateKind;
+
+/** Structural preflight: values/bound texture identities deliberately do not participate. @internal */
+export const isRetainedMaterialStateValid = (state: RetainedMaterialState): boolean =>
+  state.material._bindingSchema === state.bindingSchema && state.material.pipelineKey === state.pipelineKey;

--- a/src/rendering/material/SpriteMaterial.ts
+++ b/src/rendering/material/SpriteMaterial.ts
@@ -8,10 +8,10 @@ import { ShaderSource } from './ShaderSource';
 /**
  * Material specialization for {@link Sprite} drawables.
  *
- * API shell for the sprite custom-material path; the renderer integration
- * and instancing contract are added in a later phase. The base texture
- * stays on the sprite — this material supplies the fragment program,
- * uniforms, and additional texture bindings.
+ * The base texture stays on the sprite and is sampled through the engine's
+ * `sampleBase(slot, uv)` helper, which preserves batching and resolves the
+ * backend's premultiplied-alpha convention. The material supplies the custom
+ * fragment program, uniforms, additional texture bindings, and blend mode.
  * @advanced
  */
 export class SpriteMaterial extends Material {

--- a/src/rendering/plan/RenderCommand.ts
+++ b/src/rendering/plan/RenderCommand.ts
@@ -19,10 +19,10 @@ export const enum RenderEntryKind {
  * eventual instanced batching.
  *
  * - {@link pipelineKey} drives pipeline/program reuse: identical key ⇒
- *   identical GPU pipeline state (shader + blend + sampler). Two draws
+ *   identical GPU pipeline state (shader + blend). Two draws
  *   with the same pipeline key can be issued with a single pipeline bind.
- * - {@link bindKey} drives texture-bind reuse: identical key ⇒ identical
- *   texture bindings. Two draws with the same bind key can share a bind
+ * - {@link bindKey} drives texture/sampler-bind reuse: identical key ⇒
+ *   identical bindings. Two draws with the same bind key can share a bind
  *   group / texture-slot state.
  *
  * When the drawable carries a {@link Material}, both keys are taken

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -434,7 +434,11 @@ export class RenderPlanBuilder {
     command.seq = slot.seq;
     command.zIndex = slot.zIndex;
     command.groupIndex = undefined;
-    command.material = slot.material;
+    // Own-material values and texture identities are live even while the
+    // fragment itself stays clean. Re-derive their key on the entry-replay
+    // fallback so a structural retained invalidation cannot regroup using the
+    // record-time snapshot before the replacement capture is produced.
+    command.material = slot.material.ownMaterial ? slot.drawable._getOrComputeMaterialKey(this.backend) : slot.material;
     command.minX = slot.minX;
     command.minY = slot.minY;
     command.maxX = slot.maxX;

--- a/src/rendering/plan/RetainedInstructionSet.ts
+++ b/src/rendering/plan/RetainedInstructionSet.ts
@@ -241,14 +241,16 @@ export class RetainedInstructionSet {
 
 /**
  * Structural capability flag for renderers that support flush-level batch
- * recording. v1 opt-in: the sprite renderers' default path only —
- * the concrete backends set `_supportsRetainedBatches = true` on their sprite
- * renderers when they implement the record/replay hooks. Same
+ * recording. Own-material draws require the additional per-draw opt-in below,
+ * so a renderer can support its default path without accidentally promising
+ * live custom-state replay. Same
  * structural-flag convention as `_consumesSharedTransform`.
  * @internal
  */
 export interface RetainedBatchCapableRenderer {
   readonly _supportsRetainedBatches?: boolean;
+  /** Opt an own-material drawable into retained recording. @internal */
+  _canRecordRetainedDrawable?(drawable: Drawable): boolean;
 }
 
 interface BackendWithRendererRegistry {
@@ -258,10 +260,9 @@ interface BackendWithRendererRegistry {
 }
 
 /**
- * The v1 recordability predicate: a captured fragment can be recorded
- * as an instruction set iff every captured draw uses a renderer that opts in
- * via {@link RetainedBatchCapableRenderer}, has no own material (custom
- * uniforms re-upload live at flush and their mutation bumps no revision); and no
+ * A captured fragment can be recorded as an instruction set iff every draw's
+ * renderer opts in via {@link RetainedBatchCapableRenderer}; own-material
+ * draws additionally pass that renderer's live-state capability check; and no
  * barrier record exists anywhere in the fragment (barriers re-dispatch live
  * per frame and cannot interleave with cached batch runs). Nested
  * plain/retained groups recurse. Anything non-recordable stays on the
@@ -296,10 +297,6 @@ const entriesRecordable = (entries: readonly RetainedFragmentEntry[], registry: 
 
     const drawable = entry.drawable;
 
-    if (drawableHasOwnMaterial(drawable)) {
-      return false;
-    }
-
     let renderer: RetainedBatchCapableRenderer | null;
 
     try {
@@ -310,6 +307,10 @@ const entriesRecordable = (entries: readonly RetainedFragmentEntry[], registry: 
     }
 
     if (renderer === null || typeof renderer !== 'object' || renderer._supportsRetainedBatches !== true) {
+      return false;
+    }
+
+    if (drawableHasOwnMaterial(drawable) && renderer._canRecordRetainedDrawable?.(drawable) !== true) {
       return false;
     }
   }

--- a/src/rendering/public.ts
+++ b/src/rendering/public.ts
@@ -62,7 +62,7 @@ export type { GradientStop, GradientToTextureOptions, GradientType } from '#rend
 export { Gradient } from '#rendering/gradient/Gradient';
 export { LinearGradient } from '#rendering/gradient/LinearGradient';
 export { RadialGradient } from '#rendering/gradient/RadialGradient';
-export type { MaterialOptions, UniformValue } from '#rendering/material/Material';
+export type { MaterialOptions, MaterialSamplerOptions, UniformValue } from '#rendering/material/Material';
 export { Material } from '#rendering/material/Material';
 export { MeshMaterial } from '#rendering/material/MeshMaterial';
 export type { ShaderSourceOptions } from '#rendering/material/ShaderSource';

--- a/src/rendering/sprite/spriteMaterialSources.ts
+++ b/src/rendering/sprite/spriteMaterialSources.ts
@@ -25,6 +25,9 @@
  * up to {@link spriteMaterialTextureSlots} base textures through the group(1)
  * (WGSL) / unit 0..N-1 (WebGL2) slot table, and the fragment reads its own
  * instance's texture through the engine-provided `sampleBase(slot, uv)` helper.
+ * On WebGPU the value passed as `slot` also carries the engine-owned sample-
+ * premultiplication flag in bit 8; `sampleBase` masks and applies it. Custom
+ * fragments must treat it as opaque and pass it through unchanged.
  * Material uniforms and additional textures bind on top (WebGL2 units
  * {@link spriteMaterialTextureSlots}..N / WGSL group(2)).
  */
@@ -262,7 +265,7 @@ struct TransformSlot {
 struct VertexInput {
     @location(0) localBounds: vec4<f32>,
     @location(3) uvBounds: vec4<f32>,
-    @location(5) textureSlot: u32,
+    @location(5) packedSlotFlags: u32, // bits 0..7 = texture slot, bit 8 = premultiply sample
     @location(6) nodeIndex: u32,
 };
 
@@ -270,8 +273,8 @@ struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) texcoord: vec2<f32>,
     @location(1) color: vec4<f32>,
-    // Slot this instance's base texture occupies in the batch's slot table;
-    // pass it to sampleBase() to read the base texture.
+    // Opaque packed slot/flag word. Pass it unchanged to sampleBase(); custom
+    // fragments must not interpret it as a plain slot index.
     @location(2) @interpolate(flat) textureSlot: u32,
 };
 
@@ -347,7 +350,7 @@ fn vertexMain(input: VertexInput, @builtin(vertex_index) vid: u32) -> VertexOutp
     output.texcoord = vec2<f32>(u, v);
 
     output.color = vec4<f32>(tint.rgb * tint.a, tint.a);
-    output.textureSlot = input.textureSlot;
+    output.textureSlot = input.packedSlotFlags;
 
     return output;
 }
@@ -408,12 +411,17 @@ ${sampleCases}
 export const spriteMaterialPrologueWgsl = `${spriteVertexWgsl}
 ${buildSpriteTextureSlotWgsl(spriteMaterialTextureSlots)}
 
-// Sample this instance's base texture. \`slot\` is \`input.textureSlot\`; \`uv\` is
-// normally \`input.texcoord\` but may be any coordinate the effect derives from
-// it. Derivatives are taken here, before the per-slot switch, because
+// Sample this instance's base texture. \`packedSlotFlags\` is the opaque
+// \`input.textureSlot\` carrier: bits 0..7 select the texture and bit 8 asks
+// the engine to convert its unpremultiplied sample to premultiplied alpha.
+// \`uv\` is normally \`input.texcoord\` but may be any coordinate the effect
+// derives from it. Derivatives are taken here, before the per-slot switch, because
 // multi-texture batching makes the slot non-uniform across a quad and
 // textureSampleGrad is the only sampling form valid in that control flow.
-fn sampleBase(slot: u32, uv: vec2<f32>) -> vec4<f32> {
-    return sampleTexture(slot, uv, dpdx(uv), dpdy(uv));
+fn sampleBase(packedSlotFlags: u32, uv: vec2<f32>) -> vec4<f32> {
+    let slot = packedSlotFlags & 0xffu;
+    let sample = sampleTexture(slot, uv, dpdx(uv), dpdy(uv));
+    let premultiplySample = ((packedSlotFlags >> 8u) & 1u) == 1u;
+    return select(sample, vec4<f32>(sample.rgb * sample.a, sample.a), premultiplySample);
 }
 `;

--- a/src/rendering/text/textAtlasTextureSlots.ts
+++ b/src/rendering/text/textAtlasTextureSlots.ts
@@ -1,0 +1,31 @@
+import { buildSpriteTextureSlotWgsl, composeSpriteMaterialFragmentGlsl, spriteMaterialTextureSlots } from '#rendering/sprite/spriteMaterialSources';
+
+/** Atlas textures rotated through one Text renderer batch. @internal */
+export const textAtlasTextureSlots = spriteMaterialTextureSlots;
+
+/** Low bits reserved for Text's dense per-flush node row. @internal */
+export const textNodeIndexMask = 0x00ffffff;
+
+/** Bit shift of the atlas-texture slot in the packed per-vertex word. @internal */
+export const textAtlasSlotShift = 24;
+
+/** Pack one dense Text node row and atlas slot into the existing 32-bit vertex word. @internal */
+export const packTextNodeAtlasSlot = (nodeIndex: number, atlasSlot: number): number => nodeIndex | (atlasSlot << textAtlasSlotShift);
+
+const dimensionCases = Array.from({ length: textAtlasTextureSlots }, (_, slot) =>
+  slot < textAtlasTextureSlots - 1
+    ? `        case ${slot}u: { return textureDimensions(spriteTexture${slot}, 0); }`
+    : `        default: { return textureDimensions(spriteTexture${slot}, 0); }`,
+).join('\n');
+
+/** WGSL atlas slot table plus per-slot dimensions used for shadow UV conversion. @internal */
+export const textAtlasTextureSlotWgsl = `${buildSpriteTextureSlotWgsl(textAtlasTextureSlots)}
+
+fn atlasTextureDimensions(slot: u32) -> vec2<u32> {
+    switch slot {
+${dimensionCases}
+    }
+}`;
+
+/** Inject the shared GLSL slot table into a shipped Text fragment shader. @internal */
+export const composeTextAtlasFragmentGlsl = composeSpriteMaterialFragmentGlsl;

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -9,6 +9,7 @@ import type { BackendRenderPass } from '#rendering/BackendRenderPass';
 import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
 import { dataTextureBytesPerPixel, estimateTextureBytes, GpuResourceAccountant } from '#rendering/GpuResourceAccountant';
+import type { MaterialSamplerOptions } from '#rendering/material/Material';
 import type { Mesh } from '#rendering/mesh/Mesh';
 import { type DrawCommand, drawCommandUsesSharedTransform, RenderEntryKind } from '#rendering/plan/RenderCommand';
 import type { ScopeEntry } from '#rendering/plan/RenderScope';
@@ -222,6 +223,8 @@ export class WebGl2Backend implements RenderBackend {
   private readonly _renderTargetStates: Map<RenderTarget, ManagedRenderTargetState> = new Map<RenderTarget, ManagedRenderTargetState>();
   private readonly _textureDestroyHandlers: Map<Texture | RenderTexture, () => void> = new Map<Texture | RenderTexture, () => void>();
   private readonly _textureReleaseHandlers: Map<Texture, () => void> = new Map<Texture, () => void>();
+  /** Context-local base-texture sampler overrides shared by custom materials. */
+  private readonly _materialSamplers = new Map<string, WebGLSampler>();
   private readonly _renderTargetDestroyHandlers: Map<RenderTarget, () => void> = new Map<RenderTarget, () => void>();
   private readonly _renderTexturePool: RenderTexturePool = new RenderTexturePool();
   private readonly _clipBoundsStack: Rectangle[] = [];
@@ -949,6 +952,39 @@ export class WebGl2Backend implements RenderBackend {
     // because its parameter and upload calls act on whatever is bound to the
     // active unit — binding a second time here would only duplicate GL work.
     this._syncTexture(texture);
+
+    return this;
+  }
+
+  /** Bind a material's base-texture sampler override to one texture unit. @internal */
+  public bindMaterialSampler(options: MaterialSamplerOptions, unit: number): this {
+    const key = `${options.scaleMode}:${options.wrapMode}`;
+    let sampler = this._materialSamplers.get(key);
+
+    if (sampler === undefined) {
+      const gl = this._context;
+      const created = gl.createSampler();
+
+      if (created === null) {
+        throw new Error('WebGl2Backend: could not create a material sampler.');
+      }
+
+      gl.samplerParameteri(created, gl.TEXTURE_MAG_FILTER, options.scaleMode);
+      gl.samplerParameteri(created, gl.TEXTURE_MIN_FILTER, options.scaleMode);
+      gl.samplerParameteri(created, gl.TEXTURE_WRAP_S, options.wrapMode);
+      gl.samplerParameteri(created, gl.TEXTURE_WRAP_T, options.wrapMode);
+      this._materialSamplers.set(key, created);
+      sampler = created;
+    }
+
+    this._context.bindSampler(unit, sampler);
+
+    return this;
+  }
+
+  /** Restore a texture unit to its texture-owned sampler state. @internal */
+  public unbindMaterialSampler(unit: number): this {
+    this._context.bindSampler(unit, null);
 
     return this;
   }
@@ -1863,6 +1899,12 @@ export class WebGl2Backend implements RenderBackend {
     for (const texture of [...this._textureStates.keys()]) {
       this._evictTexture(texture);
     }
+
+    for (const sampler of this._materialSamplers.values()) {
+      this._context.deleteSampler(sampler);
+    }
+
+    this._materialSamplers.clear();
   }
 
   private _getRenderTargetState(target: RenderTarget): ManagedRenderTargetState {

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -284,6 +284,7 @@ export class WebGl2Backend implements RenderBackend {
   private _drawPlanDepth = 0;
   private readonly _planBaseStack: number[] = [];
   private readonly _planHashStack: number[] = [];
+  private _renderPlanEpoch = 0;
   // Retained instruction-set capture state.
   private readonly _retainedCaptures: RetainedCaptureFrame[] = [];
   private readonly _retainedBundles = new Set<WebGl2RetainedGroupResources>();
@@ -409,8 +410,14 @@ export class WebGl2Backend implements RenderBackend {
     return this._transformBuffer.count;
   }
 
+  /** Monotonic render-plan token for per-material replay deduplication. @internal */
+  public get renderPlanEpoch(): number {
+    return this._renderPlanEpoch;
+  }
+
   /** @internal */
   public _beginDrawPlan(_nodeCount: number): void {
+    this._renderPlanEpoch++;
     // Do NOT reset the transform buffer here — it is frame-scoped (reset in
     // resetStats). The builder already based this plan's node indices at the
     // current buffer count, so writes land in fresh frame-global slots and
@@ -1480,6 +1487,12 @@ export class WebGl2Backend implements RenderBackend {
       const payload = instruction.payload as WebGl2RetainedBatchPayload | null;
 
       if (payload === null || typeof payload !== 'object' || !(payload.bundle instanceof WebGl2RetainedGroupResources)) {
+        return false;
+      }
+
+      if (payload.replayer._validateRetainedBatch?.(payload) === false) {
+        set.invalidate();
+
         return false;
       }
 

--- a/src/rendering/webgl2/WebGl2MeshRenderer.ts
+++ b/src/rendering/webgl2/WebGl2MeshRenderer.ts
@@ -5,7 +5,7 @@ import type { Mesh } from '#rendering/mesh/Mesh';
 import { type DrawCommand, RenderEntryKind } from '#rendering/plan/RenderCommand';
 import type { InstanceDataView } from '#rendering/RenderBatch';
 import { Shader } from '#rendering/shader/Shader';
-import { RenderTexture } from '#rendering/texture/RenderTexture';
+import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import { Texture } from '#rendering/texture/Texture';
 import { BlendModes, BufferTypes, BufferUsage, RenderingPrimitives } from '#rendering/types';
 
@@ -1209,47 +1209,34 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
     // Texture bindings take consecutive slots starting at 1 (slot 0 belongs to
     // the mesh's own `u_texture`). Texture-valued uniforms bind first, then the
     // entries of the material's dedicated `textures` map.
+    for (const name of material._bindingSchema.scalarUniformNames) {
+      if (shader.uniforms.has(name)) {
+        shader.getUniform(name).setValue(this._marshalUniformValue(material._getUniformValue(name) as Exclude<UniformValue, Texture | RenderTexture>));
+      }
+    }
+
     let textureSlot = 1;
 
-    const uniforms = material.uniforms;
-    for (const name in uniforms) {
-      if (!shader.uniforms.has(name)) {
-        continue;
-      }
-
-      // `name` iterates own keys of `uniforms`, so the lookup is defined.
-      const value = uniforms[name]!;
-      const uniform = shader.getUniform(name);
-
-      if (value instanceof Texture || value instanceof RenderTexture) {
-        if (textureSlot >= maxCustomTextureSlots) {
-          throw new Error(`Mesh material requested more than ${maxCustomTextureSlots - 1} texture bindings.`);
-        }
-        backend.bindTexture(value, textureSlot);
-        // In-bounds: `textureSlot < maxCustomTextureSlots` (guarded) and
-        // `_slotScratches` has `maxCustomTextureSlots + 1` pre-allocated entries.
-        uniform.setValue(this._slotScratches[textureSlot]!);
-        textureSlot++;
-      } else {
-        uniform.setValue(this._marshalUniformValue(value));
-      }
+    for (const name of material._bindingSchema.textureUniformNames) {
+      textureSlot = this._bindCustomTexture(shader, name, material._getUniformValue(name) as Texture | RenderTexture, textureSlot, backend);
     }
 
-    const textures = material.textures;
-    for (const name in textures) {
-      if (!shader.uniforms.has(name)) {
-        continue;
-      }
+    for (const name of material._bindingSchema.textureNames) {
+      textureSlot = this._bindCustomTexture(shader, name, material._getTextureValue(name), textureSlot, backend);
+    }
+  }
 
-      if (textureSlot >= maxCustomTextureSlots) {
-        throw new Error(`Mesh material requested more than ${maxCustomTextureSlots - 1} texture bindings.`);
-      }
+  private _bindCustomTexture(shader: Shader, name: string, texture: Texture | RenderTexture, textureSlot: number, backend: WebGl2Backend): number {
+    if (textureSlot >= maxCustomTextureSlots) {
+      throw new Error(`Mesh material requested more than ${maxCustomTextureSlots - 1} texture bindings.`);
+    }
 
-      // `name` iterates own keys of `textures`, so the lookup is defined.
-      backend.bindTexture(textures[name]!, textureSlot);
+    if (shader.uniforms.has(name)) {
+      backend.bindTexture(texture, textureSlot);
       shader.getUniform(name).setValue(this._slotScratches[textureSlot]!);
-      textureSlot++;
     }
+
+    return textureSlot + 1;
   }
 
   private _marshalUniformValue(value: Exclude<UniformValue, Texture | RenderTexture>): Float32Array | Int32Array {

--- a/src/rendering/webgl2/WebGl2MeshRenderer.ts
+++ b/src/rendering/webgl2/WebGl2MeshRenderer.ts
@@ -249,7 +249,9 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
       connection.dynamicInstanceBuffer.upload(instances.data.subarray(0, count * instances.strideFloats));
     }
 
+    this._bindBaseTextureSampler(backend, material);
     vao.drawInstanced(cacheEntry.indexCount, 0, count, RenderingPrimitives.Triangles);
+    this._unbindBaseTextureSampler(backend, material);
 
     backend.stats.batches++;
     backend.stats.drawCalls++;
@@ -490,7 +492,9 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
     this._bindInstancedShaderState(first.shader, first.texture, first.material, backend, maxNodeIndex);
     backend.bindVertexArrayObject(vao);
     connection.dynamicNodeIndexBuffer.upload(this._nodeIndexData.subarray(0, count));
+    this._bindBaseTextureSampler(backend, first.material);
     vao.drawInstanced(cacheEntry.indexCount, 0, count, RenderingPrimitives.Triangles);
+    this._unbindBaseTextureSampler(backend, first.material);
 
     backend.stats.batches++;
     backend.stats.drawCalls++;
@@ -559,7 +563,9 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
     backend.bindVertexArrayObject(connection.dynamicVao);
     connection.dynamicVertexBuffer.upload(this._float32View.subarray(0, mesh.vertexCount * vertexStrideWords));
     connection.dynamicIndexBuffer.upload(this._indexData.subarray(0, mesh.indexCount));
+    this._bindBaseTextureSampler(backend, draw.material);
     connection.dynamicVao.draw(mesh.indexCount, 0, RenderingPrimitives.Triangles);
+    this._unbindBaseTextureSampler(backend, draw.material);
 
     backend.stats.batches++;
     backend.stats.drawCalls++;
@@ -604,6 +610,18 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
     }
 
     shader.sync();
+  }
+
+  private _bindBaseTextureSampler(backend: WebGl2Backend, material: Material | null): void {
+    if (material?.sampler !== null && material?.sampler !== undefined) {
+      backend.bindMaterialSampler(material.sampler, 0);
+    }
+  }
+
+  private _unbindBaseTextureSampler(backend: WebGl2Backend, material: Material | null): void {
+    if (material?.sampler !== null && material?.sampler !== undefined) {
+      backend.unbindMaterialSampler(0);
+    }
   }
 
   // ── Retained-batch record/replay (mesh opt-in) ────────────────────────────

--- a/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
+++ b/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
@@ -137,6 +137,8 @@ export interface WebGl2RetainedBatchReplayer {
   _rebaseRetainedNodeIndices(payload: WebGl2RetainedBatchPayload, base: number): void;
   /** Point `payload.vao`'s attributes at the bundle instance buffer, based at `payload.byteOffset`. */
   _configureRetainedVao(payload: WebGl2RetainedBatchPayload): void;
+  /** Preflight structural live state before any instruction in the set draws. */
+  _validateRetainedBatch?(payload: WebGl2RetainedBatchPayload): boolean;
   /** Replay the batch: live state (blend, uniforms, textures), cached data (bytes, transforms). */
   _replayRetainedBatch(payload: WebGl2RetainedBatchPayload): void;
 }

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -1,12 +1,19 @@
 import type { ReadonlyRectangle } from '#math/Rectangle';
 import { packedGroupChanged } from '#rendering/affinePacking';
+import type { Drawable } from '#rendering/Drawable';
 import type { UniformValue } from '#rendering/material/Material';
+import {
+  createRetainedMaterialState,
+  isRetainedMaterialState,
+  isRetainedMaterialStateValid,
+  type RetainedMaterialState,
+} from '#rendering/material/RetainedMaterialState';
 import type { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import { Shader } from '#rendering/shader/Shader';
 import type { Sprite } from '#rendering/sprite/Sprite';
 import { composeSpriteMaterialFragmentGlsl, spriteMaterialTextureSlots, spriteVertexGlsl } from '#rendering/sprite/spriteMaterialSources';
-import { RenderTexture } from '#rendering/texture/RenderTexture';
-import { Texture } from '#rendering/texture/Texture';
+import type { RenderTexture } from '#rendering/texture/RenderTexture';
+import type { Texture } from '#rendering/texture/Texture';
 import { BlendModes, BufferTypes, BufferUsage, RenderingPrimitives } from '#rendering/types';
 import type { View } from '#rendering/View';
 
@@ -92,14 +99,17 @@ interface SpriteRendererConnection {
 
 export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> implements WebGl2RetainedBatchReplayer {
   /**
-   * Retained-batch capability opt-in: the DEFAULT
-   * path's flushes can be recorded into a group's instruction set and
-   * replayed from group-owned resources. Custom-material and pixel-snapped
-   * draws are excluded by the plan-level recordability predicate (and
-   * belt-and-braces poisoning below).
+   * Retained-batch capability opt-in: default and live SpriteMaterial flushes
+   * can be recorded into a group's instruction set and replayed from
+   * group-owned resources.
    * @internal
    */
   public readonly _supportsRetainedBatches = true;
+
+  /** Custom SpriteMaterial batches implement the live-material replay contract. @internal */
+  public _canRecordRetainedDrawable(drawable: Drawable): boolean {
+    return (drawable as Sprite).material !== null;
+  }
 
   private readonly _shader: Shader;
   private readonly _batchSize: number;
@@ -130,6 +140,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
   private readonly _transformUnitScratch: Int32Array = new Int32Array([transformTextureUnit]);
   private readonly _tintUnitScratch: Int32Array = new Int32Array([transformTintTextureUnit]);
   private _currentMaterial: SpriteMaterial | null = null;
+  private readonly _retainedPreparedEpoch = new WeakMap<SpriteMaterial, number>();
   // Local bounds resolved for the sprite currently being packed. Geometry-mode
   // boundary snapping now happens in the vertex shader, so this is always the
   // sprite's logical local bounds; the field lets _packInstance read the value
@@ -169,16 +180,6 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
 
     const backend = this.getBackend();
     const material = sprite.material;
-
-    // Belt-and-braces for retained recording: the collect-time
-    // recordability predicate excludes custom-material draws from ever arming a
-    // capture (both pixel-snap modes are resolved in-shader and stay recordable).
-    // If one still arrives inside an active capture window, poison the recording
-    // so the resulting set can never validate — degrading to entry replay instead
-    // of wrong pixels.
-    if (backend._isRetainedCapturing && material !== null) {
-      backend._poisonRetainedCaptures();
-    }
 
     // The transform lives in the shared buffer, keyed by the draw command's
     // stable nodeIndex (already packed at the render-group upload boundary).
@@ -244,7 +245,8 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
 
       // Base textures are already bound to their slot units by _renderCustom;
       // the sampler uniforms are pinned once when the program is compiled.
-      this._bindCustomUniforms(shader, material, backend);
+      this._stageCustomUniforms(shader, material);
+      this._bindCustomTextures(shader, material, backend);
     }
 
     // Bind the shared transform buffer texture (one row per nodeIndex) on the
@@ -269,12 +271,9 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     backend.stats.batches++;
     backend.stats.drawCalls++;
 
-    // Retained recording: while a capture window is open,
-    // hand the exact packed instance words of this DEFAULT-path flush to the
-    // backend — byte-identical to what just drew, no duplicated packing
-    // logic. Custom-material batches are never recorded (the render()-time
-    // poison above already invalidated the capture if one slipped through).
-    if (material === null && backend._isRetainedCapturing) {
+    // Retained recording: cache byte-identical instance data and retain only a
+    // live descriptor for custom material state.
+    if (backend._isRetainedCapturing) {
       backend._recordRetainedBatch(
         this,
         this._instanceUint32.subarray(0, this._instanceCount * wordsPerInstance),
@@ -282,6 +281,8 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
         this._currentBlendMode ?? BlendModes.Normal,
         this._activeTextures,
         this._slotCount,
+        null,
+        material === null ? null : createRetainedMaterialState(material),
       );
     }
 
@@ -399,6 +400,8 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     const vao = payload.vao;
     const transformTexture = payload.bundle.transformTexture;
     const tintTexture = payload.bundle.tintTexture;
+    const materialState = this._retainedMaterialState(payload);
+    const material = materialState?.material ?? null;
 
     if (backend === null || vao === null || transformTexture === null || tintTexture === null) {
       // Defensive: a bundle in this state never validates (generation), so a
@@ -413,7 +416,30 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     }
 
     backend.setBlendMode(payload.blendMode);
-    this._stageDefaultViewUniforms(backend);
+    const shader = material === null ? this._shader : this._getOrCreateCustomShader(material, backend.context);
+
+    if (material === null) {
+      this._stageDefaultViewUniforms(backend);
+    } else {
+      if (shader.uniforms.has('u_projection')) {
+        shader.getUniform('u_projection').setValue(backend.view.getTransform().toArray(false));
+      }
+
+      if (shader.uniforms.has('u_group')) {
+        const groupTransform = backend.renderGroupTransform;
+
+        shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
+      }
+
+      backend._stageViewportUniform(shader);
+
+      if (this._retainedPreparedEpoch.get(material) !== backend.renderPlanEpoch) {
+        this._stageCustomUniforms(shader, material);
+        this._retainedPreparedEpoch.set(material, backend.renderPlanEpoch);
+      }
+
+      this._bindCustomTextures(shader, material, backend);
+    }
 
     const textures = payload.textures;
 
@@ -427,19 +453,30 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     // re-binds the shared texture through bindTransformBufferTexture.
     backend.bindTexture(transformTexture, transformTextureUnit);
 
-    if (this._shader.uniforms.has('u_transforms')) {
-      this._shader.getUniform('u_transforms').setValue(this._transformUnitScratch);
+    if (shader.uniforms.has('u_transforms')) {
+      shader.getUniform('u_transforms').setValue(this._transformUnitScratch);
     }
 
     backend.bindTexture(tintTexture, transformTintTextureUnit);
 
-    if (this._shader.uniforms.has('u_tintTexture')) {
-      this._shader.getUniform('u_tintTexture').setValue(this._tintUnitScratch);
+    if (shader.uniforms.has('u_tintTexture')) {
+      shader.getUniform('u_tintTexture').setValue(this._tintUnitScratch);
     }
 
-    this._shader.sync();
+    shader.sync();
     backend.bindVertexArrayObject(vao);
     vao.drawInstanced(4, 0, payload.instanceCount, RenderingPrimitives.TriangleStrip);
+  }
+
+  /** Structural preflight called for every batch before the set is spliced. @internal */
+  public _validateRetainedBatch(payload: WebGl2RetainedBatchPayload): boolean {
+    const state = this._retainedMaterialState(payload);
+
+    return state === null || isRetainedMaterialStateValid(state);
+  }
+
+  private _retainedMaterialState(payload: WebGl2RetainedBatchPayload): RetainedMaterialState<SpriteMaterial> | null {
+    return isRetainedMaterialState(payload.rendererData) ? (payload.rendererData as RetainedMaterialState<SpriteMaterial>) : null;
   }
 
   protected onConnect(backend: WebGl2Backend): void {
@@ -679,54 +716,48 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     return shader;
   }
 
-  private _bindCustomUniforms(shader: Shader, material: SpriteMaterial, backend: WebGl2Backend): void {
-    // Texture bindings take consecutive units above the base-texture slot table
-    // (units 0..spriteMaterialTextureSlots-1 belong to the sprites' own base
-    // textures). Texture-valued uniforms bind first, then the entries of the
-    // material's dedicated `textures` map.
-    let textureSlot = customTextureUnitBase;
-
-    const uniforms = material.uniforms;
-
-    for (const name in uniforms) {
-      if (!shader.uniforms.has(name)) {
-        continue;
-      }
-
-      // `name` iterates own keys of `uniforms`, so the lookup is defined.
-      const value = uniforms[name]!;
-      const uniform = shader.getUniform(name);
-
-      if (value instanceof Texture || value instanceof RenderTexture) {
-        if (textureSlot >= customTextureUnitBase + maxCustomTextureSlots) {
-          throw new Error(`SpriteMaterial requested more than ${maxCustomTextureSlots} texture bindings.`);
-        }
-
-        backend.bindTexture(value, textureSlot);
-        // In-bounds: `textureSlot < customTextureUnitBase + maxCustomTextureSlots
-        // <= maxBatchTextures` (guarded) and `_slotScratches` has
-        // `maxBatchTextures` entries.
-        uniform.setValue(this._slotScratches[textureSlot]!);
-        textureSlot++;
-      } else {
-        uniform.setValue(this._marshalUniformValue(value));
+  private _stageCustomUniforms(shader: Shader, material: SpriteMaterial): void {
+    for (const name of material._bindingSchema.scalarUniformNames) {
+      if (shader.uniforms.has(name)) {
+        shader.getUniform(name).setValue(this._marshalUniformValue(material._getUniformValue(name) as Exclude<UniformValue, Texture | RenderTexture>));
       }
     }
 
-    const textures = material.textures;
+    let textureSlot = customTextureUnitBase;
 
-    for (const name in textures) {
-      if (!shader.uniforms.has(name)) {
-        continue;
-      }
+    for (const name of material._bindingSchema.textureUniformNames) {
+      this._stageCustomTextureUnit(shader, name, textureSlot++);
+    }
 
-      if (textureSlot >= customTextureUnitBase + maxCustomTextureSlots) {
-        throw new Error(`SpriteMaterial requested more than ${maxCustomTextureSlots} texture bindings.`);
-      }
+    for (const name of material._bindingSchema.textureNames) {
+      this._stageCustomTextureUnit(shader, name, textureSlot++);
+    }
+  }
 
-      // `name` iterates own keys of `textures`, so the lookup is defined.
-      backend.bindTexture(textures[name]!, textureSlot);
+  private _stageCustomTextureUnit(shader: Shader, name: string, textureSlot: number): void {
+    if (textureSlot >= customTextureUnitBase + maxCustomTextureSlots) {
+      throw new Error(`SpriteMaterial requested more than ${maxCustomTextureSlots} texture bindings.`);
+    }
+
+    if (shader.uniforms.has(name)) {
       shader.getUniform(name).setValue(this._slotScratches[textureSlot]!);
+    }
+  }
+
+  private _bindCustomTextures(shader: Shader, material: SpriteMaterial, backend: WebGl2Backend): void {
+    let textureSlot = customTextureUnitBase;
+
+    for (const name of material._bindingSchema.textureUniformNames) {
+      if (shader.uniforms.has(name)) {
+        backend.bindTexture(material._getUniformValue(name) as Texture | RenderTexture, textureSlot);
+      }
+      textureSlot++;
+    }
+
+    for (const name of material._bindingSchema.textureNames) {
+      if (shader.uniforms.has(name)) {
+        backend.bindTexture(material._getTextureValue(name), textureSlot);
+      }
       textureSlot++;
     }
   }

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -267,7 +267,9 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
     shader.sync();
     backend.bindVertexArrayObject(vao);
     instanceBuffer.upload(this._instanceFloat32.subarray(0, this._instanceCount * wordsPerInstance));
+    this._bindBaseTextureSamplers(backend, material, this._slotCount);
     vao.drawInstanced(4, 0, this._instanceCount, RenderingPrimitives.TriangleStrip);
+    this._unbindBaseTextureSamplers(backend, material, this._slotCount);
     backend.stats.batches++;
     backend.stats.drawCalls++;
 
@@ -465,7 +467,31 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
 
     shader.sync();
     backend.bindVertexArrayObject(vao);
+    this._bindBaseTextureSamplers(backend, material, textures.length);
     vao.drawInstanced(4, 0, payload.instanceCount, RenderingPrimitives.TriangleStrip);
+    this._unbindBaseTextureSamplers(backend, material, textures.length);
+  }
+
+  private _bindBaseTextureSamplers(backend: WebGl2Backend, material: SpriteMaterial | null, slotCount: number): void {
+    const sampler = material?.sampler;
+
+    if (sampler === null || sampler === undefined) {
+      return;
+    }
+
+    for (let slot = 0; slot < slotCount; slot++) {
+      backend.bindMaterialSampler(sampler, slot);
+    }
+  }
+
+  private _unbindBaseTextureSamplers(backend: WebGl2Backend, material: SpriteMaterial | null, slotCount: number): void {
+    if (material?.sampler === null || material?.sampler === undefined) {
+      return;
+    }
+
+    for (let slot = 0; slot < slotCount; slot++) {
+      backend.unbindMaterialSampler(slot);
+    }
   }
 
   /** Structural preflight called for every batch before the set is spliced. @internal */

--- a/src/rendering/webgl2/WebGl2TextRenderer.ts
+++ b/src/rendering/webgl2/WebGl2TextRenderer.ts
@@ -5,6 +5,7 @@ import { Shader } from '#rendering/shader/Shader';
 import { type BitmapText } from '#rendering/text/BitmapText';
 import type { TextPageQuads } from '#rendering/text/Text';
 import { Text } from '#rendering/text/Text';
+import { composeTextAtlasFragmentGlsl, packTextNodeAtlasSlot, textAtlasTextureSlots, textNodeIndexMask } from '#rendering/text/textAtlasTextureSlots';
 import { DataTexture } from '#rendering/texture/DataTexture';
 import type { Texture } from '#rendering/texture/Texture';
 import { BlendModes, BufferTypes, BufferUsage, IndexElementTypes, RenderingPrimitives, TextureFormat } from '#rendering/types';
@@ -44,8 +45,8 @@ import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './
 // Texel 8 : (r,  g,  b,  a )  — gradientBottom
 // Texel 9 : (minX, minY, w, h) — text block bounds (local space, for gradient UV)
 //
-// The shaders divide shadowOffset by u_pageSize (a per-batch uniform = atlas texture width)
-// to convert px → UV space.
+// The shaders divide shadowOffset by u_pageSize (a per-batch uniform shared by
+// compatible atlas textures) to convert px → UV space.
 
 const nodeTexels = 10;
 const nodeFloats = nodeTexels * 4; // 40 floats per node
@@ -55,7 +56,7 @@ const identityGroupMat3 = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
 // Per-vertex layout (20 bytes), mirrors WebGpuTextRenderer's vertex buffer exactly:
 //   a_position : vec2  f32  (offset  0,  8 bytes)  ← LOCAL space
 //   a_texcoord : vec2  f32  (offset  8,  8 bytes)
-//   a_nodeIndex: float f32  (offset 16,  4 bytes)  ← row into the data texture (transform + style)
+//   a_packedNodeSlot: uint u32 (offset 16, 4 bytes) ← 24-bit node row + 8-bit atlas slot
 //
 // The vertex shader reads the world transform live from the per-node data texture via
 // texelFetch (same texture the fragment stage already reads style from), keyed by
@@ -81,6 +82,9 @@ interface PendingQuad {
   readonly atlasTexture: Texture;
   readonly node: Text | BitmapText;
 }
+
+const sharesAtlasBatchClass = (a: PendingQuad, b: PendingQuad): boolean =>
+  a.shaderType === b.shaderType && a.atlasTexture.width === b.atlasTexture.width && a.atlasTexture.height === b.atlasTexture.height;
 
 /**
  * Record-time payload carried from `flush()` to `_configureRetainedVao`/replay.
@@ -138,8 +142,9 @@ interface TextRendererConnection {
  * - `text-color` — RGBA atlas (emoji / colour fonts)
  *
  * All per-node data (world transform + style) is packed into a single
- * `RGBA32F` data texture uploaded once per {@link flush}.  Nodes sharing the
- * same shader type and atlas page are drawn in a single `drawElements` call.
+ * `RGBA32F` data texture uploaded once per {@link flush}. Compatible atlas
+ * textures rotate through an eight-slot table, so one `drawElements` call can
+ * cover several fonts/pages.
  */
 export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText> implements WebGl2RetainedBatchReplayer, OwnTransformRowPatcher {
   /**
@@ -151,13 +156,11 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
   public readonly _consumesSharedTransform = false;
 
   /**
-   * Retained-batch opt-in: a flush whose glyph quads all
-   * share one (shaderType, atlasTexture) — the overwhelmingly common case, one
-   * font/atlas per flush — records the vertex bytes into the group instance
-   * buffer and replays them with `drawElements`. A flush that spans multiple
-   * (shaderType, atlasTexture) batches, or a second Text flush inside the same
-   * capture window, poisons the capture instead — always safe, just a missed
-   * optimization.
+   * Retained-batch opt-in: one compatible shader/page class containing at most
+   * eight atlas textures records the vertex bytes into the group instance
+   * buffer and replays them with `drawElements`. A flush that needs several
+   * batches, or a second Text flush inside the same capture window, poisons the
+   * capture instead — always safe, just a missed optimization.
    *
    * The world transform is read live in the vertex shader (mirrors
    * `WebGpuTextRenderer`), so an own-transform move is an O(1) GPU-side texel
@@ -168,12 +171,11 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
    */
   public readonly _supportsRetainedBatches = true;
 
-  private readonly _sdfShader: Shader = new Shader(textVertSource, textSdfFragSource);
-  private readonly _msdfShader: Shader = new Shader(textVertSource, textMsdfFragSource);
-  private readonly _colorShader: Shader = new Shader(textVertSource, textColorFragSource);
+  private readonly _sdfShader: Shader = new Shader(textVertSource, composeTextAtlasFragmentGlsl(textSdfFragSource));
+  private readonly _msdfShader: Shader = new Shader(textVertSource, composeTextAtlasFragmentGlsl(textMsdfFragSource));
+  private readonly _colorShader: Shader = new Shader(textVertSource, composeTextAtlasFragmentGlsl(textColorFragSource));
 
-  private readonly _textureUnitScratch = new Int32Array([0]);
-  private readonly _nodeDataUnitScratch = new Int32Array([1]);
+  private readonly _nodeDataUnitScratch = new Int32Array([textAtlasTextureSlots]);
   private readonly _floatScratch = new Float32Array(1);
   // Own-transform-move patch scratch: 2 texels (transform cols 0-1), mirrors
   // WebGpuTextRenderer's `_patchRowScratch`.
@@ -192,8 +194,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
   // (nesting-safe — one entry per capture-open call).
   private _retainedQuadIndexBuffer: WebGl2RenderBuffer | null = null;
   private _retainedQuadCapacity = 0;
-  private readonly _retainedTextureUnit0Scratch = new Int32Array([0]);
-  private readonly _retainedNodeDataUnitScratch = new Int32Array([1]);
+  private readonly _retainedNodeDataUnitScratch = new Int32Array([textAtlasTextureSlots]);
   private readonly _recordedCaptures = new WeakSet<WebGl2RetainedGroupResources>();
 
   private _nodeDataArray: Float32Array = new Float32Array(initialNodeCapacity * nodeFloats);
@@ -250,6 +251,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     this._sdfShader.sync();
     this._msdfShader.sync();
     this._colorShader.sync();
+    this._pinAtlasSamplerUnits();
 
     const indexBuffer = new WebGl2RenderBuffer(BufferTypes.ElementArrayBuffer, this._indexData, BufferUsage.DynamicDraw).connect(
       this._createBufferRuntime(gl, buffers),
@@ -267,7 +269,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       .addIndex(indexBuffer, IndexElementTypes.UnsignedInt)
       .addAttribute(vertexBuffer, this._sdfShader.getAttribute('a_position'), gl.FLOAT, false, vertexStrideBytes, 0)
       .addAttribute(vertexBuffer, this._sdfShader.getAttribute('a_texcoord'), gl.FLOAT, false, vertexStrideBytes, 8)
-      .addAttribute(vertexBuffer, this._sdfShader.getAttribute('a_nodeIndex'), gl.FLOAT, false, vertexStrideBytes, 16);
+      .addAttribute(vertexBuffer, this._sdfShader.getAttribute('a_packedNodeSlot'), gl.UNSIGNED_INT, false, vertexStrideBytes, 16, true);
 
     vao.connect(this._createVaoRuntime(gl, vaoHandle));
 
@@ -331,6 +333,10 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     if (existing !== undefined) return existing;
 
     const idx = this._nodeCount++;
+
+    if (idx > textNodeIndexMask) {
+      throw new Error(`WebGl2TextRenderer: node index ${idx} exceeds the 24-bit packed vertex limit.`);
+    }
     this._nodeIndexMap.set(node, idx);
     this._ensureNodeCapacity(idx + 1);
     this._packNodeData(idx, node);
@@ -446,7 +452,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     // invisible whenever it is the first draw of a frame. A raw gl.bindTexture
     // would likewise leave the bind cache claiming unit 1 still holds whatever
     // managed texture was there last.
-    this.getBackend().setActiveTextureUnit(1).bindRawTexture(c.nodeDataTexture);
+    this.getBackend().setActiveTextureUnit(textAtlasTextureSlots).bindRawTexture(c.nodeDataTexture);
     gl.texSubImage2D(
       gl.TEXTURE_2D,
       0,
@@ -471,10 +477,15 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       }
     }
 
-    // Sort by (shaderType, atlasTexture) so equal-key quads are contiguous
+    // Sort by compatible atlas class, then texture identity. Up to eight
+    // textures of one class share a draw through the shader slot table.
     this._pendingQuads.sort((a, b) => {
       const sc = a.shaderType.localeCompare(b.shaderType);
       if (sc !== 0) return sc;
+      const wc = a.atlasTexture.width - b.atlasTexture.width;
+      if (wc !== 0) return wc;
+      const hc = a.atlasTexture.height - b.atlasTexture.height;
+      if (hc !== 0) return hc;
       return (this._textureKeyMap.get(a.atlasTexture) ?? 0) - (this._textureKeyMap.get(b.atlasTexture) ?? 0);
     });
 
@@ -483,25 +494,33 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     let i = 0;
 
     // Retained recording: a recordable Text flush is a
-    // SINGLE (shaderType, atlasTexture) batch. A second batch this flush (or a
+    // SINGLE compatible multi-atlas batch. A second batch this flush (or a
     // second flush into the same capture window) poisons the capture below.
     const capturing = backend._isRetainedCapturing;
     let batchCount = 0;
     let recWordCount = 0;
     let recQuadCount = 0;
-    let recAtlas: Texture | null = null;
+    let recAtlases: readonly Texture[] = [];
     let recShaderType: ShaderType = 'sdf';
 
     while (i < quads.length) {
       // In-bounds: `i` < `quads.length` per the loop guard.
       const first = quads[i]!;
-      const firstTextureKey = this._textureKeyMap.get(first.atlasTexture);
+      const atlasSlots = new Map<Texture, number>();
+      const atlasTextures: Texture[] = [];
+      let j = i;
 
-      let j = i + 1;
       while (j < quads.length) {
         // In-bounds: `j` < `quads.length` per the loop guard.
         const pq = quads[j]!;
-        if (pq.shaderType !== first.shaderType || this._textureKeyMap.get(pq.atlasTexture) !== firstTextureKey) break;
+        if (!sharesAtlasBatchClass(first, pq)) break;
+
+        if (!atlasSlots.has(pq.atlasTexture)) {
+          if (atlasTextures.length === textAtlasTextureSlots) break;
+          atlasSlots.set(pq.atlasTexture, atlasTextures.length);
+          atlasTextures.push(pq.atlasTexture);
+        }
+
         j++;
       }
 
@@ -527,7 +546,8 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
 
       for (let k = i; k < j; k++) {
         // In-bounds: `k` ranges over `[i, j)` ⊆ `[0, quads.length)`.
-        const { quads: batch, nodeIndex } = quads[k]!;
+        const { quads: batch, nodeIndex, atlasTexture } = quads[k]!;
+        const atlasSlot = atlasSlots.get(atlasTexture)!;
         const qVerts = batch.quadCount * 4;
         const { vertices, uvs, indices } = batch;
 
@@ -539,7 +559,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
           this._float32View[w + 1] = vertices[vp + 1]!;
           this._float32View[w + 2] = uvs[vp]!;
           this._float32View[w + 3] = uvs[vp + 1]!;
-          this._float32View[w + 4] = nodeIndex;
+          this._uint32View[w + 4] = packTextNodeAtlasSlot(nodeIndex, atlasSlot);
         }
 
         for (let x = 0; x < indices.length; x++) {
@@ -555,7 +575,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       if (recordThisBatch) {
         recWordCount = totalVerts * vertexStrideWords;
         recQuadCount = totalIndices / 6;
-        recAtlas = first.atlasTexture;
+        recAtlases = atlasTextures;
         recShaderType = first.shaderType;
       }
 
@@ -565,7 +585,9 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       c.indexBuffer.upload(this._indexData.subarray(0, totalIndices));
 
       backend.bindVertexArrayObject(c.vao);
-      backend.bindTexture(first.atlasTexture, 0);
+      for (let slot = 0; slot < atlasTextures.length; slot++) {
+        backend.bindTexture(atlasTextures[slot]!, slot);
+      }
 
       if (shader.uniforms.has('u_projection')) {
         shader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
@@ -576,9 +598,6 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
         shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
       }
       backend._stageViewportUniform(shader);
-      if (shader.uniforms.has('u_texture')) {
-        shader.getUniform('u_texture').setValue(this._textureUnitScratch);
-      }
       if (shader.uniforms.has('u_nodeData')) {
         shader.getUniform('u_nodeData').setValue(this._nodeDataUnitScratch);
       }
@@ -603,15 +622,16 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     }
 
     if (capturing) {
-      this._tryRecordRetainedBatch(backend, batchCount, recWordCount, recQuadCount, recShaderType, recAtlas);
+      this._tryRecordRetainedBatch(backend, batchCount, recWordCount, recQuadCount, recShaderType, recAtlases);
     }
   }
 
   /**
    * Record this flush's ONE glyph-quad batch for retained replay, or poison the
    * capture when it is not a clean single batch (multiple distinct
-   * (shaderType, atlasTexture) combinations this flush, or a second Text flush
-   * into the same capture window). Poisoning is always safe: the group falls
+   * incompatible shader/page classes or more than eight atlas textures this
+   * flush, or a second Text flush into the same capture window). Poisoning is
+   * always safe: the group falls
    * back to entry replay for that frame, never wrong pixels.
    */
   private _tryRecordRetainedBatch(
@@ -620,7 +640,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     wordCount: number,
     quadCount: number,
     shaderType: ShaderType,
-    atlas: Texture | null,
+    atlases: readonly Texture[],
   ): void {
     const bundle = backend._currentRetainedCaptureBundle;
 
@@ -628,7 +648,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       return;
     }
 
-    if (batchCount !== 1 || atlas === null || this._recordedCaptures.has(bundle)) {
+    if (batchCount !== 1 || atlases.length === 0 || this._recordedCaptures.has(bundle)) {
       backend._poisonRetainedCaptures();
 
       return;
@@ -642,7 +662,16 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       shaderType,
     };
 
-    backend._recordRetainedBatch(this, this._uint32View.subarray(0, wordCount), this._nodeCount, BlendModes.Normal, [atlas], 1, null, rendererData);
+    backend._recordRetainedBatch(
+      this,
+      this._uint32View.subarray(0, wordCount),
+      this._nodeCount,
+      BlendModes.Normal,
+      atlases,
+      atlases.length,
+      null,
+      rendererData,
+    );
 
     this._recordedCaptures.add(bundle);
   }
@@ -651,6 +680,19 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     if (type === 'sdf') return this._sdfShader;
     if (type === 'msdf') return this._msdfShader;
     return this._colorShader;
+  }
+
+  private _pinAtlasSamplerUnits(): void {
+    const samplerUnit = new Int32Array(1);
+
+    for (const shader of [this._sdfShader, this._msdfShader, this._colorShader]) {
+      for (let slot = 0; slot < textAtlasTextureSlots; slot++) {
+        samplerUnit[0] = slot;
+        shader.getUniform(`u_texture${slot}`).setValue(samplerUnit);
+      }
+
+      shader.sync();
+    }
   }
 
   // ── Retained-batch record/replay ──────────────────────────────────────────
@@ -705,7 +747,7 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       .addIndex(indexBuffer, IndexElementTypes.UnsignedInt)
       .addAttribute(buffer, shader.getAttribute('a_position'), gl.FLOAT, false, vertexStrideBytes, base + 0)
       .addAttribute(buffer, shader.getAttribute('a_texcoord'), gl.FLOAT, false, vertexStrideBytes, base + 8)
-      .addAttribute(buffer, shader.getAttribute('a_nodeIndex'), gl.FLOAT, false, vertexStrideBytes, base + 16);
+      .addAttribute(buffer, shader.getAttribute('a_packedNodeSlot'), gl.UNSIGNED_INT, false, vertexStrideBytes, base + 16, true);
 
     const state = this._getTextReplayState(payload.bundle);
 
@@ -757,15 +799,16 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
     }
 
     const shader = this._shaderFor(data.shaderType);
-    // Text's recording always stages exactly one atlas page texture (single
-    // batch); the payload's shared type is wider only because other renderers
-    // can target a RenderTexture.
+    // Text's recording stages one or more atlas page textures in packed-slot
+    // order. All belong to the same shader/page-size class.
     const atlas = payload.textures[0] as Texture;
     const view = backend.view;
 
     backend.setBlendMode(payload.blendMode);
-    backend.bindTexture(atlas, 0);
-    backend.bindTexture(state.nodeDataTexture, 1);
+    for (let slot = 0; slot < payload.textures.length; slot++) {
+      backend.bindTexture(payload.textures[slot]!, slot);
+    }
+    backend.bindTexture(state.nodeDataTexture, textAtlasTextureSlots);
 
     if (shader.uniforms.has('u_projection')) {
       shader.getUniform('u_projection').setValue(view.getTransform().toArray(false));
@@ -776,9 +819,6 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       shader.getUniform('u_group').setValue(groupTransform !== null ? groupTransform.toArray(false) : identityGroupMat3);
     }
     backend._stageViewportUniform(shader);
-    if (shader.uniforms.has('u_texture')) {
-      shader.getUniform('u_texture').setValue(this._retainedTextureUnit0Scratch);
-    }
     if (shader.uniforms.has('u_nodeData')) {
       shader.getUniform('u_nodeData').setValue(this._retainedNodeDataUnitScratch);
     }
@@ -992,8 +1032,13 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
               attribute.buffer.bind();
               lastBuffer = attribute.buffer;
             }
-            gl.vertexAttribPointer(attribute.location, attribute.size, attribute.type, attribute.normalized, attribute.stride, attribute.start);
+            if (attribute.integer) {
+              gl.vertexAttribIPointer(attribute.location, attribute.size, attribute.type, attribute.stride, attribute.start);
+            } else {
+              gl.vertexAttribPointer(attribute.location, attribute.size, attribute.type, attribute.normalized, attribute.stride, attribute.start);
+            }
             gl.enableVertexAttribArray(attribute.location);
+            gl.vertexAttribDivisor(attribute.location, attribute.divisor);
           }
           if (vao.indexBuffer) vao.indexBuffer.bind();
           appliedVersion = vao.version;

--- a/src/rendering/webgl2/glsl/text-color.frag
+++ b/src/rendering/webgl2/glsl/text-color.frag
@@ -1,7 +1,6 @@
 #version 300 es
 precision mediump float;
 
-uniform sampler2D u_texture;   // RGBA colour-font / emoji atlas
 uniform sampler2D u_nodeData;  // RGBA32F per-node data
 
 flat in int  v_nodeIndex;
@@ -12,6 +11,6 @@ layout(location = 0) out vec4 fragColor;
 void main(void) {
   // texel 2: fillColor (tint multiplier; (1,1,1,1) = no tint)
   vec4 tint   = texelFetch(u_nodeData, ivec2(2, v_nodeIndex), 0);
-  vec4 texel  = texture(u_texture, v_texcoord);
+  vec4 texel  = sampleBase(v_textureSlot, v_texcoord);
   fragColor   = texel * tint;
 }

--- a/src/rendering/webgl2/glsl/text-msdf.frag
+++ b/src/rendering/webgl2/glsl/text-msdf.frag
@@ -1,7 +1,6 @@
 #version 300 es
 precision mediump float;
 
-uniform sampler2D u_texture;   // RGB MSDF atlas
 uniform sampler2D u_nodeData;  // RGBA32F per-node data (see WebGl2TextRenderer)
 uniform float     u_pageSize;  // atlas page size in px (for shadow UV conversion)
 
@@ -34,7 +33,7 @@ void main(void) {
   vec2  shadowOffset = tShadow2.xy / u_pageSize;
   float gradVertical = tShadow2.z;
 
-  vec3  msd  = texture(u_texture, v_texcoord).rgb;
+  vec3  msd  = sampleBase(v_textureSlot, v_texcoord).rgb;
   float sd   = median(msd.r, msd.g, msd.b);
   float fill = smoothstep(0.5 - soft, 0.5 + soft, sd);
 
@@ -42,7 +41,7 @@ void main(void) {
     ? smoothstep(outlineMin - soft, outlineMin + soft, sd) * (1.0 - fill)
     : 0.0;
 
-  vec3  shadowMsd = texture(u_texture, v_texcoord - shadowOffset).rgb;
+  vec3  shadowMsd = sampleBase(v_textureSlot, v_texcoord - shadowOffset).rgb;
   float shadowSd  = median(shadowMsd.r, shadowMsd.g, shadowMsd.b);
   float shadow    = smoothstep(0.5 - soft, 0.5 + soft, shadowSd)
                     * shadowAlpha * (1.0 - fill) * (1.0 - outline);

--- a/src/rendering/webgl2/glsl/text-sdf.frag
+++ b/src/rendering/webgl2/glsl/text-sdf.frag
@@ -1,7 +1,6 @@
 #version 300 es
 precision mediump float;
 
-uniform sampler2D u_texture;   // R8 SDF atlas
 uniform sampler2D u_nodeData;  // RGBA32F per-node data (see WebGl2TextRenderer)
 uniform float     u_pageSize;  // atlas page size in px (for shadow UV conversion)
 
@@ -37,14 +36,14 @@ void main(void) {
   vec2  shadowOffset = tShadow2.xy / u_pageSize;
   float gradVertical = tShadow2.z;
 
-  float sd   = texture(u_texture, v_texcoord).r;
+  float sd   = sampleBase(v_textureSlot, v_texcoord).r;
   float fill = smoothstep(0.5 - soft, 0.5 + soft, sd);
 
   float outline = outlineMin < 0.5
     ? smoothstep(outlineMin - soft, outlineMin + soft, sd) * (1.0 - fill)
     : 0.0;
 
-  float shadowSd = texture(u_texture, v_texcoord - shadowOffset).r;
+  float shadowSd = sampleBase(v_textureSlot, v_texcoord - shadowOffset).r;
   float shadow   = smoothstep(0.5 - soft, 0.5 + soft, shadowSd)
                    * shadowAlpha * (1.0 - fill) * (1.0 - outline);
 

--- a/src/rendering/webgl2/glsl/text.vert
+++ b/src/rendering/webgl2/glsl/text.vert
@@ -4,11 +4,12 @@ precision highp float;
 // Mirrors WebGpuTextRenderer's WGSL vertex stage exactly: a_position arrives in
 // LOCAL space, and the world transform is read live from the per-node data
 // texture (same texture the fragment stage reads style from) via texelFetch,
-// keyed by a_nodeIndex — the same pattern Sprite/Mesh/NineSlice use for their
+// keyed by the node-index portion of a_packedNodeSlot — the same pattern
+// Sprite/Mesh/NineSlice use for their
 // shared transform buffer, just against Text's own private node-data texture.
 layout(location = 0) in vec2  a_position;   // local-space quad corner
 layout(location = 1) in vec2  a_texcoord;
-layout(location = 2) in float a_nodeIndex;  // row into the per-node data texture (transform + style)
+layout(location = 2) in uint a_packedNodeSlot; // bits 0..23 = node row, bits 24..31 = atlas slot
 
 uniform mat3 u_projection;
 uniform mat3 u_group;
@@ -16,11 +17,12 @@ uniform vec4 u_viewport;
 uniform sampler2D u_nodeData;
 
 flat out int  v_nodeIndex;
+flat out uint v_textureSlot;
      out vec2 v_texcoord;
      out vec2 v_gradUV;
 
 void main(void) {
-    int ni = int(a_nodeIndex);
+    int ni = int(a_packedNodeSlot & 0x00ffffffu);
 
     // texel 0: (a, c, snapMode, tx) — mat3 column-major: col0 + snap flag + translate.x
     // texel 1: (b, d, 0, ty) — mat3 column-major: col1 + translate.y
@@ -52,6 +54,7 @@ void main(void) {
     gl_Position = vec4(clip, 0.0, 1.0);
     v_texcoord  = a_texcoord;
     v_nodeIndex = ni;
+    v_textureSlot = a_packedNodeSlot >> 24u;
 
     vec2 bSize = t9.zw;
     v_gradUV = (bSize.x > 0.0 && bSize.y > 0.0)

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -241,6 +241,7 @@ export class WebGpuBackend implements RenderBackend {
   private _drawPlanDepth = 0;
   private readonly _planBaseStack: number[] = [];
   private readonly _planHashStack: number[] = [];
+  private _renderPlanEpoch = 0;
   // Retained instruction-set record/replay.
   // Active capture windows, innermost last; live bundle registry for
   // device-loss generation bumps; permanently vetoed (poisoned) sets.
@@ -397,8 +398,14 @@ export class WebGpuBackend implements RenderBackend {
     return this._getTransformStorage().buffer.count;
   }
 
+  /** Monotonic render-plan token for per-material replay deduplication. @internal */
+  public get renderPlanEpoch(): number {
+    return this._renderPlanEpoch;
+  }
+
   /** @internal */
   public _beginDrawPlan(nodeCount: number): void {
+    this._renderPlanEpoch++;
     const storage = this._getTransformStorage();
 
     // Do NOT reset the transform buffer here — it is frame-scoped (reset in
@@ -1301,6 +1308,12 @@ export class WebGpuBackend implements RenderBackend {
       }
 
       if (!payload.bundle.isReady) {
+        set.invalidate();
+
+        return false;
+      }
+
+      if (payload.renderer._validateRetainedBatch?.(payload) === false) {
         set.invalidate();
 
         return false;

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -12,6 +12,7 @@ import type { BackendRenderPass } from '#rendering/BackendRenderPass';
 import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
 import { dataTextureBytesPerPixel, estimateTextureBytes, GpuResourceAccountant } from '#rendering/GpuResourceAccountant';
+import type { MaterialSamplerOptions } from '#rendering/material/Material';
 import type { Mesh } from '#rendering/mesh/Mesh';
 import { type DrawCommand, drawCommandUsesSharedTransform, RenderEntryKind } from '#rendering/plan/RenderCommand';
 import type { ScopeEntry } from '#rendering/plan/RenderScope';
@@ -199,6 +200,8 @@ export class WebGpuBackend implements RenderBackend {
   private readonly _textureStates: Map<Texture | RenderTexture, ManagedWebGpuTextureState> = new Map<Texture | RenderTexture, ManagedWebGpuTextureState>();
   private readonly _textureDestroyHandlers: Map<Texture | RenderTexture, () => void> = new Map<Texture | RenderTexture, () => void>();
   private readonly _textureReleaseHandlers: Map<Texture, () => void> = new Map<Texture, () => void>();
+  /** Device-local material sampler overrides, interned by effective filter/wrap state. */
+  private readonly _materialSamplers = new Map<string, GPUSampler>();
   private readonly _renderTargetDestroyHandlers: Map<RenderTarget, () => void> = new Map<RenderTarget, () => void>();
   private readonly _renderTexturePool: RenderTexturePool = new RenderTexturePool();
   private readonly _clipBoundsStack: Rectangle[] = [];
@@ -878,6 +881,7 @@ export class WebGpuBackend implements RenderBackend {
     this._passCoordinatorInstance?.discardPass();
     this.rendererRegistry.destroy();
     this._destroyManagedTextures();
+    this._materialSamplers.clear();
     this._renderTexturePool.destroy();
 
     for (const clipBounds of this._clipBoundsStack) {
@@ -1017,7 +1021,10 @@ export class WebGpuBackend implements RenderBackend {
     return { width: target.width, height: target.height };
   }
 
-  public getTextureBinding(texture: Texture | RenderTexture): {
+  public getTextureBinding(
+    texture: Texture | RenderTexture,
+    samplerOverride: MaterialSamplerOptions | null = null,
+  ): {
     readonly view: GPUTextureView;
     readonly sampler: GPUSampler;
   } {
@@ -1025,7 +1032,7 @@ export class WebGpuBackend implements RenderBackend {
 
     return {
       view: state.view,
-      sampler: state.sampler,
+      sampler: samplerOverride === null ? state.sampler : this._getMaterialSampler(texture, samplerOverride),
     };
   }
 
@@ -1870,6 +1877,7 @@ export class WebGpuBackend implements RenderBackend {
     this._textureDestroyHandlers.clear();
     this._textureReleaseHandlers.clear();
     this._textureStates.clear();
+    this._materialSamplers.clear();
 
     // Recycled RenderTexture pool: drop entries — their backing GPUTexture
     // is gone with the dead device.
@@ -2583,6 +2591,31 @@ export class WebGpuBackend implements RenderBackend {
       minFilter: filter,
       mipmapFilter: isFloatData ? 'nearest' : this._getMipmapFilterMode(texture.scaleMode),
     });
+  }
+
+  private _getMaterialSampler(texture: Texture | RenderTexture, options: MaterialSamplerOptions): GPUSampler {
+    // Match the managed-texture path: float32 data textures are non-filterable
+    // unless an optional device feature is requested, which this backend does
+    // not currently expose.
+    const isFloatData = texture instanceof DataTexture && (texture.format === TextureFormat.R32F || texture.format === TextureFormat.Rgba32F);
+    const filter: GPUFilterMode = isFloatData ? 'nearest' : this._getFilterMode(options.scaleMode);
+    const addressMode = this._getAddressMode(options.wrapMode);
+    const key = `${filter}:${addressMode}`;
+    let sampler = this._materialSamplers.get(key);
+
+    if (sampler === undefined) {
+      sampler = this.device.createSampler({
+        label: 'backend:material-sampler',
+        addressModeU: addressMode,
+        addressModeV: addressMode,
+        magFilter: filter,
+        minFilter: filter,
+        mipmapFilter: isFloatData ? 'nearest' : this._getMipmapFilterMode(options.scaleMode),
+      });
+      this._materialSamplers.set(key, sampler);
+    }
+
+    return sampler;
   }
 
   private _getGpuTextureFormat(texture: Texture | RenderTexture): GPUTextureFormat {

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -306,8 +306,7 @@ interface CustomShaderResources {
   // texture view it was built from so a mutable texture (DataTexture content
   // update / resize) invalidates it. WeakMap avoids retaining short-lived
   // textures across long sessions.
-  meshTextureBindGroups: WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView }>;
-  sampler: GPUSampler;
+  meshTextureBindGroups: WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView; sampler: GPUSampler }>;
   // Per-frame state, reset in flush().
   drawCount: number;
   totalVertices: number;
@@ -631,7 +630,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
       this._instancedBatchUniformBuffersInPass.add(uniformPlan!.buffer);
 
       pass.setPipeline(this._getOrCreateCustomInstancedPipeline(resources, blendMode, renderTargetFormat, stencil, instances));
-      pass.setBindGroup(1, this._getOrCreateMeshTextureBindGroup(resources, backend, texture));
+      pass.setBindGroup(1, this._getOrCreateMeshTextureBindGroup(resources, backend, texture, material!.sampler));
       pass.setBindGroup(2, this._getUserBindGroup(backend, material!, resources));
     }
 
@@ -1131,7 +1130,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
 
         if (dc.texture !== lastTexture) {
           lastTexture = dc.texture;
-          pass.setBindGroup(1, this._getOrCreateMeshTextureBindGroup(resources, backend, dc.texture));
+          pass.setBindGroup(1, this._getOrCreateMeshTextureBindGroup(resources, backend, dc.texture, dc.customShader.sampler));
         }
 
         pass.setVertexBuffer(0, resources.vertexBuffer, dc.vertexByteOffset);
@@ -2396,14 +2395,6 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
       bindGroupLayouts: [this._instancedTransformBindGroupLayout!, meshTextureLayout, userLayout],
     });
 
-    const sampler = device.createSampler({
-      label: 'mesh:material-sampler',
-      magFilter: 'linear',
-      minFilter: 'linear',
-      addressModeU: 'clamp-to-edge',
-      addressModeV: 'clamp-to-edge',
-    });
-
     const initialVertexCount = 64;
     const initialIndexCount = 192;
     const vertexData = new ArrayBuffer(initialVertexCount * vertexStrideBytes);
@@ -2432,7 +2423,6 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
       userUniformBufferCapacity: 0,
       userUniform: createUserUniformState(),
       meshTextureBindGroups: new WeakMap(),
-      sampler,
       drawCount: 0,
       totalVertices: 0,
       totalIndices: 0,
@@ -2619,13 +2609,18 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     return pipeline;
   }
 
-  private _getOrCreateMeshTextureBindGroup(resources: CustomShaderResources, backend: WebGpuBackend, texture: Texture | RenderTexture): GPUBindGroup {
+  private _getOrCreateMeshTextureBindGroup(
+    resources: CustomShaderResources,
+    backend: WebGpuBackend,
+    texture: Texture | RenderTexture,
+    samplerOverride: Material['sampler'],
+  ): GPUBindGroup {
     // Always resolve the binding so a mutable base texture uploads its dirty
     // region before sampling; reuse the cached group only while the view holds.
-    const binding = backend.getTextureBinding(texture);
+    const binding = backend.getTextureBinding(texture, samplerOverride);
     const cached = resources.meshTextureBindGroups.get(texture);
 
-    if (cached?.view === binding.view) {
+    if (cached?.view === binding.view && cached.sampler === binding.sampler) {
       return cached.group;
     }
 
@@ -2638,7 +2633,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
       ],
     });
 
-    resources.meshTextureBindGroups.set(texture, { group, view: binding.view });
+    resources.meshTextureBindGroups.set(texture, { group, view: binding.view, sampler: binding.sampler });
 
     return group;
   }
@@ -2732,7 +2727,7 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     resources.userUniformBuffer?.destroy();
     resources.pipelines.clear();
     resources.instancedPipelines.clear();
-    resources.meshTextureBindGroups = new WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView }>();
+    resources.meshTextureBindGroups = new WeakMap<Texture | RenderTexture, { group: GPUBindGroup; view: GPUTextureView; sampler: GPUSampler }>();
     resources.vertexBuffer = null;
     resources.indexBuffer = null;
     resources.meshUniformBuffer = null;

--- a/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
+++ b/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
@@ -138,6 +138,8 @@ export interface WebGpuRetainedBatchReplayer extends Renderer {
   _scanRetainedNodeIndexRange(bytes: Uint8Array, range: WebGpuRetainedNodeIndexRange): void;
   /** Rewrite `bytes`' instance node indices in place to group-local (`index - base`). */
   _rebaseRetainedNodeIndices(bytes: Uint8Array, base: number): void;
+  /** Preflight structural live state before any instruction in the set draws. */
+  _validateRetainedBatch?(payload: WebGpuRetainedBatchPayload): boolean;
   /** Replay the batch: live state (pipeline, uniforms, textures), cached data (bytes, transforms). */
   _replayRetainedBatch(payload: WebGpuRetainedBatchPayload): void;
 }
@@ -175,7 +177,7 @@ export class WebGpuRetainedCaptureFrame {
   public totalBytes = 0;
   /**
    * Set when playback inside the window issued work the recorder cannot
-   * replay (non-recordable renderer, custom material, compositor). Should be
+   * replay (non-recordable renderer or compositor). Should be
    * unreachable — the collect-time recordability predicate excludes
    * all of it — but wrong pixels are never an acceptable failure mode, so a
    * poisoned window is dropped and its set permanently vetoed.

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -3,6 +3,13 @@
 import { Matrix } from '#math/Matrix';
 import type { ReadonlyRectangle } from '#math/Rectangle';
 import { affineMat4FloatCount, packAffineMat4, packedGroupChanged } from '#rendering/affinePacking';
+import type { Drawable } from '#rendering/Drawable';
+import {
+  createRetainedMaterialState,
+  isRetainedMaterialState,
+  isRetainedMaterialStateValid,
+  type RetainedMaterialState,
+} from '#rendering/material/RetainedMaterialState';
 import type { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import type { Sprite } from '#rendering/sprite/Sprite';
 import { buildSpriteTextureSlotWgsl, spriteMaterialPrologueWgsl, spriteMaterialTextureSlots } from '#rendering/sprite/spriteMaterialSources';
@@ -313,11 +320,20 @@ interface CustomSpriteResources {
   // Base-texture slot count the cached shader module and pipeline layout were
   // generated for. Fixed for the custom path, so this only ever asserts.
   textureSlots: number;
+  /** Render-plan token whose retained replay preparation is cached below. */
+  replayEpoch: number;
+  /** Live group(2) resolved once per material/render plan during retained replay. */
+  replayBindGroup: GPUBindGroup | null;
 }
 
 export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> implements WebGpuRetainedBatchReplayer {
-  /** Retained-batch capability flag: the default path records/replays flush-level batches. */
+  /** Retained-batch capability flag: default and live SpriteMaterial batches replay. */
   public readonly _supportsRetainedBatches = true;
+
+  /** Custom SpriteMaterial batches implement the live-material replay contract. @internal */
+  public _canRecordRetainedDrawable(drawable: Drawable): boolean {
+    return (drawable as Sprite).material !== null;
+  }
 
   private readonly _projectionData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
   // View whose transform the projection UBO currently holds, plus its updateId
@@ -828,16 +844,11 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       backend._passCoordinator.acquirePass();
     }
 
-    // Retained capture: while a capture window is
-    // active, additionally stage this batch's exact packed bytes into the
-    // group-owned bundle — the recorded data IS the drawn data, byte-identical
-    // by construction. Custom-material batches are unreplayable (live user
-    // uniforms) and poison the window instead; the recordability
-    // predicate makes that unreachable.
+    // Retained capture: stage the exact packed bytes plus a live material
+    // descriptor. Geometry/transform rows stay recorded; material values and
+    // texture identities are resolved again at replay.
     if (this._instanceCount > 0 && backend._retainedCaptureActive) {
-      if (isCustom) {
-        backend._poisonActiveRetainedCaptures();
-      } else if (this._currentBlendMode !== null) {
+      if (this._currentBlendMode !== null) {
         backend._recordRetainedBatch(
           this,
           this._instanceData,
@@ -846,6 +857,8 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
           this._currentBlendMode,
           this._activeTextures,
           this._slotCount,
+          null,
+          isCustom ? createRetainedMaterialState(this._currentMaterial!) : null,
         );
       }
     }
@@ -1049,6 +1062,8 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     const backend = this._backend;
     const device = this._device;
     const bundle = payload.bundle;
+    const materialState = this._retainedMaterialState(payload);
+    const material = materialState?.material ?? null;
 
     if (!backend || !device || this._indexBuffer === null || !bundle.isReady) {
       return;
@@ -1068,6 +1083,11 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     }
 
     const coordinator = backend._passCoordinator;
+    const currentPass = coordinator.activePass;
+
+    if (currentPass !== null) {
+      this._syncUniformHazardPass(currentPass);
+    }
 
     // Same-frame texture mutation guard: resolving the bindings below
     // re-uploads mutated content on the queue timeline BEFORE the deferred
@@ -1089,7 +1109,39 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
 
     // Resolve the batch textures LIVE through the shared texture-set cache
     // (syncs dirty content, adopts refreshed views/samplers).
-    const textureBindGroup = this._getOrCreateTextureBindGroup(device, backend, payload.textures);
+    const textureBindGroup = this._getOrCreateTextureBindGroup(device, backend, payload.textures, material !== null);
+
+    let customResources: CustomSpriteResources | null = null;
+    let userBindGroup: GPUBindGroup | null = null;
+
+    if (material !== null) {
+      customResources = this._getOrCreateCustomResources(material, device);
+
+      if (customResources.replayEpoch !== backend.renderPlanEpoch || customResources.replayBindGroup === null) {
+        if (coordinator.passHasDraws) {
+          for (const texture of collectTextureBindings(material)) {
+            if (backend._textureUploadWouldMutate(texture)) {
+              coordinator.endPass();
+              this._instanceArena.resetPass();
+              break;
+            }
+          }
+        }
+
+        const uniformPlan = planUserUniformUpload(material, customResources, device, 'sprite:material-user-uniform-buffer');
+
+        if (this._uniformWriteWouldAlias(uniformPlan)) {
+          coordinator.endPass();
+          this._instanceArena.resetPass();
+        }
+
+        applyUserUniformUpload(uniformPlan, customResources, device);
+        customResources.replayBindGroup = this._getUserBindGroup(material, customResources, backend, device);
+        customResources.replayEpoch = backend.renderPlanEpoch;
+      }
+
+      userBindGroup = customResources.replayBindGroup;
+    }
 
     // Group UBO: skip the write while (view, updateId, group bytes) match
     // what the buffer holds; guard the double-replay aliasing case first.
@@ -1135,12 +1187,25 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     const active = coordinator.acquirePass();
     const pass = active.pass;
 
-    pass.setPipeline(this._getPipeline(payload.blendMode, backend.renderTargetFormat, coordinator.stencilActive));
+    this._syncUniformHazardPass(active);
+
+    pass.setPipeline(
+      material === null
+        ? this._getPipeline(payload.blendMode, backend.renderTargetFormat, coordinator.stencilActive)
+        : this._getOrCreateCustomPipeline(customResources!, payload.blendMode, backend.renderTargetFormat, coordinator.stencilActive, device),
+    );
     pass.setBindGroup(0, bundle.getBindGroup(device, this._uniformBindGroupLayout!, true));
     pass.setBindGroup(1, textureBindGroup);
+    if (userBindGroup !== null) {
+      pass.setBindGroup(2, userBindGroup);
+    }
     pass.setVertexBuffer(0, bundle.instanceBuffer, payload.byteOffset);
     pass.setIndexBuffer(this._indexBuffer, 'uint16');
     pass.drawIndexed(indicesPerSprite, payload.instanceCount, 0, 0, 0);
+
+    if (customResources !== null) {
+      this._uniformBuffersInPass.add(customResources.userUniformBuffer!);
+    }
 
     bundle.drawsInPass = active;
     coordinator.markPassDraws();
@@ -1150,6 +1215,17 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
 
   /** Scratch for the packed group matrix compared at replay (see `_replayRetainedBatch`). */
   private readonly _stagedReplayGroupData = new Float32Array(16);
+
+  /** Structural preflight called for every batch before the set is spliced. @internal */
+  public _validateRetainedBatch(payload: WebGpuRetainedBatchPayload): boolean {
+    const state = this._retainedMaterialState(payload);
+
+    return state === null || isRetainedMaterialStateValid(state);
+  }
+
+  private _retainedMaterialState(payload: WebGpuRetainedBatchPayload): RetainedMaterialState<SpriteMaterial> | null {
+    return isRetainedMaterialState(payload.rendererData) ? (payload.rendererData as RetainedMaterialState<SpriteMaterial>) : null;
+  }
 
   public destroy(): void {
     this.disconnect();
@@ -1584,6 +1660,8 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       userUniformBufferCapacity: 0,
       userUniform: createUserUniformState(),
       textureSlots: spriteMaterialTextureSlots,
+      replayEpoch: -1,
+      replayBindGroup: null,
     };
 
     this._customMaterials.set(material, resources);
@@ -1707,5 +1785,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     resources.userUniformBuffer = null;
     resources.userUniformBufferCapacity = 0;
     resetUserUniformState(resources.userUniform);
+    resources.replayEpoch = -1;
+    resources.replayBindGroup = null;
   }
 }

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -685,8 +685,11 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       this._activeTextures[slot] = texture;
     }
 
+    const premultiplySample = backend.shouldPremultiplyTextureSample(texture) ? 1 : 0;
+    const packedSlotFlags = slot | (premultiplySample << 8);
+
     this._ensureInstanceCapacity(this._instanceCount + 1);
-    this._packInstance(sprite, texture, slot, nodeIndex);
+    this._packInstance(sprite, texture, packedSlotFlags, nodeIndex);
     this._instanceCount++;
   }
 
@@ -1109,7 +1112,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
 
     // Resolve the batch textures LIVE through the shared texture-set cache
     // (syncs dirty content, adopts refreshed views/samplers).
-    const textureBindGroup = this._getOrCreateTextureBindGroup(device, backend, payload.textures, material !== null);
+    const textureBindGroup = this._getOrCreateTextureBindGroup(device, backend, payload.textures, material !== null, material?.sampler ?? null);
 
     let customResources: CustomSpriteResources | null = null;
     let userBindGroup: GPUBindGroup | null = null;
@@ -1382,6 +1385,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     backend: WebGpuBackend,
     textures: ReadonlyArray<Texture | RenderTexture | null | undefined>,
     custom = false,
+    samplerOverride: SpriteMaterial['sampler'] = null,
   ): GPUBindGroup {
     // Slots beyond the active count get the slot-0 texture as a filler so
     // the bind-group layout always sees N valid texture views and samplers.
@@ -1400,7 +1404,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     // group(1) layout) instead of the device-tier default one.
     const slotCapacity = custom ? spriteMaterialTextureSlots : this._maxBatchTextures;
     const fallbackTexture = textures[0] ?? Texture.empty;
-    const fallbackBinding = backend.getTextureBinding(fallbackTexture);
+    const fallbackBinding = backend.getTextureBinding(fallbackTexture, samplerOverride);
     const resolvedTextures = new Array<Texture | RenderTexture>(slotCapacity);
     const resolvedBindings = new Array<ReturnType<WebGpuBackend['getTextureBinding']>>(slotCapacity);
 
@@ -1408,7 +1412,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       const texture = textures[i] ?? fallbackTexture;
 
       resolvedTextures[i] = texture;
-      resolvedBindings[i] = texture === fallbackTexture ? fallbackBinding : backend.getTextureBinding(texture);
+      resolvedBindings[i] = texture === fallbackTexture ? fallbackBinding : backend.getTextureBinding(texture, samplerOverride);
     }
 
     // Cache lookup, anchored on the resolved slot-0 texture. An entry matches
@@ -1610,7 +1614,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
 
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, transformBindGroup);
-    pass.setBindGroup(1, this._getOrCreateTextureBindGroup(device, backend, this._activeTextures, true));
+    pass.setBindGroup(1, this._getOrCreateTextureBindGroup(device, backend, this._activeTextures, true, material.sampler));
     pass.setBindGroup(2, this._getUserBindGroup(material, resources, backend, device));
     pass.setVertexBuffer(0, instanceBuffer, instanceByteOffset);
     pass.setIndexBuffer(this._indexBuffer!, 'uint16');

--- a/src/rendering/webgpu/WebGpuTextRenderer.ts
+++ b/src/rendering/webgpu/WebGpuTextRenderer.ts
@@ -8,6 +8,13 @@ import type { OwnTransformRowPatcher } from '#rendering/RetainedContainer';
 import { type BitmapText } from '#rendering/text/BitmapText';
 import type { TextPageQuads } from '#rendering/text/Text';
 import { Text } from '#rendering/text/Text';
+import {
+  packTextNodeAtlasSlot,
+  textAtlasSlotShift,
+  textAtlasTextureSlots,
+  textAtlasTextureSlotWgsl,
+  textNodeIndexMask,
+} from '#rendering/text/textAtlasTextureSlots';
 import type { Texture } from '#rendering/texture/Texture';
 import { BlendModes } from '#rendering/types';
 import type { View } from '#rendering/View';
@@ -45,7 +52,7 @@ import { stencilContentDepthStencilState } from './WebGpuStencilState';
 const nodeTexels = 10;
 const nodeFloats = nodeTexels * 4;
 
-// Per-vertex layout (20 bytes): pos f32x2 + uv f32x2 + nodeIndex f32
+// Per-vertex layout (20 bytes): pos f32x2 + uv f32x2 + packed node/atlas u32
 const vertexStrideBytes = 20;
 const vertexStrideWords = vertexStrideBytes / 4;
 // Word offset of the per-vertex node index within one vertex.
@@ -85,12 +92,24 @@ interface PendingQuad {
 
 interface BatchDraw {
   readonly shaderType: ShaderType;
-  readonly atlasTexture: Texture;
+  readonly atlasTextures: readonly Texture[];
   readonly firstVertex: number;
   readonly vertexCount: number;
   readonly firstIndex: number;
   readonly indexCount: number;
 }
+
+interface TextTextureSetBindGroupEntry {
+  readonly textures: readonly Texture[];
+  views: GPUTextureView[];
+  samplers: GPUSampler[];
+  group: GPUBindGroup;
+}
+
+const maxTextureSetsPerAnchor = 8;
+
+const sharesAtlasBatchClass = (a: PendingQuad, b: PendingQuad): boolean =>
+  a.shaderType === b.shaderType && a.atlasTexture.width === b.atlasTexture.width && a.atlasTexture.height === b.atlasTexture.height;
 
 /**
  * Opaque, renderer-private snapshot carried on {@link WebGpuRetainedBatchPayload.rendererData}
@@ -170,13 +189,12 @@ struct FrameUniforms {
 @group(0) @binding(0) var<uniform>       frame : FrameUniforms;
 @group(0) @binding(1) var<storage, read> nodes : array<vec4<f32>>;
 
-@group(1) @binding(0) var atlasTexture : texture_2d<f32>;
-@group(1) @binding(1) var atlasSampler : sampler;
+${textAtlasTextureSlotWgsl}
 
 struct VertexInput {
     @location(0) position  : vec2<f32>,
     @location(1) texcoord  : vec2<f32>,
-    @location(2) nodeIndex : f32,
+    @location(2) packedNodeSlot : u32,
 };
 
 struct VertexOutput {
@@ -184,11 +202,12 @@ struct VertexOutput {
     @location(0)                    texcoord : vec2<f32>,
     @location(1)                    gradUV   : vec2<f32>,
     @location(2) @interpolate(flat) nodeIdx  : u32,
+    @location(3) @interpolate(flat) textureSlot : u32,
 };
 
 @vertex
 fn vertexMain(input: VertexInput) -> VertexOutput {
-    let ni   = u32(input.nodeIndex);
+    let ni   = input.packedNodeSlot & ${textNodeIndexMask}u;
     let base = ni * 10u;
 
     let t0 = nodes[base + 0u];
@@ -239,6 +258,7 @@ fn vertexMain(input: VertexInput) -> VertexOutput {
     out.texcoord = input.texcoord;
     out.gradUV   = gradUV;
     out.nodeIdx  = ni;
+    out.textureSlot = input.packedNodeSlot >> ${textAtlasSlotShift}u;
     return out;
 }
 
@@ -261,14 +281,16 @@ fn fragmentSdf(in: VertexOutput) -> @location(0) vec4<f32> {
     let shadowAlpha  = tParams.y;
     let soft         = max(tParams.z, 0.001);
     let gradEnabled  = tParams.w;
-    let pageSize     = f32(textureDimensions(atlasTexture, 0).x);
+    let pageSize     = f32(atlasTextureDimensions(in.textureSlot).x);
     let shadowOffset = tShadow2.xy / pageSize;
     let gradVertical = tShadow2.z;
 
-    let sd   = textureSample(atlasTexture, atlasSampler, in.texcoord).r;
+    let uvDx = dpdx(in.texcoord);
+    let uvDy = dpdy(in.texcoord);
+    let sd   = sampleTexture(in.textureSlot, in.texcoord, uvDx, uvDy).r;
     let fill = smoothstep(0.5 - soft, 0.5 + soft, sd);
 
-    let shadowSd = textureSample(atlasTexture, atlasSampler, in.texcoord - shadowOffset).r;
+    let shadowSd = sampleTexture(in.textureSlot, in.texcoord - shadowOffset, uvDx, uvDy).r;
 
     let outline = select(0.0,
         smoothstep(outlineMin - soft, outlineMin + soft, sd) * (1.0 - fill),
@@ -313,15 +335,17 @@ fn fragmentMsdf(in: VertexOutput) -> @location(0) vec4<f32> {
     let shadowAlpha  = tParams.y;
     let soft         = max(tParams.z, 0.001);
     let gradEnabled  = tParams.w;
-    let pageSize     = f32(textureDimensions(atlasTexture, 0).x);
+    let pageSize     = f32(atlasTextureDimensions(in.textureSlot).x);
     let shadowOffset = tShadow2.xy / pageSize;
     let gradVertical = tShadow2.z;
 
-    let msd  = textureSample(atlasTexture, atlasSampler, in.texcoord).rgb;
+    let uvDx = dpdx(in.texcoord);
+    let uvDy = dpdy(in.texcoord);
+    let msd  = sampleTexture(in.textureSlot, in.texcoord, uvDx, uvDy).rgb;
     let sd   = median3(msd.r, msd.g, msd.b);
     let fill = smoothstep(0.5 - soft, 0.5 + soft, sd);
 
-    let shadowMsd = textureSample(atlasTexture, atlasSampler, in.texcoord - shadowOffset).rgb;
+    let shadowMsd = sampleTexture(in.textureSlot, in.texcoord - shadowOffset, uvDx, uvDy).rgb;
     let shadowSd  = median3(shadowMsd.r, shadowMsd.g, shadowMsd.b);
 
     let outline = select(0.0,
@@ -351,7 +375,7 @@ fn fragmentColor(in: VertexOutput) -> @location(0) vec4<f32> {
     let ni     = in.nodeIdx;
     let base   = ni * 10u;
     let tint   = nodes[base + 2u];
-    let sample = textureSample(atlasTexture, atlasSampler, in.texcoord);
+    let sample = sampleTexture(in.textureSlot, in.texcoord, dpdx(in.texcoord), dpdy(in.texcoord));
     return sample * tint;
 }
 `;
@@ -362,8 +386,8 @@ fn fragmentColor(in: VertexOutput) -> @location(0) vec4<f32> {
  * Mirrors {@link WebGl2TextRenderer}: per-node style data is packed once per
  * flush into a `var<storage, read>` buffer, three specialised WGSL fragment
  * variants handle SDF / MSDF / colour-atlas glyphs, and quads are sorted and
- * batched by (shaderType, atlasPage) to minimise draw calls within a single
- * render pass.
+ * batched by compatible shader/page classes with up to eight atlas textures
+ * per draw.
  */
 export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText> implements WebGpuRetainedBatchReplayer, OwnTransformRowPatcher {
   /**
@@ -375,12 +399,11 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
   public readonly _consumesSharedTransform = false;
 
   /**
-   * Retained-batch opt-in: a flush whose glyph quads all
-   * share one (shaderType, atlasTexture) — the overwhelmingly common case, one
-   * font/atlas per flush — is a recordable batch. A flush that mixes multiple
-   * distinct (shaderType, atlasTexture) combinations, or a second Text flush
-   * within the same capture window, poisons the capture instead (see
-   * `_tryRecordRetainedBatch`) — always safe, just a missed optimization.
+   * Retained-batch opt-in: one compatible shader/page class containing at most
+   * eight atlas textures is recordable. A flush that needs several batches, or
+   * a second Text flush within the same capture window, poisons the capture
+   * instead (see `_tryRecordRetainedBatch`) — always safe, just a missed
+   * optimization.
    * @internal
    */
   public readonly _supportsRetainedBatches = true;
@@ -406,12 +429,10 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
   private _pipelineLayout: GPUPipelineLayout | null = null;
 
   private readonly _pipelines = new Map<string, GPURenderPipeline>();
-  // Weak cache: avoids retaining transient atlas textures via strong keys. The
-  // bind group is stored alongside the texture view it was built from — a
-  // mutable DataTexture (the glyph atlas) keeps the same view across content
-  // updates but gets a fresh one when the backend recreates the GPU texture on
-  // resize, so the cache is invalidated only then.
-  private _texBindGroups = new WeakMap<Texture, { group: GPUBindGroup; view: GPUTextureView }>();
+  // Ordered texture sets are cached under their slot-0 texture. Weak anchoring
+  // avoids retaining dead atlases; a small per-anchor bound covers stable UI
+  // combinations without letting pathological rotations grow indefinitely.
+  private _textureSetBindGroups = new WeakMap<Texture, TextTextureSetBindGroupEntry[]>();
 
   private _projBuffer: GPUBuffer | null = null;
   private _nodeBuffer: GPUBuffer | null = null;
@@ -461,6 +482,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
   private _indexCapacity = initialIndexCapacity;
   private _vertexData: ArrayBuffer = new ArrayBuffer(initialVertexCapacity * vertexStrideBytes);
   private _float32View: Float32Array = new Float32Array(this._vertexData);
+  private _uint32View: Uint32Array = new Uint32Array(this._vertexData);
   private _indexData: Uint32Array = new Uint32Array(initialIndexCapacity);
   private _projData: Float32Array = new Float32Array(projectionBytes / 4);
 
@@ -501,10 +523,15 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       }
     }
 
-    // Sort by (shaderType, atlasTexture) so equal-key quads are contiguous
+    // Sort by compatible atlas class, then texture identity. Up to eight
+    // textures of one class share a draw through the shader slot table.
     this._pendingQuads.sort((a, b) => {
       const sc = a.shaderType.localeCompare(b.shaderType);
       if (sc !== 0) return sc;
+      const wc = a.atlasTexture.width - b.atlasTexture.width;
+      if (wc !== 0) return wc;
+      const hc = a.atlasTexture.height - b.atlasTexture.height;
+      if (hc !== 0) return hc;
       return (this._textureKeyMap.get(a.atlasTexture) ?? 0) - (this._textureKeyMap.get(b.atlasTexture) ?? 0);
     });
 
@@ -545,12 +572,20 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     while (qi < quads.length) {
       // qi/qj/k are all bounded by `quads.length` via the loop guards above.
       const first = quads[qi]!;
-      const firstTextureKey = this._textureKeyMap.get(first.atlasTexture);
+      const atlasSlots = new Map<Texture, number>();
+      const atlasTextures: Texture[] = [];
+      let qj = qi;
 
-      let qj = qi + 1;
       while (qj < quads.length) {
         const pq = quads[qj]!;
-        if (pq.shaderType !== first.shaderType || this._textureKeyMap.get(pq.atlasTexture) !== firstTextureKey) break;
+        if (!sharesAtlasBatchClass(first, pq)) break;
+
+        if (!atlasSlots.has(pq.atlasTexture)) {
+          if (atlasTextures.length === textAtlasTextureSlots) break;
+          atlasSlots.set(pq.atlasTexture, atlasTextures.length);
+          atlasTextures.push(pq.atlasTexture);
+        }
+
         qj++;
       }
 
@@ -559,7 +594,8 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       let batchIndexCount = 0;
 
       for (let k = qi; k < qj; k++) {
-        const { quads: batch, nodeIndex } = quads[k]!;
+        const { quads: batch, nodeIndex, atlasTexture } = quads[k]!;
+        const atlasSlot = atlasSlots.get(atlasTexture)!;
         const qVerts = batch.quadCount * 4;
         const { vertices, uvs, indices } = batch;
 
@@ -571,7 +607,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
           this._float32View[w + 1] = vertices[vp + 1]!;
           this._float32View[w + 2] = uvs[vp]!;
           this._float32View[w + 3] = uvs[vp + 1]!;
-          this._float32View[w + 4] = nodeIndex;
+          this._uint32View[w + 4] = packTextNodeAtlasSlot(nodeIndex, atlasSlot);
         }
 
         for (let x = 0; x < indices.length; x++) {
@@ -585,7 +621,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
 
       batches.push({
         shaderType: first.shaderType,
-        atlasTexture: first.atlasTexture,
+        atlasTextures,
         firstVertex: batchFirstVertex,
         vertexCount: packedV - batchFirstVertex,
         firstIndex: batchFirstIndex,
@@ -660,8 +696,14 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     if (nodeBase > 0) {
       for (let v = 0; v < packedV; v++) {
         const w = v * vertexStrideWords + nodeIndexWord;
+        const packedNodeSlot = this._uint32View[w]!;
+        const nodeIndex = (packedNodeSlot & textNodeIndexMask) + nodeBase;
 
-        this._float32View[w] = this._float32View[w]! + nodeBase;
+        if (nodeIndex > textNodeIndexMask) {
+          throw new Error(`WebGpuTextRenderer: packed node index ${nodeIndex} exceeds the 24-bit vertex limit.`);
+        }
+
+        this._uint32View[w] = (packedNodeSlot & ~textNodeIndexMask) | nodeIndex;
       }
     }
 
@@ -687,10 +729,12 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     // the freshly opened pass) still read them there. Rewinding would let a
     // later append overwrite bytes those draws read.
     if (coordinator.passHasDraws) {
-      for (const batch of batches) {
-        if (backend._textureUploadWouldMutate(batch.atlasTexture)) {
-          coordinator.endPass();
-          break;
+      outer: for (const batch of batches) {
+        for (const texture of batch.atlasTextures) {
+          if (backend._textureUploadWouldMutate(texture)) {
+            coordinator.endPass();
+            break outer;
+          }
         }
       }
     }
@@ -705,18 +749,13 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     pass.setIndexBuffer(this._indexBuffer!, 'uint32', indexBase);
 
     let lastShaderType: ShaderType | null = null;
-    let lastTexture: Texture | null = null;
-
     for (const batch of batches) {
       if (batch.shaderType !== lastShaderType) {
         pass.setPipeline(this._getPipeline(batch.shaderType, format, stencil));
         pass.setBindGroup(0, frameBindGroup);
         lastShaderType = batch.shaderType;
       }
-      if (batch.atlasTexture !== lastTexture) {
-        pass.setBindGroup(1, this._getTexBindGroup(device, backend, batch.atlasTexture));
-        lastTexture = batch.atlasTexture;
-      }
+      pass.setBindGroup(1, this._getTexBindGroup(device, backend, batch.atlasTextures));
       pass.drawIndexed(batch.indexCount, 1, batch.firstIndex, 0, 0);
       coordinator.markPassDraws();
       backend.stats.batches++;
@@ -815,16 +854,16 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     this._textureBindGroupLayout = device.createBindGroupLayout({
       label: 'WebGpuTextRenderer/texture',
       entries: [
-        {
-          binding: 0,
+        ...Array.from({ length: textAtlasTextureSlots }, (_, binding) => ({
+          binding,
           visibility: GPUShaderStage.FRAGMENT,
-          texture: { sampleType: 'float' },
-        },
-        {
-          binding: 1,
+          texture: { sampleType: 'float' as const },
+        })),
+        ...Array.from({ length: textAtlasTextureSlots }, (_, slot) => ({
+          binding: textAtlasTextureSlots + slot,
           visibility: GPUShaderStage.FRAGMENT,
-          sampler: { type: 'filtering' },
-        },
+          sampler: { type: 'filtering' as const },
+        })),
       ],
     });
 
@@ -891,7 +930,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     this._resetPassCursors();
 
     this._pipelines.clear();
-    this._texBindGroups = new WeakMap<Texture, { group: GPUBindGroup; view: GPUTextureView }>();
+    this._textureSetBindGroups = new WeakMap<Texture, TextTextureSetBindGroupEntry[]>();
 
     this._pipelineLayout = null;
     this._textureBindGroupLayout = null;
@@ -939,6 +978,10 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     if (existing !== undefined) return existing;
 
     const idx = this._nodeCount++;
+
+    if (idx > textNodeIndexMask) {
+      throw new Error(`WebGpuTextRenderer: node index ${idx} exceeds the 24-bit packed vertex limit.`);
+    }
     this._nodeIndexMap.set(node, idx);
     this._ensureNodeCapacity(idx + 1);
     this._packNodeData(idx, node);
@@ -1114,27 +1157,71 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     return this._frameBindGroup;
   }
 
-  private _getTexBindGroup(device: GPUDevice, backend: WebGpuBackend, texture: Texture): GPUBindGroup {
-    // Always resolve the binding so the backend syncs the texture first: a glyph
-    // atlas that gained new glyphs (e.g. a scene switch introducing new
-    // characters) uploads its dirty region here. Returning a cached bind group
-    // without this call would leave those new glyphs un-uploaded — they sample
-    // empty atlas texels and render invisibly.
-    const { view, sampler } = backend.getTextureBinding(texture);
+  private _getTexBindGroup(device: GPUDevice, backend: WebGpuBackend, textures: readonly Texture[]): GPUBindGroup {
+    if (textures.length === 0 || textures.length > textAtlasTextureSlots) {
+      throw new Error(`WebGpuTextRenderer: expected 1-${textAtlasTextureSlots} atlas textures, got ${textures.length}.`);
+    }
 
-    const cached = this._texBindGroups.get(texture);
-    if (cached?.view === view) return cached.group;
+    // WebGPU bind groups are fixed-layout. Duplicate slot 0 into unused entries;
+    // packed vertices can only select the real prefix. Resolve every live
+    // binding before the cache lookup so dirty pages still upload and sampler
+    // mutations are visible even when their texture view stays stable.
+    const fallbackTexture = textures[0]!;
+    const fallbackBinding = backend.getTextureBinding(fallbackTexture);
+    const resolvedTextures = new Array<Texture>(textAtlasTextureSlots);
+    const bindings = new Array<ReturnType<WebGpuBackend['getTextureBinding']>>(textAtlasTextureSlots);
 
-    const group = device.createBindGroup({
+    for (let slot = 0; slot < textAtlasTextureSlots; slot++) {
+      const texture = textures[slot] ?? fallbackTexture;
+
+      resolvedTextures[slot] = texture;
+      bindings[slot] = texture === fallbackTexture ? fallbackBinding : backend.getTextureBinding(texture);
+    }
+
+    let cachedEntries = this._textureSetBindGroups.get(fallbackTexture);
+
+    if (cachedEntries === undefined) {
+      cachedEntries = [];
+      this._textureSetBindGroups.set(fallbackTexture, cachedEntries);
+    }
+
+    for (const cached of cachedEntries) {
+      if (!cached.textures.every((texture, slot) => texture === resolvedTextures[slot])) continue;
+
+      const bindingChanged = cached.views.some((view, slot) => view !== bindings[slot]!.view || cached.samplers[slot] !== bindings[slot]!.sampler);
+
+      if (bindingChanged) {
+        cached.views = bindings.map(binding => binding.view);
+        cached.samplers = bindings.map(binding => binding.sampler);
+        cached.group = this._buildTextureBindGroup(device, bindings);
+      }
+
+      return cached.group;
+    }
+
+    const group = this._buildTextureBindGroup(device, bindings);
+
+    cachedEntries.push({
+      textures: resolvedTextures,
+      views: bindings.map(binding => binding.view),
+      samplers: bindings.map(binding => binding.sampler),
+      group,
+    });
+
+    if (cachedEntries.length > maxTextureSetsPerAnchor) cachedEntries.shift();
+
+    return group;
+  }
+
+  private _buildTextureBindGroup(device: GPUDevice, bindings: ReadonlyArray<ReturnType<WebGpuBackend['getTextureBinding']>>): GPUBindGroup {
+    return device.createBindGroup({
       label: 'WebGpuTextRenderer/texture-bind-group',
       layout: this._textureBindGroupLayout!,
       entries: [
-        { binding: 0, resource: view },
-        { binding: 1, resource: sampler },
+        ...bindings.map(({ view }, binding) => ({ binding, resource: view })),
+        ...bindings.map(({ sampler }, slot) => ({ binding: textAtlasTextureSlots + slot, resource: sampler })),
       ],
     });
-    this._texBindGroups.set(texture, { group, view });
-    return group;
   }
 
   // ── Pipeline helpers ─────────────────────────────────────────────────────
@@ -1172,7 +1259,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
             attributes: [
               { shaderLocation: 0, offset: 0, format: 'float32x2' },
               { shaderLocation: 1, offset: 8, format: 'float32x2' },
-              { shaderLocation: 2, offset: 16, format: 'float32' },
+              { shaderLocation: 2, offset: 16, format: 'uint32' },
             ],
           },
         ],
@@ -1205,6 +1292,7 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
     while (this._vertexCapacity < vertexCount) this._vertexCapacity *= 2;
     this._vertexData = new ArrayBuffer(this._vertexCapacity * vertexStrideBytes);
     this._float32View = new Float32Array(this._vertexData);
+    this._uint32View = new Uint32Array(this._vertexData);
   }
 
   private _ensureIndexCapacity(indexCount: number): void {
@@ -1255,13 +1343,14 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
   }
 
   /**
-   * Stage this flush's ONE batch for retained replay, or poison the active
+   * Stage this flush's ONE multi-atlas batch for retained replay, or poison the active
    * capture(s) when this flush is not a clean single-batch recording.
    * `TextRetainedReplayState` holds at most one recorded batch per bundle per
    * capture window (identified via `backend._currentRetainedCaptureFrame`,
    * unique per capture-open call) — a flush spanning multiple distinct
-   * (shaderType, atlasTexture) combinations, or a second Text flush within the
-   * same window, would need a second slot this design doesn't provide.
+   * incompatible shader/page classes or more than eight atlas textures, or a
+   * second Text flush within the same window, would need a second slot this
+   * design doesn't provide.
    * Poisoning is always safe: the group falls back to entry replay for this
    * frame only, never wrong pixels.
    */
@@ -1293,7 +1382,17 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       quadCount: batch.indexCount / 6,
     };
 
-    backend._recordRetainedBatch(this, vertexBytes, vertexByteLength, this._nodeCount, BlendModes.Normal, [batch.atlasTexture], 1, null, rendererData);
+    backend._recordRetainedBatch(
+      this,
+      vertexBytes,
+      vertexByteLength,
+      this._nodeCount,
+      BlendModes.Normal,
+      batch.atlasTextures,
+      batch.atlasTextures.length,
+      null,
+      rendererData,
+    );
 
     this._recordedCaptureFrames.add(frame);
   }
@@ -1378,20 +1477,24 @@ export class WebGpuTextRenderer extends AbstractWebGpuRenderer<Text | BitmapText
       device.queue.writeBuffer(state.uniformBuffer!, 0, state.uboData.buffer, state.uboData.byteOffset, projectionBytes);
     }
 
-    // Text's own recording always stages exactly one `Texture` (the atlas
-    // page — see `_tryRecordRetainedBatch`'s `[batch.atlasTexture]`), never a
-    // `RenderTexture`; the payload's shared type is wider only because other
-    // renderers can target one.
+    // Text's own recording stages one or more atlas `Texture`s in packed-slot
+    // order, never a `RenderTexture`; the payload's shared type is wider only
+    // because other renderers can target one.
     // Same-frame atlas-mutation guard: syncing a dirty glyph page below lands on
     // the queue timeline ahead of the deferred submit, retroactively changing
     // draws already recorded into the open pass — from any renderer, since the
     // pass survives a renderer switch.
-    if (coordinator.passHasDraws && backend._textureUploadWouldMutate(payload.textures[0]!)) {
-      coordinator.endPass();
-      state.drawsInPass = null;
+    if (coordinator.passHasDraws) {
+      for (const texture of payload.textures) {
+        if (backend._textureUploadWouldMutate(texture)) {
+          coordinator.endPass();
+          state.drawsInPass = null;
+          break;
+        }
+      }
     }
 
-    const textureBindGroup = this._getTexBindGroup(device, backend, payload.textures[0]! as Texture);
+    const textureBindGroup = this._getTexBindGroup(device, backend, payload.textures as readonly Texture[]);
     const frameBindGroup = this._getTextReplayBindGroup(state, device);
     const indexBuffer = this._ensureRetainedQuadIndexBuffer(device, data.quadCount, coordinator);
 

--- a/src/rendering/webgpu/webgpuUserUniforms.ts
+++ b/src/rendering/webgpu/webgpuUserUniforms.ts
@@ -1,6 +1,6 @@
 /// <reference types="@webgpu/types" />
 
-import type { Material, UniformValue } from '#rendering/material/Material';
+import { isTextureUniformValue, type Material, type UniformValue } from '#rendering/material/Material';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
 
@@ -24,25 +24,15 @@ import type { WebGpuBackend } from './WebGpuBackend';
 
 /** Whether a uniform value is a bound texture rather than a scalar/vector. */
 export function isTextureUniform(value: UniformValue): value is Texture | RenderTexture {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'width' in value &&
-    'height' in value &&
-    !(value instanceof Float32Array) &&
-    !(value instanceof Int32Array) &&
-    !Array.isArray(value)
-  );
+  return isTextureUniformValue(value);
 }
 
 /** Scalar/vector/matrix uniforms (texture values excluded) in declaration order. */
 export function collectScalarUniforms(material: Material): Array<Exclude<UniformValue, Texture | RenderTexture>> {
   const result: Array<Exclude<UniformValue, Texture | RenderTexture>> = [];
 
-  for (const value of Object.values(material.uniforms)) {
-    if (!isTextureUniform(value)) {
-      result.push(value);
-    }
+  for (const name of material._bindingSchema.scalarUniformNames) {
+    result.push(material._getUniformValue(name) as Exclude<UniformValue, Texture | RenderTexture>);
   }
 
   return result;
@@ -57,14 +47,12 @@ export function collectScalarUniforms(material: Material): Array<Exclude<Uniform
 export function collectTextureBindings(material: Material): Array<Texture | RenderTexture> {
   const result: Array<Texture | RenderTexture> = [];
 
-  for (const value of Object.values(material.uniforms)) {
-    if (isTextureUniform(value)) {
-      result.push(value);
-    }
+  for (const name of material._bindingSchema.textureUniformNames) {
+    result.push(material._getUniformValue(name) as Texture | RenderTexture);
   }
 
-  for (const texture of Object.values(material.textures)) {
-    result.push(texture);
+  for (const name of material._bindingSchema.textureNames) {
+    result.push(material._getTextureValue(name));
   }
 
   return result;

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -264,6 +264,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "MaskSource: type alias",
   "Material: class",
   "MaterialOptions: interface",
+  "MaterialSamplerOptions: interface",
   "MathUtils: variable",
   "Matrix: class",
   "MemoryStore: class",

--- a/test/rendering/browser/webgl2-custom-mesh-material.test.ts
+++ b/test/rendering/browser/webgl2-custom-mesh-material.test.ts
@@ -7,7 +7,7 @@ import { ShaderSource } from '#rendering/material/ShaderSource';
 import { Mesh } from '#rendering/mesh/Mesh';
 import type { RenderNode } from '#rendering/RenderNode';
 import { Texture } from '#rendering/texture/Texture';
-import { BlendModes } from '#rendering/types';
+import { BlendModes, ScaleModes, WrapModes } from '#rendering/types';
 import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
 
 import { readWebGl2Pixel } from './_backendSetup';
@@ -209,8 +209,11 @@ describe('custom MeshMaterial WebGL2 browser', () => {
       shader: new ShaderSource({ glsl: { vertex: customVertex, fragment: customFragment } }),
       uniforms: { u_userColor: [1, 0, 0.5, 1] as const },
       textures: { u_pattern: pattern },
+      sampler: { scaleMode: ScaleModes.Nearest, wrapMode: WrapModes.Repeat },
     });
     const mesh = createQuadMesh(16, material);
+    const bindMaterialSampler = vi.spyOn(backend, 'bindMaterialSampler');
+    const unbindMaterialSampler = vi.spyOn(backend, 'unbindMaterialSampler');
 
     try {
       mesh.setPosition(24, 24);
@@ -221,6 +224,8 @@ describe('custom MeshMaterial WebGL2 browser', () => {
       expectPixelNear(readWebGl2Pixel(backend, 32, 32), [128, 0, 64, 255]);
       // Outside the quad stays clear-black.
       expectPixelNear(readWebGl2Pixel(backend, 4, 4), [0, 0, 0, 255]);
+      expect(bindMaterialSampler).toHaveBeenCalledWith(material.sampler, 0);
+      expect(unbindMaterialSampler).toHaveBeenCalledWith(0);
     } finally {
       mesh.destroy();
       material.destroy();

--- a/test/rendering/browser/webgl2-custom-sprite-material.test.ts
+++ b/test/rendering/browser/webgl2-custom-sprite-material.test.ts
@@ -4,9 +4,11 @@ import { Container } from '#rendering/Container';
 import { ShaderSource } from '#rendering/material/ShaderSource';
 import { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
 import { Sprite } from '#rendering/sprite/Sprite';
 import { spriteMaterialTextureSlots, spriteVertexGlsl } from '#rendering/sprite/spriteMaterialSources';
 import { Texture } from '#rendering/texture/Texture';
+import { BlendModes } from '#rendering/types';
 import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
 
 import { readWebGl2Pixel } from './_backendSetup';
@@ -117,6 +119,105 @@ const createTintMaterial = (color: readonly [number, number, number, number]): S
   });
 
 describe('custom SpriteMaterial WebGL2 browser', () => {
+  test('retained replay keeps uniform values live and recoverably re-records blend changes', async () => {
+    const backend = await createBackend();
+    const texture = createSolidTexture(255, 255, 255);
+    const values = new Float32Array([1, 0, 0, 1]);
+    const material = createTintMaterial(values as unknown as readonly [number, number, number, number]);
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.material = material;
+      sprite.setPosition(16, 16);
+      group.addChild(sprite);
+
+      render(backend, group); // fragment capture
+      render(backend, group); // instruction recording
+
+      let replay = vi.spyOn(backend, '_replayRetainedBatch');
+
+      render(backend, group);
+      expect(replay).toHaveBeenCalledTimes(1);
+      expectPixelNear(readWebGl2Pixel(backend, 24, 24), [255, 0, 0, 255]);
+
+      material.setUniform('u_userColor', [0, 1, 0, 1]);
+      replay.mockClear();
+      render(backend, group);
+
+      expect(replay).toHaveBeenCalledTimes(1);
+      expectPixelNear(readWebGl2Pixel(backend, 24, 24), [0, 255, 0, 255]);
+
+      values.set([0, 1, 0, 1]);
+      material.setUniform('u_userColor', values);
+      render(backend, group);
+      values[0] = 0;
+      values[1] = 0;
+      values[2] = 1;
+      replay.mockClear();
+      render(backend, group);
+
+      expect(replay).toHaveBeenCalledTimes(1);
+      expectPixelNear(readWebGl2Pixel(backend, 24, 24), [0, 0, 255, 255]);
+
+      material.blendMode = BlendModes.Additive;
+      replay.mockClear();
+      render(backend, group);
+      expect(replay).not.toHaveBeenCalled();
+
+      replay.mockRestore();
+      replay = vi.spyOn(backend, '_replayRetainedBatch');
+      render(backend, group);
+      expect(replay).toHaveBeenCalledTimes(1);
+      replay.mockRestore();
+    } finally {
+      group.destroy();
+      material.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('retained replay resolves a replacement material texture identity live', async () => {
+    const backend = await createBackend();
+    const base = createSolidTexture(255, 255, 255);
+    const firstPattern = createSolidTexture(255, 0, 0);
+    const secondPattern = createSolidTexture(0, 255, 0);
+    const material = new SpriteMaterial({
+      shader: new ShaderSource({ glsl: { vertex: spriteVertexGlsl, fragment: patternFragment } }),
+      textures: { u_pattern: firstPattern },
+    });
+    const group = new RetainedContainer();
+    const sprite = new Sprite(base);
+
+    try {
+      sprite.material = material;
+      sprite.setPosition(16, 16);
+      group.addChild(sprite);
+
+      render(backend, group);
+      render(backend, group);
+      render(backend, group);
+      expectPixelNear(readWebGl2Pixel(backend, 24, 24), [255, 0, 0, 255]);
+
+      const replay = vi.spyOn(backend, '_replayRetainedBatch');
+
+      material.setTexture('u_pattern', secondPattern);
+      render(backend, group);
+
+      expect(replay).toHaveBeenCalledTimes(1);
+      expectPixelNear(readWebGl2Pixel(backend, 24, 24), [0, 255, 0, 255]);
+      replay.mockRestore();
+    } finally {
+      group.destroy();
+      material.destroy();
+      secondPattern.destroy();
+      firstPattern.destroy();
+      base.destroy();
+      backend.destroy();
+    }
+  });
+
   test('renders a custom fragment sampling the base texture and a user uniform', async () => {
     const backend = await createBackend();
     // Mid-gray base proves the texture is sampled; the per-channel uniform

--- a/test/rendering/browser/webgl2-custom-sprite-material.test.ts
+++ b/test/rendering/browser/webgl2-custom-sprite-material.test.ts
@@ -8,7 +8,7 @@ import { RetainedContainer } from '#rendering/RetainedContainer';
 import { Sprite } from '#rendering/sprite/Sprite';
 import { spriteMaterialTextureSlots, spriteVertexGlsl } from '#rendering/sprite/spriteMaterialSources';
 import { Texture } from '#rendering/texture/Texture';
-import { BlendModes } from '#rendering/types';
+import { BlendModes, ScaleModes, WrapModes } from '#rendering/types';
 import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
 
 import { readWebGl2Pixel } from './_backendSetup';
@@ -87,6 +87,26 @@ const createSolidTexture = (r: number, g: number, b: number, a = 255, size = 16)
   return new Texture(source);
 };
 
+const createSplitTexture = (): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = 2;
+  source.height = 2;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = '#f00';
+  context.fillRect(0, 0, 1, 2);
+  context.fillStyle = '#00f';
+  context.fillRect(1, 0, 1, 2);
+
+  return new Texture(source, { scaleMode: ScaleModes.Linear, generateMipMap: false });
+};
+
 // Custom fragment: samples this instance's base texture through the engine's
 // spliced `sampleBase` helper and modulates it by a user vec4 uniform.
 const tintFragment = `#version 300 es
@@ -119,6 +139,45 @@ const createTintMaterial = (color: readonly [number, number, number, number]): S
   });
 
 describe('custom SpriteMaterial WebGL2 browser', () => {
+  test('material sampler overrides base-texture sampling and mutates live during retained replay', async () => {
+    const backend = await createBackend();
+    const texture = createSplitTexture();
+    const material = createTintMaterial([1, 1, 1, 1]);
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    try {
+      material.sampler = { scaleMode: ScaleModes.Nearest, wrapMode: WrapModes.ClampToEdge };
+      sprite.material = material;
+      sprite.setPosition(16, 16).setScale(16, 16);
+      group.addChild(sprite);
+
+      render(backend, group);
+      render(backend, group);
+      render(backend, group);
+      expectPixelNear(readWebGl2Pixel(backend, 31, 24), [255, 0, 0, 255]);
+
+      const replay = vi.spyOn(backend, '_replayRetainedBatch');
+
+      material.sampler.scaleMode = ScaleModes.Linear;
+      render(backend, group);
+
+      const blended = readWebGl2Pixel(backend, 31, 24);
+
+      expect(replay).toHaveBeenCalledTimes(1);
+      expect(blended[0]).toBeGreaterThan(100);
+      expect(blended[0]).toBeLessThan(200);
+      expect(blended[2]).toBeGreaterThan(50);
+      expect(blended[2]).toBeLessThan(160);
+      replay.mockRestore();
+    } finally {
+      group.destroy();
+      material.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
   test('retained replay keeps uniform values live and recoverably re-records blend changes', async () => {
     const backend = await createBackend();
     const texture = createSolidTexture(255, 255, 255);

--- a/test/rendering/browser/webgl2-shader-compile.test.ts
+++ b/test/rendering/browser/webgl2-shader-compile.test.ts
@@ -13,6 +13,8 @@
 // against the same SwiftShader driver the WebGL2 browser project runs on. A
 // reserved-word (or any other compile) regression now fails right here.
 
+import { composeTextAtlasFragmentGlsl } from '#rendering/text/textAtlasTextureSlots';
+
 // Core shaders plus the extension packages' own — the particle stage ships
 // from `@codexo/exojs-particles`, so a glob over `src/` alone would leave the
 // only GLSL outside core uncompiled here.
@@ -27,18 +29,28 @@ type ShaderStage = 'vertex' | 'fragment';
 interface ShaderEntry {
   readonly name: string;
   readonly source: string;
+  /** Source exactly as the owning renderer submits it to WebGL. */
+  readonly runtimeSource: string;
   readonly stage: ShaderStage;
 }
 
+const composeRuntimeSource = (name: string, source: string): string =>
+  name.startsWith('text-') && name.endsWith('.frag') ? composeTextAtlasFragmentGlsl(source) : source;
+
 const shaders: readonly ShaderEntry[] = Object.entries(shaderModules)
-  .map(([path, source]) => ({
-    name: path.slice(path.lastIndexOf('/') + 1),
-    source,
-    stage: path.endsWith('.vert') ? 'vertex' : 'fragment',
-  }))
+  .map(([path, source]) => {
+    const name = path.slice(path.lastIndexOf('/') + 1);
+
+    return {
+      name,
+      source,
+      runtimeSource: composeRuntimeSource(name, source),
+      stage: path.endsWith('.vert') ? 'vertex' : 'fragment',
+    };
+  })
   .sort((a, b) => a.name.localeCompare(b.name));
 
-const sourceByName: Record<string, string> = Object.fromEntries(shaders.map(entry => [entry.name, entry.source]));
+const sourceByName: Record<string, string> = Object.fromEntries(shaders.map(entry => [entry.name, entry.runtimeSource]));
 
 // Vertex/fragment pairs as wired up by the renderer sources; `text.vert` is
 // shared across all three text-fragment variants, while `particle.*` and
@@ -117,8 +129,8 @@ describe('WebGL2 GLSL shader sources', () => {
     }
   });
 
-  test.each(shaders)('compiles $name', ({ name, source, stage }) => {
-    const { shader, log } = compileShader(gl, stage, source);
+  test.each(shaders)('compiles $name', ({ name, runtimeSource, stage }) => {
+    const { shader, log } = compileShader(gl, stage, runtimeSource);
 
     try {
       expect(log, `${name} failed to compile:\n${log ?? ''}`).toBeNull();

--- a/test/rendering/browser/webgl2-text-atlas-texture-slots.test.ts
+++ b/test/rendering/browser/webgl2-text-atlas-texture-slots.test.ts
@@ -1,0 +1,171 @@
+/** WebGL2 pixel + binding + draw-count coverage for Text atlas multi-texture batching. */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+import type { FontWeight } from '#rendering/text/TextStyle';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+const width = 200;
+const height = 96;
+const cellWidth = 40;
+const cellHeight = 48;
+const weights: readonly FontWeight[] = ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700'];
+
+const setupBackend = async (): Promise<WebGl2Backend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = width;
+  canvas.height = height;
+
+  const app = {
+    canvas,
+    options: {
+      canvas: { width, height },
+      clearColor: Color.black,
+      rendering: { webglAttributes: { preserveDrawingBuffer: true } },
+    },
+  } as unknown as Application;
+  const backend = new WebGl2Backend(app);
+
+  await backend.initialize();
+  wireCoreRenderers(backend, app.options.rendering);
+
+  return backend;
+};
+
+const buildTexts = (count: number): { root: Container; texts: Text[] } => {
+  const root = new Container();
+  const texts = weights.slice(0, count).map((fontWeight, index) => {
+    const text = new Text('M', { fontSize: 28, fontWeight, fillColor: Color.white });
+
+    text.setPosition((index % 5) * cellWidth + 4, Math.floor(index / 5) * cellHeight + 4);
+    root.addChild(text);
+
+    return text;
+  });
+
+  return { root, texts };
+};
+
+const render = (backend: WebGl2Backend, root: Container): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  root.render(backend);
+  backend.flush();
+};
+
+const readFrame = (backend: WebGl2Backend): Uint8Array => {
+  const frame = new Uint8Array(width * height * 4);
+  const gl = backend.context;
+
+  gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, frame);
+
+  return frame;
+};
+
+const cellHasInk = (frame: ArrayLike<number>, index: number): boolean => {
+  const x0 = (index % 5) * cellWidth;
+
+  // readPixels uses a bottom-left origin while scene coordinates are top-left;
+  // scan the full narrow x-cell so this assertion is about the atlas slot's
+  // pixels, not framebuffer orientation.
+  for (let y = 0; y < height; y++) {
+    for (let x = x0; x < x0 + cellWidth; x++) {
+      const offset = (y * width + x) * 4;
+
+      if (frame[offset]! + frame[offset + 1]! + frame[offset + 2]! > 80) return true;
+    }
+  }
+
+  return false;
+};
+
+interface FragmentCarrier {
+  _fragment: RetainedGroupFragment;
+}
+
+describe('WebGL2 Text atlas texture slots', () => {
+  beforeEach(() => resetDefaultGlyphAtlasPool());
+  afterEach(() => resetDefaultGlyphAtlasPool());
+
+  test('four font atlases bind to four slots and render every glyph in one draw', async () => {
+    const backend = await setupBackend();
+    const scene = buildTexts(4);
+    const bindTextureSpy = vi.spyOn(backend, 'bindTexture');
+
+    try {
+      expect(backend.context.getError()).toBe(backend.context.NO_ERROR);
+      backend.resetStats();
+      backend.clear(Color.black);
+      expect(backend.context.getError()).toBe(backend.context.NO_ERROR);
+      scene.root.render(backend);
+      expect(backend.context.getError()).toBe(backend.context.NO_ERROR);
+      backend.flush();
+      expect(backend.context.getError()).toBe(backend.context.NO_ERROR);
+      render(backend, scene.root);
+
+      expect(backend.stats.drawCalls).toBe(1);
+      expect(scene.texts.every(text => text.pageQuads.some(batch => batch.quadCount > 0))).toBe(true);
+
+      const atlasBinds = bindTextureSpy.mock.calls.filter(([, unit]) => unit !== undefined && unit >= 0 && unit < 4);
+
+      expect([...new Set(atlasBinds.map(([, unit]) => unit))].sort()).toEqual([0, 1, 2, 3]);
+      expect(new Set(atlasBinds.map(([texture]) => texture)).size).toBeGreaterThanOrEqual(4);
+      expect(backend.context.getError()).toBe(backend.context.NO_ERROR);
+
+      const frame = readFrame(backend);
+
+      for (let index = 0; index < scene.texts.length; index++) {
+        expect(cellHasInk(frame, index), `text cell ${index} has no glyph pixels`).toBe(true);
+      }
+    } finally {
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('nine compatible font atlases split only at the eight-slot limit', async () => {
+    const backend = await setupBackend();
+    const scene = buildTexts(9);
+
+    try {
+      render(backend, scene.root);
+      render(backend, scene.root);
+
+      expect(backend.stats.drawCalls).toBe(2);
+    } finally {
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('a four-atlas retained group records and replays one multi-texture batch', async () => {
+    const backend = await setupBackend();
+    const scene = buildTexts(4);
+    const group = new RetainedContainer();
+
+    scene.texts.forEach(text => group.addChild(text));
+    scene.root.addChild(group);
+
+    try {
+      render(backend, scene.root);
+      render(backend, scene.root);
+      render(backend, scene.root);
+
+      const fragment = (group as unknown as FragmentCarrier)._fragment;
+
+      expect(fragment.instructions?.hasRecording).toBe(true);
+      expect(backend.stats.drawCalls).toBe(1);
+    } finally {
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-custom-mesh-material.test.ts
+++ b/test/rendering/browser/webgpu-custom-mesh-material.test.ts
@@ -19,6 +19,7 @@ import { MeshMaterial } from '#rendering/material/MeshMaterial';
 import { ShaderSource } from '#rendering/material/ShaderSource';
 import { Mesh } from '#rendering/mesh/Mesh';
 import { Texture } from '#rendering/texture/Texture';
+import { ScaleModes, WrapModes } from '#rendering/types';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { wireCoreRenderers } from './_coreRenderers';
@@ -163,8 +164,10 @@ describe('custom MeshMaterial WebGPU browser', () => {
       shader: new ShaderSource({ wgsl: customWgsl }),
       uniforms: { u_userColor: [1, 0, 0.5, 1] as const },
       textures: { u_pattern: pattern },
+      sampler: { scaleMode: ScaleModes.Nearest, wrapMode: WrapModes.Repeat },
     });
     const mesh = createQuadMesh(16, material);
+    const getTextureBinding = vi.spyOn(backend, 'getTextureBinding');
 
     mesh.setPosition(24, 24);
 
@@ -199,6 +202,8 @@ describe('custom MeshMaterial WebGPU browser', () => {
     try {
       expect(validationError).toBeNull();
       expect(backend.stats.drawCalls).toBeGreaterThan(0);
+      expect(getTextureBinding).toHaveBeenCalledWith(Texture.white, material.sampler);
+      expect(getTextureBinding).toHaveBeenCalledWith(pattern);
     } finally {
       mesh.destroy();
       material.destroy();

--- a/test/rendering/browser/webgpu-custom-sprite-material.test.ts
+++ b/test/rendering/browser/webgpu-custom-sprite-material.test.ts
@@ -22,7 +22,7 @@ import { RetainedContainer } from '#rendering/RetainedContainer';
 import { Sprite } from '#rendering/sprite/Sprite';
 import { spriteMaterialTextureSlots } from '#rendering/sprite/spriteMaterialSources';
 import { Texture } from '#rendering/texture/Texture';
-import { BlendModes } from '#rendering/types';
+import { BlendModes, ScaleModes, WrapModes } from '#rendering/types';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { readWebGpuPixels } from './_backendSetup';
@@ -67,7 +67,7 @@ const makeApp = (canvas: HTMLCanvasElement): Application =>
     },
   }) as unknown as Application;
 
-const createSolidTexture = (r: number, g: number, b: number): Texture => {
+const createSolidTexture = (r: number, g: number, b: number, a = 255): Texture => {
   const source = document.createElement('canvas');
 
   source.width = 16;
@@ -79,16 +79,48 @@ const createSolidTexture = (r: number, g: number, b: number): Texture => {
     throw new Error('2D context is required to create test textures.');
   }
 
-  context.fillStyle = `rgb(${r}, ${g}, ${b})`;
+  context.fillStyle = `rgba(${r}, ${g}, ${b}, ${a / 255})`;
   context.fillRect(0, 0, source.width, source.height);
 
   return new Texture(source);
+};
+
+const createSplitTexture = (): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = 2;
+  source.height = 2;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = '#f00';
+  context.fillRect(0, 0, 1, 2);
+  context.fillStyle = '#00f';
+  context.fillRect(1, 0, 1, 2);
+
+  return new Texture(source, { scaleMode: ScaleModes.Linear, generateMipMap: false });
 };
 
 const createMaterial = (): SpriteMaterial =>
   new SpriteMaterial({
     shader: new ShaderSource({ wgsl: customFragmentWgsl }),
     uniforms: { u_userColor: [1, 0, 0.5, 1] },
+  });
+
+const createPassThroughMaterial = (): SpriteMaterial =>
+  new SpriteMaterial({
+    shader: new ShaderSource({
+      wgsl: `
+@fragment
+fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  return sampleBase(input.textureSlot, input.texcoord) * input.color;
+}
+`.trim(),
+    }),
   });
 
 const render = async (backend: WebGpuBackend, node: RenderNode): Promise<void> => {
@@ -100,6 +132,67 @@ const render = async (backend: WebGpuBackend, node: RenderNode): Promise<void> =
 };
 
 describe('custom SpriteMaterial WebGPU browser', () => {
+  test('material sampler overrides only base-texture sampling and mutates live during retained replay', async ctx => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+
+    const backend = new WebGpuBackend(makeApp(canvas));
+
+    await backend.initialize();
+    wireCoreRenderers(backend);
+
+    const texture = createSplitTexture();
+    const material = createPassThroughMaterial();
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    material.sampler = { scaleMode: ScaleModes.Nearest, wrapMode: WrapModes.ClampToEdge };
+    sprite.material = material;
+    sprite.setPosition(16, 16).setScale(16, 16);
+    group.addChild(sprite);
+
+    const cleanup = (): void => {
+      group.destroy();
+      material.destroy();
+      texture.destroy();
+      backend.destroy();
+    };
+
+    try {
+      await render(backend, group);
+      await render(backend, group);
+      await render(backend, group);
+      expectPixelNear(readWebGpuPixels(backend, 64)(31, 24), [255, 0, 0, 255]);
+
+      const replay = vi.spyOn(backend, '_replayRetainedBatch');
+
+      material.sampler.scaleMode = ScaleModes.Linear;
+      await render(backend, group);
+
+      const blended = readWebGpuPixels(backend, 64)(31, 24);
+
+      expect(replay).toHaveBeenCalledTimes(1);
+      expect(blended[0]).toBeGreaterThan(100);
+      expect(blended[0]).toBeLessThan(200);
+      expect(blended[2]).toBeGreaterThan(50);
+      expect(blended[2]).toBeLessThan(160);
+      replay.mockRestore();
+    } catch (error) {
+      if (error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError')) {
+        cleanup();
+        // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
+        ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+        return;
+      }
+
+      throw error;
+    } finally {
+      if (!texture.destroyed) cleanup();
+    }
+  });
+
   test('retained replay keeps uniform values live and recoverably re-records blend changes', async ctx => {
     const canvas = document.createElement('canvas');
     canvas.width = 64;
@@ -237,6 +330,82 @@ describe('custom SpriteMaterial WebGPU browser', () => {
       firstPattern.destroy();
       base.destroy();
       backend.destroy();
+    }
+  });
+
+  test('matches the default premultiply result and preserves per-texture flags inside one custom batch', async ctx => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+
+    const backend = new WebGpuBackend(makeApp(canvas));
+
+    await backend.initialize();
+    wireCoreRenderers(backend);
+
+    const device = getBackendDevice(backend);
+    // Browser-source pixels are unpremultiplied. The default-true texture must
+    // therefore resolve (200, 100, 50, .5) to roughly (100, 50, 25, .5), while
+    // the false texture already stores those premultiplied RGB channels.
+    const defaultTexture = createSolidTexture(200, 100, 50, 128);
+    const customPremultiplyTexture = createSolidTexture(200, 100, 50, 128);
+    const customAlreadyPremultipliedTexture = createSolidTexture(100, 50, 25, 128);
+
+    customAlreadyPremultipliedTexture.setPremultiplyAlpha(false);
+
+    const material = createPassThroughMaterial();
+    const root = new Container();
+    const defaultSprite = new Sprite(defaultTexture);
+    const customPremultiplySprite = new Sprite(customPremultiplyTexture);
+    const customAlreadyPremultipliedSprite = new Sprite(customAlreadyPremultipliedTexture);
+
+    defaultSprite.setPosition(4, 16);
+    customPremultiplySprite.setPosition(24, 16);
+    customAlreadyPremultipliedSprite.setPosition(44, 16);
+    customPremultiplySprite.material = material;
+    customAlreadyPremultipliedSprite.material = material;
+    root.addChild(defaultSprite);
+    root.addChild(customPremultiplySprite);
+    root.addChild(customAlreadyPremultipliedSprite);
+
+    const cleanup = (): void => {
+      root.destroy();
+      material.destroy();
+      defaultTexture.destroy();
+      customPremultiplyTexture.destroy();
+      customAlreadyPremultipliedTexture.destroy();
+      backend.destroy();
+    };
+
+    device.pushErrorScope('validation');
+
+    try {
+      backend.resetStats();
+      backend.clear(Color.black);
+      root.render(backend);
+      backend.flush();
+
+      const validationError = await device.popErrorScope();
+      const readPixel = readWebGpuPixels(backend, 64);
+      const expected = [100, 50, 25, 255] as const;
+
+      expect(validationError).toBeNull();
+      expect(backend.stats.drawCalls).toBe(2);
+      expectPixelNear(readPixel(8, 20), expected);
+      expectPixelNear(readPixel(28, 20), expected);
+      expectPixelNear(readPixel(48, 20), expected);
+    } catch (error) {
+      if (error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError')) {
+        cleanup();
+        // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
+        ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+        return;
+      }
+
+      throw error;
+    } finally {
+      if (!defaultTexture.destroyed) cleanup();
     }
   });
 

--- a/test/rendering/browser/webgpu-custom-sprite-material.test.ts
+++ b/test/rendering/browser/webgpu-custom-sprite-material.test.ts
@@ -17,12 +17,17 @@ import { Color } from '#core/Color';
 import { Container } from '#rendering/Container';
 import { ShaderSource } from '#rendering/material/ShaderSource';
 import { SpriteMaterial } from '#rendering/material/SpriteMaterial';
+import type { RenderNode } from '#rendering/RenderNode';
+import { RetainedContainer } from '#rendering/RetainedContainer';
 import { Sprite } from '#rendering/sprite/Sprite';
 import { spriteMaterialTextureSlots } from '#rendering/sprite/spriteMaterialSources';
 import { Texture } from '#rendering/texture/Texture';
+import { BlendModes } from '#rendering/types';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
+import { readWebGpuPixels } from './_backendSetup';
 import { wireCoreRenderers } from './_coreRenderers';
+import { expectPixelNear } from './_pixels';
 import { getBackendDevice } from './webgpu-test-helpers';
 
 // Fragment-only WGSL: the engine prepends the canonical sprite material
@@ -38,6 +43,18 @@ struct UserUniforms { color: vec4<f32> };
 fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
   let base = sampleBase(input.textureSlot, input.texcoord);
   return vec4<f32>(base.rgb * u_user.color.rgb, 1.0);
+}
+`.trim();
+
+const materialTextureFragmentWgsl = `
+struct UserUniforms { unused: vec4<f32> };
+@group(2) @binding(0) var<uniform> u_user: UserUniforms;
+@group(2) @binding(1) var u_pattern: texture_2d<f32>;
+@group(2) @binding(2) var u_patternSampler: sampler;
+
+@fragment
+fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  return textureSample(u_pattern, u_patternSampler, input.texcoord);
 }
 `.trim();
 
@@ -74,7 +91,155 @@ const createMaterial = (): SpriteMaterial =>
     uniforms: { u_userColor: [1, 0, 0.5, 1] },
   });
 
+const render = async (backend: WebGpuBackend, node: RenderNode): Promise<void> => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  node.render(backend);
+  backend.flush();
+  await getBackendDevice(backend).queue.onSubmittedWorkDone();
+};
+
 describe('custom SpriteMaterial WebGPU browser', () => {
+  test('retained replay keeps uniform values live and recoverably re-records blend changes', async ctx => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+
+    const backend = new WebGpuBackend(makeApp(canvas));
+
+    await backend.initialize();
+    wireCoreRenderers(backend);
+
+    const device = getBackendDevice(backend);
+    const writeBuffer = vi.spyOn(device.queue, 'writeBuffer');
+    const texture = createSolidTexture(255, 255, 255);
+    const values = new Float32Array([1, 0, 0, 1]);
+    const material = new SpriteMaterial({
+      shader: new ShaderSource({ wgsl: customFragmentWgsl }),
+      uniforms: { u_userColor: values },
+    });
+    const group = new RetainedContainer();
+    const sprite = new Sprite(texture);
+
+    sprite.material = material;
+    sprite.setPosition(16, 16);
+    group.addChild(sprite);
+
+    const cleanup = (): void => {
+      group.destroy();
+      material.destroy();
+      texture.destroy();
+      backend.destroy();
+    };
+
+    try {
+      await render(backend, group); // fragment capture
+      await render(backend, group); // instruction recording
+
+      let replay = vi.spyOn(backend, '_replayRetainedBatch');
+
+      await render(backend, group);
+      expect(replay).toHaveBeenCalledTimes(1);
+      expect(backend.stats.drawCalls).toBe(1);
+      expectPixelNear(readWebGpuPixels(backend, 64)(24, 24), [255, 0, 0, 255]);
+
+      material.setUniform('u_userColor', [0, 1, 0, 1]);
+      replay.mockClear();
+      await render(backend, group);
+
+      expect(replay).toHaveBeenCalledTimes(1);
+      expectPixelNear(readWebGpuPixels(backend, 64)(24, 24), [0, 255, 0, 255]);
+
+      values.set([0, 1, 0, 1]);
+      material.setUniform('u_userColor', values);
+      await render(backend, group);
+      values[0] = 0;
+      values[1] = 0;
+      values[2] = 1;
+      replay.mockClear();
+      const writesBeforeMutation = writeBuffer.mock.calls.length;
+      await render(backend, group);
+      expect(replay).toHaveBeenCalledTimes(1);
+      const materialWrites = writeBuffer.mock.calls.slice(writesBeforeMutation).filter(([buffer]) => buffer.label === 'sprite:material-user-uniform-buffer');
+
+      expect(materialWrites).toHaveLength(1);
+      expect(backend.stats.drawCalls).toBe(1);
+      expect(Array.from(new Float32Array(materialWrites[0]![2] as ArrayBuffer).subarray(0, 4))).toEqual([0, 0, 1, 1]);
+      expectPixelNear(readWebGpuPixels(backend, 64)(24, 24), [0, 0, 255, 255]);
+
+      material.blendMode = BlendModes.Additive;
+      replay.mockClear();
+      await render(backend, group);
+      expect(replay).not.toHaveBeenCalled();
+
+      replay.mockRestore();
+      replay = vi.spyOn(backend, '_replayRetainedBatch');
+      await render(backend, group);
+      expect(replay).toHaveBeenCalledTimes(1);
+      replay.mockRestore();
+    } catch (error) {
+      if (error instanceof DOMException && (error.name === 'OperationError' || error.name === 'AbortError')) {
+        cleanup();
+        // eslint-disable-next-line vitest/no-disabled-tests -- intentional runtime guard: the software WebGPU adapter can drop the device mid-test
+        ctx.skip('WebGPU device lost mid-test — unstable software adapter');
+
+        return;
+      }
+
+      throw error;
+    } finally {
+      if (!texture.destroyed) cleanup();
+    }
+  });
+
+  test('retained replay resolves a replacement material texture identity live', async () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 64;
+    canvas.height = 64;
+
+    const backend = new WebGpuBackend(makeApp(canvas));
+
+    await backend.initialize();
+    wireCoreRenderers(backend);
+
+    const base = createSolidTexture(255, 255, 255);
+    const firstPattern = createSolidTexture(255, 0, 0);
+    const secondPattern = createSolidTexture(0, 255, 0);
+    const material = new SpriteMaterial({
+      shader: new ShaderSource({ wgsl: materialTextureFragmentWgsl }),
+      textures: { u_pattern: firstPattern },
+    });
+    const group = new RetainedContainer();
+    const sprite = new Sprite(base);
+
+    try {
+      sprite.material = material;
+      sprite.setPosition(16, 16);
+      group.addChild(sprite);
+
+      await render(backend, group);
+      await render(backend, group);
+      await render(backend, group);
+      expectPixelNear(readWebGpuPixels(backend, 64)(24, 24), [255, 0, 0, 255]);
+
+      const replay = vi.spyOn(backend, '_replayRetainedBatch');
+
+      material.setTexture('u_pattern', secondPattern);
+      await render(backend, group);
+
+      expect(replay).toHaveBeenCalledTimes(1);
+      expectPixelNear(readWebGpuPixels(backend, 64)(24, 24), [0, 255, 0, 255]);
+      replay.mockRestore();
+    } finally {
+      group.destroy();
+      material.destroy();
+      secondPattern.destroy();
+      firstPattern.destroy();
+      base.destroy();
+      backend.destroy();
+    }
+  });
+
   test('issues an instanced custom-material draw with a user uniform and no validation error', async ctx => {
     const canvas = document.createElement('canvas');
     canvas.width = 64;

--- a/test/rendering/browser/webgpu-text-atlas-texture-slots.test.ts
+++ b/test/rendering/browser/webgpu-text-atlas-texture-slots.test.ts
@@ -1,0 +1,142 @@
+/** WebGPU pixel + draw-count coverage for Text atlas multi-texture batching. */
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import type { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { resetDefaultGlyphAtlasPool } from '#rendering/text/GlyphAtlasPool';
+import { Text } from '#rendering/text/Text';
+import type { FontWeight } from '#rendering/text/TextStyle';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { readWebGpuFrame } from './_backendSetup';
+import { wireCoreRenderers } from './_coreRenderers';
+
+const width = 200;
+const height = 96;
+const cellWidth = 40;
+const cellHeight = 48;
+const weights: readonly FontWeight[] = ['normal', 'bold', '100', '200', '300', '400', '500', '600', '700'];
+
+const setupBackend = async (): Promise<WebGpuBackend> => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = width;
+  canvas.height = height;
+
+  const app = {
+    canvas,
+    options: { canvas: { width, height }, clearColor: Color.black },
+  } as unknown as Application;
+  const backend = new WebGpuBackend(app);
+
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+const buildTexts = (count: number): { root: Container; texts: Text[] } => {
+  const root = new Container();
+  const texts = weights.slice(0, count).map((fontWeight, index) => {
+    const text = new Text('M', { fontSize: 28, fontWeight, fillColor: Color.white });
+
+    text.setPosition((index % 5) * cellWidth + 4, Math.floor(index / 5) * cellHeight + 4);
+    root.addChild(text);
+
+    return text;
+  });
+
+  return { root, texts };
+};
+
+const render = (backend: WebGpuBackend, root: Container): void => {
+  backend.resetStats();
+  backend.clear(Color.black);
+  root.render(backend);
+  backend.flush();
+};
+
+const cellHasInk = (frame: ArrayLike<number>, index: number): boolean => {
+  const x0 = (index % 5) * cellWidth;
+  const y0 = Math.floor(index / 5) * cellHeight;
+
+  for (let y = y0; y < y0 + cellHeight; y++) {
+    for (let x = x0; x < x0 + cellWidth; x++) {
+      const offset = (y * width + x) * 4;
+
+      if (frame[offset]! + frame[offset + 1]! + frame[offset + 2]! > 80) return true;
+    }
+  }
+
+  return false;
+};
+
+interface FragmentCarrier {
+  _fragment: RetainedGroupFragment;
+}
+
+describe('WebGPU Text atlas texture slots', () => {
+  beforeEach(() => resetDefaultGlyphAtlasPool());
+  afterEach(() => resetDefaultGlyphAtlasPool());
+
+  test('four font atlases render in one draw with every glyph visible', async () => {
+    const backend = await setupBackend();
+    const scene = buildTexts(4);
+
+    try {
+      render(backend, scene.root);
+      render(backend, scene.root);
+
+      expect(backend.stats.drawCalls).toBe(1);
+
+      const frame = readWebGpuFrame(backend, width);
+
+      for (let index = 0; index < scene.texts.length; index++) {
+        expect(cellHasInk(frame, index), `text cell ${index} has no glyph pixels`).toBe(true);
+      }
+    } finally {
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('nine compatible font atlases split only at the eight-slot limit', async () => {
+    const backend = await setupBackend();
+    const scene = buildTexts(9);
+
+    try {
+      render(backend, scene.root);
+      render(backend, scene.root);
+
+      expect(backend.stats.drawCalls).toBe(2);
+    } finally {
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('a four-atlas retained group records and replays one multi-texture batch', async () => {
+    const backend = await setupBackend();
+    const scene = buildTexts(4);
+    const group = new RetainedContainer();
+
+    scene.texts.forEach(text => group.addChild(text));
+    scene.root.addChild(group);
+
+    try {
+      render(backend, scene.root);
+      render(backend, scene.root);
+      render(backend, scene.root);
+
+      const fragment = (group as unknown as FragmentCarrier)._fragment;
+
+      expect(fragment.instructions?.hasRecording).toBe(true);
+      expect(backend.stats.drawCalls).toBe(1);
+    } finally {
+      scene.root.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/material-grouping.test.ts
+++ b/test/rendering/material-grouping.test.ts
@@ -634,11 +634,13 @@ describe('material grouping', () => {
 
   test('the retained-replay path folds replayed materials into hasMixedPipeline', () => {
     const { backend } = createRuntime();
-    const a = new BoxDrawable('a');
-    const b = new BoxDrawable('b');
+    const mixedA = new KeyedDrawable(100, 100);
+    const mixedB = new KeyedDrawable(200, 200);
+    const uniformA = new KeyedDrawable(100, 100);
+    const uniformB = new KeyedDrawable(100, 100);
 
-    const mixed = new ReplayOnlyContainer([mkSlot(a, 0, 100, 100), mkSlot(b, 1, 200, 200)]);
-    const uniform = new ReplayOnlyContainer([mkSlot(a, 0, 100, 100), mkSlot(b, 1, 100, 100)]);
+    const mixed = new ReplayOnlyContainer([mkSlot(mixedA, 0, 100, 100), mkSlot(mixedB, 1, 200, 200)]);
+    const uniform = new ReplayOnlyContainer([mkSlot(uniformA, 0, 100, 100), mkSlot(uniformB, 1, 100, 100)]);
 
     const builder = RenderPlanBuilder.acquire();
 

--- a/test/rendering/material/material.test.ts
+++ b/test/rendering/material/material.test.ts
@@ -138,13 +138,35 @@ describe('Material base', () => {
   });
 
   test('setUniform and setTexture mutate state and return this', () => {
-    const material = new MeshMaterial(createMaterialOptions());
     const texture = new Texture();
+    const replacement = new Texture();
+    const material = new MeshMaterial(createMaterialOptions({ uniforms: { u_time: 0 }, textures: { u_noise: texture } }));
 
     expect(material.setUniform('u_time', 3)).toBe(material);
-    expect(material.setTexture('u_noise', texture)).toBe(material);
+    expect(material.setTexture('u_noise', replacement)).toBe(material);
     expect(material.uniforms.u_time).toBe(3);
-    expect(material.textures.u_noise).toBe(texture);
+    expect(material.textures.u_noise).toBe(replacement);
+  });
+
+  test('fixes binding names and kinds at construction while keeping values live', () => {
+    const material = new MeshMaterial(createMaterialOptions({ uniforms: { u_time: 0, u_pattern: new Texture() }, textures: { u_noise: new Texture() } }));
+
+    expect(() => material.setUniform('u_missing', 1)).toThrow(/fixed binding schema/);
+    expect(() => material.setTexture('u_missing', new Texture())).toThrow(/fixed binding schema/);
+    expect(() => material.setUniform('u_time', new Texture())).toThrow(/cannot change binding kind/);
+    expect(() => material.setUniform('u_pattern', 1)).toThrow(/cannot change binding kind/);
+    expect(() => {
+      material.uniforms.u_missing = 1;
+    }).toThrow();
+    expect(() => {
+      delete material.textures.u_noise;
+    }).toThrow();
+  });
+
+  test('rejects duplicate names across uniform and texture binding maps', () => {
+    expect(() => new MeshMaterial(createMaterialOptions({ uniforms: { u_pattern: new Texture() }, textures: { u_pattern: new Texture() } }))).toThrow(
+      /declared in both/,
+    );
   });
 
   test('destroy invokes dispose callbacks once', () => {
@@ -214,7 +236,7 @@ describe('Material.pipelineKey', () => {
   });
 
   test('does not change when a scalar uniform changes', () => {
-    const material = new MeshMaterial(createMaterialOptions());
+    const material = new MeshMaterial(createMaterialOptions({ uniforms: { u_time: 0 } }));
     const initial = material.pipelineKey;
 
     material.setUniform('u_time', 42);
@@ -231,7 +253,7 @@ describe('Material.bindKey', () => {
   });
 
   test('does not change when a scalar uniform changes', () => {
-    const material = new MeshMaterial(createMaterialOptions());
+    const material = new MeshMaterial(createMaterialOptions({ uniforms: { u_time: 0 } }));
     const initial = material.bindKey;
 
     material.setUniform('u_time', 7);
@@ -240,22 +262,22 @@ describe('Material.bindKey', () => {
     expect(material.bindKey).toBe(initial);
   });
 
-  test('changes when a texture binding is added or swapped', () => {
-    const material = new MeshMaterial(createMaterialOptions());
+  test('changes when a declared texture binding is swapped', () => {
+    const material = new MeshMaterial(createMaterialOptions({ textures: { u_noise: new Texture() } }));
     const initial = material.bindKey;
 
     material.setTexture('u_noise', new Texture());
-    const withTexture = material.bindKey;
+    const swappedOnce = material.bindKey;
 
     material.setTexture('u_noise', new Texture());
     const swapped = material.bindKey;
 
-    expect(withTexture).not.toBe(initial);
-    expect(swapped).not.toBe(withTexture);
+    expect(swappedOnce).not.toBe(initial);
+    expect(swapped).not.toBe(swappedOnce);
   });
 
   test('treats a texture-valued uniform as a binding', () => {
-    const material = new MeshMaterial(createMaterialOptions());
+    const material = new MeshMaterial(createMaterialOptions({ uniforms: { u_extraTex: new Texture() } }));
     const initial = material.bindKey;
 
     material.setUniform('u_extraTex', new Texture());
@@ -263,28 +285,13 @@ describe('Material.bindKey', () => {
     expect(material.bindKey).not.toBe(initial);
   });
 
-  test('is independent of insertion order for the same bindings', () => {
-    const shader = createShaderSource();
-    const texA = new Texture();
-    const texB = new Texture();
+  test('keeps the construction-time binding order stable', () => {
+    const material = new MeshMaterial(createMaterialOptions({ textures: { a: new Texture(), b: new Texture() } }));
 
-    const first = new MeshMaterial({ shader });
-    first.setTexture('a', texA);
-    first.setTexture('b', texB);
+    material.setTexture('b', new Texture());
+    material.setTexture('a', new Texture());
 
-    const second = new MeshMaterial({ shader });
-    second.setTexture('b', texB);
-    second.setTexture('a', texA);
-
-    // Same material identity is required for an equal bind key, so compare the
-    // descriptor effect by re-deriving on one instance with swapped order.
-    const ordered = first.bindKey;
-    delete first.textures.a;
-    delete first.textures.b;
-    first.setTexture('b', texB);
-    first.setTexture('a', texA);
-
-    expect(first.bindKey).toBe(ordered);
+    expect(material._bindingSchema.textureNames).toEqual(['a', 'b']);
   });
 
   test('differs between distinct material instances even with equal bindings', () => {

--- a/test/rendering/material/material.test.ts
+++ b/test/rendering/material/material.test.ts
@@ -1,8 +1,7 @@
-import type { MaterialOptions } from '#rendering/material/Material';
+import type { MaterialOptions, MaterialSamplerOptions } from '#rendering/material/Material';
 import { MeshMaterial } from '#rendering/material/MeshMaterial';
 import { ShaderSource } from '#rendering/material/ShaderSource';
 import { SpriteMaterial } from '#rendering/material/SpriteMaterial';
-import type { SamplerOptions } from '#rendering/texture/Sampler';
 import { Texture } from '#rendering/texture/Texture';
 import { BlendModes, ScaleModes, WrapModes } from '#rendering/types';
 
@@ -38,20 +37,14 @@ const createMaterialOptions = (overrides: Partial<MaterialOptions> = {}): Materi
   ...overrides,
 });
 
-const linearClamp: SamplerOptions = {
+const linearClamp: MaterialSamplerOptions = {
   scaleMode: ScaleModes.Linear,
   wrapMode: WrapModes.ClampToEdge,
-  premultiplyAlpha: false,
-  generateMipMap: false,
-  flipY: false,
 };
 
-const nearestRepeat: SamplerOptions = {
+const nearestRepeat: MaterialSamplerOptions = {
   scaleMode: ScaleModes.Nearest,
   wrapMode: WrapModes.Repeat,
-  premultiplyAlpha: false,
-  generateMipMap: false,
-  flipY: false,
 };
 
 describe('ShaderSource', () => {
@@ -227,12 +220,12 @@ describe('Material.pipelineKey', () => {
     expect(material.pipelineKey).toBe(initial);
   });
 
-  test('changes with sampler state', () => {
+  test('does not change with sampler binding state', () => {
     const shader = createShaderSource();
     const a = new MeshMaterial({ shader, sampler: linearClamp });
     const b = new MeshMaterial({ shader, sampler: nearestRepeat });
 
-    expect(a.pipelineKey).not.toBe(b.pipelineKey);
+    expect(a.pipelineKey).toBe(b.pipelineKey);
   });
 
   test('does not change when a scalar uniform changes', () => {
@@ -259,6 +252,19 @@ describe('Material.bindKey', () => {
     material.setUniform('u_time', 7);
     material.setUniform('u_time', 8);
 
+    expect(material.bindKey).toBe(initial);
+  });
+
+  test('changes with sampler state, including in-place mutation', () => {
+    const material = new MeshMaterial(createMaterialOptions({ sampler: { ...linearClamp } }));
+    const initial = material.bindKey;
+
+    material.sampler!.scaleMode = ScaleModes.Nearest;
+    const changed = material.bindKey;
+
+    material.sampler!.scaleMode = ScaleModes.Linear;
+
+    expect(changed).not.toBe(initial);
     expect(material.bindKey).toBe(initial);
   });
 

--- a/test/rendering/render-plan-grouping-key-audit.test.ts
+++ b/test/rendering/render-plan-grouping-key-audit.test.ts
@@ -501,7 +501,7 @@ describe('render plan grouping key audit', () => {
     });
 
     test('different material blend modes produce different groupIndices', () => {
-      // material.pipelineKey is derived via derivePipelineKey(shaderId, material.blendMode, sampler).
+      // material.pipelineKey is derived from shader identity + blend mode.
       // Two materials with different blendModes therefore produce different
       // pipelineKeys and end up in different optimizer groups — matching the
       // sprite renderer's flush-on-blendMode-change boundary.

--- a/test/rendering/retained-instruction-set.test.ts
+++ b/test/rendering/retained-instruction-set.test.ts
@@ -51,6 +51,8 @@ class MaterialLeaf extends Drawable {
   }
 }
 
+class RetainedMaterialLeaf extends MaterialLeaf {}
+
 class UnregisteredLeaf extends Drawable {
   public constructor() {
     super();
@@ -60,6 +62,7 @@ class UnregisteredLeaf extends Drawable {
 
 // Capability flag carrier: sprite-renderer default path only.
 const flaggedRenderer = { _supportsRetainedBatches: true };
+const retainedMaterialRenderer = { _supportsRetainedBatches: true, _canRecordRetainedDrawable: () => true };
 const unflaggedRenderer = {};
 
 // File-local fake backend (repo convention keeps test harnesses file-local).
@@ -74,6 +77,10 @@ const createTestBackend = (): RenderBackend => {
     renderTarget,
     rendererRegistry: {
       resolve(drawable: Drawable) {
+        if (drawable instanceof RetainedMaterialLeaf) {
+          return retainedMaterialRenderer;
+        }
+
         if (drawable instanceof RecordableLeaf || drawable instanceof MaterialLeaf) {
           return flaggedRenderer;
         }
@@ -202,6 +209,20 @@ describe('recordability predicate: records default-path flagged renderers only',
     const fragment = captureFragment(group, backend);
 
     expect(fragment.isRecordable(backend)).toBe(false);
+
+    group.parent!.destroy();
+    backend.destroy();
+  });
+
+  test('an own-material drawable is recordable only when its renderer opts into the live-state contract', () => {
+    const backend = createTestBackend();
+    const group = new RetainedContainer();
+
+    group.addChild(new RetainedMaterialLeaf());
+
+    const fragment = captureFragment(group, backend);
+
+    expect(fragment.isRecordable(backend)).toBe(true);
 
     group.parent!.destroy();
     backend.destroy();

--- a/test/rendering/webgpu-retained-record-replay.test.ts
+++ b/test/rendering/webgpu-retained-record-replay.test.ts
@@ -30,6 +30,8 @@ import { materializeRendererBindings } from '#extensions/materialize';
 import { Container } from '#rendering/Container';
 import { buildCoreRendererBindings } from '#rendering/coreRendererBindings';
 import { GpuResourceAccountant } from '#rendering/GpuResourceAccountant';
+import { ShaderSource } from '#rendering/material/ShaderSource';
+import { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import type { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
 import { RetainedInstructionSet } from '#rendering/plan/RetainedInstructionSet';
 import type { RenderNode } from '#rendering/RenderNode';
@@ -37,6 +39,7 @@ import { createRenderStats } from '#rendering/RenderStats';
 import { RetainedContainer } from '#rendering/RetainedContainer';
 import { Sprite } from '#rendering/sprite/Sprite';
 import { Texture } from '#rendering/texture/Texture';
+import { BlendModes } from '#rendering/types';
 import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 import { WebGpuRetainedGroupBundle } from '#rendering/webgpu/WebGpuRetainedGroupResources';
 
@@ -249,6 +252,23 @@ const retainedTransformLabel = 'sprite:retained-transform-buffer';
 const retainedUniformLabel = 'sprite:retained-uniform-buffer';
 const arenaInstanceLabel = 'sprite:instance-buffer';
 const sharedTransformLabel = 'transform:storage-buffer';
+const materialUniformLabel = 'sprite:material-user-uniform-buffer';
+
+const retainedMaterialFragment = `
+struct UserUniforms { color: vec4<f32> };
+@group(2) @binding(0) var<uniform> u_user: UserUniforms;
+
+@fragment
+fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  return sampleBase(input.textureSlot, input.texcoord) * u_user.color;
+}
+`.trim();
+
+const createRetainedSpriteMaterial = (): SpriteMaterial =>
+  new SpriteMaterial({
+    shader: new ShaderSource({ wgsl: retainedMaterialFragment }),
+    uniforms: { u_userColor: new Float32Array([1, 0, 0, 1]) },
+  });
 
 const countLabel = (writes: readonly CapturedWrite[], label: string, from = 0): number => {
   let count = 0;
@@ -287,6 +307,83 @@ const buildGroupScene = (texture: Texture, groupCount: number): { root: Containe
 };
 
 describe('WebGPU retained record/replay: fallback ladder + submit collapse', () => {
+  test('SpriteMaterial values stay live on instruction replay and structural state re-records recoverably', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const backend = await createBackend(environment);
+      const texture = createCanvasTexture();
+      const material = createRetainedSpriteMaterial();
+      const group = new RetainedContainer();
+
+      const blends = [BlendModes.Normal, BlendModes.Additive, BlendModes.Multiply] as const;
+
+      for (let i = 0; i < blends.length; i++) {
+        const sprite = new Sprite(texture);
+
+        sprite.material = material;
+        sprite.blendMode = blends[i]!;
+        sprite.setPosition(i * 12, 0);
+        group.addChild(sprite);
+      }
+
+      renderFrame(backend, group); // fragment capture
+      renderFrame(backend, group); // entry replay + instruction recording
+
+      const set = fragmentOf(group).instructions;
+
+      expect(set?.hasRecording).toBe(true);
+
+      renderFrame(backend, group); // first instruction replay
+
+      const instanceMark = environment.writes().length;
+      const submitMark = environment.submitCount();
+      const values = material.uniforms.u_userColor as Float32Array;
+
+      values[0] = 0;
+      values[2] = 1;
+      renderFrame(backend, group);
+
+      // Value mutation remains on the instruction tier: no instance recapture,
+      // exactly one live material upload for the shared material.
+      expect(fragmentOf(group).instructions).toBe(set);
+      expect(countLabel(environment.writes(), retainedInstanceLabel, instanceMark)).toBe(0);
+      expect(countLabel(environment.writes(), materialUniformLabel, instanceMark)).toBe(1);
+      expect(environment.submitCount() - submitMark).toBe(1);
+
+      const staticMark = environment.writes().length;
+
+      renderFrame(backend, group);
+      expect(countLabel(environment.writes(), materialUniformLabel, staticMark)).toBe(0);
+
+      // Blend participates in batch/pipeline structure. Preflight invalidates
+      // before replay, entry-replays once, and records a replacement set.
+      material.blendMode = BlendModes.Additive;
+      const structuralMark = environment.writes().length;
+
+      renderFrame(backend, group);
+
+      expect(fragmentOf(group).instructions).toBe(set);
+      expect(set?.hasRecording).toBe(true);
+      // Normal now resolves to the material's Additive blend and merges with
+      // the explicitly-Additive sprite; the live fallback therefore records
+      // two real batches (Additive + Multiply), not the old three-way split.
+      expect(countLabel(environment.writes(), retainedInstanceLabel, structuralMark)).toBe(2);
+
+      const recoveredMark = environment.writes().length;
+
+      renderFrame(backend, group);
+      expect(countLabel(environment.writes(), retainedInstanceLabel, recoveredMark)).toBe(0);
+
+      group.destroy();
+      material.destroy();
+      texture.destroy();
+      backend.destroy();
+    } finally {
+      environment.restore();
+    }
+  });
+
   test('N cached groups replay in one submit; the uncached path splits at every distinct group matrix', async () => {
     const environment = createMockWebGpuEnvironment();
 


### PR DESCRIPTION
## Summary
- replay retained SpriteMaterial batches from recorded instance/transform data while resolving uniform values, material textures, blend state, and base-texture sampler bindings live
- fix Material binding schemas at construction so WebGPU layouts remain valid while declared values and texture identities stay mutable
- batch up to eight compatible text atlas textures per draw on WebGPU and WebGL2
- preserve Texture.premultiplyAlpha semantics in custom WebGPU SpriteMaterial batches, including mixed-texture batches
- implement Material.sampler as a live filter/wrap override for the drawable base texture across Sprite, Mesh, and Particle paths on both backends
- ratchet the minified IIFE gzip budget from 250 kB to 255 kB after measuring the deliberate renderer feature growth at 252.74 kB

## Semantics
- Material.sampler contains only scaleMode and wrapMode
- null inherits the base texture sampler; additional material textures keep their own sampler state
- upload state remains texture-owned
- sampler state participates in bindKey, not pipelineKey, and in-place changes are visible during retained replay

## Performance
Three local headless runs at 25k nodes (mixed-material-atlased, retained):
- WebGPU median: 24.98 ms -> 1.24 ms (~95% lower)
- WebGL2 median: 25.40 ms -> 1.57 ms (~94% lower)
- draw count remains 782; retained cost now scales with batches rather than nodes

## Validation
- pnpm verify:quick (pre-push hook)
- pnpm test:core (388 files, 6666 tests)
- targeted WebGL2/WebGPU custom SpriteMaterial, MeshMaterial, text-atlas, shader-compile, and particle browser suites
- pnpm typecheck, pnpm typecheck:test, pnpm typecheck:packages
- pnpm lint and pnpm lint:packages
- pnpm format:check
- pnpm docs:api:check
- pnpm build and pnpm size (252.74 kB / 255 kB IIFE gzip budget)
- git diff --check