### PR TITLE
fix(review): resolve NEU-N2, NEU-M1, NEU-O37 and NEU-O42

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "docs:api:check": "tsx scripts/check-api-docs-sync.ts",
     "examples:sync:check": "tsx scripts/check-examples-sync.ts",
     "typecheck": "tsc --noEmit",
+    "typecheck:full-bundle": "tsc --noEmit -p tsconfig.full-bundle.json",
     "typecheck:examples": "tsc --noEmit -p tsconfig.examples.json",
     "typecheck:type-tests": "tsc --noEmit -p tsconfig.type-tests.json && tsc --noEmit -p tsconfig.type-tests-strict.json && tsc --noEmit -p tsconfig.type-tests.json --strict false --strictNullChecks false",
     "typecheck:guides": "tsx scripts/extract-guide-snippets.ts && tsx scripts/typecheck-guides.ts",

--- a/packages/exojs-bench/src/rendering/EngineAdapter.ts
+++ b/packages/exojs-bench/src/rendering/EngineAdapter.ts
@@ -16,7 +16,8 @@ export type ArchetypeId =
   | 'mixed-material'
   | 'mixed-material-atlased'
   | 'instanced-batch'
-  | 'mixed-sprite-mesh';
+  | 'mixed-sprite-mesh-array'
+  | 'mixed-sprite-mesh-static';
 
 /** Structural definition of a scene archetype, independent of any engine or backend. */
 export interface ArchetypeSpec {
@@ -128,6 +129,14 @@ export interface ArchetypeSpec {
    * meaning.
    */
   readonly meshEvery?: number;
+  /** Consecutive mesh leaves at each {@link meshEvery} boundary; defaults to one. */
+  readonly meshRunLength?: number;
+  /**
+   * Storage form used by mesh leaves. Array meshes exercise per-leaf packing
+   * and retained-cache poisoning; shared static geometry exercises replayable
+   * renderer switches. Meaningful only when {@link meshEvery} is set.
+   */
+  readonly meshStorage?: 'array' | 'shared-static-geometry';
 }
 
 /** One matrix cell: a single (engine, config, backend, archetype, node count) combination to measure. */

--- a/packages/exojs-bench/src/rendering/adapters/exojs.ts
+++ b/packages/exojs-bench/src/rendering/adapters/exojs.ts
@@ -20,17 +20,18 @@ import { mutationSignature, selectMutationIndices } from '../../shared/mutation'
 import type { ArchetypeSpec, Backend, EngineAdapter } from '../EngineAdapter';
 
 /**
- * One mesh leaf for the `mixed-sprite-mesh` archetype: the same SPRITE_SIZE quad
- * a sprite leaf covers, as a flat six-vertex triangle list with full-texture UVs.
- * Deliberately the plainest mesh the renderer has — no material, no indices — so
- * the archetype measures the renderer SWITCH and not mesh-specific work.
+ * One array-backed mesh leaf: the same SPRITE_SIZE quad a sprite leaf covers,
+ * as a flat six-vertex triangle list with full-texture UVs.
  */
-const createLeafMesh = (texture: Texture): Mesh =>
+const createArrayLeafMesh = (texture: Texture): Mesh =>
   new Mesh({
     vertices: new Float32Array([0, 0, SPRITE_SIZE, 0, SPRITE_SIZE, SPRITE_SIZE, 0, 0, SPRITE_SIZE, SPRITE_SIZE, 0, SPRITE_SIZE]),
     uvs: new Float32Array([0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1]),
     texture,
   });
+
+/** One mesh leaf backed by the scene's shared, retained-recordable geometry. */
+const createStaticLeafMesh = (texture: Texture, geometry: Geometry): Mesh => new Mesh({ geometry, texture });
 
 /**
  * One SPRITE_SIZE quad in local space, the single geometry every instance of the
@@ -233,6 +234,8 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
    */
   let batches: RenderBatch[] = [];
   let batchGeometry: Geometry | null = null;
+  /** Shared by every mesh leaf in `mixed-sprite-mesh-static`; absent for the array case. */
+  let sharedMeshGeometry: Geometry | null = null;
 
   /** Drop the `instanced-batch` scene so a rebuild (or teardown) leaks no GPU resources. */
   const releaseBatchScene = (): void => {
@@ -335,6 +338,8 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
       }
 
       releaseBatchScene();
+      sharedMeshGeometry?.destroy();
+      sharedMeshGeometry = null;
 
       // `instanced-batch` leaves the scene graph behind entirely: nodeCount
       // instances are laid out on the same grid every other archetype uses, but
@@ -354,6 +359,9 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
       const materialCount = Math.max(0, spec.materialCount ?? 0);
       const materialRunLength = Math.max(1, spec.materialRunLength ?? 1);
       const meshEvery = Math.max(0, spec.meshEvery ?? 0);
+      const meshRunLength = Math.max(1, Math.min(spec.meshRunLength ?? 1, meshEvery));
+
+      sharedMeshGeometry = spec.meshStorage === 'shared-static-geometry' ? createBatchQuad() : null;
 
       materials = [];
 
@@ -422,8 +430,15 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
         // scene changes. Left unset, every leaf is a sprite — the pre-existing
         // shape.
         const leafTexture = textures[Math.floor(i / spine.length) % textures.length]!;
-        const isMesh = meshEvery > 0 && i % meshEvery === meshEvery - 1;
-        const leaf: Sprite | Mesh = isMesh ? createLeafMesh(leafTexture) : new Sprite(leafTexture);
+        const isMesh = meshEvery > 0 && i % meshEvery >= meshEvery - meshRunLength;
+
+        let leaf: Sprite | Mesh;
+
+        if (isMesh) {
+          leaf = sharedMeshGeometry === null ? createArrayLeafMesh(leafTexture) : createStaticLeafMesh(leafTexture, sharedMeshGeometry);
+        } else {
+          leaf = new Sprite(leafTexture);
+        }
 
         leaf.cullable = spec.cullingEnabled;
 
@@ -571,6 +586,9 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
         root.destroy();
         root = null;
       }
+
+      sharedMeshGeometry?.destroy();
+      sharedMeshGeometry = null;
 
       for (const texture of textures) {
         texture.destroy();

--- a/packages/exojs-bench/src/rendering/archetypes.ts
+++ b/packages/exojs-bench/src/rendering/archetypes.ts
@@ -122,16 +122,41 @@ export const ARCHETYPES: readonly ArchetypeSpec[] = [
   // call, so the frame cost scaled with the CALL count rather than the instance
   // count. ExoJS-only — see `ArchetypeSpec.batchSize`.
   { id: 'instanced-batch', nodeCounts: GPU_BOUND_COUNTS, nestingDepth: 1, textureCount: 1, mutationFraction: 0, cullingEnabled: false, batchSize: 64 },
-  // The only archetype that puts TWO renderers in one frame. Every other one
-  // draws through a single renderer, so the cost of handing the draw stream from
-  // one to the next — a pass end plus a `queue.submit` per switch on WebGPU —
-  // was invisible to the whole matrix. `meshEvery: 64` mirrors the blend and
-  // material plateaus in switch density (a few hundred in a 25k frame, the shape
-  // a real mixed scene of sprites plus custom geometry produces) while keeping
-  // the mesh leaf count low: the default mesh path draws one call per leaf, so
-  // an even sprite/mesh split would measure per-mesh draw-call cost instead of
-  // the switch. ExoJS-only — see `ArchetypeSpec.meshEvery`.
-  { id: 'mixed-sprite-mesh', nodeCounts: GPU_BOUND_COUNTS, nestingDepth: 2, textureCount: 1, mutationFraction: 0, cullingEnabled: false, meshEvery: 64 },
+  // The only archetypes that put TWO renderers in one frame. Every other one
+  // draws through a single renderer, so the cost of handing the draw stream
+  // from one to the next was invisible to the matrix. Both use the same
+  // `meshEvery: 64` switch density and four global mesh leaves per plateau;
+  // their only intentional difference is mesh storage. Leaves are distributed
+  // round-robin over the depth-2 spine, so four global leaves become two
+  // adjacent meshes in each traversal stream. WebGPU needs that run of two
+  // identical static meshes to select its instanced, retained-recordable path.
+  // The shared static geometry case therefore isolates renderer-switch/replay
+  // cost. The array case cannot be retained and instead isolates per-leaf
+  // repacking/residency cost. Keeping distinct
+  // IDs prevents results from the old ambiguous archetype being compared as if
+  // its semantics had not changed. ExoJS-only — see `ArchetypeSpec.meshEvery`.
+  {
+    id: 'mixed-sprite-mesh-static',
+    nodeCounts: GPU_BOUND_COUNTS,
+    nestingDepth: 2,
+    textureCount: 1,
+    mutationFraction: 0,
+    cullingEnabled: false,
+    meshEvery: 64,
+    meshRunLength: 4,
+    meshStorage: 'shared-static-geometry',
+  },
+  {
+    id: 'mixed-sprite-mesh-array',
+    nodeCounts: GPU_BOUND_COUNTS,
+    nestingDepth: 2,
+    textureCount: 1,
+    mutationFraction: 0,
+    cullingEnabled: false,
+    meshEvery: 64,
+    meshRunLength: 4,
+    meshStorage: 'array',
+  },
   {
     id: 'mixed-material-atlased',
     nodeCounts: GPU_BOUND_COUNTS,

--- a/packages/exojs-bench/test/archetypes.test.ts
+++ b/packages/exojs-bench/test/archetypes.test.ts
@@ -70,6 +70,19 @@ describe('ARCHETYPES', () => {
     expect(byId['static-heavy']!.mutationFraction).toBe(0);
     expect(byId['dynamic-heavy']!.mutationFraction).toBeGreaterThan(0);
   });
+
+  test('separates retained-recordable mesh switches from array-mesh repacking', () => {
+    const byId = Object.fromEntries(ARCHETYPES.map(a => [a.id, a]));
+    const staticMesh = byId['mixed-sprite-mesh-static']!;
+    const arrayMesh = byId['mixed-sprite-mesh-array']!;
+
+    expect(staticMesh.meshEvery).toBe(64);
+    expect(arrayMesh.meshEvery).toBe(staticMesh.meshEvery);
+    expect(staticMesh.meshRunLength).toBe(4);
+    expect(arrayMesh.meshRunLength).toBe(staticMesh.meshRunLength);
+    expect(staticMesh.meshStorage).toBe('shared-static-geometry');
+    expect(arrayMesh.meshStorage).toBe('array');
+  });
 });
 
 describe('buildMatrix', () => {

--- a/packages/exojs-ldtk/src/LdtkData.ts
+++ b/packages/exojs-ldtk/src/LdtkData.ts
@@ -289,6 +289,10 @@ export interface LdtkLayerDef {
   readonly tilesetDefUid?: number | null;
   readonly gridSize: number;
   readonly intGridValues?: readonly LdtkIntGridValueDef[];
+  /** Definition-level horizontal pixel offset, added to each layer instance offset. */
+  readonly pxOffsetX?: number;
+  /** Definition-level vertical pixel offset, added to each layer instance offset. */
+  readonly pxOffsetY?: number;
   /**
    * Parallax horizontal factor, in `[-1, 1]`. `0` (the default) means "no
    * parallax" — the layer scrolls at normal camera speed, same as every
@@ -302,11 +306,7 @@ export interface LdtkLayerDef {
    * Whether a non-zero parallax factor also scales this layer up/down to
    * simulate depth. Defaults to `true` (LDtk's own default) when absent.
    *
-   * Parsed and validated for round-trip fidelity, but not currently carried
-   * onto any runtime layer — the runtime tilemap model has no field for a
-   * parallax-driven scale multiplier (unlike `parallaxX`/`parallaxY`, which
-   * map onto the existing `TileLayer`/`ObjectLayer` fields also used by the
-   * Tiled adapter), and whether/how to add one is an open decision.
+   * Converted to the runtime layer's uniform `parallaxScale` multiplier.
    */
   readonly parallaxScaling?: boolean;
 }

--- a/packages/exojs-ldtk/src/ldtkParallax.ts
+++ b/packages/exojs-ldtk/src/ldtkParallax.ts
@@ -1,44 +1,52 @@
 // LDtk → runtime parallax conversion.
 //
 // LDtk's `parallaxFactorX`/`parallaxFactorY` (declared on `defs.layers[]`,
-// range `[-1, 1]`) describe "how much slower this layer scrolls relative to
-// the camera", with `0` — the LDtk default — meaning "no parallax, scrolls at
-// normal camera speed". LDtk itself does not mandate a rendering formula for
-// this value: its own reference implementation (`ldtk-haxe-api`) only carries
-// the raw field through and leaves interpretation to the consuming game.
+// range `[-1, 1]`) use `0` for normal camera speed. The runtime tilemap model
+// uses the opposite convention: `1` is normal speed, and render code derives
+// the camera-relative shift as `camCenter * (1 - parallaxX)`. Therefore the
+// scroll conversion is `runtimeFactor = 1 - ldtkFactor`.
 //
-// The runtime `TileLayer`/`ObjectLayer` model (shared with the Tiled adapter)
-// instead uses `parallaxX`/`parallaxY` with the opposite convention: `1` (the
-// default) means "no parallax, normal camera speed", and render code derives
-// the on-screen shift as `camCenter * (1 - parallaxX)` — see
-// `ChunkStreamer.ts` / `TileLayerNode.ts` / `ImageLayerNode.ts` in
-// `@codexo/exojs-tilemap`. The two conventions share the same "no parallax"
-// origin (LDtk `0` ↔ runtime `1`), so `runtimeFactor = 1 - ldtkFactor` is the
-// direct, order-preserving conversion between them: a layer with a larger
-// LDtk factor lags the camera more, which is exactly a smaller runtime
-// `parallaxX`/`parallaxY`.
+// LDtk's editor applies one uniform scale derived from the horizontal factor:
+// `max(0.01, 1 - parallaxFactorX)`. Scaling happens around the layer origin.
+// When scaling is disabled, the editor offsets the unscaled layer by half its
+// dimensions times the factor so its centre follows the same parallax path.
 
 import type { LdtkData } from './LdtkData';
 
-/** Resolved runtime parallax factors for one LDtk layer instance. */
+/** Resolved runtime parallax transform for one LDtk layer instance. */
 export interface LdtkLayerParallax {
   readonly parallaxX: number;
   readonly parallaxY: number;
+  readonly parallaxScale: number;
+  /** Definition offset plus LDtk's unscaled-parallax centre compensation. */
+  readonly offsetX: number;
+  /** Definition offset plus LDtk's unscaled-parallax centre compensation. */
+  readonly offsetY: number;
 }
 
 /**
- * Resolve the runtime `parallaxX`/`parallaxY` for the layer definition
- * identified by `layerDefUid`, converting from LDtk's `parallaxFactorX`/
- * `parallaxFactorY` convention to the runtime `TileLayer`/`ObjectLayer`
- * convention — see the module doc comment for the formula and why it exists.
- *
- * Falls back to `{ parallaxX: 1, parallaxY: 1 }` (no parallax) when the layer
- * definition cannot be found or declares no parallax factors, matching
- * LDtk's own default.
+ * Resolve the runtime parallax transform for a layer instance. Missing
+ * definitions and factors use LDtk's defaults: no shift and scale `1`.
  */
-export function resolveLdtkLayerParallax(data: LdtkData, layerDefUid: number): LdtkLayerParallax {
-  const layerDef = data.defs.layers.find(def => def.uid === layerDefUid);
+export function resolveLdtkLayerParallax(
+  data: LdtkData,
+  layer: {
+    readonly layerDefUid: number;
+    readonly __cWid: number;
+    readonly __cHei: number;
+    readonly __gridSize: number;
+  },
+): LdtkLayerParallax {
+  const layerDef = data.defs.layers.find(def => def.uid === layer.layerDefUid);
   const factorX = layerDef?.parallaxFactorX ?? 0;
   const factorY = layerDef?.parallaxFactorY ?? 0;
-  return { parallaxX: 1 - factorX, parallaxY: 1 - factorY };
+  const scaling = layerDef?.parallaxScaling ?? true;
+
+  return {
+    parallaxX: 1 - factorX,
+    parallaxY: 1 - factorY,
+    parallaxScale: scaling && factorX !== 0 ? Math.max(0.01, 1 - factorX) : 1,
+    offsetX: (layerDef?.pxOffsetX ?? 0) + (scaling ? 0 : -layer.__cWid * layer.__gridSize * 0.5 * factorX),
+    offsetY: (layerDef?.pxOffsetY ?? 0) + (scaling ? 0 : -layer.__cHei * layer.__gridSize * 0.5 * factorY),
+  };
 }

--- a/packages/exojs-ldtk/src/ldtkToTileMap.ts
+++ b/packages/exojs-ldtk/src/ldtkToTileMap.ts
@@ -95,7 +95,7 @@ function convertLevel(
     // Layer IDs must be unique within a TileMap (= one level).
     // Use layerDefUid directly — it is unique per layer definition in the file.
     const layerId = layerInst.layerDefUid;
-    const parallax = resolveLdtkLayerParallax(data, layerInst.layerDefUid);
+    const parallax = resolveLdtkLayerParallax(data, layerInst);
 
     switch (layerInst.__type) {
       case 'Tiles':
@@ -197,10 +197,11 @@ function convertEntitiesLayer(
     name: layerInst.__identifier,
     visible: layerInst.visible,
     opacity: layerInst.opacity ?? 1,
-    offsetX: layerInst.pxOffsetX ?? 0,
-    offsetY: layerInst.pxOffsetY ?? 0,
+    offsetX: parallax.offsetX + (layerInst.pxOffsetX ?? 0),
+    offsetY: parallax.offsetY + (layerInst.pxOffsetY ?? 0),
     parallaxX: parallax.parallaxX,
     parallaxY: parallax.parallaxY,
+    parallaxScale: parallax.parallaxScale,
     objects,
   });
 }
@@ -224,10 +225,11 @@ function makeTileLayer(
     tileHeight: layerInst.__gridSize,
     visible: layerInst.visible,
     opacity: layerInst.opacity ?? 1,
-    offsetX: layerInst.pxOffsetX ?? 0,
-    offsetY: layerInst.pxOffsetY ?? 0,
+    offsetX: parallax.offsetX + (layerInst.pxOffsetX ?? 0),
+    offsetY: parallax.offsetY + (layerInst.pxOffsetY ?? 0),
     parallaxX: parallax.parallaxX,
     parallaxY: parallax.parallaxY,
+    parallaxScale: parallax.parallaxScale,
     ...(properties && { properties }),
   });
 }

--- a/packages/exojs-ldtk/src/validate.ts
+++ b/packages/exojs-ldtk/src/validate.ts
@@ -194,6 +194,8 @@ function validateLayerDef(raw: unknown, source: string, path: string): void {
   expectString(def.identifier, source, joinPath(path, 'identifier'));
   validateLayerType(def.type, source, joinPath(path, 'type'));
   expectNonNegativeInteger(def.gridSize, source, joinPath(path, 'gridSize'));
+  optionalNumber(def, 'pxOffsetX', source, path);
+  optionalNumber(def, 'pxOffsetY', source, path);
   optionalNumber(def, 'parallaxFactorX', source, path);
   optionalNumber(def, 'parallaxFactorY', source, path);
   optionalBoolean(def, 'parallaxScaling', source, path);

--- a/packages/exojs-ldtk/test/ldtkToTileMap.test.ts
+++ b/packages/exojs-ldtk/test/ldtkToTileMap.test.ts
@@ -383,6 +383,7 @@ describe('ldtkToTileMap', () => {
       const tilesLayer = result.levels[0]?.layers.find(l => l.name === 'Tiles');
       expect(tilesLayer?.parallaxX).toBeCloseTo(0.5);
       expect(tilesLayer?.parallaxY).toBeCloseTo(1.25);
+      expect(tilesLayer?.parallaxScale).toBeCloseTo(0.5);
     });
 
     it('defaults a TileLayer to parallaxX/Y = 1 (no parallax) when the layer def has no factors', () => {
@@ -390,6 +391,7 @@ describe('ldtkToTileMap', () => {
       const groundLayer = result.levels[0]?.layers.find(l => l.name === 'Ground');
       expect(groundLayer?.parallaxX).toBe(1);
       expect(groundLayer?.parallaxY).toBe(1);
+      expect(groundLayer?.parallaxScale).toBe(1);
     });
 
     it('converts a layer def parallax factor into the runtime ObjectLayer parallaxX/Y', () => {
@@ -397,6 +399,48 @@ describe('ldtkToTileMap', () => {
       const entitiesLayer = result.levels[0]?.objectLayers[0];
       expect(entitiesLayer?.parallaxX).toBe(0);
       expect(entitiesLayer?.parallaxY).toBe(1);
+      expect(entitiesLayer?.parallaxScale).toBeCloseTo(0.01);
+    });
+
+    it('keeps scale at 1 and applies LDtk centre compensation when parallaxScaling is false', () => {
+      const data: LdtkData = {
+        ...parallaxData,
+        defs: {
+          ...parallaxData.defs,
+          layers: parallaxData.defs.layers.map(def =>
+            def.uid === 101
+              ? { ...def, parallaxFactorX: 0.5, parallaxFactorY: -0.25, parallaxScaling: false }
+              : def,
+          ),
+        },
+      };
+      const tilesLayer = ldtkToTileMap(data).levels[0]?.layers.find(l => l.name === 'Tiles');
+
+      expect(tilesLayer?.parallaxScale).toBe(1);
+      expect(tilesLayer?.offsetX).toBe(-32);
+      expect(tilesLayer?.offsetY).toBe(16);
+    });
+
+    it('adds layer-definition offsets to each instance offset', () => {
+      const data: LdtkData = {
+        ...layeredData,
+        defs: {
+          ...layeredData.defs,
+          layers: layeredData.defs.layers.map(def =>
+            def.uid === 101 ? { ...def, pxOffsetX: 7, pxOffsetY: -9 } : def,
+          ),
+        },
+        levels: layeredData.levels.map(level => ({
+          ...level,
+          layerInstances: level.layerInstances?.map(layer =>
+            layer.layerDefUid === 101 ? { ...layer, pxOffsetX: 3, pxOffsetY: 4 } : layer,
+          ) ?? null,
+        })),
+      };
+      const tilesLayer = ldtkToTileMap(data).levels[0]?.layers.find(l => l.name === 'Tiles');
+
+      expect(tilesLayer?.offsetX).toBe(10);
+      expect(tilesLayer?.offsetY).toBe(-5);
     });
   });
 

--- a/packages/exojs-ldtk/test/validate.test.ts
+++ b/packages/exojs-ldtk/test/validate.test.ts
@@ -102,6 +102,8 @@ describe('validateLdtkData — accepts well-formed documents', () => {
       root.defs.layers[0].parallaxFactorX = 0.5;
       root.defs.layers[0].parallaxFactorY = -0.25;
       root.defs.layers[0].parallaxScaling = false;
+      root.defs.layers[0].pxOffsetX = 3;
+      root.defs.layers[0].pxOffsetY = -4;
     }), SOURCE)).not.toThrow();
   });
 });
@@ -205,6 +207,12 @@ describe('validateLdtkData — rejects malformed documents', () => {
     expect(() => validateLdtkData(withRoot(root => {
       root.defs.layers[0].parallaxScaling = 'yes';
     }), SOURCE)).toThrow(/defs\.layers\[0\]\.parallaxScaling/);
+  });
+
+  it('rejects a non-numeric definition-level layer offset', () => {
+    expect(() => validateLdtkData(withRoot(root => {
+      root.defs.layers[0].pxOffsetX = 'right';
+    }), SOURCE)).toThrow(/defs\.layers\[0\]\.pxOffsetX/);
   });
 });
 

