### PR TITLE
fix(rendering): guard non-indexed mesh index overflow

### DIFF
--- a/src/rendering/mesh/Mesh.ts
+++ b/src/rendering/mesh/Mesh.ts
@@ -5,6 +5,14 @@ import type { MeshMaterial } from '#rendering/material/MeshMaterial';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
 
+const maxUint16VertexCount = 0x10000;
+
+const assertImplicitIndexRange = (vertexCount: number): void => {
+  if (vertexCount > maxUint16VertexCount) {
+    throw new Error(`Non-indexed Mesh vertex count ${vertexCount} exceeds the 16-bit implicit-index limit of ${maxUint16VertexCount} vertices.`);
+  }
+};
+
 /**
  * Construction-time options for a {@link Mesh}.
  *
@@ -179,8 +187,12 @@ export class Mesh extends Drawable {
           throw new Error(`Mesh index ${indices[i]!} at position ${i} is out of range for vertex count ${vertexCount}.`);
         }
       }
-    } else if (vertexCount % 3 !== 0) {
-      throw new Error(`Non-indexed Mesh requires a vertex count that is a multiple of 3 (got ${vertexCount}).`);
+    } else {
+      assertImplicitIndexRange(vertexCount);
+
+      if (vertexCount % 3 !== 0) {
+        throw new Error(`Non-indexed Mesh requires a vertex count that is a multiple of 3 (got ${vertexCount}).`);
+      }
     }
 
     this._vertices = vertices;
@@ -286,6 +298,11 @@ export function readGeometry(geometry: Geometry): {
 
   const color = findAttribute(geometry.attributes, colorAttributeNames);
   const vertexCount = geometry.vertexCount;
+
+  if (geometry.indices === null) {
+    assertImplicitIndexRange(vertexCount);
+  }
+
   const { stride } = geometry;
   const source = geometry.vertexData;
   const view = source instanceof Float32Array ? new DataView(source.buffer, source.byteOffset, source.byteLength) : new DataView(source);

--- a/test/rendering/mesh.test.ts
+++ b/test/rendering/mesh.test.ts
@@ -159,6 +159,20 @@ describe('Mesh', () => {
     ).toThrow(/multiple of 3/);
   });
 
+  test('rejects non-indexed meshes beyond the 16-bit implicit-index range', () => {
+    const largestTriangleListVertexCount = 0xffff;
+    const overflowingTriangleListVertexCount = 0x10002;
+    const overflowingGeometry = new Geometry({
+      attributes: [{ name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 }],
+      vertexData: new Float32Array(overflowingTriangleListVertexCount * 2),
+      stride: 8,
+    });
+
+    expect(() => new Mesh({ vertices: new Float32Array(largestTriangleListVertexCount * 2) })).not.toThrow();
+    expect(() => new Mesh({ vertices: new Float32Array(overflowingTriangleListVertexCount * 2) })).toThrow(/16-bit implicit-index limit of 65536 vertices/);
+    expect(() => new Mesh({ geometry: overflowingGeometry })).toThrow(/16-bit implicit-index limit of 65536 vertices/);
+  });
+
   test('texture setter swaps the bound texture', () => {
     const mesh = new Mesh({ vertices: validVertices() });
     const fakeTexture = { width: 1, height: 1 } as unknown as NonNullable<Mesh['texture']>;


### PR DESCRIPTION
## Summary

- reject non-indexed meshes whose implicit indices exceed the 16-bit range
- apply the same guard while flattening `Geometry`, covering `drawGeometry` and `drawBatch`
- pin the safe and overflowing triangle-list boundaries with a regression test

## Test plan

- `pnpm test -- test/rendering/mesh.test.ts test/rendering/rendering-context.test.ts` (62/62)
- `pnpm verify:quick` (11/11 gates)
- `pnpm test` (9,699 passed, 1 skipped)
- `pnpm test:browser:webgpu` (339/339)
- `pnpm test:browser:webgl` (294/294)

## Follow-up

End-to-end dual `uint16`/`uint32` mesh index support remains a separate spec-first item; this PR only closes the silent-wrap correctness gap.