--- a/packages/exojs-tilemap/src/ChunkStreamer.ts
+++ b/packages/exojs-tilemap/src/ChunkStreamer.ts
@@ -178,9 +178,14 @@ export class ChunkStreamer {
 
     const shiftX = centerX * (1 - layer.parallaxX);
     const shiftY = centerY * (1 - layer.parallaxY);
+    const scale = layer.parallaxScale;
 
-    const topLeftTile = layer.pixelToTile(bounds.left - shiftX, bounds.top - shiftY);
-    const bottomRightTile = layer.pixelToTile(bounds.right - shiftX, bounds.bottom - shiftY);
+    const layerLeft = layer.offsetX + (bounds.left - shiftX - layer.offsetX) / scale;
+    const layerTop = layer.offsetY + (bounds.top - shiftY - layer.offsetY) / scale;
+    const layerRight = layer.offsetX + (bounds.right - shiftX - layer.offsetX) / scale;
+    const layerBottom = layer.offsetY + (bounds.bottom - shiftY - layer.offsetY) / scale;
+    const topLeftTile = layer.pixelToTile(layerLeft, layerTop);
+    const bottomRightTile = layer.pixelToTile(layerRight, layerBottom);
 
     const topLeftChunk = tileToChunkCoord(topLeftTile.tx, topLeftTile.ty, layer.chunkWidth, layer.chunkHeight);
     const bottomRightChunk = tileToChunkCoord(bottomRightTile.tx, bottomRightTile.ty, layer.chunkWidth, layer.chunkHeight);

--- a/packages/exojs-tilemap/src/ImageLayer.ts
+++ b/packages/exojs-tilemap/src/ImageLayer.ts
@@ -26,6 +26,8 @@ export interface ImageLayerOptions {
   readonly parallaxX?: number;
   /** Vertical parallax factor. Default `1`. */
   readonly parallaxY?: number;
+  /** Uniform parallax scale around the layer origin. Default `1`. */
+  readonly parallaxScale?: number;
   /** Tint colour as `0xRRGGBB`, or `null`. Default `null`. */
   readonly tintColor?: number | null;
   /** Whether the image repeats horizontally. Default `false`. */
@@ -76,6 +78,8 @@ export class ImageLayer {
   public readonly parallaxX: number;
   /** Vertical parallax factor. */
   public readonly parallaxY: number;
+  /** Uniform scale applied around the layer origin during parallax rendering. */
+  public readonly parallaxScale: number;
   /** Tint colour as `0xRRGGBB`, or `null`. */
   public readonly tintColor: number | null;
   /** Whether the image repeats horizontally. */
@@ -97,6 +101,10 @@ export class ImageLayer {
     this.offsetY = options.offsetY ?? 0;
     this.parallaxX = options.parallaxX ?? 1;
     this.parallaxY = options.parallaxY ?? 1;
+    this.parallaxScale = options.parallaxScale ?? 1;
+    if (!Number.isFinite(this.parallaxScale) || this.parallaxScale <= 0) {
+      throw new Error('ImageLayer parallaxScale must be a positive finite number.');
+    }
     this.tintColor = options.tintColor ?? null;
     this.repeatX = options.repeatX ?? false;
     this.repeatY = options.repeatY ?? false;

--- a/packages/exojs-tilemap/src/ImageLayerNode.ts
+++ b/packages/exojs-tilemap/src/ImageLayerNode.ts
@@ -104,7 +104,7 @@ export class ImageLayerNode extends Container {
     this._sprite = sprite;
     this.addChild(sprite);
 
-    if (layer.repeatX || layer.repeatY || layer.parallaxX !== 1 || layer.parallaxY !== 1) {
+    if (layer.repeatX || layer.repeatY || layer.parallaxX !== 1 || layer.parallaxY !== 1 || layer.parallaxScale !== 1) {
       this.cullable = false;
     }
   }
@@ -155,19 +155,37 @@ export class ImageLayerNode extends Container {
 
     const layer = this._layer;
 
-    if (layer.parallaxX !== 1 || layer.parallaxY !== 1) {
+    const patchesPosition = layer.parallaxX !== 1 || layer.parallaxY !== 1;
+    const patchesScale = layer.parallaxScale !== 1;
+
+    if (patchesPosition || patchesScale) {
       const camCenter = builder.view.center;
       const prevX = this.x;
       const prevY = this.y;
+      const prevScaleX = this.scale.x;
+      const prevScaleY = this.scale.y;
 
-      this.x = this._baseOffsetX + camCenter.x * (1 - layer.parallaxX);
-      this.y = this._baseOffsetY + camCenter.y * (1 - layer.parallaxY);
+      if (patchesPosition) {
+        this.x = this._baseOffsetX + camCenter.x * (1 - layer.parallaxX);
+        this.y = this._baseOffsetY + camCenter.y * (1 - layer.parallaxY);
+      }
 
-      this._updateRepeatCoverage(builder);
-      super._collectContent(builder);
+      if (patchesScale) {
+        this.setScale(prevScaleX * layer.parallaxScale, prevScaleY * layer.parallaxScale);
+      }
 
-      this.x = prevX;
-      this.y = prevY;
+      try {
+        this._updateRepeatCoverage(builder, layer.parallaxScale);
+        super._collectContent(builder);
+      } finally {
+        if (patchesPosition) {
+          this.setPosition(prevX, prevY);
+        }
+
+        if (patchesScale) {
+          this.setScale(prevScaleX, prevScaleY);
+        }
+      }
     } else {
       this._updateRepeatCoverage(builder);
       super._collectContent(builder);
@@ -190,7 +208,7 @@ export class ImageLayerNode extends Container {
    * follows the parallax-shifted origin. Skips the rebuild when neither the view
    * span nor the patched origin changed since the last frame.
    */
-  private _updateRepeatCoverage(builder: RenderPlanBuilder): void {
+  private _updateRepeatCoverage(builder: RenderPlanBuilder, parallaxScale = 1): void {
     const layer = this._layer;
     const sprite = this._sprite;
 
@@ -227,9 +245,10 @@ export class ImageLayerNode extends Container {
 
     if (layer.repeatX) {
       const imgW = this._imageWidth;
-      const localViewMin = bounds.x - originX;
+      const localViewMin = (bounds.x - originX) / parallaxScale;
+      const localViewWidth = bounds.width / parallaxScale;
       const startLocal = Math.floor(localViewMin / imgW) * imgW;
-      const periods = Math.ceil((localViewMin + bounds.width - startLocal) / imgW);
+      const periods = Math.ceil((localViewMin + localViewWidth - startLocal) / imgW);
 
       childX = startLocal;
       childWidth = periods * imgW;
@@ -237,9 +256,10 @@ export class ImageLayerNode extends Container {
 
     if (layer.repeatY) {
       const imgH = this._imageHeight;
-      const localViewMin = bounds.y - originY;
+      const localViewMin = (bounds.y - originY) / parallaxScale;
+      const localViewHeight = bounds.height / parallaxScale;
       const startLocal = Math.floor(localViewMin / imgH) * imgH;
-      const periods = Math.ceil((localViewMin + bounds.height - startLocal) / imgH);
+      const periods = Math.ceil((localViewMin + localViewHeight - startLocal) / imgH);
 
       childY = startLocal;
       childHeight = periods * imgH;

--- a/packages/exojs-tilemap/src/ObjectLayer.ts
+++ b/packages/exojs-tilemap/src/ObjectLayer.ts
@@ -273,6 +273,8 @@ export interface ObjectLayerOptions {
    * `0.5` = half speed (farther away), `0` = stationary. Default `1`.
    */
   readonly parallaxY?: number;
+  /** Uniform parallax scale around the layer origin. Default `1`. */
+  readonly parallaxScale?: number;
   /**
    * Multiplicative layer tint as a `0xRRGGBB` integer, or `null` for no tint
    * (Tiled `tintcolor`). Default `null`.
@@ -298,7 +300,8 @@ export interface ObjectLayerOptions {
  *
  * The presentation fields the source format attaches to a layer —
  * {@link visible}, {@link opacity}, {@link offsetX}/{@link offsetY},
- * {@link parallaxX}/{@link parallaxY} and {@link tintColor} — are carried
+ * {@link parallaxX}/{@link parallaxY}, {@link parallaxScale}, and
+ * {@link tintColor} — are carried
  * through in full, with any enclosing group layers' contribution already
  * folded in, so an object layer describes the same placement and shading its
  * neighbouring tile and image layers do. Nothing here acts on them: code that
@@ -351,6 +354,8 @@ export class ObjectLayer<S extends ObjectSchema = ObjectSchema> {
   public readonly parallaxX: number;
   /** Parallax scroll factor on the Y axis. See {@link ObjectLayer.parallaxX}. */
   public readonly parallaxY: number;
+  /** Uniform scale applied around the layer origin by consumers that render this data-only layer. */
+  public readonly parallaxScale: number;
   /**
    * Multiplicative layer tint as `0xRRGGBB`, or `null` for no tint. Carried
    * from the source map (including the accumulated tint of any enclosing group
@@ -375,6 +380,10 @@ export class ObjectLayer<S extends ObjectSchema = ObjectSchema> {
     this.offsetY = options.offsetY ?? 0;
     this.parallaxX = options.parallaxX ?? 1;
     this.parallaxY = options.parallaxY ?? 1;
+    this.parallaxScale = options.parallaxScale ?? 1;
+    if (!Number.isFinite(this.parallaxScale) || this.parallaxScale <= 0) {
+      throw new Error('ObjectLayer parallaxScale must be a positive finite number.');
+    }
     this.tintColor = options.tintColor ?? null;
     this.drawOrder = options.drawOrder ?? 'topdown';
     this.properties = options.properties ? Object.freeze({ ...options.properties }) : Object.freeze({});

--- a/packages/exojs-tilemap/src/TileLayer.ts
+++ b/packages/exojs-tilemap/src/TileLayer.ts
@@ -59,6 +59,11 @@ export interface TileLayerOptions {
    * `0.5` = half speed (farther away), `0.0` = stationary. Default 1.
    */
   readonly parallaxY?: number;
+  /**
+   * Uniform scale applied together with the camera-relative parallax shift.
+   * `1` keeps the layer at its authored size. Default `1`.
+   */
+  readonly parallaxScale?: number;
   /** Layer class/type string (Tiled `class`). Defaults to `''`. */
   readonly class?: string;
   /**
@@ -110,6 +115,16 @@ interface ResolvedTileLayerOptions {
   readonly offsetY: number;
   readonly parallaxX: number;
   readonly parallaxY: number;
+  readonly parallaxScale: number;
+}
+
+/** Resolve and validate the optional uniform parallax scale. */
+function resolveParallaxScale(value = 1): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error('TileLayer parallaxScale must be a positive finite number.');
+  }
+
+  return value;
 }
 
 /**
@@ -152,7 +167,9 @@ function validateTileLayerOptions(options: TileLayerOptions): ResolvedTileLayerO
     throw new Error('TileLayer parallax must be finite numbers.');
   }
 
-  return { chunkWidth, chunkHeight, opacity, offsetX, offsetY, parallaxX, parallaxY };
+  const parallaxScale = resolveParallaxScale(options.parallaxScale);
+
+  return { chunkWidth, chunkHeight, opacity, offsetX, offsetY, parallaxX, parallaxY, parallaxScale };
 }
 
 /**
@@ -226,6 +243,8 @@ export class TileLayer {
    * `1.0` = full camera speed, `0.5` = half speed, `0.0` = stationary.
    */
   public readonly parallaxY: number;
+  /** Uniform scale applied around the layer origin during parallax rendering. */
+  public readonly parallaxScale: number;
 
   /** Layer class/type string (Tiled `class`; may be empty). */
   public readonly class: string;
@@ -258,7 +277,7 @@ export class TileLayer {
    * @throws When dimensions, chunk size, or other options are invalid.
    */
   public constructor(options: TileLayerOptions) {
-    const { chunkWidth, chunkHeight, opacity, offsetX, offsetY, parallaxX, parallaxY } =
+    const { chunkWidth, chunkHeight, opacity, offsetX, offsetY, parallaxX, parallaxY, parallaxScale } =
       validateTileLayerOptions(options);
 
     this.id = options.id;
@@ -276,6 +295,7 @@ export class TileLayer {
     this.offsetY = offsetY;
     this.parallaxX = parallaxX;
     this.parallaxY = parallaxY;
+    this.parallaxScale = parallaxScale;
     this.class = options.class ?? '';
     this.tintColor = options.tintColor ?? null;
     this.properties = options.properties

--- a/packages/exojs-tilemap/src/TileLayerNode.ts
+++ b/packages/exojs-tilemap/src/TileLayerNode.ts
@@ -103,7 +103,7 @@ export class TileLayerNode extends Container {
     this.setPosition(layer.offsetX, layer.offsetY);
     this._buildChunkNodes();
 
-    if (!this._layer.bounded || layer.parallaxX !== 1 || layer.parallaxY !== 1) {
+    if (!this._layer.bounded || layer.parallaxX !== 1 || layer.parallaxY !== 1 || layer.parallaxScale !== 1) {
       this.cullable = false;
     }
 
@@ -206,18 +206,36 @@ export class TileLayerNode extends Container {
 
     const layer = this._layer;
 
-    if (layer.parallaxX !== 1 || layer.parallaxY !== 1) {
+    const patchesPosition = layer.parallaxX !== 1 || layer.parallaxY !== 1;
+    const patchesScale = layer.parallaxScale !== 1;
+
+    if (patchesPosition || patchesScale) {
       const camCenter = builder.view.center;
       const prevX = this.x;
       const prevY = this.y;
+      const prevScaleX = this.scale.x;
+      const prevScaleY = this.scale.y;
 
-      this.x = this._baseOffsetX + camCenter.x * (1 - layer.parallaxX);
-      this.y = this._baseOffsetY + camCenter.y * (1 - layer.parallaxY);
+      if (patchesPosition) {
+        this.x = this._baseOffsetX + camCenter.x * (1 - layer.parallaxX);
+        this.y = this._baseOffsetY + camCenter.y * (1 - layer.parallaxY);
+      }
 
-      super._collectContent(builder);
+      if (patchesScale) {
+        this.setScale(prevScaleX * layer.parallaxScale, prevScaleY * layer.parallaxScale);
+      }
 
-      this.x = prevX;
-      this.y = prevY;
+      try {
+        super._collectContent(builder);
+      } finally {
+        if (patchesPosition) {
+          this.setPosition(prevX, prevY);
+        }
+
+        if (patchesScale) {
+          this.setScale(prevScaleX, prevScaleY);
+        }
+      }
     } else {
       super._collectContent(builder);
     }

--- a/packages/exojs-tilemap/test/ChunkStreamer.test.ts
+++ b/packages/exojs-tilemap/test/ChunkStreamer.test.ts
@@ -353,6 +353,32 @@ describe('ChunkStreamer.update() — parallax-aware wanted range', () => {
     expect(layer.getChunk(bottomRightChunk.cx + 1, bottomRightChunk.cy + 1)).toBeDefined();
     expect(layer.getChunk(topLeftChunk.cx - 2, topLeftChunk.cy - 2)).toBeUndefined();
   });
+
+  it('inverts parallax scale when computing the streamed layer-space range', () => {
+    const tileset = makeTileset();
+    const view = new View(500, 0, 40, 40);
+    const layer = new TileLayer({
+      id: 0, name: 'scaled', offsetX: 20,
+      tileWidth: 10, tileHeight: 10, tilesets: [tileset],
+      chunkWidth: 4, chunkHeight: 4,
+      parallaxX: 0.5, parallaxY: 1, parallaxScale: 0.5,
+    });
+
+    new ChunkStreamer(layer, makeAlwaysAvailableSource(), view, { loadRadius: 0, unloadRadius: 0 }).update();
+
+    const bounds = view.getBounds();
+    const shiftX = view.center.x * (1 - layer.parallaxX);
+    const toLayerX = (worldX: number): number => layer.offsetX + (worldX - shiftX - layer.offsetX) / layer.parallaxScale;
+    const topLeft = layer.pixelToTile(toLayerX(bounds.left), bounds.top);
+    const bottomRight = layer.pixelToTile(toLayerX(bounds.right), bounds.bottom);
+    const first = tileToChunkCoord(topLeft.tx, topLeft.ty, layer.chunkWidth, layer.chunkHeight);
+    const last = tileToChunkCoord(bottomRight.tx, bottomRight.ty, layer.chunkWidth, layer.chunkHeight);
+
+    expect(layer.getChunk(first.cx, first.cy)).toBeDefined();
+    expect(layer.getChunk(last.cx, last.cy)).toBeDefined();
+    expect(layer.getChunk(first.cx - 1, first.cy)).toBeUndefined();
+    expect(layer.getChunk(last.cx + 1, last.cy)).toBeUndefined();
+  });
 });
 
 describe('ChunkStreamer.destroy()', () => {

--- a/packages/exojs-tilemap/test/ImageLayer.test.ts
+++ b/packages/exojs-tilemap/test/ImageLayer.test.ts
@@ -18,6 +18,7 @@ describe('ImageLayer', () => {
     expect(layer.offsetY).toBe(0);
     expect(layer.parallaxX).toBe(1);
     expect(layer.parallaxY).toBe(1);
+    expect(layer.parallaxScale).toBe(1);
     expect(layer.tintColor).toBeNull();
     expect(layer.repeatX).toBe(false);
     expect(layer.repeatY).toBe(false);
@@ -35,6 +36,7 @@ describe('ImageLayer', () => {
       offsetY: -4,
       parallaxX: 0.5,
       parallaxY: 0.25,
+      parallaxScale: 0.75,
       tintColor: 0xff8800,
       repeatX: true,
       repeatY: true,
@@ -49,9 +51,14 @@ describe('ImageLayer', () => {
     expect(layer.offsetY).toBe(-4);
     expect(layer.parallaxX).toBe(0.5);
     expect(layer.parallaxY).toBe(0.25);
+    expect(layer.parallaxScale).toBe(0.75);
     expect(layer.tintColor).toBe(0xff8800);
     expect(layer.repeatX).toBe(true);
     expect(layer.repeatY).toBe(true);
+  });
+
+  it('rejects a non-positive parallax scale', () => {
+    expect(() => new ImageLayer({ id: 1, image: 'bg.png', parallaxScale: 0 })).toThrow(/positive finite number/);
   });
 
   it('properties default to a frozen empty object', () => {

--- a/packages/exojs-tilemap/test/ImageLayerNode.test.ts
+++ b/packages/exojs-tilemap/test/ImageLayerNode.test.ts
@@ -132,6 +132,29 @@ describe('ImageLayerNode parallax', () => {
     expect(node.y).toBe(20);
   });
 
+  it('applies a uniform parallax scale during collection and restores caller scale', () => {
+    const node = new ImageLayerNode(makeLayer({ parallaxScale: 0.5 })).setScale(2, 3);
+    const setScale = vi.spyOn(node, 'setScale');
+
+    collect(node, mockBuilder());
+
+    expect(setScale).toHaveBeenNthCalledWith(1, 1, 1.5);
+    expect(setScale).toHaveBeenLastCalledWith(2, 3);
+    expect(node.scale.x).toBe(2);
+    expect(node.scale.y).toBe(3);
+    expect(node.cullable).toBe(false);
+  });
+
+  it('expands repeat coverage in local space when parallax scaling shrinks the node', () => {
+    const node = new ImageLayerNode(
+      makeLayer({ texture: fakeTexture(64, 64), repeatX: true, parallaxScale: 0.5 }),
+    );
+
+    collect(node, mockBuilder({ bounds: { x: 0, y: 0, width: 160, height: 64 } }));
+
+    expect(spriteOf(node).width).toBe(320);
+  });
+
   it('position is restored to the base offset after _collectContent', () => {
     const node = new ImageLayerNode(
       makeLayer({ offsetX: 10, offsetY: 20, parallaxX: 0.5, parallaxY: 0.5 }),

--- a/packages/exojs-tilemap/test/nodes.test.ts
+++ b/packages/exojs-tilemap/test/nodes.test.ts
@@ -159,6 +159,24 @@ describe('TileLayerNode', () => {
     expect(node.y).toBe(20);
   });
 
+  it('parallax scale is applied during collection and restores a caller scale afterwards', () => {
+    const tileset = makeTileset();
+    const layer = new TileLayer({
+      id: 1, name: 'bg', width: 4, height: 4, tileWidth: 32, tileHeight: 32,
+      tilesets: [tileset], parallaxScale: 0.5,
+    });
+    const node = new TileLayerNode(layer).setScale(2, 3);
+    const setScale = vi.spyOn(node, 'setScale');
+
+    (node as unknown as { _collectContent(b: unknown): void })._collectContent({ view: { center: { x: 0, y: 0 } } });
+
+    expect(setScale).toHaveBeenNthCalledWith(1, 1, 1.5);
+    expect(setScale).toHaveBeenLastCalledWith(2, 3);
+    expect(node.scale.x).toBe(2);
+    expect(node.scale.y).toBe(3);
+    expect(node.cullable).toBe(false);
+  });
+
   it('bounded parallax layer opts out of static-bounds culling', () => {
     const tileset = makeTileset();
     const layer = new TileLayer({

--- a/packages/exojs-tilemap/test/object-layer.test.ts
+++ b/packages/exojs-tilemap/test/object-layer.test.ts
@@ -49,6 +49,7 @@ describe('ObjectLayer', () => {
     expect(layer.offsetY).toBe(0);
     expect(layer.parallaxX).toBe(1);
     expect(layer.parallaxY).toBe(1);
+    expect(layer.parallaxScale).toBe(1);
     expect(layer.tintColor).toBe(null);
     expect(layer.objects).toHaveLength(1);
     expect(Object.isFrozen(layer.objects)).toBe(true);
@@ -64,6 +65,7 @@ describe('ObjectLayer', () => {
       offsetY: -8,
       parallaxX: 0.25,
       parallaxY: 2,
+      parallaxScale: 0.75,
       tintColor: 0x804020,
     });
 
@@ -73,7 +75,12 @@ describe('ObjectLayer', () => {
     expect(layer.offsetY).toBe(-8);
     expect(layer.parallaxX).toBe(0.25);
     expect(layer.parallaxY).toBe(2);
+    expect(layer.parallaxScale).toBe(0.75);
     expect(layer.tintColor).toBe(0x804020);
+  });
+
+  it('rejects a non-positive parallax scale', () => {
+    expect(() => new ObjectLayer({ id: 1, parallaxScale: 0 })).toThrow(/positive finite number/);
   });
 
   it('query filters by name / type / kind / property (+ value), all combinable', () => {

--- a/packages/exojs-tilemap/test/tilemap.test.ts
+++ b/packages/exojs-tilemap/test/tilemap.test.ts
@@ -592,6 +592,10 @@ describe('TileLayer', () => {
       id: 0, name: 'l', width: 4, height: 4,
       tileWidth: 16, tileHeight: 16, tilesets: [ts], parallaxY: Infinity,
     })).toThrow(/parallax must be finite/);
+    expect(() => new TileLayer({
+      id: 0, name: 'l', width: 4, height: 4,
+      tileWidth: 16, tileHeight: 16, tilesets: [ts], parallaxScale: 0,
+    })).toThrow(/parallaxScale must be a positive finite number/);
   });
 
   it('inBounds check', () => {
@@ -1268,6 +1272,7 @@ describe('TileLayer', () => {
     });
     expect(layer.parallaxX).toBe(1);
     expect(layer.parallaxY).toBe(1);
+    expect(layer.parallaxScale).toBe(1);
   });
 
   it('parallaxX and parallaxY can be set via options', () => {
@@ -1276,9 +1281,11 @@ describe('TileLayer', () => {
       tileWidth: 16, tileHeight: 16, tilesets: [ts],
       parallaxX: 0.5,
       parallaxY: 0.25,
+      parallaxScale: 0.5,
     });
     expect(layer.parallaxX).toBe(0.5);
     expect(layer.parallaxY).toBe(0.25);
+    expect(layer.parallaxScale).toBe(0.5);
   });
 
   it('parallaxX = 0.0 is valid (stationary layer)', () => {

--- a/scripts/ci/gate-groups.ts
+++ b/scripts/ci/gate-groups.ts
@@ -9,7 +9,7 @@
 
 /** Package.json script names per owning CI job. Order within a group is the run order. */
 export const GATE_GROUPS = {
-  typecheck: ['typecheck', 'typecheck:guides', 'typecheck:examples', 'typecheck:type-tests', 'typecheck:packages', 'typecheck:test'],
+  typecheck: ['typecheck', 'typecheck:full-bundle', 'typecheck:guides', 'typecheck:examples', 'typecheck:type-tests', 'typecheck:packages', 'typecheck:test'],
   lint: ['lint:all', 'format:check'],
   sync: ['docs:api:check', 'examples:sync:check'],
   site: ['typecheck:site'],

--- a/scripts/exo-full.entry.ts
+++ b/scripts/exo-full.entry.ts
@@ -14,9 +14,38 @@ export * from '@codexo/exojs-particles';
 // ── Audio FX ──────────────────────────────────────────────────────────────────
 export * from '@codexo/exojs-audio-fx';
 
-// ── Tilemap (base) — tiled + ldtk re-export the same runtime symbols;
-//    only import once here to avoid duplicate named exports. ──────────────────
-export * from '@codexo/exojs-tilemap';
+// ── Tilemap (base) — value exports only. The package's object-layer
+// `TextStyle` interface collides with core's runtime `TextStyle` class, while
+// type-only exports do not exist on the IIFE global. Tiled + LDtk also
+// re-export these runtime symbols, so import them exactly once here. ──────────
+export {
+  autoTile,
+  buildTileCollisionGeometry,
+  ChunkStreamer,
+  createSampledChunkSource,
+  createWorkerSampledChunkSource,
+  ImageLayer,
+  ImageLayerNode,
+  ObjectKind,
+  ObjectLayer,
+  packTile,
+  refreshCell,
+  TILE_TRANSFORM_IDENTITY,
+  TileAnimator,
+  TileLayer,
+  TileLayerNode,
+  TileMap,
+  TileMapBand,
+  TileMapNode,
+  TileMapView,
+  TilePropertyKind,
+  TileSet,
+  tilemapExtension,
+  tileToChunkCoord,
+  tileToLocalInChunk,
+  unpackTile,
+  WangSet,
+} from '@codexo/exojs-tilemap';
 
 // ── Physics ────────────────────────────────────────────────────────────────────
 export * from '@codexo/exojs-physics';

--- a/site/scripts/build-api.ts
+++ b/site/scripts/build-api.ts
@@ -5,6 +5,7 @@ import { Application, ReflectionKind } from 'typedoc';
 
 import { apiSymbolSchema } from '../src/lib/api-schema';
 import type { ApiCounts, ApiMember, ApiSection, ApiToken, ApiSymbolData } from '../src/lib/api-schema';
+import { sortUnionMembers } from './sort-union-members';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -189,6 +190,7 @@ const toParagraphs = (value: string): string[] =>
 const punct = (text: string): ApiToken => ({ text, kind: 'punctuation' });
 const keyword = (text: string): ApiToken => ({ text, kind: 'keyword' });
 const typeToken = (text: string): ApiToken => ({ text, kind: 'type' });
+const tokensToText = (tokens: ApiToken[]): string => tokens.map(token => token.text).join('');
 
 /** Concatenate token groups, inserting a punctuation separator between them. */
 const joinTokenGroups = (groups: ApiToken[][], separator: string): ApiToken[] => {
@@ -218,8 +220,11 @@ const tokenizeType = (type: any): ApiToken[] => {
             }
             return tokens;
         }
-        case 'union':
-            return type.types?.length ? joinTokenGroups(type.types.map(tokenizeType), ' | ') : [keyword('unknown')];
+        case 'union': {
+            if (!type.types?.length) return [keyword('unknown')];
+            const members = sortUnionMembers(type.types.map(tokenizeType), tokensToText);
+            return joinTokenGroups(members, ' | ');
+        }
         case 'intersection':
             return type.types?.length ? joinTokenGroups(type.types.map(tokenizeType), ' & ') : [keyword('unknown')];
         case 'array':
@@ -281,8 +286,6 @@ const tokenizeType = (type: any): ApiToken[] => {
             return [type.name ? typeToken(type.name) : keyword(type.type ?? 'unknown')];
     }
 };
-
-const tokensToText = (tokens: ApiToken[]): string => tokens.map(token => token.text).join('');
 
 const renderType = (type: any): string => tokensToText(tokenizeType(type));
 

--- a/site/scripts/sort-union-members.ts
+++ b/site/scripts/sort-union-members.ts
@@ -1,0 +1,13 @@
+/**
+ * Return a deterministically ordered copy of union members. TypeScript and
+ * TypeDoc may expose semantically identical unions in type-creation order,
+ * which can change after an unrelated import. Source order is not part of a
+ * union's meaning, so generated documentation sorts by rendered text.
+ */
+export function sortUnionMembers<T>(members: readonly T[], textOf: (member: T) => string): T[] {
+    return [...members].sort((left, right) => {
+        const leftText = textOf(left);
+        const rightText = textOf(right);
+        return leftText < rightText ? -1 : leftText > rightText ? 1 : 0;
+    });
+}

--- a/site/src/content/api/abstract-text.json
+++ b/site/src/content/api/abstract-text.json
@@ -1989,7 +1989,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2000,7 +2000,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2008,7 +2008,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2093,7 +2093,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2104,7 +2104,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2112,7 +2112,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2227,7 +2227,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2238,7 +2238,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2246,7 +2246,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/action.json
+++ b/site/src/content/api/action.json
@@ -30,16 +30,8 @@
       "members": [
         {
           "name": "Action",
-          "signature": "ButtonAction | AxisAction | VectorAction | ChordAction | SequenceAction",
+          "signature": "AxisAction | ButtonAction | ChordAction | SequenceAction | VectorAction",
           "signatureTokens": [
-            {
-              "text": "ButtonAction",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "AxisAction",
               "kind": "type"
@@ -49,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "VectorAction",
+              "text": "ButtonAction",
               "kind": "type"
             },
             {
@@ -66,6 +58,14 @@
             },
             {
               "text": "SequenceAction",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "VectorAction",
               "kind": "type"
             }
           ],

--- a/site/src/content/api/animated-sprite.json
+++ b/site/src/content/api/animated-sprite.json
@@ -33,7 +33,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(texture: Texture | RenderTexture | null, clips?: Readonly<Record<string, AnimatedSpriteClipDefinition>>): AnimatedSprite",
+          "signature": "new(texture: RenderTexture | Texture | null, clips?: Readonly<Record<string, AnimatedSpriteClipDefinition>>): AnimatedSprite",
           "signatureTokens": [
             {
               "text": "new",
@@ -52,7 +52,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -60,7 +60,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {
@@ -139,7 +139,7 @@
           "params": [
             {
               "name": "texture",
-              "type": "Texture | RenderTexture | null",
+              "type": "RenderTexture | Texture | null",
               "optional": false
             },
             {
@@ -1889,7 +1889,7 @@
         },
         {
           "name": "setTexture",
-          "signature": "setTexture(texture: Texture | RenderTexture | null): this",
+          "signature": "setTexture(texture: RenderTexture | Texture | null): this",
           "signatureTokens": [
             {
               "text": "setTexture",
@@ -1908,7 +1908,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -1916,7 +1916,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {
@@ -1943,7 +1943,7 @@
           "params": [
             {
               "name": "texture",
-              "type": "Texture | RenderTexture | null",
+              "type": "RenderTexture | Texture | null",
               "optional": false
             }
           ],
@@ -2399,7 +2399,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2410,7 +2410,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2418,7 +2418,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2503,7 +2503,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2514,7 +2514,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2522,7 +2522,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2637,7 +2637,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2648,7 +2648,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2656,7 +2656,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {
@@ -2724,7 +2724,7 @@
         },
         {
           "name": "currentClip",
-          "signature": "currentClip: string | null",
+          "signature": "currentClip: null | string",
           "signatureTokens": [
             {
               "text": "currentClip",
@@ -2735,7 +2735,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2743,7 +2743,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -3201,7 +3201,7 @@
         },
         {
           "name": "texture",
-          "signature": "texture: Texture | RenderTexture | null",
+          "signature": "texture: RenderTexture | Texture | null",
           "signatureTokens": [
             {
               "text": "texture",
@@ -3212,7 +3212,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -3220,7 +3220,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {

--- a/site/src/content/api/application-like.json
+++ b/site/src/content/api/application-like.json
@@ -30,28 +30,8 @@
       "members": [
         {
           "name": "ApplicationLike",
-          "signature": "Application<any> | (args: any[]) => Application<any>",
+          "signature": "(args: any[]) => Application<any> | Application<any>",
           "signatureTokens": [
-            {
-              "text": "Application",
-              "kind": "type"
-            },
-            {
-              "text": "<",
-              "kind": "punctuation"
-            },
-            {
-              "text": "any",
-              "kind": "keyword"
-            },
-            {
-              "text": ">",
-              "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "(",
               "kind": "punctuation"
@@ -74,6 +54,26 @@
             },
             {
               "text": ") => ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Application",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "any",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {

--- a/site/src/content/api/application.json
+++ b/site/src/content/api/application.json
@@ -358,7 +358,7 @@
         },
         {
           "name": "setCursor",
-          "signature": "setCursor(cursor: string | HTMLCanvasElement | HTMLImageElement | Texture): this",
+          "signature": "setCursor(cursor: HTMLCanvasElement | HTMLImageElement | Texture | string): this",
           "signatureTokens": [
             {
               "text": "setCursor",
@@ -374,14 +374,6 @@
             },
             {
               "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "string",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -405,6 +397,14 @@
               "kind": "type"
             },
             {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -420,7 +420,7 @@
           "params": [
             {
               "name": "cursor",
-              "type": "string | HTMLCanvasElement | HTMLImageElement | Texture",
+              "type": "HTMLCanvasElement | HTMLImageElement | Texture | string",
               "optional": false
             }
           ],

--- a/site/src/content/api/arcade-stick-gamepad-mapping.json
+++ b/site/src/content/api/arcade-stick-gamepad-mapping.json
@@ -98,7 +98,7 @@
         },
         {
           "name": "hasChannel",
-          "signature": "hasChannel(channel: GamepadButtonChannel | GamepadAxisChannel): boolean",
+          "signature": "hasChannel(channel: GamepadAxisChannel | GamepadButtonChannel): boolean",
           "signatureTokens": [
             {
               "text": "hasChannel",
@@ -117,7 +117,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -125,7 +125,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -144,7 +144,7 @@
           "params": [
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],

--- a/site/src/content/api/asset-cache-error.json
+++ b/site/src/content/api/asset-cache-error.json
@@ -113,7 +113,7 @@
         },
         {
           "name": "key",
-          "signature": "key: string | null",
+          "signature": "key: null | string",
           "signatureTokens": [
             {
               "text": "key",
@@ -124,7 +124,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -132,7 +132,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -230,7 +230,7 @@
         },
         {
           "name": "store",
-          "signature": "store: string | null",
+          "signature": "store: null | string",
           "signatureTokens": [
             {
               "text": "store",
@@ -241,7 +241,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -249,7 +249,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/asset-cache-operation.json
+++ b/site/src/content/api/asset-cache-operation.json
@@ -30,10 +30,34 @@
       "members": [
         {
           "name": "AssetCacheOperation",
-          "signature": "\"connect\" | \"load\" | \"save\" | \"delete\" | \"clear\" | \"delete-storage\"",
+          "signature": "\"clear\" | \"connect\" | \"delete\" | \"delete-storage\" | \"load\" | \"save\"",
           "signatureTokens": [
             {
+              "text": "\"clear\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
               "text": "\"connect\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"delete\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"delete-storage\"",
               "kind": "keyword"
             },
             {
@@ -50,30 +74,6 @@
             },
             {
               "text": "\"save\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"delete\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"clear\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"delete-storage\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/asset-inspection.json
+++ b/site/src/content/api/asset-inspection.json
@@ -135,7 +135,7 @@
         },
         {
           "name": "state",
-          "signature": "state: \"idle\" | \"loading\" | \"ready\" | \"failed\" | \"queued\"",
+          "signature": "state: \"failed\" | \"idle\" | \"loading\" | \"queued\" | \"ready\"",
           "signatureTokens": [
             {
               "text": "state",
@@ -143,6 +143,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"failed\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -162,23 +170,15 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"ready\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"failed\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "\"queued\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"ready\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/asset-network-error.json
+++ b/site/src/content/api/asset-network-error.json
@@ -180,7 +180,7 @@
         },
         {
           "name": "status",
-          "signature": "status: number | null",
+          "signature": "status: null | number",
           "signatureTokens": [
             {
               "text": "status",
@@ -191,7 +191,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -199,7 +199,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],
@@ -209,7 +209,7 @@
         },
         {
           "name": "statusText",
-          "signature": "statusText: string | null",
+          "signature": "statusText: null | string",
           "signatureTokens": [
             {
               "text": "statusText",
@@ -220,7 +220,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -228,7 +228,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/atlas-mode.json
+++ b/site/src/content/api/atlas-mode.json
@@ -30,10 +30,10 @@
       "members": [
         {
           "name": "AtlasMode",
-          "signature": "\"sdf\" | \"color\"",
+          "signature": "\"color\" | \"sdf\"",
           "signatureTokens": [
             {
-              "text": "\"sdf\"",
+              "text": "\"color\"",
               "kind": "keyword"
             },
             {
@@ -41,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"color\"",
+              "text": "\"sdf\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/attribute-type.json
+++ b/site/src/content/api/attribute-type.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "AttributeType",
-          "signature": "\"f32\" | \"u8\" | \"u16\" | \"u32\" | \"i32\"",
+          "signature": "\"f32\" | \"i32\" | \"u16\" | \"u32\" | \"u8\"",
           "signatureTokens": [
             {
               "text": "\"f32\"",
@@ -41,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"u8\"",
+              "text": "\"i32\"",
               "kind": "keyword"
             },
             {
@@ -65,7 +65,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"i32\"",
+              "text": "\"u8\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/audio-analyser-source.json
+++ b/site/src/content/api/audio-analyser-source.json
@@ -28,7 +28,7 @@
       "members": [
         {
           "name": "AudioAnalyserSource",
-          "signature": "AudioBus | Voice | MediaStream | AudioNode | null",
+          "signature": "AudioBus | AudioNode | MediaStream | Voice | null",
           "signatureTokens": [
             {
               "text": "AudioBus",
@@ -39,7 +39,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Voice",
+              "text": "AudioNode",
               "kind": "type"
             },
             {
@@ -55,7 +55,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "AudioNode",
+              "text": "Voice",
               "kind": "type"
             },
             {

--- a/site/src/content/api/audio-listener-target.json
+++ b/site/src/content/api/audio-listener-target.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "AudioListenerTarget",
-          "signature": "SceneNode | View | { x: number; y: number } | null",
+          "signature": "SceneNode | View | null | { x: number; y: number }",
           "signatureTokens": [
             {
               "text": "SceneNode",
@@ -43,6 +43,14 @@
             {
               "text": "View",
               "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
             },
             {
               "text": " | ",
@@ -83,14 +91,6 @@
             {
               "text": " }",
               "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
             }
           ],
           "params": [],

--- a/site/src/content/api/axis-binding.json
+++ b/site/src/content/api/axis-binding.json
@@ -30,16 +30,8 @@
       "members": [
         {
           "name": "AxisBinding",
-          "signature": "InputChannel | AtLeastOne<AxisCompositeBinding>",
+          "signature": "AtLeastOne<AxisCompositeBinding> | InputChannel",
           "signatureTokens": [
-            {
-              "text": "InputChannel",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "AtLeastOne",
               "kind": "type"
@@ -55,6 +47,14 @@
             {
               "text": ">",
               "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InputChannel",
+              "kind": "type"
             }
           ],
           "params": [],

--- a/site/src/content/api/beat-detector-source.json
+++ b/site/src/content/api/beat-detector-source.json
@@ -28,7 +28,7 @@
       "members": [
         {
           "name": "BeatDetectorSource",
-          "signature": "AudioBus | Voice | MediaStream | AudioNode | null",
+          "signature": "AudioBus | AudioNode | MediaStream | Voice | null",
           "signatureTokens": [
             {
               "text": "AudioBus",
@@ -39,7 +39,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Voice",
+              "text": "AudioNode",
               "kind": "type"
             },
             {
@@ -55,7 +55,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "AudioNode",
+              "text": "Voice",
               "kind": "type"
             },
             {

--- a/site/src/content/api/beat-info.json
+++ b/site/src/content/api/beat-info.json
@@ -154,7 +154,7 @@
         },
         {
           "name": "status",
-          "signature": "status: \"provisional\" | \"locked\"",
+          "signature": "status: \"locked\" | \"provisional\"",
           "signatureTokens": [
             {
               "text": "status",
@@ -165,7 +165,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"provisional\"",
+              "text": "\"locked\"",
               "kind": "keyword"
             },
             {
@@ -173,7 +173,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"locked\"",
+              "text": "\"provisional\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/bitmap-text-options.json
+++ b/site/src/content/api/bitmap-text-options.json
@@ -155,7 +155,7 @@
         },
         {
           "name": "fontStyle",
-          "signature": "fontStyle?: \"normal\" | \"italic\"",
+          "signature": "fontStyle?: \"italic\" | \"normal\"",
           "signatureTokens": [
             {
               "text": "fontStyle",
@@ -170,7 +170,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"normal\"",
+              "text": "\"italic\"",
               "kind": "keyword"
             },
             {
@@ -178,7 +178,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"italic\"",
+              "text": "\"normal\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/bitmap-text.json
+++ b/site/src/content/api/bitmap-text.json
@@ -2110,7 +2110,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2121,7 +2121,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2129,7 +2129,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2214,7 +2214,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2225,7 +2225,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2233,7 +2233,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2348,7 +2348,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2359,7 +2359,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2367,7 +2367,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/body-type.json
+++ b/site/src/content/api/body-type.json
@@ -31,7 +31,7 @@
       "members": [
         {
           "name": "BodyType",
-          "signature": "\"dynamic\" | \"static\" | \"kinematic\"",
+          "signature": "\"dynamic\" | \"kinematic\" | \"static\"",
           "signatureTokens": [
             {
               "text": "\"dynamic\"",
@@ -42,7 +42,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"static\"",
+              "text": "\"kinematic\"",
               "kind": "keyword"
             },
             {
@@ -50,7 +50,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"kinematic\"",
+              "text": "\"static\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/box-area.json
+++ b/site/src/content/api/box-area.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(minX: number, maxX: number, minY: number, maxY: number, mode: \"volume\" | \"edge\"): BoxArea",
+          "signature": "new(minX: number, maxX: number, minY: number, maxY: number, mode: \"edge\" | \"volume\"): BoxArea",
           "signatureTokens": [
             {
               "text": "new",
@@ -113,7 +113,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"volume\"",
+              "text": "\"edge\"",
               "kind": "keyword"
             },
             {
@@ -121,7 +121,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"edge\"",
+              "text": "\"volume\"",
               "kind": "keyword"
             },
             {
@@ -160,7 +160,7 @@
             },
             {
               "name": "mode",
-              "type": "\"volume\" | \"edge\"",
+              "type": "\"edge\" | \"volume\"",
               "optional": false
             }
           ],
@@ -318,7 +318,7 @@
         },
         {
           "name": "mode",
-          "signature": "mode: \"volume\" | \"edge\"",
+          "signature": "mode: \"edge\" | \"volume\"",
           "signatureTokens": [
             {
               "text": "mode",
@@ -329,7 +329,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"volume\"",
+              "text": "\"edge\"",
               "kind": "keyword"
             },
             {
@@ -337,7 +337,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"edge\"",
+              "text": "\"volume\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/button.json
+++ b/site/src/content/api/button.json
@@ -2374,7 +2374,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2385,7 +2385,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2393,7 +2393,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2478,7 +2478,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2489,7 +2489,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2497,7 +2497,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2624,7 +2624,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2635,7 +2635,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2643,7 +2643,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {
@@ -2661,7 +2661,7 @@
         },
         {
           "name": "colors",
-          "signature": "colors: Readonly<Record<\"normal\" | \"hover\" | \"pressed\" | \"disabled\", Color>>",
+          "signature": "colors: Readonly<Record<\"disabled\" | \"hover\" | \"normal\" | \"pressed\", Color>>",
           "signatureTokens": [
             {
               "text": "colors",
@@ -2688,7 +2688,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"normal\"",
+              "text": "\"disabled\"",
               "kind": "keyword"
             },
             {
@@ -2704,7 +2704,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"pressed\"",
+              "text": "\"normal\"",
               "kind": "keyword"
             },
             {
@@ -2712,7 +2712,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"disabled\"",
+              "text": "\"pressed\"",
               "kind": "keyword"
             },
             {

--- a/site/src/content/api/canvas-application-options.json
+++ b/site/src/content/api/canvas-application-options.json
@@ -78,7 +78,7 @@
         },
         {
           "name": "imageRendering",
-          "signature": "imageRendering?: \"auto\" | \"pixelated\" | \"crisp-edges\"",
+          "signature": "imageRendering?: \"auto\" | \"crisp-edges\" | \"pixelated\"",
           "signatureTokens": [
             {
               "text": "imageRendering",
@@ -101,7 +101,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"pixelated\"",
+              "text": "\"crisp-edges\"",
               "kind": "keyword"
             },
             {
@@ -109,7 +109,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"crisp-edges\"",
+              "text": "\"pixelated\"",
               "kind": "keyword"
             }
           ],
@@ -119,7 +119,7 @@
         },
         {
           "name": "mount",
-          "signature": "mount?: string | HTMLElement",
+          "signature": "mount?: HTMLElement | string",
           "signatureTokens": [
             {
               "text": "mount",
@@ -134,16 +134,16 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
-              "kind": "keyword"
+              "text": "HTMLElement",
+              "kind": "type"
             },
             {
               "text": " | ",
               "kind": "punctuation"
             },
             {
-              "text": "HTMLElement",
-              "kind": "type"
+              "text": "string",
+              "kind": "keyword"
             }
           ],
           "params": [],

--- a/site/src/content/api/canvas-sizing-mode.json
+++ b/site/src/content/api/canvas-sizing-mode.json
@@ -30,16 +30,8 @@
       "members": [
         {
           "name": "CanvasSizingMode",
-          "signature": "\"fixed\" | \"fill\" | \"fit\" | \"shrink\" | \"letterbox\"",
+          "signature": "\"fill\" | \"fit\" | \"fixed\" | \"letterbox\" | \"shrink\"",
           "signatureTokens": [
-            {
-              "text": "\"fixed\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "\"fill\"",
               "kind": "keyword"
@@ -57,7 +49,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"shrink\"",
+              "text": "\"fixed\"",
               "kind": "keyword"
             },
             {
@@ -66,6 +58,14 @@
             },
             {
               "text": "\"letterbox\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"shrink\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/capabilities.json
+++ b/site/src/content/api/capabilities.json
@@ -354,7 +354,7 @@
         },
         {
           "name": "webgpuArchitecture",
-          "signature": "webgpuArchitecture: string | null",
+          "signature": "webgpuArchitecture: null | string",
           "signatureTokens": [
             {
               "text": "webgpuArchitecture",
@@ -365,7 +365,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -373,7 +373,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -383,7 +383,7 @@
         },
         {
           "name": "webgpuVendor",
-          "signature": "webgpuVendor: string | null",
+          "signature": "webgpuVendor: null | string",
           "signatureTokens": [
             {
               "text": "webgpuVendor",
@@ -394,7 +394,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -402,7 +402,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/catalog-entry.json
+++ b/site/src/content/api/catalog-entry.json
@@ -30,11 +30,11 @@
       "members": [
         {
           "name": "CatalogEntry",
-          "signature": "string | Asset<unknown> | AnyAssetConfig",
+          "signature": "AnyAssetConfig | Asset<unknown> | string",
           "signatureTokens": [
             {
-              "text": "string",
-              "kind": "keyword"
+              "text": "AnyAssetConfig",
+              "kind": "type"
             },
             {
               "text": " | ",
@@ -61,8 +61,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "AnyAssetConfig",
-              "kind": "type"
+              "text": "string",
+              "kind": "keyword"
             }
           ],
           "params": [],

--- a/site/src/content/api/chord-binding.json
+++ b/site/src/content/api/chord-binding.json
@@ -30,11 +30,11 @@
       "members": [
         {
           "name": "ChordBinding",
-          "signature": "string | InputChord | InputAlternation",
+          "signature": "InputAlternation | InputChord | string",
           "signatureTokens": [
             {
-              "text": "string",
-              "kind": "keyword"
+              "text": "InputAlternation",
+              "kind": "type"
             },
             {
               "text": " | ",
@@ -49,8 +49,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "InputAlternation",
-              "kind": "type"
+              "text": "string",
+              "kind": "keyword"
             }
           ],
           "params": [],

--- a/site/src/content/api/circle-area.json
+++ b/site/src/content/api/circle-area.json
@@ -31,7 +31,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(centerX: number, centerY: number, radius: number, mode: \"volume\" | \"edge\"): CircleArea",
+          "signature": "new(centerX: number, centerY: number, radius: number, mode: \"edge\" | \"volume\"): CircleArea",
           "signatureTokens": [
             {
               "text": "new",
@@ -98,7 +98,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"volume\"",
+              "text": "\"edge\"",
               "kind": "keyword"
             },
             {
@@ -106,7 +106,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"edge\"",
+              "text": "\"volume\"",
               "kind": "keyword"
             },
             {
@@ -140,7 +140,7 @@
             },
             {
               "name": "mode",
-              "type": "\"volume\" | \"edge\"",
+              "type": "\"edge\" | \"volume\"",
               "optional": false
             }
           ],
@@ -256,7 +256,7 @@
         },
         {
           "name": "mode",
-          "signature": "mode: \"volume\" | \"edge\"",
+          "signature": "mode: \"edge\" | \"volume\"",
           "signatureTokens": [
             {
               "text": "mode",
@@ -267,7 +267,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"volume\"",
+              "text": "\"edge\"",
               "kind": "keyword"
             },
             {
@@ -275,7 +275,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"edge\"",
+              "text": "\"volume\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/color-texture-format.json
+++ b/site/src/content/api/color-texture-format.json
@@ -31,16 +31,8 @@
       "members": [
         {
           "name": "ColorTextureFormat",
-          "signature": "TextureFormat.Rgba8 | TextureFormat.Rgba16F | TextureFormat.Rgba32F",
+          "signature": "TextureFormat.Rgba16F | TextureFormat.Rgba32F | TextureFormat.Rgba8",
           "signatureTokens": [
-            {
-              "text": "TextureFormat.Rgba8",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "TextureFormat.Rgba16F",
               "kind": "type"
@@ -51,6 +43,14 @@
             },
             {
               "text": "TextureFormat.Rgba32F",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextureFormat.Rgba8",
               "kind": "type"
             }
           ],

--- a/site/src/content/api/container.json
+++ b/site/src/content/api/container.json
@@ -2037,7 +2037,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2048,7 +2048,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2056,7 +2056,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2141,7 +2141,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2152,7 +2152,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2160,7 +2160,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2287,7 +2287,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2298,7 +2298,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2306,7 +2306,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/data-texture-buffer.json
+++ b/site/src/content/api/data-texture-buffer.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "DataTextureBuffer",
-          "signature": "F extends TextureFormat.R8 | TextureFormat.Rgba8 ? Uint8Array : F extends TextureFormat.R32F | TextureFormat.Rgba32F ? Float32Array : Uint8Array | Float32Array",
+          "signature": "F extends TextureFormat.R8 | TextureFormat.Rgba8 ? Uint8Array : F extends TextureFormat.R32F | TextureFormat.Rgba32F ? Float32Array : Float32Array | Uint8Array",
           "signatureTokens": [
             {
               "text": "F",
@@ -113,7 +113,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Uint8Array",
+              "text": "Float32Array",
               "kind": "type"
             },
             {
@@ -121,7 +121,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Float32Array",
+              "text": "Uint8Array",
               "kind": "type"
             }
           ],

--- a/site/src/content/api/data-texture-format.json
+++ b/site/src/content/api/data-texture-format.json
@@ -31,16 +31,8 @@
       "members": [
         {
           "name": "DataTextureFormat",
-          "signature": "TextureFormat.R8 | TextureFormat.R32F | TextureFormat.Rgba8 | TextureFormat.Rgba32F",
+          "signature": "TextureFormat.R32F | TextureFormat.R8 | TextureFormat.Rgba32F | TextureFormat.Rgba8",
           "signatureTokens": [
-            {
-              "text": "TextureFormat.R8",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "TextureFormat.R32F",
               "kind": "type"
@@ -50,7 +42,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "TextureFormat.Rgba8",
+              "text": "TextureFormat.R8",
               "kind": "type"
             },
             {
@@ -59,6 +51,14 @@
             },
             {
               "text": "TextureFormat.Rgba32F",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TextureFormat.Rgba8",
               "kind": "type"
             }
           ],

--- a/site/src/content/api/data-texture.json
+++ b/site/src/content/api/data-texture.json
@@ -695,7 +695,7 @@
         },
         {
           "name": "fromColor",
-          "signature": "fromColor(color: string | Color, size: number): Texture",
+          "signature": "fromColor(color: Color | string, size: number): Texture",
           "signatureTokens": [
             {
               "text": "fromColor",
@@ -714,16 +714,16 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
-              "kind": "keyword"
+              "text": "Color",
+              "kind": "type"
             },
             {
               "text": " | ",
               "kind": "punctuation"
             },
             {
-              "text": "Color",
-              "kind": "type"
+              "text": "string",
+              "kind": "keyword"
             },
             {
               "text": ", ",
@@ -757,7 +757,7 @@
           "params": [
             {
               "name": "color",
-              "type": "string | Color",
+              "type": "Color | string",
               "optional": false
             },
             {

--- a/site/src/content/api/decompress-format.json
+++ b/site/src/content/api/decompress-format.json
@@ -30,16 +30,8 @@
       "members": [
         {
           "name": "DecompressFormat",
-          "signature": "\"gzip\" | \"deflate\" | \"deflate-raw\"",
+          "signature": "\"deflate\" | \"deflate-raw\" | \"gzip\"",
           "signatureTokens": [
-            {
-              "text": "\"gzip\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "\"deflate\"",
               "kind": "keyword"
@@ -50,6 +42,14 @@
             },
             {
               "text": "\"deflate-raw\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"gzip\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/deserialize-context.json
+++ b/site/src/content/api/deserialize-context.json
@@ -77,7 +77,7 @@
         },
         {
           "name": "resolveAsset",
-          "signature": "resolveAsset(source: string | null | undefined, type: AssetConstructor<T>): T | null",
+          "signature": "resolveAsset(source: null | string | undefined, type: AssetConstructor<T>): T | null",
           "signatureTokens": [
             {
               "text": "resolveAsset",
@@ -96,7 +96,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -104,7 +104,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             },
             {
@@ -167,7 +167,7 @@
           "params": [
             {
               "name": "source",
-              "type": "string | null | undefined",
+              "type": "null | string | undefined",
               "optional": false
             },
             {

--- a/site/src/content/api/distance-model.json
+++ b/site/src/content/api/distance-model.json
@@ -31,10 +31,10 @@
       "members": [
         {
           "name": "DistanceModel",
-          "signature": "\"linear\" | \"inverse\" | \"exponential\"",
+          "signature": "\"exponential\" | \"inverse\" | \"linear\"",
           "signatureTokens": [
             {
-              "text": "\"linear\"",
+              "text": "\"exponential\"",
               "kind": "keyword"
             },
             {
@@ -50,7 +50,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"exponential\"",
+              "text": "\"linear\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/drawable.json
+++ b/site/src/content/api/drawable.json
@@ -1675,7 +1675,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -1686,7 +1686,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1694,7 +1694,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -1779,7 +1779,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -1790,7 +1790,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1798,7 +1798,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -1913,7 +1913,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -1924,7 +1924,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -1932,7 +1932,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/extension.json
+++ b/site/src/content/api/extension.json
@@ -31,7 +31,7 @@
       "members": [
         {
           "name": "install",
-          "signature": "install?(app: Application): void | ExtensionDisposer",
+          "signature": "install?(app: Application): ExtensionDisposer | void",
           "signatureTokens": [
             {
               "text": "install",
@@ -66,16 +66,16 @@
               "kind": "punctuation"
             },
             {
-              "text": "void",
-              "kind": "keyword"
+              "text": "ExtensionDisposer",
+              "kind": "type"
             },
             {
               "text": " | ",
               "kind": "punctuation"
             },
             {
-              "text": "ExtensionDisposer",
-              "kind": "type"
+              "text": "void",
+              "kind": "keyword"
             }
           ],
           "params": [
@@ -85,7 +85,7 @@
               "optional": false
             }
           ],
-          "returnType": "void | ExtensionDisposer",
+          "returnType": "ExtensionDisposer | void",
           "description": "Set this application up for whatever the binding arrays cannot express — an app-level System on Application.systems, a subscription on Application.onResize, a MutationObserver, a worker, a debug overlay appended next to the canvas. Runs once per Application, as the final construction step: every core manager and every materialised binding already exists, and dependencies listed in Extension.dependencies are installed first. Return an ExtensionDisposer to undo it. The Application holds the disposers of everything it installed and runs them in reverse installation order — during Application.destroy, or, if a later construction step throws, during that constructor's rollback. Return nothing when there is nothing to undo. A disposer that throws is reported and the remaining ones still run. An extension's lifetime is its Application's lifetime: there is no uninstall at runtime, and no scene-level scope — extensions equip an application, not a scene. install throwing aborts construction, and whatever it had already done before throwing is its own to undo: the disposer it never returned cannot be run for it."
         }
       ],

--- a/site/src/content/api/fade-scene-transition-options.json
+++ b/site/src/content/api/fade-scene-transition-options.json
@@ -105,7 +105,7 @@
         },
         {
           "name": "placement",
-          "signature": "placement?: \"screen\" | \"scene\"",
+          "signature": "placement?: \"scene\" | \"screen\"",
           "signatureTokens": [
             {
               "text": "placement",
@@ -120,7 +120,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"screen\"",
+              "text": "\"scene\"",
               "kind": "keyword"
             },
             {
@@ -128,7 +128,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"scene\"",
+              "text": "\"screen\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/fade-scene-transition.json
+++ b/site/src/content/api/fade-scene-transition.json
@@ -666,7 +666,7 @@
         },
         {
           "name": "placement",
-          "signature": "placement: \"screen\" | \"scene\"",
+          "signature": "placement: \"scene\" | \"screen\"",
           "signatureTokens": [
             {
               "text": "placement",
@@ -677,7 +677,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"screen\"",
+              "text": "\"scene\"",
               "kind": "keyword"
             },
             {
@@ -685,7 +685,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"scene\"",
+              "text": "\"screen\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/font-format.json
+++ b/site/src/content/api/font-format.json
@@ -28,18 +28,10 @@
       "members": [
         {
           "name": "FontFormat",
-          "signature": "\"woff2\" | \"woff\" | \"ttf\" | \"otf\"",
+          "signature": "\"otf\" | \"ttf\" | \"woff\" | \"woff2\"",
           "signatureTokens": [
             {
-              "text": "\"woff2\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"woff\"",
+              "text": "\"otf\"",
               "kind": "keyword"
             },
             {
@@ -55,7 +47,15 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"otf\"",
+              "text": "\"woff\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"woff2\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/font-weight.json
+++ b/site/src/content/api/font-weight.json
@@ -30,24 +30,8 @@
       "members": [
         {
           "name": "FontWeight",
-          "signature": "\"normal\" | \"bold\" | \"100\" | \"200\" | \"300\" | \"400\" | \"500\" | \"600\" | \"700\" | \"800\" | \"900\"",
+          "signature": "\"100\" | \"200\" | \"300\" | \"400\" | \"500\" | \"600\" | \"700\" | \"800\" | \"900\" | \"bold\" | \"normal\"",
           "signatureTokens": [
-            {
-              "text": "\"normal\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"bold\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "\"100\"",
               "kind": "keyword"
@@ -114,6 +98,22 @@
             },
             {
               "text": "\"900\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"bold\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"normal\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/gamepad-axis.json
+++ b/site/src/content/api/gamepad-axis.json
@@ -33,7 +33,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(index: number, channel: GamepadButtonChannel | GamepadAxisChannel, options: GamepadAxisOptions): GamepadAxis",
+          "signature": "new(index: number, channel: GamepadAxisChannel | GamepadButtonChannel, options: GamepadAxisOptions): GamepadAxis",
           "signatureTokens": [
             {
               "text": "new",
@@ -68,7 +68,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -76,7 +76,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -116,7 +116,7 @@
             },
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             },
             {
@@ -237,7 +237,7 @@
         },
         {
           "name": "channel",
-          "signature": "channel: GamepadButtonChannel | GamepadAxisChannel",
+          "signature": "channel: GamepadAxisChannel | GamepadButtonChannel",
           "signatureTokens": [
             {
               "text": "channel",
@@ -248,7 +248,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -256,7 +256,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             }
           ],
@@ -329,7 +329,7 @@
         },
         {
           "name": "pair",
-          "signature": "pair: number | null",
+          "signature": "pair: null | number",
           "signatureTokens": [
             {
               "text": "pair",
@@ -340,7 +340,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -348,7 +348,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/gamepad-definition-result.json
+++ b/site/src/content/api/gamepad-definition-result.json
@@ -31,11 +31,27 @@
       "members": [
         {
           "name": "GamepadDefinitionResult",
-          "signature": "GamepadMapping | { mapping: GamepadMapping; name?: string } | null | undefined",
+          "signature": "GamepadMapping | null | undefined | { mapping: GamepadMapping; name?: string }",
           "signatureTokens": [
             {
               "text": "GamepadMapping",
               "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "undefined",
+              "kind": "keyword"
             },
             {
               "text": " | ",
@@ -80,22 +96,6 @@
             {
               "text": " }",
               "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "undefined",
-              "kind": "keyword"
             }
           ],
           "params": [],

--- a/site/src/content/api/gamepad-descriptor.json
+++ b/site/src/content/api/gamepad-descriptor.json
@@ -115,7 +115,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -126,7 +126,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -134,7 +134,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -144,7 +144,7 @@
         },
         {
           "name": "productId",
-          "signature": "productId: string | null",
+          "signature": "productId: null | string",
           "signatureTokens": [
             {
               "text": "productId",
@@ -155,7 +155,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -163,7 +163,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -173,7 +173,7 @@
         },
         {
           "name": "productKey",
-          "signature": "productKey: string | null",
+          "signature": "productKey: null | string",
           "signatureTokens": [
             {
               "text": "productKey",
@@ -184,7 +184,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -192,7 +192,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -202,7 +202,7 @@
         },
         {
           "name": "vendorId",
-          "signature": "vendorId: string | null",
+          "signature": "vendorId: null | string",
           "signatureTokens": [
             {
               "text": "vendorId",
@@ -213,7 +213,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -221,7 +221,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/gamepad-info.json
+++ b/site/src/content/api/gamepad-info.json
@@ -72,7 +72,7 @@
         },
         {
           "name": "productId",
-          "signature": "productId: string | null",
+          "signature": "productId: null | string",
           "signatureTokens": [
             {
               "text": "productId",
@@ -83,7 +83,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -91,7 +91,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -101,7 +101,7 @@
         },
         {
           "name": "productKey",
-          "signature": "productKey: string | null",
+          "signature": "productKey: null | string",
           "signatureTokens": [
             {
               "text": "productKey",
@@ -112,7 +112,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -120,7 +120,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -130,7 +130,7 @@
         },
         {
           "name": "vendorId",
-          "signature": "vendorId: string | null",
+          "signature": "vendorId: null | string",
           "signatureTokens": [
             {
               "text": "vendorId",
@@ -141,7 +141,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -149,7 +149,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/gamepad-mapping.json
+++ b/site/src/content/api/gamepad-mapping.json
@@ -206,7 +206,7 @@
         },
         {
           "name": "hasChannel",
-          "signature": "hasChannel(channel: GamepadButtonChannel | GamepadAxisChannel): boolean",
+          "signature": "hasChannel(channel: GamepadAxisChannel | GamepadButtonChannel): boolean",
           "signatureTokens": [
             {
               "text": "hasChannel",
@@ -225,7 +225,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -233,7 +233,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -252,7 +252,7 @@
           "params": [
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],

--- a/site/src/content/api/gamepad-prompt-control.json
+++ b/site/src/content/api/gamepad-prompt-control.json
@@ -31,10 +31,10 @@
       "members": [
         {
           "name": "GamepadPromptControl",
-          "signature": "\"DPad\" | \"DPadUp\" | \"DPadDown\" | \"DPadLeft\" | \"DPadRight\" | \"ButtonNorth\" | \"ButtonWest\" | \"ButtonEast\" | \"ButtonSouth\" | \"LeftShoulder\" | \"RightShoulder\" | \"LeftTrigger\" | \"RightTrigger\" | \"Select\" | \"Start\" | \"LeftStick\" | \"RightStick\" | \"Paddle1\" | \"Paddle2\" | \"Paddle3\" | \"Paddle4\"",
+          "signature": "\"ButtonEast\" | \"ButtonNorth\" | \"ButtonSouth\" | \"ButtonWest\" | \"DPad\" | \"DPadDown\" | \"DPadLeft\" | \"DPadRight\" | \"DPadUp\" | \"LeftShoulder\" | \"LeftStick\" | \"LeftTrigger\" | \"Paddle1\" | \"Paddle2\" | \"Paddle3\" | \"Paddle4\" | \"RightShoulder\" | \"RightStick\" | \"RightTrigger\" | \"Select\" | \"Start\"",
           "signatureTokens": [
             {
-              "text": "\"DPad\"",
+              "text": "\"ButtonEast\"",
               "kind": "keyword"
             },
             {
@@ -42,7 +42,31 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"DPadUp\"",
+              "text": "\"ButtonNorth\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"ButtonSouth\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"ButtonWest\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"DPad\"",
               "kind": "keyword"
             },
             {
@@ -74,31 +98,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"ButtonNorth\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"ButtonWest\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"ButtonEast\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"ButtonSouth\"",
+              "text": "\"DPadUp\"",
               "kind": "keyword"
             },
             {
@@ -114,46 +114,6 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"RightShoulder\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"LeftTrigger\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"RightTrigger\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"Select\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"Start\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "\"LeftStick\"",
               "kind": "keyword"
             },
@@ -162,7 +122,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"RightStick\"",
+              "text": "\"LeftTrigger\"",
               "kind": "keyword"
             },
             {
@@ -195,6 +155,46 @@
             },
             {
               "text": "\"Paddle4\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"RightShoulder\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"RightStick\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"RightTrigger\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"Select\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"Start\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/gamepad-slot-strategy.json
+++ b/site/src/content/api/gamepad-slot-strategy.json
@@ -31,10 +31,10 @@
       "members": [
         {
           "name": "GamepadSlotStrategy",
-          "signature": "\"sticky\" | \"compact\"",
+          "signature": "\"compact\" | \"sticky\"",
           "signatureTokens": [
             {
-              "text": "\"sticky\"",
+              "text": "\"compact\"",
               "kind": "keyword"
             },
             {
@@ -42,7 +42,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"compact\"",
+              "text": "\"sticky\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/gamepad.json
+++ b/site/src/content/api/gamepad.json
@@ -162,7 +162,7 @@
         },
         {
           "name": "hasChannel",
-          "signature": "hasChannel(channel: GamepadButtonChannel | GamepadAxisChannel): boolean",
+          "signature": "hasChannel(channel: GamepadAxisChannel | GamepadButtonChannel): boolean",
           "signatureTokens": [
             {
               "text": "hasChannel",
@@ -181,7 +181,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -189,7 +189,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -208,7 +208,7 @@
           "params": [
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],
@@ -765,7 +765,7 @@
         },
         {
           "name": "resolveChannelOffset",
-          "signature": "resolveChannelOffset(channel: GamepadButtonChannel | GamepadAxisChannel): number",
+          "signature": "resolveChannelOffset(channel: GamepadAxisChannel | GamepadButtonChannel): number",
           "signatureTokens": [
             {
               "text": "resolveChannelOffset",
@@ -784,7 +784,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -792,7 +792,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -811,7 +811,7 @@
           "params": [
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],
@@ -908,7 +908,7 @@
         },
         {
           "name": "resolveChannelOffset",
-          "signature": "resolveChannelOffset(slot: number, channel: GamepadButtonChannel | GamepadAxisChannel): number",
+          "signature": "resolveChannelOffset(slot: number, channel: GamepadAxisChannel | GamepadButtonChannel): number",
           "signatureTokens": [
             {
               "text": "resolveChannelOffset",
@@ -943,7 +943,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -951,7 +951,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -975,7 +975,7 @@
             },
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],
@@ -1093,7 +1093,7 @@
         },
         {
           "name": "internalIndex",
-          "signature": "internalIndex: number | null",
+          "signature": "internalIndex: null | number",
           "signatureTokens": [
             {
               "text": "internalIndex",
@@ -1104,7 +1104,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1112,7 +1112,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/generic-dual-analog-gamepad-mapping.json
+++ b/site/src/content/api/generic-dual-analog-gamepad-mapping.json
@@ -196,7 +196,7 @@
         },
         {
           "name": "hasChannel",
-          "signature": "hasChannel(channel: GamepadButtonChannel | GamepadAxisChannel): boolean",
+          "signature": "hasChannel(channel: GamepadAxisChannel | GamepadButtonChannel): boolean",
           "signatureTokens": [
             {
               "text": "hasChannel",
@@ -215,7 +215,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -223,7 +223,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -242,7 +242,7 @@
           "params": [
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],

--- a/site/src/content/api/geometry-usage.json
+++ b/site/src/content/api/geometry-usage.json
@@ -31,10 +31,10 @@
       "members": [
         {
           "name": "GeometryUsage",
-          "signature": "\"static\" | \"dynamic\" | \"stream\"",
+          "signature": "\"dynamic\" | \"static\" | \"stream\"",
           "signatureTokens": [
             {
-              "text": "\"static\"",
+              "text": "\"dynamic\"",
               "kind": "keyword"
             },
             {
@@ -42,7 +42,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"dynamic\"",
+              "text": "\"static\"",
               "kind": "keyword"
             },
             {

--- a/site/src/content/api/glyph-atlas.json
+++ b/site/src/content/api/glyph-atlas.json
@@ -32,7 +32,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(family: string, fontStyle: \"normal\" | \"italic\", fontWeight: string, pageSize: number, mode: AtlasMode, sdfRadius: number): GlyphAtlas",
+          "signature": "new(family: string, fontStyle: \"italic\" | \"normal\", fontWeight: string, pageSize: number, mode: AtlasMode, sdfRadius: number): GlyphAtlas",
           "signatureTokens": [
             {
               "text": "new",
@@ -67,7 +67,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"normal\"",
+              "text": "\"italic\"",
               "kind": "keyword"
             },
             {
@@ -75,7 +75,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"italic\"",
+              "text": "\"normal\"",
               "kind": "keyword"
             },
             {
@@ -163,7 +163,7 @@
             },
             {
               "name": "fontStyle",
-              "type": "\"normal\" | \"italic\"",
+              "type": "\"italic\" | \"normal\"",
               "optional": false
             },
             {

--- a/site/src/content/api/gradient-axis.json
+++ b/site/src/content/api/gradient-axis.json
@@ -28,10 +28,10 @@
       "members": [
         {
           "name": "GradientAxis",
-          "signature": "\"vertical\" | \"horizontal\"",
+          "signature": "\"horizontal\" | \"vertical\"",
           "signatureTokens": [
             {
-              "text": "\"vertical\"",
+              "text": "\"horizontal\"",
               "kind": "keyword"
             },
             {
@@ -39,7 +39,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"horizontal\"",
+              "text": "\"vertical\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/gradient-to-texture-options.json
+++ b/site/src/content/api/gradient-to-texture-options.json
@@ -28,7 +28,7 @@
       "members": [
         {
           "name": "format",
-          "signature": "format?: Rgba8 | Rgba32F",
+          "signature": "format?: Rgba32F | Rgba8",
           "signatureTokens": [
             {
               "text": "format",
@@ -43,7 +43,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rgba8",
+              "text": "Rgba32F",
               "kind": "type"
             },
             {
@@ -51,7 +51,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rgba32F",
+              "text": "Rgba8",
               "kind": "type"
             }
           ],

--- a/site/src/content/api/graphics.json
+++ b/site/src/content/api/graphics.json
@@ -3548,7 +3548,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -3559,7 +3559,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -3567,7 +3567,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -3652,7 +3652,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -3663,7 +3663,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -3671,7 +3671,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -3798,7 +3798,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -3809,7 +3809,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -3817,7 +3817,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/htmltext.json
+++ b/site/src/content/api/htmltext.json
@@ -2281,7 +2281,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2292,7 +2292,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2300,7 +2300,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2385,7 +2385,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2396,7 +2396,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2404,7 +2404,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2531,7 +2531,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2542,7 +2542,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2550,7 +2550,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/image-layer-node.json
+++ b/site/src/content/api/image-layer-node.json
@@ -2056,7 +2056,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2067,7 +2067,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2075,7 +2075,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2160,7 +2160,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2171,7 +2171,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2179,7 +2179,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2306,7 +2306,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2317,7 +2317,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2325,7 +2325,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/image-layer-options.json
+++ b/site/src/content/api/image-layer-options.json
@@ -6,11 +6,11 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "stable",
-  "memberCount": 15,
+  "memberCount": 16,
   "counts": {
     "constructors": 0,
     "methods": 0,
-    "properties": 15,
+    "properties": 16,
     "events": 0
   },
   "sections": [
@@ -196,6 +196,31 @@
           "description": "Layer opacity in [0, 1]. Default 1."
         },
         {
+          "name": "parallaxScale",
+          "signature": "parallaxScale?: number",
+          "signatureTokens": [
+            {
+              "text": "parallaxScale",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Uniform parallax scale around the layer origin. Default 1."
+        },
+        {
           "name": "parallaxX",
           "signature": "parallaxX?: number",
           "signatureTokens": [
@@ -355,7 +380,7 @@
         },
         {
           "name": "tintColor",
-          "signature": "tintColor?: number | null",
+          "signature": "tintColor?: null | number",
           "signatureTokens": [
             {
               "text": "tintColor",
@@ -370,7 +395,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -378,7 +403,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/image-layer.json
+++ b/site/src/content/api/image-layer.json
@@ -6,11 +6,11 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "advanced",
-  "memberCount": 17,
+  "memberCount": 18,
   "counts": {
     "constructors": 1,
     "methods": 0,
-    "properties": 16,
+    "properties": 17,
     "events": 0
   },
   "sections": [
@@ -254,6 +254,27 @@
           "description": "Layer opacity in [0, 1]."
         },
         {
+          "name": "parallaxScale",
+          "signature": "parallaxScale: number",
+          "signatureTokens": [
+            {
+              "text": "parallaxScale",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Uniform scale applied around the layer origin during parallax rendering."
+        },
+        {
           "name": "parallaxX",
           "signature": "parallaxX: number",
           "signatureTokens": [
@@ -389,7 +410,7 @@
         },
         {
           "name": "tintColor",
-          "signature": "tintColor: number | null",
+          "signature": "tintColor: null | number",
           "signatureTokens": [
             {
               "text": "tintColor",
@@ -400,7 +421,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -408,7 +429,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/indexed-db-key-value-store.json
+++ b/site/src/content/api/indexed-db-key-value-store.json
@@ -31,7 +31,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(nameOrOptions: string | IndexedDbKeyValueStoreOptions): IndexedDbKeyValueStore",
+          "signature": "new(nameOrOptions: IndexedDbKeyValueStoreOptions | string): IndexedDbKeyValueStore",
           "signatureTokens": [
             {
               "text": "new",
@@ -50,16 +50,16 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
-              "kind": "keyword"
+              "text": "IndexedDbKeyValueStoreOptions",
+              "kind": "type"
             },
             {
               "text": " | ",
               "kind": "punctuation"
             },
             {
-              "text": "IndexedDbKeyValueStoreOptions",
-              "kind": "type"
+              "text": "string",
+              "kind": "keyword"
             },
             {
               "text": ")",
@@ -77,7 +77,7 @@
           "params": [
             {
               "name": "nameOrOptions",
-              "type": "string | IndexedDbKeyValueStoreOptions",
+              "type": "IndexedDbKeyValueStoreOptions | string",
               "optional": false
             }
           ],

--- a/site/src/content/api/indexed-db-store.json
+++ b/site/src/content/api/indexed-db-store.json
@@ -31,7 +31,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(nameOrOptions: string | IndexedDbStoreOptions): IndexedDbStore",
+          "signature": "new(nameOrOptions: IndexedDbStoreOptions | string): IndexedDbStore",
           "signatureTokens": [
             {
               "text": "new",
@@ -50,16 +50,16 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
-              "kind": "keyword"
+              "text": "IndexedDbStoreOptions",
+              "kind": "type"
             },
             {
               "text": " | ",
               "kind": "punctuation"
             },
             {
-              "text": "IndexedDbStoreOptions",
-              "kind": "type"
+              "text": "string",
+              "kind": "keyword"
             },
             {
               "text": ")",
@@ -77,7 +77,7 @@
           "params": [
             {
               "name": "nameOrOptions",
-              "type": "string | IndexedDbStoreOptions",
+              "type": "IndexedDbStoreOptions | string",
               "optional": false
             }
           ],

--- a/site/src/content/api/input-channel.json
+++ b/site/src/content/api/input-channel.json
@@ -30,16 +30,8 @@
       "members": [
         {
           "name": "InputChannel",
-          "signature": "GamepadButtonChannel | GamepadAxisChannel | PointerChannel | Keyboard | PointerButton",
+          "signature": "GamepadAxisChannel | GamepadButtonChannel | Keyboard | PointerButton | PointerChannel",
           "signatureTokens": [
-            {
-              "text": "GamepadButtonChannel",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "GamepadAxisChannel",
               "kind": "type"
@@ -49,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "PointerChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -66,6 +58,14 @@
             },
             {
               "text": "PointerButton",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PointerChannel",
               "kind": "type"
             }
           ],

--- a/site/src/content/api/input-sequence.json
+++ b/site/src/content/api/input-sequence.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "InputSequence",
-          "signature": "ReadonlyArray<InputChannel | InputChord | InputAlternation>",
+          "signature": "ReadonlyArray<InputAlternation | InputChannel | InputChord>",
           "signatureTokens": [
             {
               "text": "ReadonlyArray",
@@ -38,6 +38,14 @@
             },
             {
               "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InputAlternation",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -50,14 +58,6 @@
             },
             {
               "text": "InputChord",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "InputAlternation",
               "kind": "type"
             },
             {

--- a/site/src/content/api/interaction-event-type.json
+++ b/site/src/content/api/interaction-event-type.json
@@ -30,66 +30,10 @@
       "members": [
         {
           "name": "InteractionEventType",
-          "signature": "\"pointerdown\" | \"pointerup\" | \"pointermove\" | \"pointerover\" | \"pointerout\" | \"pointertap\" | \"contextmenu\" | \"dragstart\" | \"drag\" | \"dragend\"",
+          "signature": "\"contextmenu\" | \"drag\" | \"dragend\" | \"dragstart\" | \"pointerdown\" | \"pointermove\" | \"pointerout\" | \"pointerover\" | \"pointertap\" | \"pointerup\"",
           "signatureTokens": [
             {
-              "text": "\"pointerdown\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"pointerup\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"pointermove\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"pointerover\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"pointerout\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"pointertap\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "\"contextmenu\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"dragstart\"",
               "kind": "keyword"
             },
             {
@@ -106,6 +50,62 @@
             },
             {
               "text": "\"dragend\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"dragstart\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"pointerdown\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"pointermove\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"pointerout\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"pointerover\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"pointertap\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"pointerup\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/joy-con-left-gamepad-mapping.json
+++ b/site/src/content/api/joy-con-left-gamepad-mapping.json
@@ -102,7 +102,7 @@
         },
         {
           "name": "hasChannel",
-          "signature": "hasChannel(channel: GamepadButtonChannel | GamepadAxisChannel): boolean",
+          "signature": "hasChannel(channel: GamepadAxisChannel | GamepadButtonChannel): boolean",
           "signatureTokens": [
             {
               "text": "hasChannel",
@@ -121,7 +121,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -129,7 +129,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -148,7 +148,7 @@
           "params": [
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],

--- a/site/src/content/api/joy-con-right-gamepad-mapping.json
+++ b/site/src/content/api/joy-con-right-gamepad-mapping.json
@@ -101,7 +101,7 @@
         },
         {
           "name": "hasChannel",
-          "signature": "hasChannel(channel: GamepadButtonChannel | GamepadAxisChannel): boolean",
+          "signature": "hasChannel(channel: GamepadAxisChannel | GamepadButtonChannel): boolean",
           "signatureTokens": [
             {
               "text": "hasChannel",
@@ -120,7 +120,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -128,7 +128,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -147,7 +147,7 @@
           "params": [
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],

--- a/site/src/content/api/label.json
+++ b/site/src/content/api/label.json
@@ -2395,7 +2395,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2406,7 +2406,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2414,7 +2414,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2499,7 +2499,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2510,7 +2510,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2518,7 +2518,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2645,7 +2645,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2656,7 +2656,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2664,7 +2664,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/layout-options.json
+++ b/site/src/content/api/layout-options.json
@@ -163,7 +163,7 @@
         },
         {
           "name": "overflow",
-          "signature": "overflow?: \"visible\" | \"clip\" | \"ellipsis\"",
+          "signature": "overflow?: \"clip\" | \"ellipsis\" | \"visible\"",
           "signatureTokens": [
             {
               "text": "overflow",
@@ -178,14 +178,6 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"visible\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "\"clip\"",
               "kind": "keyword"
             },
@@ -196,6 +188,14 @@
             {
               "text": "\"ellipsis\"",
               "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"visible\"",
+              "kind": "keyword"
             }
           ],
           "params": [],
@@ -204,7 +204,7 @@
         },
         {
           "name": "whiteSpace",
-          "signature": "whiteSpace?: \"pre\" | \"normal\" | \"pre-line\"",
+          "signature": "whiteSpace?: \"normal\" | \"pre\" | \"pre-line\"",
           "signatureTokens": [
             {
               "text": "whiteSpace",
@@ -219,7 +219,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"pre\"",
+              "text": "\"normal\"",
               "kind": "keyword"
             },
             {
@@ -227,7 +227,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"normal\"",
+              "text": "\"pre\"",
               "kind": "keyword"
             },
             {

--- a/site/src/content/api/ldtk-field-instance.json
+++ b/site/src/content/api/ldtk-field-instance.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "LdtkFieldInstance",
-          "signature": "{ __identifier: string; __type: LdtkFieldScalarType; __value: string | number | boolean | null } | { __identifier: string; __type: \"Point\"; __value: LdtkFieldPointValue | null } | { __identifier: string; __type: \"EntityRef\"; __value: LdtkFieldEntityRefValue | null } | { __identifier: string; __type: \"Tile\"; __value: LdtkFieldTileValue | null } | { __identifier: string; __type: templateLiteral; __value: readonly unknown[] | null }",
+          "signature": "{ __identifier: string; __type: \"EntityRef\"; __value: LdtkFieldEntityRefValue | null } | { __identifier: string; __type: \"Point\"; __value: LdtkFieldPointValue | null } | { __identifier: string; __type: \"Tile\"; __value: LdtkFieldTileValue | null } | { __identifier: string; __type: LdtkFieldScalarType; __value: boolean | null | number | string } | { __identifier: string; __type: templateLiteral; __value: null | readonly unknown[] }",
           "signatureTokens": [
             {
               "text": "{ ",
@@ -61,8 +61,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "LdtkFieldScalarType",
-              "kind": "type"
+              "text": "\"EntityRef\"",
+              "kind": "keyword"
             },
             {
               "text": "; ",
@@ -77,24 +77,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
+              "text": "LdtkFieldEntityRefValue",
+              "kind": "type"
             },
             {
               "text": " | ",
@@ -158,70 +142,6 @@
             },
             {
               "text": "LdtkFieldPointValue",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
-            },
-            {
-              "text": " }",
-              "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "{ ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "__identifier",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "string",
-              "kind": "keyword"
-            },
-            {
-              "text": "; ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "__type",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"EntityRef\"",
-              "kind": "keyword"
-            },
-            {
-              "text": "; ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "__value",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "LdtkFieldEntityRefValue",
               "kind": "type"
             },
             {
@@ -333,6 +253,86 @@
               "kind": "punctuation"
             },
             {
+              "text": "LdtkFieldScalarType",
+              "kind": "type"
+            },
+            {
+              "text": "; ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "__value",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " }",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "{ ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "__identifier",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": "; ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "__type",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
               "text": "templateLiteral",
               "kind": "keyword"
             },
@@ -346,6 +346,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -363,14 +371,6 @@
             {
               "text": "[]",
               "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
             },
             {
               "text": " }",

--- a/site/src/content/api/ldtk-int-grid-value-def.json
+++ b/site/src/content/api/ldtk-int-grid-value-def.json
@@ -51,7 +51,7 @@
         },
         {
           "name": "identifier",
-          "signature": "identifier: string | null",
+          "signature": "identifier: null | string",
           "signatureTokens": [
             {
               "text": "identifier",
@@ -62,7 +62,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -70,7 +70,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/ldtk-layer-def.json
+++ b/site/src/content/api/ldtk-layer-def.json
@@ -6,11 +6,11 @@
   "subsystem": "ldtk",
   "importPath": "@codexo/exojs-ldtk",
   "tier": "stable",
-  "memberCount": 9,
+  "memberCount": 11,
   "counts": {
     "constructors": 0,
     "methods": 0,
-    "properties": 9,
+    "properties": 11,
     "events": 0
   },
   "sections": [
@@ -180,11 +180,61 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "Whether a non-zero parallax factor also scales this layer up/down to simulate depth. Defaults to true (LDtk's own default) when absent. Parsed and validated for round-trip fidelity, but not currently carried onto any runtime layer — the runtime tilemap model has no field for a parallax-driven scale multiplier (unlike parallaxX/parallaxY, which map onto the existing TileLayer/ObjectLayer fields also used by the Tiled adapter), and whether/how to add one is an open decision."
+          "description": "Whether a non-zero parallax factor also scales this layer up/down to simulate depth. Defaults to true (LDtk's own default) when absent. Converted to the runtime layer's uniform parallaxScale multiplier."
+        },
+        {
+          "name": "pxOffsetX",
+          "signature": "pxOffsetX?: number",
+          "signatureTokens": [
+            {
+              "text": "pxOffsetX",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Definition-level horizontal pixel offset, added to each layer instance offset."
+        },
+        {
+          "name": "pxOffsetY",
+          "signature": "pxOffsetY?: number",
+          "signatureTokens": [
+            {
+              "text": "pxOffsetY",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Definition-level vertical pixel offset, added to each layer instance offset."
         },
         {
           "name": "tilesetDefUid",
-          "signature": "tilesetDefUid?: number | null",
+          "signature": "tilesetDefUid?: null | number",
           "signatureTokens": [
             {
               "text": "tilesetDefUid",
@@ -199,7 +249,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -207,7 +257,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/ldtk-layer-type.json
+++ b/site/src/content/api/ldtk-layer-type.json
@@ -30,18 +30,10 @@
       "members": [
         {
           "name": "LdtkLayerType",
-          "signature": "\"Tiles\" | \"IntGrid\" | \"Entities\" | \"AutoLayer\"",
+          "signature": "\"AutoLayer\" | \"Entities\" | \"IntGrid\" | \"Tiles\"",
           "signatureTokens": [
             {
-              "text": "\"Tiles\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"IntGrid\"",
+              "text": "\"AutoLayer\"",
               "kind": "keyword"
             },
             {
@@ -57,7 +49,15 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"AutoLayer\"",
+              "text": "\"IntGrid\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"Tiles\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/ldtk-level.json
+++ b/site/src/content/api/ldtk-level.json
@@ -159,7 +159,7 @@
         },
         {
           "name": "layerInstances",
-          "signature": "layerInstances: readonly LdtkLayerInstance[] | null",
+          "signature": "layerInstances: null | readonly LdtkLayerInstance[]",
           "signatureTokens": [
             {
               "text": "layerInstances",
@@ -167,6 +167,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -184,14 +192,6 @@
             {
               "text": "[]",
               "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
             }
           ],
           "params": [],

--- a/site/src/content/api/ldtk-tileset-def.json
+++ b/site/src/content/api/ldtk-tileset-def.json
@@ -118,7 +118,7 @@
         },
         {
           "name": "relPath",
-          "signature": "relPath: string | null",
+          "signature": "relPath: null | string",
           "signatureTokens": [
             {
               "text": "relPath",
@@ -129,7 +129,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -137,7 +137,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/load-state-value.json
+++ b/site/src/content/api/load-state-value.json
@@ -30,8 +30,16 @@
       "members": [
         {
           "name": "LoadStateValue",
-          "signature": "\"idle\" | \"loading\" | \"ready\" | \"failed\"",
+          "signature": "\"failed\" | \"idle\" | \"loading\" | \"ready\"",
           "signatureTokens": [
+            {
+              "text": "\"failed\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
             {
               "text": "\"idle\"",
               "kind": "keyword"
@@ -50,14 +58,6 @@
             },
             {
               "text": "\"ready\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"failed\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/loader.json
+++ b/site/src/content/api/loader.json
@@ -789,7 +789,7 @@
         },
         {
           "name": "keyFor",
-          "signature": "keyFor(resource: object): { source: string; type: AssetConstructor } | null",
+          "signature": "keyFor(resource: object): null | { source: string; type: AssetConstructor }",
           "signatureTokens": [
             {
               "text": "keyFor",
@@ -817,6 +817,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -854,14 +862,6 @@
             {
               "text": " }",
               "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
             }
           ],
           "params": [
@@ -871,7 +871,7 @@
               "optional": false
             }
           ],
-          "returnType": "{ source: string; type: AssetConstructor } | null",
+          "returnType": "null | { source: string; type: AssetConstructor }",
           "description": "Reverse lookup: given a loaded resource object, return the asset type and source key it was first loaded under, or null for runtime-created, unloaded, or non-object resources. When a resource is shared across several aliases, the **first** alias it was stored under is returned (the canonical key). Primitive results (parsed JSON, text, CSV rows) are not keyable. Used by scene serialization to turn a live asset reference back into a portable source key; the contract is that the same asset is pre-loaded under that key before a matching deserialize."
         },
         {

--- a/site/src/content/api/loading-queue.json
+++ b/site/src/content/api/loading-queue.json
@@ -61,7 +61,7 @@
         },
         {
           "name": "catch",
-          "signature": "catch(onrejected?: (reason: unknown) => Caught | PromiseLike<Caught> | null): Promise<T | Caught>",
+          "signature": "catch(onrejected?: (reason: unknown) => Caught | PromiseLike<Caught> | null): Promise<Caught | T>",
           "signatureTokens": [
             {
               "text": "catch",
@@ -152,7 +152,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "T",
+              "text": "Caught",
               "kind": "type"
             },
             {
@@ -160,7 +160,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Caught",
+              "text": "T",
               "kind": "type"
             },
             {
@@ -175,7 +175,7 @@
               "optional": true
             }
           ],
-          "returnType": "Promise<T | Caught>",
+          "returnType": "Promise<Caught | T>",
           "description": ""
         },
         {
@@ -259,7 +259,7 @@
         },
         {
           "name": "then",
-          "signature": "then(onfulfilled?: (value: T) => Fulfilled | PromiseLike<Fulfilled> | null, onrejected?: (reason: unknown) => Rejected | PromiseLike<Rejected> | null): Promise<Fulfilled | Rejected>",
+          "signature": "then(onfulfilled?: (value: T) => Fulfilled | PromiseLike<Fulfilled> | null, onrejected?: (reason: unknown) => PromiseLike<Rejected> | Rejected | null): Promise<Fulfilled | Rejected>",
           "signatureTokens": [
             {
               "text": "then",
@@ -370,14 +370,6 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rejected",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "PromiseLike",
               "kind": "type"
             },
@@ -392,6 +384,14 @@
             {
               "text": ">",
               "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Rejected",
+              "kind": "type"
             },
             {
               "text": " | ",
@@ -442,7 +442,7 @@
             },
             {
               "name": "onrejected",
-              "type": "(reason: unknown) => Rejected | PromiseLike<Rejected> | null",
+              "type": "(reason: unknown) => PromiseLike<Rejected> | Rejected | null",
               "optional": true
             }
           ],

--- a/site/src/content/api/mask-source.json
+++ b/site/src/content/api/mask-source.json
@@ -32,7 +32,7 @@
       "members": [
         {
           "name": "MaskSource",
-          "signature": "Rectangle | Texture | RenderTexture | RenderNode | null",
+          "signature": "Rectangle | RenderNode | RenderTexture | Texture | null",
           "signatureTokens": [
             {
               "text": "Rectangle",
@@ -43,7 +43,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderNode",
               "kind": "type"
             },
             {
@@ -59,7 +59,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderNode",
+              "text": "Texture",
               "kind": "type"
             },
             {

--- a/site/src/content/api/material-options.json
+++ b/site/src/content/api/material-options.json
@@ -110,7 +110,7 @@
         },
         {
           "name": "textures",
-          "signature": "textures?: Record<string, Texture | RenderTexture>",
+          "signature": "textures?: Record<string, RenderTexture | Texture>",
           "signatureTokens": [
             {
               "text": "textures",
@@ -141,7 +141,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -149,7 +149,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {

--- a/site/src/content/api/material.json
+++ b/site/src/content/api/material.json
@@ -117,7 +117,7 @@
         },
         {
           "name": "setTexture",
-          "signature": "setTexture(name: string, texture: Texture | RenderTexture): this",
+          "signature": "setTexture(name: string, texture: RenderTexture | Texture): this",
           "signatureTokens": [
             {
               "text": "setTexture",
@@ -152,7 +152,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -160,7 +160,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {
@@ -184,7 +184,7 @@
             },
             {
               "name": "texture",
-              "type": "Texture | RenderTexture",
+              "type": "RenderTexture | Texture",
               "optional": false
             }
           ],
@@ -341,7 +341,7 @@
         },
         {
           "name": "target",
-          "signature": "target: \"mesh\" | \"sprite\" | \"particle\"",
+          "signature": "target: \"mesh\" | \"particle\" | \"sprite\"",
           "signatureTokens": [
             {
               "text": "target",
@@ -360,7 +360,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"sprite\"",
+              "text": "\"particle\"",
               "kind": "keyword"
             },
             {
@@ -368,7 +368,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"particle\"",
+              "text": "\"sprite\"",
               "kind": "keyword"
             }
           ],
@@ -420,7 +420,7 @@
         },
         {
           "name": "textures",
-          "signature": "textures: Record<string, Texture | RenderTexture>",
+          "signature": "textures: Record<string, RenderTexture | Texture>",
           "signatureTokens": [
             {
               "text": "textures",
@@ -447,7 +447,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -455,7 +455,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {

--- a/site/src/content/api/mesh-material.json
+++ b/site/src/content/api/mesh-material.json
@@ -116,7 +116,7 @@
         },
         {
           "name": "setTexture",
-          "signature": "setTexture(name: string, texture: Texture | RenderTexture): this",
+          "signature": "setTexture(name: string, texture: RenderTexture | Texture): this",
           "signatureTokens": [
             {
               "text": "setTexture",
@@ -151,7 +151,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -159,7 +159,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {
@@ -183,7 +183,7 @@
             },
             {
               "name": "texture",
-              "type": "Texture | RenderTexture",
+              "type": "RenderTexture | Texture",
               "optional": false
             }
           ],
@@ -696,7 +696,7 @@
         },
         {
           "name": "textures",
-          "signature": "textures: Record<string, Texture | RenderTexture>",
+          "signature": "textures: Record<string, RenderTexture | Texture>",
           "signatureTokens": [
             {
               "text": "textures",
@@ -723,7 +723,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -731,7 +731,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {

--- a/site/src/content/api/mesh-options.json
+++ b/site/src/content/api/mesh-options.json
@@ -160,7 +160,7 @@
         },
         {
           "name": "texture",
-          "signature": "texture?: Texture | RenderTexture | null",
+          "signature": "texture?: RenderTexture | Texture | null",
           "signatureTokens": [
             {
               "text": "texture",
@@ -175,7 +175,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -183,7 +183,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {

--- a/site/src/content/api/mesh.json
+++ b/site/src/content/api/mesh.json
@@ -1725,7 +1725,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -1736,7 +1736,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1744,7 +1744,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -1829,7 +1829,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -1840,7 +1840,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1848,7 +1848,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -1963,7 +1963,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -1974,7 +1974,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -1982,7 +1982,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {
@@ -2525,7 +2525,7 @@
         },
         {
           "name": "texture",
-          "signature": "texture: Texture | RenderTexture | null",
+          "signature": "texture: RenderTexture | Texture | null",
           "signatureTokens": [
             {
               "text": "texture",
@@ -2536,7 +2536,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -2544,7 +2544,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {

--- a/site/src/content/api/nine-slice-options.json
+++ b/site/src/content/api/nine-slice-options.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "border",
-          "signature": "border?: number | Partial<NineSliceInsets>",
+          "signature": "border?: Partial<NineSliceInsets> | number",
           "signatureTokens": [
             {
               "text": "border",
@@ -42,14 +42,6 @@
             },
             {
               "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -67,6 +59,14 @@
             {
               "text": ">",
               "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
             }
           ],
           "params": [],
@@ -125,7 +125,7 @@
         },
         {
           "name": "slices",
-          "signature": "slices: number | Partial<NineSliceInsets>",
+          "signature": "slices: Partial<NineSliceInsets> | number",
           "signatureTokens": [
             {
               "text": "slices",
@@ -133,14 +133,6 @@
             },
             {
               "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -158,6 +150,14 @@
             {
               "text": ">",
               "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
             }
           ],
           "params": [],

--- a/site/src/content/api/nine-slice-sprite.json
+++ b/site/src/content/api/nine-slice-sprite.json
@@ -1174,7 +1174,7 @@
         },
         {
           "name": "setBorder",
-          "signature": "setBorder(border: number | Partial<NineSliceInsets>): this",
+          "signature": "setBorder(border: Partial<NineSliceInsets> | number): this",
           "signatureTokens": [
             {
               "text": "setBorder",
@@ -1190,14 +1190,6 @@
             },
             {
               "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -1217,6 +1209,14 @@
               "kind": "punctuation"
             },
             {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -1232,7 +1232,7 @@
           "params": [
             {
               "name": "border",
-              "type": "number | Partial<NineSliceInsets>",
+              "type": "Partial<NineSliceInsets> | number",
               "optional": false
             }
           ],
@@ -1675,7 +1675,7 @@
         },
         {
           "name": "setSlices",
-          "signature": "setSlices(slices: number | Partial<NineSliceInsets>): this",
+          "signature": "setSlices(slices: Partial<NineSliceInsets> | number): this",
           "signatureTokens": [
             {
               "text": "setSlices",
@@ -1691,14 +1691,6 @@
             },
             {
               "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -1718,6 +1710,14 @@
               "kind": "punctuation"
             },
             {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
               "text": ")",
               "kind": "punctuation"
             },
@@ -1733,7 +1733,7 @@
           "params": [
             {
               "name": "slices",
-              "type": "number | Partial<NineSliceInsets>",
+              "type": "Partial<NineSliceInsets> | number",
               "optional": false
             }
           ],
@@ -1969,7 +1969,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -1980,7 +1980,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1988,7 +1988,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2073,7 +2073,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2084,7 +2084,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2092,7 +2092,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2240,7 +2240,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2251,7 +2251,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2259,7 +2259,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/object-layer-options.json
+++ b/site/src/content/api/object-layer-options.json
@@ -6,11 +6,11 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "stable",
-  "memberCount": 13,
+  "memberCount": 14,
   "counts": {
     "constructors": 0,
     "methods": 0,
-    "properties": 13,
+    "properties": 14,
     "events": 0
   },
   "sections": [
@@ -55,7 +55,7 @@
         },
         {
           "name": "drawOrder",
-          "signature": "drawOrder?: \"topdown\" | \"index\"",
+          "signature": "drawOrder?: \"index\" | \"topdown\"",
           "signatureTokens": [
             {
               "text": "drawOrder",
@@ -70,7 +70,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"topdown\"",
+              "text": "\"index\"",
               "kind": "keyword"
             },
             {
@@ -78,7 +78,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"index\"",
+              "text": "\"topdown\"",
               "kind": "keyword"
             }
           ],
@@ -257,6 +257,31 @@
           "description": "Layer opacity in [0, 1]. Default 1."
         },
         {
+          "name": "parallaxScale",
+          "signature": "parallaxScale?: number",
+          "signatureTokens": [
+            {
+              "text": "parallaxScale",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Uniform parallax scale around the layer origin. Default 1."
+        },
+        {
           "name": "parallaxX",
           "signature": "parallaxX?: number",
           "signatureTokens": [
@@ -333,7 +358,7 @@
         },
         {
           "name": "tintColor",
-          "signature": "tintColor?: number | null",
+          "signature": "tintColor?: null | number",
           "signatureTokens": [
             {
               "text": "tintColor",
@@ -348,7 +373,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -356,7 +381,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/object-layer.json
+++ b/site/src/content/api/object-layer.json
@@ -1,16 +1,16 @@
 {
   "title": "ObjectLayer",
-  "description": "A data-only layer of TileMapObjects — spawn points, trigger zones, collision regions, markers. Object layers are not rendered by the tile renderer; they are parsed and exposed for gameplay use (e.g. building physics colliders, placing entities). The presentation fields the source format attaches to a layer — visible, opacity, offsetX/offsetY, parallaxX/parallaxY and tintColor — are carried through in full, with any enclosing group layers' contribution already folded in, so an object layer describes the same placement and shading its neighbouring tile and image layers do. Nothing here acts on them: code that draws these objects itself is what applies them. Query with query (untyped, fully back-compatible) or, when an ObjectSchema type argument `S` is supplied, with the typed accessors byType, byKind, and where — these narrow `properties` to the developer-declared shape. The schema is **opt-in**: the default type parameter reproduces the original untyped behaviour, so `new ObjectLayer(options)` and `map.getObjectLayer('x')` are unchanged.",
+  "description": "A data-only layer of TileMapObjects — spawn points, trigger zones, collision regions, markers. Object layers are not rendered by the tile renderer; they are parsed and exposed for gameplay use (e.g. building physics colliders, placing entities). The presentation fields the source format attaches to a layer — visible, opacity, offsetX/offsetY, parallaxX/parallaxY, parallaxScale, and tintColor — are carried through in full, with any enclosing group layers' contribution already folded in, so an object layer describes the same placement and shading its neighbouring tile and image layers do. Nothing here acts on them: code that draws these objects itself is what applies them. Query with query (untyped, fully back-compatible) or, when an ObjectSchema type argument `S` is supplied, with the typed accessors byType, byKind, and where — these narrow `properties` to the developer-declared shape. The schema is **opt-in**: the default type parameter reproduces the original untyped behaviour, so `new ObjectLayer(options)` and `map.getObjectLayer('x')` are unchanged.",
   "symbol": "ObjectLayer",
   "kind": "class",
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "advanced",
-  "memberCount": 21,
+  "memberCount": 22,
   "counts": {
     "constructors": 1,
     "methods": 6,
-    "properties": 14,
+    "properties": 15,
     "events": 0
   },
   "sections": [
@@ -20,7 +20,7 @@
       "members": [],
       "paragraphs": [
         "A data-only layer of TileMapObjects — spawn points, trigger zones, collision regions, markers. Object layers are not rendered by the tile renderer; they are parsed and exposed for gameplay use (e.g. building physics colliders, placing entities).",
-        "The presentation fields the source format attaches to a layer — visible, opacity, offsetX/offsetY, parallaxX/parallaxY and tintColor — are carried through in full, with any enclosing group layers' contribution already folded in, so an object layer describes the same placement and shading its neighbouring tile and image layers do. Nothing here acts on them: code that draws these objects itself is what applies them.",
+        "The presentation fields the source format attaches to a layer — visible, opacity, offsetX/offsetY, parallaxX/parallaxY, parallaxScale, and tintColor — are carried through in full, with any enclosing group layers' contribution already folded in, so an object layer describes the same placement and shading its neighbouring tile and image layers do. Nothing here acts on them: code that draws these objects itself is what applies them.",
         "Query with query (untyped, fully back-compatible) or, when an ObjectSchema type argument `S` is supplied, with the typed accessors byType, byKind, and where — these narrow `properties` to the developer-declared shape. The schema is **opt-in**: the default type parameter reproduces the original untyped behaviour, so `new ObjectLayer(options)` and `map.getObjectLayer('x')` are unchanged."
       ],
       "importLine": "import { ObjectLayer } from '@codexo/exojs-tilemap'",
@@ -100,7 +100,7 @@
       "members": [
         {
           "name": "byKind",
-          "signature": "byKind(kind: K): Extract<RectangleObject<TileProperties>, { kind: K }> | Extract<EllipseObject<TileProperties>, { kind: K }> | Extract<PointObject<TileProperties>, { kind: K }> | Extract<PolygonObject<TileProperties>, { kind: K }> | Extract<PolylineObject<TileProperties>, { kind: K }> | Extract<TileObject<TileProperties>, { kind: K }> | Extract<TextObject<TileProperties>, { kind: K }>[]",
+          "signature": "byKind(kind: K): Extract<EllipseObject<TileProperties>, { kind: K }> | Extract<PointObject<TileProperties>, { kind: K }> | Extract<PolygonObject<TileProperties>, { kind: K }> | Extract<PolylineObject<TileProperties>, { kind: K }> | Extract<RectangleObject<TileProperties>, { kind: K }> | Extract<TextObject<TileProperties>, { kind: K }> | Extract<TileObject<TileProperties>, { kind: K }>[]",
           "signatureTokens": [
             {
               "text": "byKind",
@@ -128,62 +128,6 @@
             },
             {
               "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Extract",
-              "kind": "type"
-            },
-            {
-              "text": "<",
-              "kind": "punctuation"
-            },
-            {
-              "text": "RectangleObject",
-              "kind": "type"
-            },
-            {
-              "text": "<",
-              "kind": "punctuation"
-            },
-            {
-              "text": "TileProperties",
-              "kind": "type"
-            },
-            {
-              "text": ">",
-              "kind": "punctuation"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "{ ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "kind",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "K",
-              "kind": "type"
-            },
-            {
-              "text": " }",
-              "kind": "punctuation"
-            },
-            {
-              "text": ">",
-              "kind": "punctuation"
-            },
-            {
-              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -419,7 +363,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "TileObject",
+              "text": "RectangleObject",
               "kind": "type"
             },
             {
@@ -519,6 +463,62 @@
               "kind": "punctuation"
             },
             {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Extract",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileObject",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileProperties",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "{ ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "kind",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "K",
+              "kind": "type"
+            },
+            {
+              "text": " }",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
               "text": "[]",
               "kind": "punctuation"
             }
@@ -530,7 +530,7 @@
               "optional": false
             }
           ],
-          "returnType": "Extract<RectangleObject<TileProperties>, { kind: K }> | Extract<EllipseObject<TileProperties>, { kind: K }> | Extract<PointObject<TileProperties>, { kind: K }> | Extract<PolygonObject<TileProperties>, { kind: K }> | Extract<PolylineObject<TileProperties>, { kind: K }> | Extract<TileObject<TileProperties>, { kind: K }> | Extract<TextObject<TileProperties>, { kind: K }>[]",
+          "returnType": "Extract<EllipseObject<TileProperties>, { kind: K }> | Extract<PointObject<TileProperties>, { kind: K }> | Extract<PolygonObject<TileProperties>, { kind: K }> | Extract<PolylineObject<TileProperties>, { kind: K }> | Extract<RectangleObject<TileProperties>, { kind: K }> | Extract<TextObject<TileProperties>, { kind: K }> | Extract<TileObject<TileProperties>, { kind: K }>[]",
           "description": "Objects of the given geometry ObjectKind, narrowed to that geometry's member type (e.g. byKind(ObjectKind.Polygon) yields PolygonObjects with their points). Returns a fresh array."
         },
         {
@@ -965,7 +965,7 @@
         },
         {
           "name": "drawOrder",
-          "signature": "drawOrder: \"topdown\" | \"index\"",
+          "signature": "drawOrder: \"index\" | \"topdown\"",
           "signatureTokens": [
             {
               "text": "drawOrder",
@@ -976,7 +976,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"topdown\"",
+              "text": "\"index\"",
               "kind": "keyword"
             },
             {
@@ -984,7 +984,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"index\"",
+              "text": "\"topdown\"",
               "kind": "keyword"
             }
           ],
@@ -1164,6 +1164,27 @@
           "description": "Layer opacity in [0, 1]."
         },
         {
+          "name": "parallaxScale",
+          "signature": "parallaxScale: number",
+          "signatureTokens": [
+            {
+              "text": "parallaxScale",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Uniform scale applied around the layer origin by consumers that render this data-only layer."
+        },
+        {
           "name": "parallaxX",
           "signature": "parallaxX: number",
           "signatureTokens": [
@@ -1228,7 +1249,7 @@
         },
         {
           "name": "tintColor",
-          "signature": "tintColor: number | null",
+          "signature": "tintColor: null | number",
           "signatureTokens": [
             {
               "text": "tintColor",
@@ -1239,7 +1260,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1247,7 +1268,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/oscillator-type.json
+++ b/site/src/content/api/oscillator-type.json
@@ -28,8 +28,16 @@
       "members": [
         {
           "name": "OscillatorType",
-          "signature": "\"sine\" | \"square\" | \"sawtooth\" | \"triangle\"",
+          "signature": "\"sawtooth\" | \"sine\" | \"square\" | \"triangle\"",
           "signatureTokens": [
+            {
+              "text": "\"sawtooth\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
             {
               "text": "\"sine\"",
               "kind": "keyword"
@@ -40,14 +48,6 @@
             },
             {
               "text": "\"square\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"sawtooth\"",
               "kind": "keyword"
             },
             {

--- a/site/src/content/api/panel.json
+++ b/site/src/content/api/panel.json
@@ -2374,7 +2374,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2385,7 +2385,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2393,7 +2393,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2478,7 +2478,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2489,7 +2489,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2497,7 +2497,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2687,7 +2687,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2698,7 +2698,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2706,7 +2706,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/particle-material.json
+++ b/site/src/content/api/particle-material.json
@@ -117,7 +117,7 @@
         },
         {
           "name": "setTexture",
-          "signature": "setTexture(name: string, texture: Texture | RenderTexture): this",
+          "signature": "setTexture(name: string, texture: RenderTexture | Texture): this",
           "signatureTokens": [
             {
               "text": "setTexture",
@@ -152,7 +152,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -160,7 +160,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {
@@ -184,7 +184,7 @@
             },
             {
               "name": "texture",
-              "type": "Texture | RenderTexture",
+              "type": "RenderTexture | Texture",
               "optional": false
             }
           ],
@@ -404,7 +404,7 @@
         },
         {
           "name": "textures",
-          "signature": "textures: Record<string, Texture | RenderTexture>",
+          "signature": "textures: Record<string, RenderTexture | Texture>",
           "signatureTokens": [
             {
               "text": "textures",
@@ -431,7 +431,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -439,7 +439,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {

--- a/site/src/content/api/particle-system.json
+++ b/site/src/content/api/particle-system.json
@@ -2469,7 +2469,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2480,7 +2480,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2488,7 +2488,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2636,7 +2636,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2647,7 +2647,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2655,7 +2655,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2980,7 +2980,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2991,7 +2991,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2999,7 +2999,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/phased-scene-transition-options.json
+++ b/site/src/content/api/phased-scene-transition-options.json
@@ -80,7 +80,7 @@
         },
         {
           "name": "placement",
-          "signature": "placement?: \"screen\" | \"scene\"",
+          "signature": "placement?: \"scene\" | \"screen\"",
           "signatureTokens": [
             {
               "text": "placement",
@@ -95,7 +95,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"screen\"",
+              "text": "\"scene\"",
               "kind": "keyword"
             },
             {
@@ -103,7 +103,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"scene\"",
+              "text": "\"screen\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/phased-scene-transition.json
+++ b/site/src/content/api/phased-scene-transition.json
@@ -704,7 +704,7 @@
         },
         {
           "name": "placement",
-          "signature": "placement: \"screen\" | \"scene\"",
+          "signature": "placement: \"scene\" | \"screen\"",
           "signatureTokens": [
             {
               "text": "placement",
@@ -715,7 +715,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"screen\"",
+              "text": "\"scene\"",
               "kind": "keyword"
             },
             {
@@ -723,7 +723,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"scene\"",
+              "text": "\"screen\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/play-station-gamepad-mapping.json
+++ b/site/src/content/api/play-station-gamepad-mapping.json
@@ -117,7 +117,7 @@
         },
         {
           "name": "hasChannel",
-          "signature": "hasChannel(channel: GamepadButtonChannel | GamepadAxisChannel): boolean",
+          "signature": "hasChannel(channel: GamepadAxisChannel | GamepadButtonChannel): boolean",
           "signatureTokens": [
             {
               "text": "hasChannel",
@@ -136,7 +136,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -144,7 +144,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -163,7 +163,7 @@
           "params": [
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],

--- a/site/src/content/api/progress-bar.json
+++ b/site/src/content/api/progress-bar.json
@@ -2374,7 +2374,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2385,7 +2385,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2393,7 +2393,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2478,7 +2478,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2489,7 +2489,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2497,7 +2497,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2624,7 +2624,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2635,7 +2635,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2643,7 +2643,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/render-error-code.json
+++ b/site/src/content/api/render-error-code.json
@@ -30,8 +30,40 @@
       "members": [
         {
           "name": "RenderErrorCode",
-          "signature": "\"shader-compile\" | \"shader-link\" | \"pipeline-creation\" | \"validation\" | \"out-of-memory\" | \"internal\" | \"device-recovery-failed\"",
+          "signature": "\"device-recovery-failed\" | \"internal\" | \"out-of-memory\" | \"pipeline-creation\" | \"shader-compile\" | \"shader-link\" | \"validation\"",
           "signatureTokens": [
+            {
+              "text": "\"device-recovery-failed\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"internal\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"out-of-memory\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"pipeline-creation\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
             {
               "text": "\"shader-compile\"",
               "kind": "keyword"
@@ -49,39 +81,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"pipeline-creation\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "\"validation\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"out-of-memory\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"internal\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"device-recovery-failed\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/render-error.json
+++ b/site/src/content/api/render-error.json
@@ -154,7 +154,7 @@
         },
         {
           "name": "detail",
-          "signature": "detail: string | null",
+          "signature": "detail: null | string",
           "signatureTokens": [
             {
               "text": "detail",
@@ -165,7 +165,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -173,7 +173,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -225,7 +225,7 @@
         },
         {
           "name": "resource",
-          "signature": "resource: string | null",
+          "signature": "resource: null | string",
           "signatureTokens": [
             {
               "text": "resource",
@@ -236,7 +236,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -244,7 +244,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/render-node.json
+++ b/site/src/content/api/render-node.json
@@ -1484,7 +1484,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -1495,7 +1495,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1503,7 +1503,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -1588,7 +1588,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -1599,7 +1599,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1607,7 +1607,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -1680,7 +1680,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -1691,7 +1691,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -1699,7 +1699,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/repeat-mode.json
+++ b/site/src/content/api/repeat-mode.json
@@ -31,10 +31,10 @@
       "members": [
         {
           "name": "RepeatMode",
-          "signature": "\"stretch\" | \"repeat\" | \"mirror-repeat\"",
+          "signature": "\"mirror-repeat\" | \"repeat\" | \"stretch\"",
           "signatureTokens": [
             {
-              "text": "\"stretch\"",
+              "text": "\"mirror-repeat\"",
               "kind": "keyword"
             },
             {
@@ -50,7 +50,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"mirror-repeat\"",
+              "text": "\"stretch\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/repeating-sprite.json
+++ b/site/src/content/api/repeating-sprite.json
@@ -1864,7 +1864,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -1875,7 +1875,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1883,7 +1883,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -1968,7 +1968,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -1979,7 +1979,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1987,7 +1987,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2102,7 +2102,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2113,7 +2113,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2121,7 +2121,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -2113,7 +2113,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2124,7 +2124,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2132,7 +2132,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2217,7 +2217,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2228,7 +2228,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2236,7 +2236,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2363,7 +2363,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2374,7 +2374,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2382,7 +2382,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/scene-instance-kind.json
+++ b/site/src/content/api/scene-instance-kind.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "SceneInstanceKind",
-          "signature": "\"active\" | \"retained\" | \"preloaded\"",
+          "signature": "\"active\" | \"preloaded\" | \"retained\"",
           "signatureTokens": [
             {
               "text": "\"active\"",
@@ -41,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"retained\"",
+              "text": "\"preloaded\"",
               "kind": "keyword"
             },
             {
@@ -49,7 +49,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"preloaded\"",
+              "text": "\"retained\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/scene-node.json
+++ b/site/src/content/api/scene-node.json
@@ -1171,7 +1171,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -1182,7 +1182,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1190,7 +1190,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/scene-transition-lifecycle-error.json
+++ b/site/src/content/api/scene-transition-lifecycle-error.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(reason: \"commit-reentrant\" | \"done-before-commit\" | \"aborted\"): SceneTransitionLifecycleError",
+          "signature": "new(reason: \"aborted\" | \"commit-reentrant\" | \"done-before-commit\"): SceneTransitionLifecycleError",
           "signatureTokens": [
             {
               "text": "new",
@@ -49,6 +49,14 @@
               "kind": "punctuation"
             },
             {
+              "text": "\"aborted\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
               "text": "\"commit-reentrant\"",
               "kind": "keyword"
             },
@@ -58,14 +66,6 @@
             },
             {
               "text": "\"done-before-commit\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"aborted\"",
               "kind": "keyword"
             },
             {
@@ -84,7 +84,7 @@
           "params": [
             {
               "name": "reason",
-              "type": "\"commit-reentrant\" | \"done-before-commit\" | \"aborted\"",
+              "type": "\"aborted\" | \"commit-reentrant\" | \"done-before-commit\"",
               "optional": false
             }
           ],
@@ -169,7 +169,7 @@
         },
         {
           "name": "reason",
-          "signature": "reason: \"commit-reentrant\" | \"done-before-commit\" | \"aborted\"",
+          "signature": "reason: \"aborted\" | \"commit-reentrant\" | \"done-before-commit\"",
           "signatureTokens": [
             {
               "text": "reason",
@@ -177,6 +177,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"aborted\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -189,14 +197,6 @@
             },
             {
               "text": "\"done-before-commit\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"aborted\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/scene-transition-phase-requirements.json
+++ b/site/src/content/api/scene-transition-phase-requirements.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "currentFrame",
-          "signature": "currentFrame: \"none\" | \"texture\" | \"direct\"",
+          "signature": "currentFrame: \"direct\" | \"none\" | \"texture\"",
           "signatureTokens": [
             {
               "text": "currentFrame",
@@ -38,6 +38,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"direct\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -50,14 +58,6 @@
             },
             {
               "text": "\"texture\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"direct\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/scene-transition-requirements.json
+++ b/site/src/content/api/scene-transition-requirements.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "currentFrame",
-          "signature": "currentFrame: \"none\" | \"texture\" | \"direct\"",
+          "signature": "currentFrame: \"direct\" | \"none\" | \"texture\"",
           "signatureTokens": [
             {
               "text": "currentFrame",
@@ -38,6 +38,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"direct\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -50,14 +58,6 @@
             },
             {
               "text": "\"texture\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"direct\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/scene-transition-session.json
+++ b/site/src/content/api/scene-transition-session.json
@@ -204,7 +204,7 @@
         },
         {
           "name": "placement",
-          "signature": "placement: \"screen\" | \"scene\"",
+          "signature": "placement: \"scene\" | \"screen\"",
           "signatureTokens": [
             {
               "text": "placement",
@@ -215,7 +215,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"screen\"",
+              "text": "\"scene\"",
               "kind": "keyword"
             },
             {
@@ -223,7 +223,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"scene\"",
+              "text": "\"screen\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/scene.json
+++ b/site/src/content/api/scene.json
@@ -373,7 +373,7 @@
         },
         {
           "name": "load",
-          "signature": "load(_data: Readonly<Data>): void | Promise<void>",
+          "signature": "load(_data: Readonly<Data>): Promise<void> | void",
           "signatureTokens": [
             {
               "text": "load",
@@ -416,14 +416,6 @@
               "kind": "punctuation"
             },
             {
-              "text": "void",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "Promise",
               "kind": "type"
             },
@@ -438,6 +430,14 @@
             {
               "text": ">",
               "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
             }
           ],
           "params": [
@@ -447,7 +447,7 @@
               "optional": false
             }
           ],
-          "returnType": "void | Promise<void>",
+          "returnType": "Promise<void> | void",
           "description": "Optional asynchronous loading hook. Runs once per activation, before Scene.init: initial asset loading, activation-data-dependent asset selection, remote/storage reads, or any other work that must complete before synchronous setup. Reach the loader via this.loader (scene lifetime) or this.app.loader (app lifetime). Override in subclass."
         },
         {
@@ -622,7 +622,7 @@
         },
         {
           "name": "unload",
-          "signature": "unload(): void | Promise<void>",
+          "signature": "unload(): Promise<void> | void",
           "signatureTokens": [
             {
               "text": "unload",
@@ -641,14 +641,6 @@
               "kind": "punctuation"
             },
             {
-              "text": "void",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "Promise",
               "kind": "type"
             },
@@ -663,10 +655,18 @@
             {
               "text": ">",
               "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
             }
           ],
           "params": [],
-          "returnType": "void | Promise<void>",
+          "returnType": "Promise<void> | void",
           "description": "Optional asynchronous teardown hook for a scene that completed activation successfully and is ending permanently. Use the loader to release assets that are scene-private and not shared with a scene that remains active. Not called for a scene that never completed activation (see the definition spec's failed-activation cleanup). Override in subclass."
         },
         {

--- a/site/src/content/api/scroll-container.json
+++ b/site/src/content/api/scroll-container.json
@@ -2533,7 +2533,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2544,7 +2544,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2552,7 +2552,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2637,7 +2637,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2648,7 +2648,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2656,7 +2656,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2783,7 +2783,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2794,7 +2794,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2802,7 +2802,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/scroll-direction.json
+++ b/site/src/content/api/scroll-direction.json
@@ -30,10 +30,10 @@
       "members": [
         {
           "name": "ScrollDirection",
-          "signature": "\"vertical\" | \"horizontal\" | \"both\"",
+          "signature": "\"both\" | \"horizontal\" | \"vertical\"",
           "signatureTokens": [
             {
-              "text": "\"vertical\"",
+              "text": "\"both\"",
               "kind": "keyword"
             },
             {
@@ -49,7 +49,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"both\"",
+              "text": "\"vertical\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/sequence-binding.json
+++ b/site/src/content/api/sequence-binding.json
@@ -30,19 +30,19 @@
       "members": [
         {
           "name": "SequenceBinding",
-          "signature": "string | InputSequence",
+          "signature": "InputSequence | string",
           "signatureTokens": [
             {
-              "text": "string",
-              "kind": "keyword"
+              "text": "InputSequence",
+              "kind": "type"
             },
             {
               "text": " | ",
               "kind": "punctuation"
             },
             {
-              "text": "InputSequence",
-              "kind": "type"
+              "text": "string",
+              "kind": "keyword"
             }
           ],
           "params": [],

--- a/site/src/content/api/serialize-context.json
+++ b/site/src/content/api/serialize-context.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "keyFor",
-          "signature": "keyFor(resource: object | null | undefined): string | null",
+          "signature": "keyFor(resource: null | object | undefined): null | string",
           "signatureTokens": [
             {
               "text": "keyFor",
@@ -49,7 +49,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "object",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -57,7 +57,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "object",
               "kind": "keyword"
             },
             {
@@ -77,7 +77,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -85,18 +85,18 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
           "params": [
             {
               "name": "resource",
-              "type": "object | null | undefined",
+              "type": "null | object | undefined",
               "optional": false
             }
           ],
-          "returnType": "string | null",
+          "returnType": "null | string",
           "description": "Resolve a loaded asset object to the loader source key it was loaded under, or null for runtime-created / unkeyed resources (a one-time warning is emitted in that case)."
         },
         {

--- a/site/src/content/api/shader-filter-uniform-value.json
+++ b/site/src/content/api/shader-filter-uniform-value.json
@@ -30,136 +30,8 @@
       "members": [
         {
           "name": "ShaderFilterUniformValue",
-          "signature": "number | readonly [number, number] | readonly [number, number, number] | readonly [number, number, number, number] | Float32Array | Int32Array | Texture | RenderTexture",
+          "signature": "Float32Array | Int32Array | RenderTexture | Texture | number | readonly [number, number, number, number] | readonly [number, number, number] | readonly [number, number]",
           "signatureTokens": [
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "readonly",
-              "kind": "keyword"
-            },
-            {
-              "text": " ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "[",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": "]",
-              "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "readonly",
-              "kind": "keyword"
-            },
-            {
-              "text": " ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "[",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": "]",
-              "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "readonly",
-              "kind": "keyword"
-            },
-            {
-              "text": " ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "[",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": "]",
-              "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "Float32Array",
               "kind": "type"
@@ -177,6 +49,14 @@
               "kind": "punctuation"
             },
             {
+              "text": "RenderTexture",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
               "text": "Texture",
               "kind": "type"
             },
@@ -185,8 +65,128 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
-              "kind": "type"
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
             }
           ],
           "params": [],

--- a/site/src/content/api/shader-source.json
+++ b/site/src/content/api/shader-source.json
@@ -301,7 +301,7 @@
       "members": [
         {
           "name": "glsl",
-          "signature": "glsl: { fragment: string; vertex: string } | null",
+          "signature": "glsl: null | { fragment: string; vertex: string }",
           "signatureTokens": [
             {
               "text": "glsl",
@@ -309,6 +309,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -346,14 +354,6 @@
             {
               "text": " }",
               "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
             }
           ],
           "params": [],
@@ -362,7 +362,7 @@
         },
         {
           "name": "wgsl",
-          "signature": "wgsl: string | null",
+          "signature": "wgsl: null | string",
           "signatureTokens": [
             {
               "text": "wgsl",
@@ -373,7 +373,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -381,7 +381,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/slide-direction.json
+++ b/site/src/content/api/slide-direction.json
@@ -30,8 +30,16 @@
       "members": [
         {
           "name": "SlideDirection",
-          "signature": "\"left\" | \"right\" | \"up\" | \"down\"",
+          "signature": "\"down\" | \"left\" | \"right\" | \"up\"",
           "signatureTokens": [
+            {
+              "text": "\"down\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
             {
               "text": "\"left\"",
               "kind": "keyword"
@@ -50,14 +58,6 @@
             },
             {
               "text": "\"up\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"down\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/slide-mode.json
+++ b/site/src/content/api/slide-mode.json
@@ -30,10 +30,10 @@
       "members": [
         {
           "name": "SlideMode",
-          "signature": "\"push\" | \"cover\" | \"reveal\"",
+          "signature": "\"cover\" | \"push\" | \"reveal\"",
           "signatureTokens": [
             {
-              "text": "\"push\"",
+              "text": "\"cover\"",
               "kind": "keyword"
             },
             {
@@ -41,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"cover\"",
+              "text": "\"push\"",
               "kind": "keyword"
             },
             {

--- a/site/src/content/api/slide-scene-transition-options.json
+++ b/site/src/content/api/slide-scene-transition-options.json
@@ -130,7 +130,7 @@
         },
         {
           "name": "placement",
-          "signature": "placement?: \"screen\" | \"scene\"",
+          "signature": "placement?: \"scene\" | \"screen\"",
           "signatureTokens": [
             {
               "text": "placement",
@@ -145,7 +145,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"screen\"",
+              "text": "\"scene\"",
               "kind": "keyword"
             },
             {
@@ -153,7 +153,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"scene\"",
+              "text": "\"screen\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/slide-scene-transition.json
+++ b/site/src/content/api/slide-scene-transition.json
@@ -734,7 +734,7 @@
         },
         {
           "name": "placement",
-          "signature": "placement: \"screen\" | \"scene\"",
+          "signature": "placement: \"scene\" | \"screen\"",
           "signatureTokens": [
             {
               "text": "placement",
@@ -745,7 +745,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"screen\"",
+              "text": "\"scene\"",
               "kind": "keyword"
             },
             {
@@ -753,7 +753,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"scene\"",
+              "text": "\"screen\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/sprite-material.json
+++ b/site/src/content/api/sprite-material.json
@@ -116,7 +116,7 @@
         },
         {
           "name": "setTexture",
-          "signature": "setTexture(name: string, texture: Texture | RenderTexture): this",
+          "signature": "setTexture(name: string, texture: RenderTexture | Texture): this",
           "signatureTokens": [
             {
               "text": "setTexture",
@@ -151,7 +151,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -159,7 +159,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {
@@ -183,7 +183,7 @@
             },
             {
               "name": "texture",
-              "type": "Texture | RenderTexture",
+              "type": "RenderTexture | Texture",
               "optional": false
             }
           ],
@@ -696,7 +696,7 @@
         },
         {
           "name": "textures",
-          "signature": "textures: Record<string, Texture | RenderTexture>",
+          "signature": "textures: Record<string, RenderTexture | Texture>",
           "signatureTokens": [
             {
               "text": "textures",
@@ -723,7 +723,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -731,7 +731,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {

--- a/site/src/content/api/sprite.json
+++ b/site/src/content/api/sprite.json
@@ -32,7 +32,7 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(texture: Texture | RenderTexture | null): Sprite",
+          "signature": "new(texture: RenderTexture | Texture | null): Sprite",
           "signatureTokens": [
             {
               "text": "new",
@@ -51,7 +51,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -59,7 +59,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {
@@ -86,7 +86,7 @@
           "params": [
             {
               "name": "texture",
-              "type": "Texture | RenderTexture | null",
+              "type": "RenderTexture | Texture | null",
               "optional": false
             }
           ],
@@ -1511,7 +1511,7 @@
         },
         {
           "name": "setTexture",
-          "signature": "setTexture(texture: Texture | RenderTexture | null): this",
+          "signature": "setTexture(texture: RenderTexture | Texture | null): this",
           "signatureTokens": [
             {
               "text": "setTexture",
@@ -1530,7 +1530,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -1538,7 +1538,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {
@@ -1565,7 +1565,7 @@
           "params": [
             {
               "name": "texture",
-              "type": "Texture | RenderTexture | null",
+              "type": "RenderTexture | Texture | null",
               "optional": false
             }
           ],
@@ -1898,7 +1898,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -1909,7 +1909,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1917,7 +1917,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2002,7 +2002,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2013,7 +2013,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2021,7 +2021,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2136,7 +2136,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2147,7 +2147,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2155,7 +2155,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {
@@ -2608,7 +2608,7 @@
         },
         {
           "name": "texture",
-          "signature": "texture: Texture | RenderTexture | null",
+          "signature": "texture: RenderTexture | Texture | null",
           "signatureTokens": [
             {
               "text": "texture",
@@ -2619,7 +2619,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -2627,7 +2627,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {

--- a/site/src/content/api/stack-direction.json
+++ b/site/src/content/api/stack-direction.json
@@ -28,10 +28,10 @@
       "members": [
         {
           "name": "StackDirection",
-          "signature": "\"row\" | \"column\"",
+          "signature": "\"column\" | \"row\"",
           "signatureTokens": [
             {
-              "text": "\"row\"",
+              "text": "\"column\"",
               "kind": "keyword"
             },
             {
@@ -39,7 +39,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"column\"",
+              "text": "\"row\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/stack.json
+++ b/site/src/content/api/stack.json
@@ -2450,7 +2450,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2461,7 +2461,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2469,7 +2469,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2554,7 +2554,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2565,7 +2565,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2573,7 +2573,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2700,7 +2700,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2711,7 +2711,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2719,7 +2719,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/steam-controller-gamepad-mapping.json
+++ b/site/src/content/api/steam-controller-gamepad-mapping.json
@@ -194,7 +194,7 @@
         },
         {
           "name": "hasChannel",
-          "signature": "hasChannel(channel: GamepadButtonChannel | GamepadAxisChannel): boolean",
+          "signature": "hasChannel(channel: GamepadAxisChannel | GamepadButtonChannel): boolean",
           "signatureTokens": [
             {
               "text": "hasChannel",
@@ -213,7 +213,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -221,7 +221,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -240,7 +240,7 @@
           "params": [
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],

--- a/site/src/content/api/steam-deck-gamepad-mapping.json
+++ b/site/src/content/api/steam-deck-gamepad-mapping.json
@@ -99,7 +99,7 @@
         },
         {
           "name": "hasChannel",
-          "signature": "hasChannel(channel: GamepadButtonChannel | GamepadAxisChannel): boolean",
+          "signature": "hasChannel(channel: GamepadAxisChannel | GamepadButtonChannel): boolean",
           "signatureTokens": [
             {
               "text": "hasChannel",
@@ -118,7 +118,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -126,7 +126,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -145,7 +145,7 @@
           "params": [
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],

--- a/site/src/content/api/streaming-load-event.json
+++ b/site/src/content/api/streaming-load-event.json
@@ -30,10 +30,18 @@
       "members": [
         {
           "name": "StreamingLoadEvent",
-          "signature": "\"loadedmetadata\" | \"loadeddata\" | \"canplay\" | \"canplaythrough\"",
+          "signature": "\"canplay\" | \"canplaythrough\" | \"loadeddata\" | \"loadedmetadata\"",
           "signatureTokens": [
             {
-              "text": "\"loadedmetadata\"",
+              "text": "\"canplay\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"canplaythrough\"",
               "kind": "keyword"
             },
             {
@@ -49,15 +57,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"canplay\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"canplaythrough\"",
+              "text": "\"loadedmetadata\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/style-change-hint.json
+++ b/site/src/content/api/style-change-hint.json
@@ -31,10 +31,10 @@
       "members": [
         {
           "name": "StyleChangeHint",
-          "signature": "\"tint\" | \"layout\" | \"font\"",
+          "signature": "\"font\" | \"layout\" | \"tint\"",
           "signatureTokens": [
             {
-              "text": "\"tint\"",
+              "text": "\"font\"",
               "kind": "keyword"
             },
             {
@@ -50,7 +50,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"font\"",
+              "text": "\"tint\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/switch-pro-gamepad-mapping.json
+++ b/site/src/content/api/switch-pro-gamepad-mapping.json
@@ -99,7 +99,7 @@
         },
         {
           "name": "hasChannel",
-          "signature": "hasChannel(channel: GamepadButtonChannel | GamepadAxisChannel): boolean",
+          "signature": "hasChannel(channel: GamepadAxisChannel | GamepadButtonChannel): boolean",
           "signatureTokens": [
             {
               "text": "hasChannel",
@@ -118,7 +118,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -126,7 +126,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -145,7 +145,7 @@
           "params": [
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],

--- a/site/src/content/api/synchronous.json
+++ b/site/src/content/api/synchronous.json
@@ -33,16 +33,8 @@
       "members": [
         {
           "name": "Synchronous",
-          "signature": "void | object & { then?: never }",
+          "signature": "object & { then?: never } | void",
           "signatureTokens": [
-            {
-              "text": "void",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "object",
               "kind": "keyword"
@@ -74,6 +66,14 @@
             {
               "text": " }",
               "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
             }
           ],
           "params": [],

--- a/site/src/content/api/system-phase.json
+++ b/site/src/content/api/system-phase.json
@@ -30,10 +30,10 @@
       "members": [
         {
           "name": "SystemPhase",
-          "signature": "\"preUpdate\" | \"fixedUpdate\" | \"update\" | \"draw\"",
+          "signature": "\"draw\" | \"fixedUpdate\" | \"preUpdate\" | \"update\"",
           "signatureTokens": [
             {
-              "text": "\"preUpdate\"",
+              "text": "\"draw\"",
               "kind": "keyword"
             },
             {
@@ -49,7 +49,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"update\"",
+              "text": "\"preUpdate\"",
               "kind": "keyword"
             },
             {
@@ -57,7 +57,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"draw\"",
+              "text": "\"update\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/text-alignment.json
+++ b/site/src/content/api/text-alignment.json
@@ -30,16 +30,8 @@
       "members": [
         {
           "name": "TextAlignment",
-          "signature": "\"left\" | \"center\" | \"right\" | \"justify\"",
+          "signature": "\"center\" | \"justify\" | \"left\" | \"right\"",
           "signatureTokens": [
-            {
-              "text": "\"left\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "\"center\"",
               "kind": "keyword"
@@ -49,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"right\"",
+              "text": "\"justify\"",
               "kind": "keyword"
             },
             {
@@ -57,7 +49,15 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"justify\"",
+              "text": "\"left\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"right\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/text-options.json
+++ b/site/src/content/api/text-options.json
@@ -239,7 +239,7 @@
         },
         {
           "name": "fontStyle",
-          "signature": "fontStyle?: \"normal\" | \"italic\"",
+          "signature": "fontStyle?: \"italic\" | \"normal\"",
           "signatureTokens": [
             {
               "text": "fontStyle",
@@ -254,7 +254,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"normal\"",
+              "text": "\"italic\"",
               "kind": "keyword"
             },
             {
@@ -262,7 +262,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"italic\"",
+              "text": "\"normal\"",
               "kind": "keyword"
             }
           ],
@@ -546,7 +546,7 @@
         },
         {
           "name": "overflow",
-          "signature": "overflow?: \"visible\" | \"clip\" | \"ellipsis\"",
+          "signature": "overflow?: \"clip\" | \"ellipsis\" | \"visible\"",
           "signatureTokens": [
             {
               "text": "overflow",
@@ -561,14 +561,6 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"visible\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "\"clip\"",
               "kind": "keyword"
             },
@@ -578,6 +570,14 @@
             },
             {
               "text": "\"ellipsis\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"visible\"",
               "kind": "keyword"
             }
           ],
@@ -737,7 +737,7 @@
         },
         {
           "name": "whiteSpace",
-          "signature": "whiteSpace?: \"pre\" | \"normal\" | \"pre-line\"",
+          "signature": "whiteSpace?: \"normal\" | \"pre\" | \"pre-line\"",
           "signatureTokens": [
             {
               "text": "whiteSpace",
@@ -752,7 +752,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"pre\"",
+              "text": "\"normal\"",
               "kind": "keyword"
             },
             {
@@ -760,7 +760,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"normal\"",
+              "text": "\"pre\"",
               "kind": "keyword"
             },
             {

--- a/site/src/content/api/text-style-2.json
+++ b/site/src/content/api/text-style-2.json
@@ -55,7 +55,7 @@
         },
         {
           "name": "color",
-          "signature": "color?: number | null",
+          "signature": "color?: null | number",
           "signatureTokens": [
             {
               "text": "color",
@@ -70,7 +70,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -78,7 +78,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],
@@ -113,7 +113,7 @@
         },
         {
           "name": "halign",
-          "signature": "halign?: \"left\" | \"right\" | \"center\" | \"justify\"",
+          "signature": "halign?: \"center\" | \"justify\" | \"left\" | \"right\"",
           "signatureTokens": [
             {
               "text": "halign",
@@ -128,22 +128,6 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"left\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"right\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "\"center\"",
               "kind": "keyword"
             },
@@ -153,6 +137,22 @@
             },
             {
               "text": "\"justify\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"left\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"right\"",
               "kind": "keyword"
             }
           ],
@@ -283,7 +283,7 @@
         },
         {
           "name": "valign",
-          "signature": "valign?: \"top\" | \"bottom\" | \"center\"",
+          "signature": "valign?: \"bottom\" | \"center\" | \"top\"",
           "signatureTokens": [
             {
               "text": "valign",
@@ -298,14 +298,6 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"top\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "\"bottom\"",
               "kind": "keyword"
             },
@@ -315,6 +307,14 @@
             },
             {
               "text": "\"center\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"top\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/text-style-options.json
+++ b/site/src/content/api/text-style-options.json
@@ -155,7 +155,7 @@
         },
         {
           "name": "fontStyle",
-          "signature": "fontStyle?: \"normal\" | \"italic\"",
+          "signature": "fontStyle?: \"italic\" | \"normal\"",
           "signatureTokens": [
             {
               "text": "fontStyle",
@@ -170,7 +170,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"normal\"",
+              "text": "\"italic\"",
               "kind": "keyword"
             },
             {
@@ -178,7 +178,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"italic\"",
+              "text": "\"normal\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/text-style.json
+++ b/site/src/content/api/text-style.json
@@ -315,7 +315,7 @@
         },
         {
           "name": "fontStyle",
-          "signature": "fontStyle: \"normal\" | \"italic\"",
+          "signature": "fontStyle: \"italic\" | \"normal\"",
           "signatureTokens": [
             {
               "text": "fontStyle",
@@ -326,7 +326,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"normal\"",
+              "text": "\"italic\"",
               "kind": "keyword"
             },
             {
@@ -334,7 +334,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"italic\"",
+              "text": "\"normal\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/text.json
+++ b/site/src/content/api/text.json
@@ -2040,7 +2040,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2051,7 +2051,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2059,7 +2059,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2144,7 +2144,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2155,7 +2155,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2163,7 +2163,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2328,7 +2328,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2339,7 +2339,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2347,7 +2347,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/texture-region-options.json
+++ b/site/src/content/api/texture-region-options.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "extrusion",
-          "signature": "extrusion?: number | TextureRegionInsets",
+          "signature": "extrusion?: TextureRegionInsets | number",
           "signatureTokens": [
             {
               "text": "extrusion",
@@ -45,16 +45,16 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
-              "kind": "keyword"
+              "text": "TextureRegionInsets",
+              "kind": "type"
             },
             {
               "text": " | ",
               "kind": "punctuation"
             },
             {
-              "text": "TextureRegionInsets",
-              "kind": "type"
+              "text": "number",
+              "kind": "keyword"
             }
           ],
           "params": [],

--- a/site/src/content/api/texture-source.json
+++ b/site/src/content/api/texture-source.json
@@ -30,10 +30,10 @@
       "members": [
         {
           "name": "TextureSource",
-          "signature": "HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap | null",
+          "signature": "HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | ImageBitmap | null",
           "signatureTokens": [
             {
-              "text": "HTMLImageElement",
+              "text": "HTMLCanvasElement",
               "kind": "type"
             },
             {
@@ -41,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "HTMLCanvasElement",
+              "text": "HTMLImageElement",
               "kind": "type"
             },
             {

--- a/site/src/content/api/texture.json
+++ b/site/src/content/api/texture.json
@@ -549,7 +549,7 @@
         },
         {
           "name": "fromColor",
-          "signature": "fromColor(color: string | Color, size: number): Texture",
+          "signature": "fromColor(color: Color | string, size: number): Texture",
           "signatureTokens": [
             {
               "text": "fromColor",
@@ -568,16 +568,16 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
-              "kind": "keyword"
+              "text": "Color",
+              "kind": "type"
             },
             {
               "text": " | ",
               "kind": "punctuation"
             },
             {
-              "text": "Color",
-              "kind": "type"
+              "text": "string",
+              "kind": "keyword"
             },
             {
               "text": ", ",
@@ -611,7 +611,7 @@
           "params": [
             {
               "name": "color",
-              "type": "string | Color",
+              "type": "Color | string",
               "optional": false
             },
             {

--- a/site/src/content/api/tile-collision-shape-kind.json
+++ b/site/src/content/api/tile-collision-shape-kind.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "TileCollisionShapeKind",
-          "signature": "typeof ObjectKind.Rectangle | typeof ObjectKind.Ellipse | typeof ObjectKind.Polygon | typeof ObjectKind.Polyline | typeof ObjectKind.Point",
+          "signature": "typeof ObjectKind.Ellipse | typeof ObjectKind.Point | typeof ObjectKind.Polygon | typeof ObjectKind.Polyline | typeof ObjectKind.Rectangle",
           "signatureTokens": [
             {
               "text": "typeof",
@@ -41,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "ObjectKind.Rectangle",
+              "text": "ObjectKind.Ellipse",
               "kind": "type"
             },
             {
@@ -57,7 +57,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "ObjectKind.Ellipse",
+              "text": "ObjectKind.Point",
               "kind": "type"
             },
             {
@@ -105,7 +105,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "ObjectKind.Point",
+              "text": "ObjectKind.Rectangle",
               "kind": "type"
             }
           ],

--- a/site/src/content/api/tile-layer-node.json
+++ b/site/src/content/api/tile-layer-node.json
@@ -2110,7 +2110,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2121,7 +2121,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2129,7 +2129,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2214,7 +2214,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2225,7 +2225,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2233,7 +2233,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2360,7 +2360,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2371,7 +2371,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2379,7 +2379,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/tile-layer-options.json
+++ b/site/src/content/api/tile-layer-options.json
@@ -6,11 +6,11 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "advanced",
-  "memberCount": 18,
+  "memberCount": 19,
   "counts": {
     "constructors": 0,
     "methods": 0,
-    "properties": 18,
+    "properties": 19,
     "events": 0
   },
   "sections": [
@@ -246,6 +246,31 @@
           "description": "Opacity 0..1. Default 1."
         },
         {
+          "name": "parallaxScale",
+          "signature": "parallaxScale?: number",
+          "signatureTokens": [
+            {
+              "text": "parallaxScale",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Uniform scale applied together with the camera-relative parallax shift. 1 keeps the layer at its authored size. Default 1."
+        },
+        {
           "name": "parallaxX",
           "signature": "parallaxX?: number",
           "signatureTokens": [
@@ -397,7 +422,7 @@
         },
         {
           "name": "tintColor",
-          "signature": "tintColor?: number | null",
+          "signature": "tintColor?: null | number",
           "signatureTokens": [
             {
               "text": "tintColor",
@@ -412,7 +437,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -420,7 +445,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tile-layer.json
+++ b/site/src/content/api/tile-layer.json
@@ -6,11 +6,11 @@
   "subsystem": "tilemap",
   "importPath": "@codexo/exojs-tilemap",
   "tier": "advanced",
-  "memberCount": 39,
+  "memberCount": 40,
   "counts": {
     "constructors": 1,
     "methods": 15,
-    "properties": 23,
+    "properties": 24,
     "events": 0
   },
   "sections": [
@@ -1486,6 +1486,27 @@
           "description": "Opacity 0..1 (mutable)."
         },
         {
+          "name": "parallaxScale",
+          "signature": "parallaxScale: number",
+          "signatureTokens": [
+            {
+              "text": "parallaxScale",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Uniform scale applied around the layer origin during parallax rendering."
+        },
+        {
           "name": "parallaxX",
           "signature": "parallaxX: number",
           "signatureTokens": [
@@ -1625,7 +1646,7 @@
         },
         {
           "name": "tintColor",
-          "signature": "tintColor: number | null",
+          "signature": "tintColor: null | number",
           "signatureTokens": [
             {
               "text": "tintColor",
@@ -1636,7 +1657,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1644,7 +1665,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tile-map-band.json
+++ b/site/src/content/api/tile-map-band.json
@@ -2065,7 +2065,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2076,7 +2076,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2084,7 +2084,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2307,7 +2307,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2318,7 +2318,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2326,7 +2326,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/tile-map-node.json
+++ b/site/src/content/api/tile-map-node.json
@@ -2172,7 +2172,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2183,7 +2183,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2191,7 +2191,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2276,7 +2276,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2287,7 +2287,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2295,7 +2295,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2422,7 +2422,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2433,7 +2433,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2441,7 +2441,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/tile-map-object.json
+++ b/site/src/content/api/tile-map-object.json
@@ -31,28 +31,8 @@
       "members": [
         {
           "name": "TileMapObject",
-          "signature": "RectangleObject<P> | EllipseObject<P> | PointObject<P> | PolygonObject<P> | PolylineObject<P> | TileObject<P> | TextObject<P>",
+          "signature": "EllipseObject<P> | PointObject<P> | PolygonObject<P> | PolylineObject<P> | RectangleObject<P> | TextObject<P> | TileObject<P>",
           "signatureTokens": [
-            {
-              "text": "RectangleObject",
-              "kind": "type"
-            },
-            {
-              "text": "<",
-              "kind": "punctuation"
-            },
-            {
-              "text": "P",
-              "kind": "type"
-            },
-            {
-              "text": ">",
-              "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "EllipseObject",
               "kind": "type"
@@ -134,7 +114,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "TileObject",
+              "text": "RectangleObject",
               "kind": "type"
             },
             {
@@ -155,6 +135,26 @@
             },
             {
               "text": "TextObject",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "P",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TileObject",
               "kind": "type"
             },
             {

--- a/site/src/content/api/tile-map-options.json
+++ b/site/src/content/api/tile-map-options.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "backgroundColor",
-          "signature": "backgroundColor?: number | null",
+          "signature": "backgroundColor?: null | number",
           "signatureTokens": [
             {
               "text": "backgroundColor",
@@ -45,7 +45,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -53,7 +53,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tile-map.json
+++ b/site/src/content/api/tile-map.json
@@ -1412,7 +1412,7 @@
       "members": [
         {
           "name": "backgroundColor",
-          "signature": "backgroundColor: number | null",
+          "signature": "backgroundColor: null | number",
           "signatureTokens": [
             {
               "text": "backgroundColor",
@@ -1423,7 +1423,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -1431,7 +1431,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "number",
               "kind": "keyword"
             }
           ],
@@ -1878,7 +1878,7 @@
         },
         {
           "name": "renderableLayers",
-          "signature": "renderableLayers: readonly TileLayer | ImageLayer[]",
+          "signature": "renderableLayers: readonly ImageLayer | TileLayer[]",
           "signatureTokens": [
             {
               "text": "renderableLayers",
@@ -1897,7 +1897,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "TileLayer",
+              "text": "ImageLayer",
               "kind": "type"
             },
             {
@@ -1905,7 +1905,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "ImageLayer",
+              "text": "TileLayer",
               "kind": "type"
             },
             {

--- a/site/src/content/api/tile-property-object-ref.json
+++ b/site/src/content/api/tile-property-object-ref.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "id",
-          "signature": "id: string | number",
+          "signature": "id: number | string",
           "signatureTokens": [
             {
               "text": "id",
@@ -41,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "number",
               "kind": "keyword"
             },
             {
@@ -49,7 +49,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tile-property-value.json
+++ b/site/src/content/api/tile-property-value.json
@@ -30,42 +30,10 @@
       "members": [
         {
           "name": "TilePropertyValue",
-          "signature": "null | boolean | number | string | TilePropertyPoint | TilePropertyObjectRef | TilePropertyTileRef | readonly TilePropertyValue[] | TileProperties",
+          "signature": "TileProperties | TilePropertyObjectRef | TilePropertyPoint | TilePropertyTileRef | boolean | null | number | readonly TilePropertyValue[] | string",
           "signatureTokens": [
             {
-              "text": "null",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "boolean",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "string",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "TilePropertyPoint",
+              "text": "TileProperties",
               "kind": "type"
             },
             {
@@ -81,8 +49,40 @@
               "kind": "punctuation"
             },
             {
+              "text": "TilePropertyPoint",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
               "text": "TilePropertyTileRef",
               "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
             },
             {
               "text": " | ",
@@ -109,8 +109,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "TileProperties",
-              "kind": "type"
+              "text": "string",
+              "kind": "keyword"
             }
           ],
           "params": [],

--- a/site/src/content/api/tiled-layer-data.json
+++ b/site/src/content/api/tiled-layer-data.json
@@ -30,18 +30,10 @@
       "members": [
         {
           "name": "TiledLayerData",
-          "signature": "TiledTileLayerData | TiledObjectLayerData | TiledImageLayerData | TiledGroupLayerData",
+          "signature": "TiledGroupLayerData | TiledImageLayerData | TiledObjectLayerData | TiledTileLayerData",
           "signatureTokens": [
             {
-              "text": "TiledTileLayerData",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "TiledObjectLayerData",
+              "text": "TiledGroupLayerData",
               "kind": "type"
             },
             {
@@ -57,7 +49,15 @@
               "kind": "punctuation"
             },
             {
-              "text": "TiledGroupLayerData",
+              "text": "TiledObjectLayerData",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TiledTileLayerData",
               "kind": "type"
             }
           ],

--- a/site/src/content/api/tiled-layer.json
+++ b/site/src/content/api/tiled-layer.json
@@ -377,7 +377,7 @@
         },
         {
           "name": "type",
-          "signature": "type: \"tilelayer\" | \"objectgroup\" | \"imagelayer\" | \"group\"",
+          "signature": "type: \"group\" | \"imagelayer\" | \"objectgroup\" | \"tilelayer\"",
           "signatureTokens": [
             {
               "text": "type",
@@ -388,15 +388,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"tilelayer\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"objectgroup\"",
+              "text": "\"group\"",
               "kind": "keyword"
             },
             {
@@ -412,7 +404,15 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"group\"",
+              "text": "\"objectgroup\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"tilelayer\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tiled-map-data.json
+++ b/site/src/content/api/tiled-map-data.json
@@ -434,7 +434,7 @@
         },
         {
           "name": "version",
-          "signature": "version: string | number",
+          "signature": "version: number | string",
           "signatureTokens": [
             {
               "text": "version",
@@ -445,7 +445,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "number",
               "kind": "keyword"
             },
             {
@@ -453,7 +453,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tiled-object-alignment.json
+++ b/site/src/content/api/tiled-object-alignment.json
@@ -31,58 +31,10 @@
       "members": [
         {
           "name": "TiledObjectAlignment",
-          "signature": "\"unspecified\" | \"topleft\" | \"top\" | \"topright\" | \"left\" | \"center\" | \"right\" | \"bottomleft\" | \"bottom\" | \"bottomright\"",
+          "signature": "\"bottom\" | \"bottomleft\" | \"bottomright\" | \"center\" | \"left\" | \"right\" | \"top\" | \"topleft\" | \"topright\" | \"unspecified\"",
           "signatureTokens": [
             {
-              "text": "\"unspecified\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"topleft\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"top\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"topright\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"left\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"center\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"right\"",
+              "text": "\"bottom\"",
               "kind": "keyword"
             },
             {
@@ -98,7 +50,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"bottom\"",
+              "text": "\"bottomright\"",
               "kind": "keyword"
             },
             {
@@ -106,7 +58,55 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"bottomright\"",
+              "text": "\"center\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"left\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"right\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"top\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"topleft\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"topright\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"unspecified\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tiled-object-layer-data.json
+++ b/site/src/content/api/tiled-object-layer-data.json
@@ -55,7 +55,7 @@
         },
         {
           "name": "draworder",
-          "signature": "draworder?: \"topdown\" | \"index\"",
+          "signature": "draworder?: \"index\" | \"topdown\"",
           "signatureTokens": [
             {
               "text": "draworder",
@@ -70,7 +70,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"topdown\"",
+              "text": "\"index\"",
               "kind": "keyword"
             },
             {
@@ -78,7 +78,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"index\"",
+              "text": "\"topdown\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tiled-object-layer.json
+++ b/site/src/content/api/tiled-object-layer.json
@@ -171,7 +171,7 @@
         },
         {
           "name": "drawOrder",
-          "signature": "drawOrder: NonNullable<\"topdown\" | \"index\" | undefined>",
+          "signature": "drawOrder: NonNullable<\"index\" | \"topdown\" | undefined>",
           "signatureTokens": [
             {
               "text": "drawOrder",
@@ -190,7 +190,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"topdown\"",
+              "text": "\"index\"",
               "kind": "keyword"
             },
             {
@@ -198,7 +198,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"index\"",
+              "text": "\"topdown\"",
               "kind": "keyword"
             },
             {

--- a/site/src/content/api/tiled-orientation.json
+++ b/site/src/content/api/tiled-orientation.json
@@ -30,10 +30,10 @@
       "members": [
         {
           "name": "TiledOrientation",
-          "signature": "\"orthogonal\" | \"isometric\" | \"staggered\" | \"hexagonal\"",
+          "signature": "\"hexagonal\" | \"isometric\" | \"orthogonal\" | \"staggered\"",
           "signatureTokens": [
             {
-              "text": "\"orthogonal\"",
+              "text": "\"hexagonal\"",
               "kind": "keyword"
             },
             {
@@ -49,7 +49,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"staggered\"",
+              "text": "\"orthogonal\"",
               "kind": "keyword"
             },
             {
@@ -57,7 +57,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"hexagonal\"",
+              "text": "\"staggered\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tiled-property-data.json
+++ b/site/src/content/api/tiled-property-data.json
@@ -98,7 +98,7 @@
         },
         {
           "name": "value",
-          "signature": "value: string | number | boolean | TiledClassPropertyValueData",
+          "signature": "value: TiledClassPropertyValueData | boolean | number | string",
           "signatureTokens": [
             {
               "text": "value",
@@ -109,7 +109,15 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "TiledClassPropertyValueData",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
               "kind": "keyword"
             },
             {
@@ -125,16 +133,8 @@
               "kind": "punctuation"
             },
             {
-              "text": "boolean",
+              "text": "string",
               "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "TiledClassPropertyValueData",
-              "kind": "type"
             }
           ],
           "params": [],

--- a/site/src/content/api/tiled-property-type.json
+++ b/site/src/content/api/tiled-property-type.json
@@ -30,34 +30,18 @@
       "members": [
         {
           "name": "TiledPropertyType",
-          "signature": "\"string\" | \"int\" | \"float\" | \"bool\" | \"color\" | \"file\" | \"object\" | \"class\"",
+          "signature": "\"bool\" | \"class\" | \"color\" | \"file\" | \"float\" | \"int\" | \"object\" | \"string\"",
           "signatureTokens": [
             {
-              "text": "\"string\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"int\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"float\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "\"bool\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"class\"",
               "kind": "keyword"
             },
             {
@@ -81,6 +65,22 @@
               "kind": "punctuation"
             },
             {
+              "text": "\"float\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"int\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
               "text": "\"object\"",
               "kind": "keyword"
             },
@@ -89,7 +89,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"class\"",
+              "text": "\"string\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tiled-render-order.json
+++ b/site/src/content/api/tiled-render-order.json
@@ -30,24 +30,8 @@
       "members": [
         {
           "name": "TiledRenderOrder",
-          "signature": "\"right-down\" | \"right-up\" | \"left-down\" | \"left-up\"",
+          "signature": "\"left-down\" | \"left-up\" | \"right-down\" | \"right-up\"",
           "signatureTokens": [
-            {
-              "text": "\"right-down\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"right-up\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "\"left-down\"",
               "kind": "keyword"
@@ -58,6 +42,22 @@
             },
             {
               "text": "\"left-up\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"right-down\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"right-up\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tiled-text-data.json
+++ b/site/src/content/api/tiled-text-data.json
@@ -105,7 +105,7 @@
         },
         {
           "name": "halign",
-          "signature": "halign?: \"left\" | \"center\" | \"right\" | \"justify\"",
+          "signature": "halign?: \"center\" | \"justify\" | \"left\" | \"right\"",
           "signatureTokens": [
             {
               "text": "halign",
@@ -120,14 +120,6 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"left\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
               "text": "\"center\"",
               "kind": "keyword"
             },
@@ -136,7 +128,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"right\"",
+              "text": "\"justify\"",
               "kind": "keyword"
             },
             {
@@ -144,7 +136,15 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"justify\"",
+              "text": "\"left\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"right\"",
               "kind": "keyword"
             }
           ],
@@ -300,7 +300,7 @@
         },
         {
           "name": "valign",
-          "signature": "valign?: \"top\" | \"center\" | \"bottom\"",
+          "signature": "valign?: \"bottom\" | \"center\" | \"top\"",
           "signatureTokens": [
             {
               "text": "valign",
@@ -315,7 +315,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"top\"",
+              "text": "\"bottom\"",
               "kind": "keyword"
             },
             {
@@ -331,7 +331,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"bottom\"",
+              "text": "\"top\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tiled-tileset-data.json
+++ b/site/src/content/api/tiled-tileset-data.json
@@ -434,7 +434,7 @@
         },
         {
           "name": "version",
-          "signature": "version?: string | number",
+          "signature": "version?: number | string",
           "signatureTokens": [
             {
               "text": "version",
@@ -449,7 +449,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "number",
               "kind": "keyword"
             },
             {
@@ -457,7 +457,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "string",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/tiled-tileset-ref-data.json
+++ b/site/src/content/api/tiled-tileset-ref-data.json
@@ -30,10 +30,10 @@
       "members": [
         {
           "name": "TiledTilesetRefData",
-          "signature": "TiledExternalTilesetRefData | TiledEmbeddedTilesetRefData",
+          "signature": "TiledEmbeddedTilesetRefData | TiledExternalTilesetRefData",
           "signatureTokens": [
             {
-              "text": "TiledExternalTilesetRefData",
+              "text": "TiledEmbeddedTilesetRefData",
               "kind": "type"
             },
             {
@@ -41,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "TiledEmbeddedTilesetRefData",
+              "text": "TiledExternalTilesetRefData",
               "kind": "type"
             }
           ],

--- a/site/src/content/api/tilemap-functions.json
+++ b/site/src/content/api/tilemap-functions.json
@@ -827,7 +827,7 @@
         },
         {
           "name": "unpackTile",
-          "signature": "unpackTile(packed: number): { localTileId: number; tilesetIndex: number; transform: TileTransform } | null",
+          "signature": "unpackTile(packed: number): null | { localTileId: number; tilesetIndex: number; transform: TileTransform }",
           "signatureTokens": [
             {
               "text": "unpackTile",
@@ -855,6 +855,14 @@
             },
             {
               "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
               "kind": "punctuation"
             },
             {
@@ -908,14 +916,6 @@
             {
               "text": " }",
               "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
             }
           ],
           "params": [
@@ -925,7 +925,7 @@
               "optional": false
             }
           ],
-          "returnType": "{ localTileId: number; tilesetIndex: number; transform: TileTransform } | null",
+          "returnType": "null | { localTileId: number; tilesetIndex: number; transform: TileTransform }",
           "description": "Decode a packed word into its components. Returns null for an empty cell (packed === 0)."
         }
       ],

--- a/site/src/content/api/time-interval.json
+++ b/site/src/content/api/time-interval.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "TimeInterval",
-          "signature": "1 | 1000 | 60000 | 3600000",
+          "signature": "1 | 1000 | 3600000 | 60000",
           "signatureTokens": [
             {
               "text": "1",
@@ -49,7 +49,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "60000",
+              "text": "3600000",
               "kind": "keyword"
             },
             {
@@ -57,7 +57,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "3600000",
+              "text": "60000",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/typed-array.json
+++ b/site/src/content/api/typed-array.json
@@ -30,10 +30,10 @@
       "members": [
         {
           "name": "TypedArray",
-          "signature": "Int8Array | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array",
+          "signature": "Float32Array | Float64Array | Int16Array | Int32Array | Int8Array | Uint16Array | Uint32Array | Uint8Array | Uint8ClampedArray",
           "signatureTokens": [
             {
-              "text": "Int8Array",
+              "text": "Float32Array",
               "kind": "type"
             },
             {
@@ -41,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Uint8Array",
+              "text": "Float64Array",
               "kind": "type"
             },
             {
@@ -57,7 +57,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Uint16Array",
+              "text": "Int32Array",
               "kind": "type"
             },
             {
@@ -65,7 +65,15 @@
               "kind": "punctuation"
             },
             {
-              "text": "Int32Array",
+              "text": "Int8Array",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Uint16Array",
               "kind": "type"
             },
             {
@@ -81,23 +89,15 @@
               "kind": "punctuation"
             },
             {
+              "text": "Uint8Array",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
               "text": "Uint8ClampedArray",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Float32Array",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Float64Array",
               "kind": "type"
             }
           ],

--- a/site/src/content/api/uiroot.json
+++ b/site/src/content/api/uiroot.json
@@ -2036,7 +2036,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2047,7 +2047,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2055,7 +2055,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2140,7 +2140,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2151,7 +2151,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2159,7 +2159,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2286,7 +2286,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2297,7 +2297,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2305,7 +2305,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/uniform-value.json
+++ b/site/src/content/api/uniform-value.json
@@ -30,136 +30,8 @@
       "members": [
         {
           "name": "UniformValue",
-          "signature": "number | readonly [number, number] | readonly [number, number, number] | readonly [number, number, number, number] | Float32Array | Int32Array | Texture | RenderTexture",
+          "signature": "Float32Array | Int32Array | RenderTexture | Texture | number | readonly [number, number, number, number] | readonly [number, number, number] | readonly [number, number]",
           "signatureTokens": [
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "readonly",
-              "kind": "keyword"
-            },
-            {
-              "text": " ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "[",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": "]",
-              "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "readonly",
-              "kind": "keyword"
-            },
-            {
-              "text": " ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "[",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": "]",
-              "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "readonly",
-              "kind": "keyword"
-            },
-            {
-              "text": " ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "[",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "number",
-              "kind": "keyword"
-            },
-            {
-              "text": "]",
-              "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
             {
               "text": "Float32Array",
               "kind": "type"
@@ -177,6 +49,14 @@
               "kind": "punctuation"
             },
             {
+              "text": "RenderTexture",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
               "text": "Texture",
               "kind": "type"
             },
@@ -185,8 +65,128 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
-              "kind": "type"
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "]",
+              "kind": "punctuation"
             }
           ],
           "params": [],

--- a/site/src/content/api/unload-options.json
+++ b/site/src/content/api/unload-options.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "instance",
-          "signature": "instance?: SceneInstanceKind | \"all\"",
+          "signature": "instance?: \"all\" | SceneInstanceKind",
           "signatureTokens": [
             {
               "text": "instance",
@@ -45,16 +45,16 @@
               "kind": "punctuation"
             },
             {
-              "text": "SceneInstanceKind",
-              "kind": "type"
+              "text": "\"all\"",
+              "kind": "keyword"
             },
             {
               "text": " | ",
               "kind": "punctuation"
             },
             {
-              "text": "\"all\"",
-              "kind": "keyword"
+              "text": "SceneInstanceKind",
+              "kind": "type"
             }
           ],
           "params": [],

--- a/site/src/content/api/video.json
+++ b/site/src/content/api/video.json
@@ -1923,7 +1923,7 @@
         },
         {
           "name": "setTexture",
-          "signature": "setTexture(texture: Texture | RenderTexture | null): this",
+          "signature": "setTexture(texture: RenderTexture | Texture | null): this",
           "signatureTokens": [
             {
               "text": "setTexture",
@@ -1942,7 +1942,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -1950,7 +1950,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {
@@ -1977,7 +1977,7 @@
           "params": [
             {
               "name": "texture",
-              "type": "Texture | RenderTexture | null",
+              "type": "RenderTexture | Texture | null",
               "optional": false
             }
           ],
@@ -2530,7 +2530,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2541,7 +2541,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2549,7 +2549,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2634,7 +2634,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2645,7 +2645,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2653,7 +2653,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2826,7 +2826,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2837,7 +2837,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2845,7 +2845,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {
@@ -3466,7 +3466,7 @@
         },
         {
           "name": "texture",
-          "signature": "texture: Texture | RenderTexture | null",
+          "signature": "texture: RenderTexture | Texture | null",
           "signatureTokens": [
             {
               "text": "texture",
@@ -3477,7 +3477,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Texture",
+              "text": "RenderTexture",
               "kind": "type"
             },
             {
@@ -3485,7 +3485,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "RenderTexture",
+              "text": "Texture",
               "kind": "type"
             },
             {

--- a/site/src/content/api/view-follow-target.json
+++ b/site/src/content/api/view-follow-target.json
@@ -30,11 +30,19 @@
       "members": [
         {
           "name": "ViewFollowTarget",
-          "signature": "SceneNode | { x: number; y: number } | null",
+          "signature": "SceneNode | null | { x: number; y: number }",
           "signatureTokens": [
             {
               "text": "SceneNode",
               "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
             },
             {
               "text": " | ",
@@ -75,14 +83,6 @@
             {
               "text": " }",
               "kind": "punctuation"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "null",
-              "kind": "keyword"
             }
           ],
           "params": [],

--- a/site/src/content/api/wang-set-options.json
+++ b/site/src/content/api/wang-set-options.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "blobMap",
-          "signature": "blobMap: Record<number, number> | ReadonlyMap<number, number>",
+          "signature": "blobMap: ReadonlyMap<number, number> | Record<number, number>",
           "signatureTokens": [
             {
               "text": "blobMap",
@@ -41,7 +41,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Record",
+              "text": "ReadonlyMap",
               "kind": "type"
             },
             {
@@ -69,7 +69,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "ReadonlyMap",
+              "text": "Record",
               "kind": "type"
             },
             {

--- a/site/src/content/api/widget-anchor.json
+++ b/site/src/content/api/widget-anchor.json
@@ -30,50 +30,10 @@
       "members": [
         {
           "name": "WidgetAnchor",
-          "signature": "\"top-left\" | \"top\" | \"top-right\" | \"left\" | \"center\" | \"right\" | \"bottom-left\" | \"bottom\" | \"bottom-right\"",
+          "signature": "\"bottom\" | \"bottom-left\" | \"bottom-right\" | \"center\" | \"left\" | \"right\" | \"top\" | \"top-left\" | \"top-right\"",
           "signatureTokens": [
             {
-              "text": "\"top-left\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"top\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"top-right\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"left\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"center\"",
-              "kind": "keyword"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "\"right\"",
+              "text": "\"bottom\"",
               "kind": "keyword"
             },
             {
@@ -89,7 +49,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"bottom\"",
+              "text": "\"bottom-right\"",
               "kind": "keyword"
             },
             {
@@ -97,7 +57,47 @@
               "kind": "punctuation"
             },
             {
-              "text": "\"bottom-right\"",
+              "text": "\"center\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"left\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"right\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"top\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"top-left\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"top-right\"",
               "kind": "keyword"
             }
           ],

--- a/site/src/content/api/widget.json
+++ b/site/src/content/api/widget.json
@@ -2357,7 +2357,7 @@
         },
         {
           "name": "cursor",
-          "signature": "cursor: string | null",
+          "signature": "cursor: null | string",
           "signatureTokens": [
             {
               "text": "cursor",
@@ -2368,7 +2368,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2376,7 +2376,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2461,7 +2461,7 @@
         },
         {
           "name": "name",
-          "signature": "name: string | null",
+          "signature": "name: null | string",
           "signatureTokens": [
             {
               "text": "name",
@@ -2472,7 +2472,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "string",
+              "text": "null",
               "kind": "keyword"
             },
             {
@@ -2480,7 +2480,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "null",
+              "text": "string",
               "kind": "keyword"
             }
           ],
@@ -2607,7 +2607,7 @@
         },
         {
           "name": "clipShape",
-          "signature": "clipShape: Rectangle | Geometry | null",
+          "signature": "clipShape: Geometry | Rectangle | null",
           "signatureTokens": [
             {
               "text": "clipShape",
@@ -2618,7 +2618,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Rectangle",
+              "text": "Geometry",
               "kind": "type"
             },
             {
@@ -2626,7 +2626,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "Geometry",
+              "text": "Rectangle",
               "kind": "type"
             },
             {

--- a/site/src/content/api/xbox-gamepad-mapping.json
+++ b/site/src/content/api/xbox-gamepad-mapping.json
@@ -99,7 +99,7 @@
         },
         {
           "name": "hasChannel",
-          "signature": "hasChannel(channel: GamepadButtonChannel | GamepadAxisChannel): boolean",
+          "signature": "hasChannel(channel: GamepadAxisChannel | GamepadButtonChannel): boolean",
           "signatureTokens": [
             {
               "text": "hasChannel",
@@ -118,7 +118,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadButtonChannel",
+              "text": "GamepadAxisChannel",
               "kind": "type"
             },
             {
@@ -126,7 +126,7 @@
               "kind": "punctuation"
             },
             {
-              "text": "GamepadAxisChannel",
+              "text": "GamepadButtonChannel",
               "kind": "type"
             },
             {
@@ -145,7 +145,7 @@
           "params": [
             {
               "name": "channel",
-              "type": "GamepadButtonChannel | GamepadAxisChannel",
+              "type": "GamepadAxisChannel | GamepadButtonChannel",
               "optional": false
             }
           ],

--- a/test/ci/api-union-order.test.ts
+++ b/test/ci/api-union-order.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { sortUnionMembers } from '../../site/scripts/sort-union-members';
+
+describe('API documentation union ordering', () => {
+  it('sorts by rendered member text without mutating TypeDoc input order', () => {
+    const members = [{ text: '0' }, { text: '2' }, { text: '1' }, { text: '3' }];
+
+    const sorted = sortUnionMembers(members, member => member.text);
+
+    expect(sorted.map(member => member.text)).toEqual(['0', '1', '2', '3']);
+    expect(members.map(member => member.text)).toEqual(['0', '2', '1', '3']);
+  });
+
+  it('orders nested rendered types deterministically', () => {
+    const members = ['string[]', 'AssetRef<Texture>', 'null', 'AssetRef<Sound>'];
+
+    expect(sortUnionMembers(members, member => member)).toEqual(['AssetRef<Sound>', 'AssetRef<Texture>', 'null', 'string[]']);
+  });
+});

--- a/test/ci/gate-parity.test.ts
+++ b/test/ci/gate-parity.test.ts
@@ -128,13 +128,17 @@ describe('the local pre-push hook runs the same gate set as CI', () => {
 });
 
 describe('the Typecheck job covers the type-level gates verify:quick knows about', () => {
-  // These four were the original required-CI set; typecheck:packages and
-  // typecheck:test joined them when the lists were unified. Naming them keeps a
-  // silent deletion from a group visible as a failing test rather than as a gate
-  // that quietly stops running on both sides at once.
-  it.each(['typecheck', 'typecheck:guides', 'typecheck:examples', 'typecheck:type-tests'])('`%s` is in the typecheck group', script => {
-    expect(GATE_GROUPS.typecheck).toContain(script);
-  });
+  // These gates protect distinct source surfaces; typecheck:packages and
+  // typecheck:test joined the original set when the lists were unified, while
+  // typecheck:full-bundle covers the opt-in entry the normal build omits.
+  // Naming them keeps a silent deletion visible as a failing test rather than
+  // as a gate that quietly stops running on both sides at once.
+  it.each(['typecheck', 'typecheck:full-bundle', 'typecheck:guides', 'typecheck:examples', 'typecheck:type-tests'])(
+    '`%s` is in the typecheck group',
+    script => {
+      expect(GATE_GROUPS.typecheck).toContain(script);
+    },
+  );
 
   it('keeps `typecheck:site` out of the ungated typecheck job — it needs the built dist', () => {
     expect(GATE_GROUPS.typecheck).not.toContain('typecheck:site');

--- a/tsconfig.full-bundle.json
+++ b/tsconfig.full-bundle.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "_comment": "Type-checks the opt-in all-in-one IIFE entry against every extension package's source exports. The production build only includes this entry when EXOJS_FULL_BUNDLE=1, so without this lightweight local gate a stale named export is visible only in the CI build lane.",
+  "extends": "./tsconfig.examples.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false
+  },
+  "include": ["scripts/exo-full.entry.ts", "src/typings.d.ts"]
+}


### PR DESCRIPTION
## Summary

- add a local/CI full-bundle typecheck and resolve the Tilemap/Core `TextStyle` export collision (`NEU-N2`)
- implement LDtk parallax scaling end-to-end, including inverse streaming/repeat coverage and definition offsets (`NEU-M1`, `NEU-P1`)
- stabilize generated API union ordering and normalize the checked-in API output (`NEU-O37`)
- split the mixed sprite/mesh benchmark into retained static-geometry and array-repack archetypes (`NEU-O42`)

## Verification

- `pnpm verify:quick` — all 12 gates passed
- Tilemap package — 533 tests passed
- LDtk package — 186 tests passed
- Bench package — 49 tests passed
- CI/API regression selection — 35 tests passed
- final TileLayer regression selection — 183 tests passed
- O42 25k retained hardware probes completed on WebGL2 and WebGPU without a software rasterizer