### PR TITLE
feat(bench): add the scrolling-world archetype

### DIFF
--- a/packages/exojs-bench/src/rendering/EngineAdapter.ts
+++ b/packages/exojs-bench/src/rendering/EngineAdapter.ts
@@ -17,7 +17,8 @@ export type ArchetypeId =
   | 'mixed-material-atlased'
   | 'instanced-batch'
   | 'mixed-sprite-mesh-array'
-  | 'mixed-sprite-mesh-static';
+  | 'mixed-sprite-mesh-static'
+  | 'scrolling-world';
 
 /** Structural definition of a scene archetype, independent of any engine or backend. */
 export interface ArchetypeSpec {
@@ -34,18 +35,22 @@ export interface ArchetypeSpec {
   /**
    * Whether frustum/off-screen culling is enabled for this archetype (drives
    * `.cullable` on every spine container and leaf sprite in both adapters).
-   * Currently `false` for every archetype in `archetypes.ts`: keeping every
-   * archetype's sprites on-screen means a cull
-   * check can only ever be a no-op there, and the two engines do NOT pay the
-   * same cost for an identically-set flag. ExoJS's `cullable` drives a real
-   * per-node bounds+intersection check in the render walk
-   * (`SceneNode.inView`); Pixi's `cullable` is inert unless the app registers
-   * `CullerPlugin` (or `Culler.shared.cull(...)` is called explicitly), which
-   * `adapters/pixi.ts` does not do. Leaving this `true` therefore adds
-   * cull-walk overhead to the ExoJS arm with no matching cost on the Pixi arm.
-   * If a future archetype needs genuine off-screen content, either give Pixi
-   * an equivalent `CullerPlugin` registration before flipping this back to
-   * `true`, or disclose the asymmetry explicitly in the report.
+   *
+   * `false` for every archetype whose content is fully on-screen, which is all
+   * of them except `scrolling-world`: a cull check can only ever be a no-op
+   * there, and the two engines do NOT pay the same cost for an identically-set
+   * flag. ExoJS's `cullable` drives a real per-node bounds+intersection check in
+   * the render walk (`SceneNode.inView`); Pixi's `cullable` is inert unless
+   * `Culler.shared.cull(...)` is called explicitly (`CullerPlugin` hooks the
+   * Application ticker, which this harness never runs). Leaving it `true` on a
+   * fully-visible archetype would therefore add cull-walk overhead to the ExoJS
+   * arm with no matching cost on the Pixi arm.
+   *
+   * An archetype with genuine off-screen content sets it `true` and is measured
+   * on BOTH Pixi arms — `pixi default` leaves culling off (Pixi's out-of-the-box
+   * behaviour: it draws the off-screen content too) and `pixi culled` calls
+   * `Culler.shared.cull` per frame, so the asymmetry is measured rather than
+   * assumed away.
    */
   readonly cullingEnabled: boolean;
   /**
@@ -137,6 +142,29 @@ export interface ArchetypeSpec {
    * renderer switches. Meaningful only when {@link meshEvery} is set.
    */
   readonly meshStorage?: 'array' | 'shared-static-geometry';
+  /**
+   * Camera travel per frame, in world units, along the world diagonal. Setting
+   * it to a positive value makes the archetype a SCROLLING one: the leaf grid
+   * covers {@link worldSpan} viewports per axis instead of exactly one, and the
+   * camera reflects around inside it (see `world.ts::cameraCenterAt`).
+   * `undefined`/`0` keeps the fixed, viewport-sized world with a static camera
+   * that every other archetype uses.
+   *
+   * The two arms express the camera differently and both do so idiomatically:
+   * ExoJS moves its `View` centre (the engine has a real camera, and the view
+   * rect is what its culling and its retained-product validity are keyed on),
+   * while the Pixi arm translates the world container (Pixi has no camera
+   * object). Same visible content per frame either way — disclosed in the
+   * report's Methodology rather than papered over.
+   */
+  readonly cameraSpeed?: number;
+  /**
+   * World size as a multiple of the viewport PER AXIS, so the content multiple
+   * is its square: `2` lays the scene out over 4x the viewport's area and leaves
+   * roughly 75% of it off-screen at any moment. Meaningful only together with
+   * {@link cameraSpeed}.
+   */
+  readonly worldSpan?: number;
 }
 
 /** One matrix cell: a single (engine, config, backend, archetype, node count) combination to measure. */
@@ -198,6 +226,19 @@ export interface EngineAdapter {
   readonly config: string;
   /** Whether this adapter supports the given backend. */
   supports(backend: Backend): boolean;
+  /**
+   * Whether this arm should be measured on the given archetype. Optional; an
+   * arm that omits it is measured on every archetype, which is the norm.
+   *
+   * It exists for arms that are a VARIANT of another arm rather than a whole
+   * engine — `pixi culled`, which differs from `pixi default` only by an
+   * explicit per-frame `Culler.shared.cull` call. On an archetype whose content
+   * is fully on-screen that call changes nothing except its own cost, so the
+   * variant would spend the whole matrix producing rows that duplicate the arm
+   * it varies. Restricting it to the archetypes where the variation is the
+   * point keeps the matrix honest and its runtime bounded.
+   */
+  coversArchetype?(spec: ArchetypeSpec): boolean;
   /** Initialize the engine against the given canvas and backend. */
   init(canvas: HTMLCanvasElement, backend: Backend): Promise<void>;
   /** Build a scene for the given archetype, node count, and RNG seed. */

--- a/packages/exojs-bench/src/rendering/adapters/excalibur.ts
+++ b/packages/exojs-bench/src/rendering/adapters/excalibur.ts
@@ -2,6 +2,7 @@ import * as ex from 'excalibur';
 
 import { mutationSignature, selectMutationIndices } from '../../shared/mutation';
 import type { ArchetypeSpec, Backend, EngineAdapter } from '../EngineAdapter';
+import { isScrolling } from '../world';
 
 /**
  * Excalibur 0.32 arm of the rendering benchmark.
@@ -104,6 +105,14 @@ export const createExcaliburAdapter = (): EngineAdapter => {
     supports(target: Backend): boolean {
       // Excalibur 0.32 renders WebGL2 only; it ships no WebGPU renderer.
       return target === 'webgl2';
+    },
+
+    coversArchetype(spec: ArchetypeSpec): boolean {
+      // This arm builds a fixed, viewport-sized scene with a static camera. A
+      // scrolling archetype would silently render as an ordinary fully-visible
+      // one here, i.e. a row that looks comparable and is not — so the arm sits
+      // the archetype out instead.
+      return !isScrolling(spec);
     },
 
     async init(canvas: HTMLCanvasElement, target: Backend): Promise<void> {

--- a/packages/exojs-bench/src/rendering/adapters/exojs.ts
+++ b/packages/exojs-bench/src/rendering/adapters/exojs.ts
@@ -18,6 +18,7 @@ import type { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
 
 import { mutationSignature, selectMutationIndices } from '../../shared/mutation';
 import type { ArchetypeSpec, Backend, EngineAdapter } from '../EngineAdapter';
+import { cameraCenterAt, GRID_MARGIN, gridLayout, gridPosition, isScrolling, SPRITE_SIZE, VIEWPORT_HEIGHT, VIEWPORT_WIDTH, worldExtent } from '../world';
 
 /**
  * One array-backed mesh leaf: the same SPRITE_SIZE quad a sprite leaf covers,
@@ -76,13 +77,6 @@ const createBatchQuad = (): Geometry => {
   });
 };
 
-/** Fixed design-space viewport the harness canvas renders (see `page/index.html`). */
-const VIEWPORT_WIDTH = 1280;
-const VIEWPORT_HEIGHT = 720;
-/** Inset that keeps every gridded sprite (plus its mutation wobble) inside the view so culling never removes it mid-run. */
-const GRID_MARGIN = 32;
-/** Side length of the generated per-archetype textures / sprites, in pixels. */
-const SPRITE_SIZE = 8;
 /** Peak per-axis displacement applied to a mutated leaf; small enough to never cross the viewport edge. */
 const WOBBLE_AMPLITUDE = 2;
 /** Phase step per frame for the mutation wobble. */
@@ -236,6 +230,15 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
   let batchGeometry: Geometry | null = null;
   /** Shared by every mesh leaf in `mixed-sprite-mesh-static`; absent for the array case. */
   let sharedMeshGeometry: Geometry | null = null;
+  /**
+   * The archetype currently built, when it scrolls a camera
+   * (`ArchetypeSpec.cameraSpeed`); `null` for every static-view archetype, in
+   * which case `mutate` leaves the view alone. The camera is driven through the
+   * context's own `view` — the engine's real camera, and the rect its per-node
+   * culling and its retained-product validity are keyed on — rather than by
+   * translating the world, which is the same distinction a game makes.
+   */
+  let scrollingSpec: ArchetypeSpec | null = null;
 
   /** Drop the `instanced-batch` scene so a rebuild (or teardown) leaks no GPU resources. */
   const releaseBatchScene = (): void => {
@@ -257,10 +260,7 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
    */
   const buildBatchScene = (spec: ArchetypeSpec, nodeCount: number): void => {
     const batchSize = Math.max(1, spec.batchSize ?? 1);
-    const columns = Math.max(1, Math.ceil(Math.sqrt(nodeCount)));
-    const rows = Math.max(1, Math.ceil(nodeCount / columns));
-    const cellWidth = (VIEWPORT_WIDTH - 2 * GRID_MARGIN) / columns;
-    const cellHeight = (VIEWPORT_HEIGHT - 2 * GRID_MARGIN) / rows;
+    const layout = gridLayout(nodeCount, VIEWPORT_WIDTH, VIEWPORT_HEIGHT, GRID_MARGIN);
     const transform = new Matrix();
     const tint = Color.white;
 
@@ -274,8 +274,7 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
         batches.push(current);
       }
 
-      const x = GRID_MARGIN + (i % columns) * cellWidth + cellWidth / 2;
-      const y = GRID_MARGIN + Math.floor(i / columns) * cellHeight + cellHeight / 2;
+      const { x, y } = gridPosition(i, layout, GRID_MARGIN);
 
       // `add` copies the transform and tint, so one scratch Matrix suffices.
       transform.set(1, 0, x, 0, 1, y);
@@ -397,10 +396,11 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
         spine.push(container);
       }
 
-      const columns = Math.max(1, Math.ceil(Math.sqrt(nodeCount)));
-      const rows = Math.max(1, Math.ceil(nodeCount / columns));
-      const cellWidth = (VIEWPORT_WIDTH - 2 * GRID_MARGIN) / columns;
-      const cellHeight = (VIEWPORT_HEIGHT - 2 * GRID_MARGIN) / rows;
+      // A scrolling archetype lays its leaves out over a world LARGER than the
+      // viewport (`spec.worldSpan`); every other archetype gets a world exactly
+      // the size of the viewport, i.e. the pre-existing layout unchanged.
+      const world = worldExtent(spec, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+      const layout = gridLayout(nodeCount, world.width, world.height, GRID_MARGIN);
       const overdraw = spec.id === 'overdraw';
 
       // Canonical, shared mutation selection: draw one RNG value per leaf in
@@ -475,8 +475,9 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
           leaf.height = VIEWPORT_HEIGHT;
         }
 
-        const x = overdraw ? 0 : GRID_MARGIN + (i % columns) * cellWidth + cellWidth / 2;
-        const y = overdraw ? 0 : GRID_MARGIN + Math.floor(i / columns) * cellHeight + cellHeight / 2;
+        const cell = gridPosition(i, layout, GRID_MARGIN);
+        const x = overdraw ? 0 : cell.x;
+        const y = overdraw ? 0 : cell.y;
 
         leaf.setPosition(x, y);
         spine[i % spine.length]!.addChild(leaf);
@@ -501,6 +502,15 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
       }
 
       views = spec.viewCount !== undefined && spec.viewCount > 1 ? buildViewGrid(spec.viewCount) : [];
+
+      // Park the camera on the frame-0 centre so the first warmup frame already
+      // renders the scene the timed run will see, and so a previous scrolling
+      // cell can never leave this one's view off its world.
+      scrollingSpec = isScrolling(spec) ? spec : null;
+
+      const start = cameraCenterAt(spec, 0, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+
+      app.rendering.view.setCenter(start.x, start.y);
     },
 
     mutationSignature(): string {
@@ -508,6 +518,15 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
     },
 
     mutate(frame: number): void {
+      // Camera step for a scrolling archetype. Both this and the wobble below
+      // run inside the harness's CPU bracket, which is correct: moving the
+      // camera IS the per-frame work such a scene does.
+      if (scrollingSpec !== null && app !== null) {
+        const centre = cameraCenterAt(scrollingSpec, frame, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+
+        app.rendering.view.setCenter(centre.x, centre.y);
+      }
+
       const phase = frame * WOBBLE_SPEED;
       const dx = Math.sin(phase) * WOBBLE_AMPLITUDE;
       const dy = Math.cos(phase) * WOBBLE_AMPLITUDE;
@@ -607,6 +626,7 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
       mutableLeaves = [];
       mutableIndices = [];
       views = [];
+      scrollingSpec = null;
 
       if (app !== null) {
         app.destroy();

--- a/packages/exojs-bench/src/rendering/adapters/phaser.ts
+++ b/packages/exojs-bench/src/rendering/adapters/phaser.ts
@@ -2,6 +2,7 @@ import * as Phaser from 'phaser';
 
 import { mutationSignature, selectMutationIndices } from '../../shared/mutation';
 import type { ArchetypeSpec, Backend, EngineAdapter } from '../EngineAdapter';
+import { isScrolling } from '../world';
 
 /**
  * Phaser 4.2 arm of the rendering benchmark.
@@ -108,6 +109,14 @@ export const createPhaserAdapter = (): EngineAdapter => {
       // WebGPU renderer; it runs under the harness 'webgl2' request (disclosed)
       // and never the 'webgpu' backend.
       return target === 'webgl2';
+    },
+
+    coversArchetype(spec: ArchetypeSpec): boolean {
+      // This arm builds a fixed, viewport-sized scene with a static camera. A
+      // scrolling archetype would silently render as an ordinary fully-visible
+      // one here, i.e. a row that looks comparable and is not — so the arm sits
+      // the archetype out instead.
+      return !isScrolling(spec);
     },
 
     async init(canvas: HTMLCanvasElement, target: Backend): Promise<void> {

--- a/packages/exojs-bench/src/rendering/adapters/pixi.ts
+++ b/packages/exojs-bench/src/rendering/adapters/pixi.ts
@@ -1,7 +1,8 @@
-import { Application, Container, RendererType, Sprite, Texture, type WebGPURenderer } from 'pixi.js';
+import { Application, Container, Culler, RendererType, Sprite, Texture, type WebGPURenderer } from 'pixi.js';
 
 import { mutationSignature, selectMutationIndices } from '../../shared/mutation';
 import type { ArchetypeSpec, Backend, EngineAdapter } from '../EngineAdapter';
+import { cameraCenterAt, GRID_MARGIN, gridLayout, gridPosition, isScrolling, SPRITE_SIZE, VIEWPORT_HEIGHT, VIEWPORT_WIDTH, worldExtent } from '../world';
 
 /**
  * Pixi.js v8 arm of the rendering benchmark — the direct renderer comparison and
@@ -22,13 +23,6 @@ import type { ArchetypeSpec, Backend, EngineAdapter } from '../EngineAdapter';
  * `renderer.render(...)` — the same shape as the ExoJS adapter's one-call frame.
  */
 
-/** Fixed design-space viewport the harness canvas renders (see `page/index.html`). Identical to the ExoJS arm. */
-const VIEWPORT_WIDTH = 1280;
-const VIEWPORT_HEIGHT = 720;
-/** Inset that keeps every gridded sprite (plus its mutation wobble) inside the view so culling never removes it mid-run. */
-const GRID_MARGIN = 32;
-/** Side length of the generated per-archetype textures / sprites, in pixels. */
-const SPRITE_SIZE = 8;
 /** Peak per-axis displacement applied to a mutated leaf; small enough to never cross the viewport edge. */
 const WOBBLE_AMPLITUDE = 2;
 /** Phase step per frame for the mutation wobble. */
@@ -86,7 +80,24 @@ const createDistinctTexture = (index: number, total: number): Texture => {
   return Texture.from(canvas);
 };
 
-export const createPixiAdapter = (): EngineAdapter => {
+/**
+ * Which Pixi arm this adapter represents.
+ *
+ * `default` is stock Pixi: it never culls, because Pixi culls only when the app
+ * registers `CullerPlugin` (which hooks `Application.render`, a loop this
+ * harness never runs) or calls `Culler.shared.cull(...)` itself. On an archetype
+ * with off-screen content that arm therefore draws the whole world — Pixi's real
+ * out-of-the-box behaviour, and the honest upper bound.
+ *
+ * `culled` is the same arm plus the explicit per-frame cull call, i.e. what a
+ * Pixi app that wants culling actually writes. It is measured only on
+ * archetypes with genuine off-screen content (see `coversArchetype` below);
+ * everywhere else the call could only ever be overhead over an unchanged
+ * visible set.
+ */
+export type PixiAdapterConfig = 'default' | 'culled';
+
+export const createPixiAdapter = (config: PixiAdapterConfig = 'default'): EngineAdapter => {
   let app: Application | null = null;
   let backend: Backend | null = null;
   let root: Container | null = null;
@@ -94,13 +105,27 @@ export const createPixiAdapter = (): EngineAdapter => {
   let mutableLeaves: MutableLeaf[] = [];
   /** Leaf indices the most recent buildScene selected for mutation — the source of {@link EngineAdapter.mutationSignature}. */
   let mutableIndices: number[] = [];
+  /**
+   * The archetype currently built, when it scrolls a camera; `null` otherwise.
+   * Pixi has no camera object, so the idiomatic equivalent — and what this arm
+   * does — is to translate the world container under a fixed screen rect. Same
+   * visible content per frame as the ExoJS arm's view move; different mechanism,
+   * disclosed in the report's Methodology.
+   */
+  let scrollingSpec: ArchetypeSpec | null = null;
 
   return {
     engine: 'pixi',
-    config: 'default',
+    config,
 
     supports(target: Backend): boolean {
       return target === 'webgl2' || target === 'webgpu';
+    },
+
+    coversArchetype(spec: ArchetypeSpec): boolean {
+      // The stock arm runs everywhere; the culled variant only where culling can
+      // actually remove something.
+      return config === 'default' || spec.cullingEnabled;
     },
 
     async init(canvas: HTMLCanvasElement, target: Backend): Promise<void> {
@@ -159,13 +184,14 @@ export const createPixiAdapter = (): EngineAdapter => {
       // propagation identically for a fair per-node cost.
       const sceneRoot = new Container();
 
-      // `spec.cullingEnabled` is `false` for every archetype (see
-      // `archetypes.ts` for the fairness rationale): setting `.cullable` here is a
-      // no-op anyway because this arm never registers `CullerPlugin` (nor
-      // calls `Culler.shared.cull(...)`) — the flag is inert data on Pixi
-      // unless one of those is wired up. Kept in sync with the ExoJS arm's
-      // flag purely so both scenes stay a byte-for-byte transcription of
-      // each other, not because it does anything on this side.
+      // `spec.cullingEnabled` is `false` for every fully-visible archetype (see
+      // `archetypes.ts` for the fairness rationale). On the `default` arm the
+      // flag is inert either way — Pixi acts on `.cullable` only when something
+      // calls `Culler.shared.cull(...)`, which that arm never does — and it is
+      // kept in sync with the ExoJS arm purely so both scenes stay a
+      // byte-for-byte transcription of each other. On the `culled` arm it is
+      // load-bearing: it is exactly the flag the per-frame cull in `renderFrame`
+      // reads.
       sceneRoot.cullable = spec.cullingEnabled;
 
       const spine: Container[] = [sceneRoot];
@@ -178,10 +204,12 @@ export const createPixiAdapter = (): EngineAdapter => {
         spine.push(container);
       }
 
-      const columns = Math.max(1, Math.ceil(Math.sqrt(nodeCount)));
-      const rows = Math.max(1, Math.ceil(nodeCount / columns));
-      const cellWidth = (VIEWPORT_WIDTH - 2 * GRID_MARGIN) / columns;
-      const cellHeight = (VIEWPORT_HEIGHT - 2 * GRID_MARGIN) / rows;
+      // World extent and grid come from the SAME shared helpers the ExoJS arm
+      // uses (`world.ts`), so a scrolling archetype places the identical leaf at
+      // the identical world position on both arms — the layout counterpart of
+      // the shared mutation selection below.
+      const world = worldExtent(spec, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+      const layout = gridLayout(nodeCount, world.width, world.height, GRID_MARGIN);
       const overdraw = spec.id === 'overdraw';
 
       // Shared, canonical mutation selection — the SAME helper the ExoJS arm
@@ -222,8 +250,9 @@ export const createPixiAdapter = (): EngineAdapter => {
           sprite.height = VIEWPORT_HEIGHT;
         }
 
-        const x = overdraw ? 0 : GRID_MARGIN + (i % columns) * cellWidth + cellWidth / 2;
-        const y = overdraw ? 0 : GRID_MARGIN + Math.floor(i / columns) * cellHeight + cellHeight / 2;
+        const cell = gridPosition(i, layout, GRID_MARGIN);
+        const x = overdraw ? 0 : cell.x;
+        const y = overdraw ? 0 : cell.y;
 
         sprite.position.set(x, y);
         spine[i % spine.length]!.addChild(sprite);
@@ -236,6 +265,13 @@ export const createPixiAdapter = (): EngineAdapter => {
       root = sceneRoot;
       mutableLeaves = leaves;
       mutableIndices = selectedIndices;
+      scrollingSpec = isScrolling(spec) ? spec : null;
+
+      // Park the world on the frame-0 camera centre, so the first warmup frame
+      // already shows what the timed run will see.
+      const start = cameraCenterAt(spec, 0, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+
+      sceneRoot.position.set(VIEWPORT_WIDTH / 2 - start.x, VIEWPORT_HEIGHT / 2 - start.y);
     },
 
     mutationSignature(): string {
@@ -243,6 +279,12 @@ export const createPixiAdapter = (): EngineAdapter => {
     },
 
     mutate(frame: number): void {
+      if (scrollingSpec !== null && root !== null) {
+        const centre = cameraCenterAt(scrollingSpec, frame, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+
+        root.position.set(VIEWPORT_WIDTH / 2 - centre.x, VIEWPORT_HEIGHT / 2 - centre.y);
+      }
+
       const phase = frame * WOBBLE_SPEED;
       const dx = Math.sin(phase) * WOBBLE_AMPLITUDE;
       const dy = Math.cos(phase) * WOBBLE_AMPLITUDE;
@@ -272,6 +314,17 @@ export const createPixiAdapter = (): EngineAdapter => {
         throw new Error('renderFrame was called before buildScene.');
       }
 
+      // The `culled` arm's per-frame cull, the analogue of what `CullerPlugin`
+      // would do if this harness ran Pixi's Application loop. `skipUpdateTransform`
+      // is passed FALSE (the plugin's default is true) because the camera moved
+      // in `mutate` since the last render: with stale world transforms the cull
+      // would test this frame's screen rect against last frame's bounds and
+      // decide the boundary row wrong. Pixi's own documented example for a
+      // moving scene passes false for the same reason.
+      if (config === 'culled') {
+        Culler.shared.cull(root, app.renderer.screen, false);
+      }
+
       // One explicit frame: clear + render the tree + submit, the analogue of the
       // ExoJS adapter's resetStats/clear/render/flush sequence.
       app.renderer.render({ container: root, clear: true });
@@ -290,6 +343,7 @@ export const createPixiAdapter = (): EngineAdapter => {
       textures = [];
       mutableLeaves = [];
       mutableIndices = [];
+      scrollingSpec = null;
 
       if (app !== null) {
         // `removeView: false` — keep the shared `#stage` canvas in the DOM for

--- a/packages/exojs-bench/src/rendering/archetypes.ts
+++ b/packages/exojs-bench/src/rendering/archetypes.ts
@@ -15,9 +15,10 @@ const GPU_BOUND_COUNTS = [1_000, 5_000, 25_000] as const;
  * at 25k: a 100k measurement there would be dominated by overdraw and state
  * changes and would say nothing about node scaling.
  */
-// Fairness: `cullingEnabled` is `false` on every archetype below.
-// Every archetype keeps its sprites fully on-screen (`GRID_MARGIN` in the
-// adapters), so a viewport cull check never actually removes a node here —
+// Fairness: `cullingEnabled` is `false` on every archetype below except
+// `scrolling-world`, the only one with genuine off-screen content.
+// Every other archetype keeps its sprites fully on-screen (`GRID_MARGIN` in the
+// adapters), so a viewport cull check never actually removes a node there —
 // it can only ever be a no-op. Left on, it was pure asymmetric overhead: the
 // exojs adapter's `cullable` flag drives a REAL per-node bounds+intersection
 // check in the render walk (`SceneNode.inView`, called from every
@@ -28,9 +29,11 @@ const GPU_BOUND_COUNTS = [1_000, 5_000, 25_000] as const;
 // cross-arm comparison for a check that never changed the visible set.
 // Disabling it on both arms makes them do the same visible-set work; see
 // `EngineAdapter.ts`'s `cullingEnabled` doc and the report's Methodology
-// section for the full disclosure. Re-enabling it for a future archetype that
-// genuinely has off-screen content requires giving Pixi an equivalent
-// `CullerPlugin` registration first, or the asymmetry returns.
+// section for the full disclosure. `scrolling-world` is the exception the last
+// sentence of that note asked for: it has real off-screen content, so it runs
+// on two Pixi arms — `default` (culling off, Pixi's out-of-the-box behaviour)
+// and `culled` (explicit per-frame `Culler.shared.cull`) — instead of resolving
+// the asymmetry by assumption.
 export const ARCHETYPES: readonly ArchetypeSpec[] = [
   { id: 'static-heavy', nodeCounts: SCALING_COUNTS, nestingDepth: 4, textureCount: 1, mutationFraction: 0, cullingEnabled: false },
   { id: 'dynamic-heavy', nodeCounts: SCALING_COUNTS, nestingDepth: 4, textureCount: 1, mutationFraction: 0.075, cullingEnabled: false },
@@ -157,6 +160,27 @@ export const ARCHETYPES: readonly ArchetypeSpec[] = [
     meshRunLength: 4,
     meshStorage: 'array',
   },
+  // The only archetype with content OUTSIDE the view, and the only one with a
+  // moving camera. Every other archetype builds its scene fully on-screen under
+  // a static view, so nothing in the matrix has ever measured what a scrolling
+  // map costs — which is the shape of practically every real 2D scene.
+  //
+  // `worldSpan: 2` lays `nodeCount` leaves over 4x the viewport's AREA, so about
+  // 25% are visible at any moment and the other 75% are the off-screen content
+  // under study. `nodeCount` stays the WORLD total, exactly as it is on every
+  // other archetype, so the per-node build/traversal cost is comparable across
+  // the matrix; only the drawn quarter of it reaches the GPU.
+  //
+  // `cameraSpeed: 8` is 8 world units per frame along the diagonal, i.e. ~480
+  // units/s at 60fps — a brisk but ordinary scroll rate for a 1280x720 view.
+  // It is the archetype's one free parameter, and the one to sweep when reading
+  // any "how often does the camera invalidate a cached product" curve: that
+  // frequency falls roughly linearly with (tolerance band width / camera speed).
+  //
+  // Otherwise identical to `static-heavy` (depth 4, one texture, no mutation),
+  // so the delta between the two rows is the camera and the off-screen content
+  // and nothing else.
+  { id: 'scrolling-world', nodeCounts: SCALING_COUNTS, nestingDepth: 4, textureCount: 1, mutationFraction: 0, cullingEnabled: true, worldSpan: 2, cameraSpeed: 8 },
   {
     id: 'mixed-material-atlased',
     nodeCounts: GPU_BOUND_COUNTS,
@@ -210,6 +234,10 @@ export const buildMatrix = (adapters: readonly EngineAdapter[], backends: readon
       if (!adapter.supports(backend)) continue;
 
       for (const archetype of ARCHETYPES) {
+        // Arms that are a variant of another arm cover only the archetypes
+        // where the variation is the point (see `EngineAdapter.coversArchetype`).
+        if (adapter.coversArchetype?.(archetype) === false) continue;
+
         for (const nodeCount of archetype.nodeCounts) {
           cells.push({
             engine: adapter.engine,

--- a/packages/exojs-bench/src/rendering/driver.ts
+++ b/packages/exojs-bench/src/rendering/driver.ts
@@ -9,7 +9,8 @@ import { chromium } from 'playwright';
 import type { BaseProvenance, LibraryProvenance } from '../shared/provenance';
 import { readLibraryProvenance } from '../shared/provenance';
 import { buildMatrix } from './archetypes';
-import type { Backend, CellResult, CellSpec, EngineAdapter } from './EngineAdapter';
+import type { ArchetypeSpec, Backend, CellResult, CellSpec, EngineAdapter } from './EngineAdapter';
+import { isScrolling } from './world';
 
 // Re-exported so `rendering/index.ts` and the CLI keep importing `LibraryProvenance`
 // from the rendering barrel unchanged while the definition lives in `shared/`.
@@ -139,10 +140,11 @@ const driverSideOnly = (): never => {
   throw new Error('Adapter lifecycle runs in the harness page, not in the driver process.');
 };
 
-const capabilityDescriptor = (engine: string, config: string, backends: readonly Backend[]): EngineAdapter => ({
+const capabilityDescriptor = (engine: string, config: string, backends: readonly Backend[], coversArchetype?: (spec: ArchetypeSpec) => boolean): EngineAdapter => ({
   engine,
   config,
   supports: (backend: Backend): boolean => backends.includes(backend),
+  ...(coversArchetype !== undefined && { coversArchetype }),
   init: driverSideOnly,
   buildScene: driverSideOnly,
   mutate: driverSideOnly,
@@ -159,6 +161,13 @@ const ADAPTER_CAPABILITIES: readonly EngineAdapter[] = [
   // local-only reference; its version + provenance are stamped into the report
   // header via `readLibraryProvenance`.
   capabilityDescriptor('pixi', 'default', ['webgl2', 'webgpu']),
+  // Second Pixi arm: stock Pixi PLUS the explicit per-frame `Culler.shared.cull`
+  // a Pixi app that wants culling has to write itself. It runs only on
+  // archetypes with genuine off-screen content (`cullingEnabled`), where the
+  // difference between the two arms is the measurement; on a fully-visible
+  // archetype the cull call could only ever add cost over an identical visible
+  // set, so the variant would just duplicate `pixi default` across the matrix.
+  capabilityDescriptor('pixi', 'culled', ['webgl2', 'webgpu'], spec => spec.cullingEnabled),
   // Phaser 4 and Excalibur are committed competitor arms (pinned exact
   // devDependencies). Both are WebGL2-only in this harness and never run WebGPU
   // (Phaser 4 ships no WebGPU renderer; Excalibur 0.32 has none). Phaser 4 is
@@ -169,8 +178,11 @@ const ADAPTER_CAPABILITIES: readonly EngineAdapter[] = [
   // A missing (unlinked) competitor degrades gracefully: its per-cell dynamic
   // import fails in isolation (`runCellInPage` records that cell `unavailable`
   // and the run continues), and it is left out of Vite's pre-bundle set below.
-  capabilityDescriptor('phaser', 'default', ['webgl2']),
-  capabilityDescriptor('excalibur', 'default', ['webgl2']),
+  // Both sit out the scrolling archetypes: neither arm implements a moving
+  // camera, so they would render a fixed, fully-visible scene under an id that
+  // promises off-screen content — a row that looks comparable and is not.
+  capabilityDescriptor('phaser', 'default', ['webgl2'], spec => !isScrolling(spec)),
+  capabilityDescriptor('excalibur', 'default', ['webgl2'], spec => !isScrolling(spec)),
 ];
 
 /**

--- a/packages/exojs-bench/src/rendering/page/harness.ts
+++ b/packages/exojs-bench/src/rendering/page/harness.ts
@@ -639,7 +639,7 @@ const resolveAdapter = async (engine: string, config: string): Promise<EngineAda
   } else if (engine === 'pixi') {
     const { createPixiAdapter } = await import('../adapters/pixi');
 
-    adapter = createPixiAdapter();
+    adapter = createPixiAdapter(config === 'culled' ? 'culled' : 'default');
   } else if (engine === 'phaser') {
     const { createPhaserAdapter } = await import('../adapters/phaser');
 

--- a/packages/exojs-bench/src/rendering/report.ts
+++ b/packages/exojs-bench/src/rendering/report.ts
@@ -140,19 +140,20 @@ const toMarkdown = (data: ReportData): string => {
     lines.push('');
   }
 
-  // Methodology disclosure: leaving per-archetype culling on while every
-  // archetype keeps its sprites on-screen would mean the cull check never
-  // removes a node — pure asymmetric overhead, since ExoJS's `cullable` drives
-  // a real per-node bounds check in the render walk while Pixi's `cullable` is
-  // inert unless `CullerPlugin` is registered (it is not, in `adapters/pixi.ts`).
-  // Culling is disabled on every archetype (`cullingEnabled: false` in
-  // `archetypes.ts`) so both arms do identical visible-set work; this line
-  // makes that explicit in every generated report rather than leaving it to
-  // source-comment archaeology.
+  // Methodology disclosure: leaving per-archetype culling on while an archetype
+  // keeps its sprites on-screen would mean the cull check never removes a node —
+  // pure asymmetric overhead, since ExoJS's `cullable` drives a real per-node
+  // bounds check in the render walk while Pixi's `cullable` is inert unless
+  // something calls `Culler.shared.cull(...)`. Culling is therefore disabled on
+  // every fully-visible archetype, and the one archetype with real off-screen
+  // content resolves the asymmetry by MEASURING both Pixi behaviours instead of
+  // assuming one. These lines make that explicit in every generated report
+  // rather than leaving it to source-comment archaeology.
   lines.push(
     '## Methodology',
     '',
-    '- **Culling:** disabled on every archetype (`cullingEnabled: false`). Every archetype keeps its sprites fully on-screen, so a cull check never removes a node — it can only add overhead. ExoJS\'s `cullable` flag drives a real per-node bounds/intersection check in the render walk; Pixi\'s `cullable` flag is inert unless the app registers `CullerPlugin`, which this harness does not do. The Phaser arm does no bounds culling (its default `willRender` checks only visibility/alpha flags), and the Excalibur arm never runs its off-screen culling system (only the draw path is stepped, not the update systems that tag entities off-screen). Every arm therefore does identical visible-set work.',
+    '- **Culling:** disabled on every archetype whose content is fully on-screen (`cullingEnabled: false`) — there a cull check never removes a node and can only add overhead, and the arms do not pay equally for it: ExoJS\'s `cullable` flag drives a real per-node bounds/intersection check in the render walk, while Pixi\'s `cullable` flag is inert unless something calls `Culler.shared.cull(...)`. The Phaser arm does no bounds culling (its default `willRender` checks only visibility/alpha flags), and the Excalibur arm never runs its off-screen culling system (only the draw path is stepped, not the update systems that tag entities off-screen). On those archetypes every arm therefore does identical visible-set work.',
+    '- **`scrolling-world` is the one archetype with off-screen content**, and the only one with a moving camera: `nodeCount` leaves are laid out over 4x the viewport\'s area (`worldSpan: 2`), so roughly 25% are visible at any moment, and the camera travels the world diagonal at `cameraSpeed` units per frame, reflecting off the world edges on a path that is a closed form in the frame index (identical on every arm). Two disclosures apply to its rows. **(1) Camera mechanism differs by arm, idiomatically:** ExoJS moves its `View` centre (the engine has a real camera, and the view rect is what its culling and its retained-render-product validity key on); Pixi has no camera object, so that arm translates the world container under a fixed screen rect. Both show the identical world content per frame. **(2) Two Pixi arms:** `pixi default` is stock Pixi and does NOT cull — it draws the off-screen content too, which is Pixi\'s out-of-the-box behaviour and the honest upper bound; `pixi culled` adds the explicit per-frame `Culler.shared.cull(root, renderer.screen, false)` a Pixi app that wants culling has to write itself. Read the ExoJS rows against `pixi culled` for a culling-vs-culling comparison, and against `pixi default` for the out-of-the-box one. `pixi culled` is measured only on this archetype.',
     '- **Phaser renders WebGL, not WebGL2.** The Phaser arm is measured as a stock Phaser 4 app: Phaser 4.2 is often described as a from-scratch WebGL2 renderer, but its `WebGLRenderer` requests a plain `webgl` (WebGL1) context by default (`canvas.getContext(\'webgl\')`, WebGLRenderer.js:709), uses GLSL ES 1.00 shaders, and polyfills the WebGL2-core features it needs (instanced arrays, VAO) from WebGL1 extensions — its renderer is an evolution of the Phaser 3.85+ WebGL path, not a WebGL2 rewrite. The arm runs under the `webgl2` backend *request* but its rows are WebGL-rendered. Its CPU-time column is measured identically to the other arms and **is** cross-arm comparable; its full-frame time comes from the rAF delta (as it does for any arm when the optional GPU-timer extension is absent). The WebGL2 draw-call structural probe cannot attach to a WebGL context, so the Phaser arm reports **no structural counters** (`drawCalls`/`textureBinds`/`bufferUploads` show 0 with an explanatory `note`) — the counts are omitted, never faked. Compare structural columns only among the WebGL2 arms (ExoJS, Pixi, Excalibur). Phaser 4 ships no WebGPU renderer, so it never runs the `webgpu` backend.',
     '- **Competitor render-path isolation.** Each competitor arm is driven through only its render path with its own loop suppressed: Phaser via `renderer.preRender()` + `SceneManager.render()` + `renderer.postRender()` with `game.loop.stop()`; Excalibur via its public draw sequence (`beginDrawLifecycle`/`clear`/`currentScene.draw`/`flush`/`endDrawLifecycle`) with `engine.clock.stop()`. Update/input/physics subsystems are never stepped, so only rendering is measured.',
     '',

--- a/packages/exojs-bench/src/rendering/world.ts
+++ b/packages/exojs-bench/src/rendering/world.ts
@@ -1,0 +1,191 @@
+import type { ArchetypeSpec } from './EngineAdapter';
+
+/**
+ * Shared scene-space geometry: the grid every archetype lays its leaves on, and
+ * the deterministic camera path the scrolling archetypes drive.
+ *
+ * Both live here rather than in the adapters for the same reason
+ * `selectMutationIndices` does: every arm must place the identical leaf at the
+ * identical world position and must observe the identical camera centre for a
+ * given frame index, or the arms are not comparable. A single implementation
+ * makes that a fact rather than a convention two files happen to agree on, and
+ * lets the archetype tests assert the resulting off-screen fraction against the
+ * same code the adapters run.
+ */
+
+/**
+ * Fixed design-space viewport the harness canvas renders (see
+ * `page/index.html` and `page/harness.ts`'s STAGE_*). Every arm initialises its
+ * engine at exactly this size, so it is the reference rect for both the grid
+ * layout and the camera path.
+ */
+export const VIEWPORT_WIDTH = 1280;
+export const VIEWPORT_HEIGHT = 720;
+/** Inset that keeps every gridded leaf (plus its mutation wobble) off the world edge. */
+export const GRID_MARGIN = 32;
+/** Side length of the generated per-archetype textures / leaf quads, in pixels. */
+export const SPRITE_SIZE = 8;
+
+/** Row/column layout of the leaf grid, plus the cell size derived from it. */
+export interface GridLayout {
+  /** Number of grid columns. */
+  readonly columns: number;
+  /** Number of grid rows. */
+  readonly rows: number;
+  /** Width of one grid cell, in world units. */
+  readonly cellWidth: number;
+  /** Height of one grid cell, in world units. */
+  readonly cellHeight: number;
+}
+
+/** A world-space point — the camera centre, or one leaf's resting position. */
+export interface WorldPoint {
+  /** World-space x coordinate. */
+  readonly x: number;
+  /** World-space y coordinate. */
+  readonly y: number;
+}
+
+/** Size of the world the scene is laid out across, in world units. */
+export interface WorldExtent {
+  /** World width. */
+  readonly width: number;
+  /** World height. */
+  readonly height: number;
+}
+
+/**
+ * Near-square grid covering `width` x `height` inset by `margin` on every side.
+ * The margin is what keeps a leaf (plus its mutation wobble) off the world edge,
+ * so a non-scrolling archetype's sprites stay fully inside the view.
+ */
+export const gridLayout = (nodeCount: number, width: number, height: number, margin: number): GridLayout => {
+  const columns = Math.max(1, Math.ceil(Math.sqrt(nodeCount)));
+  const rows = Math.max(1, Math.ceil(nodeCount / columns));
+
+  return {
+    columns,
+    rows,
+    cellWidth: (width - 2 * margin) / columns,
+    cellHeight: (height - 2 * margin) / rows,
+  };
+};
+
+/** Resting position of leaf `index` on `layout`, in row-major order. */
+export const gridPosition = (index: number, layout: GridLayout, margin: number): WorldPoint => ({
+  x: margin + (index % layout.columns) * layout.cellWidth + layout.cellWidth / 2,
+  y: margin + Math.floor(index / layout.columns) * layout.cellHeight + layout.cellHeight / 2,
+});
+
+/**
+ * Whether this archetype scrolls a camera across a world larger than the
+ * viewport. Keyed on {@link ArchetypeSpec.cameraSpeed} being a positive number:
+ * an archetype that leaves it unset keeps the fixed, viewport-sized world every
+ * pre-existing archetype uses.
+ */
+export const isScrolling = (spec: ArchetypeSpec): boolean => (spec.cameraSpeed ?? 0) > 0;
+
+/**
+ * World extent for an archetype: `worldSpan` viewports per AXIS, so the content
+ * multiple is its square (`worldSpan: 2` means 4x the viewport's area). A
+ * non-scrolling archetype gets exactly the viewport, which is what every
+ * pre-existing archetype assumes.
+ */
+export const worldExtent = (spec: ArchetypeSpec, viewportWidth: number, viewportHeight: number): WorldExtent => {
+  const span = isScrolling(spec) ? Math.max(1, spec.worldSpan ?? 1) : 1;
+
+  return { width: viewportWidth * span, height: viewportHeight * span };
+};
+
+/**
+ * Triangle wave: `value` folded back and forth inside `[0, span]`.
+ *
+ * A reflecting path rather than a wrapping one, because a wrap teleports the
+ * camera by a full span in one frame — a single frame of total re-collection
+ * that has nothing to do with the scroll rate under study. Reflection keeps the
+ * speed constant and the path continuous, so the only discontinuity in the whole
+ * run is the direction flip at each wall.
+ */
+const reflect = (value: number, span: number): number => {
+  if (span <= 0) {
+    return 0;
+  }
+
+  const period = 2 * span;
+  const wrapped = ((value % period) + period) % period;
+
+  return wrapped <= span ? wrapped : period - wrapped;
+};
+
+/**
+ * Camera centre for `frame`, as a CLOSED FORM in the frame index rather than an
+ * accumulated position. Warmup and timed frames therefore see one continuous
+ * path, a re-run lands on the identical centres, and both arms agree without
+ * having to synchronise any state.
+ *
+ * The camera travels the diagonal at {@link ArchetypeSpec.cameraSpeed} world
+ * units per frame — equal per-axis components of a unit diagonal, so the SPEED
+ * is the archetype's parameter, not the per-axis rate — and reflects off the
+ * world edges. The two axes have different travel spans whenever the viewport is
+ * not square (1280x720 gives 1280 and 720), so the reflections desync and the
+ * path never degenerates into retracing one line.
+ */
+export const cameraCenterAt = (spec: ArchetypeSpec, frame: number, viewportWidth: number, viewportHeight: number): WorldPoint => {
+  const world = worldExtent(spec, viewportWidth, viewportHeight);
+
+  if (!isScrolling(spec)) {
+    return { x: world.width / 2, y: world.height / 2 };
+  }
+
+  // The centre may travel only as far as keeps the view inside the world, so
+  // the visible rect is always fully covered by content and the off-screen
+  // fraction stays at the archetype's design value for every frame.
+  const travel = frame * (spec.cameraSpeed ?? 0) * Math.SQRT1_2;
+
+  return {
+    x: viewportWidth / 2 + reflect(travel, world.width - viewportWidth),
+    y: viewportHeight / 2 + reflect(travel, world.height - viewportHeight),
+  };
+};
+
+/**
+ * Number of leaves whose quad intersects the view rect at `frame` — the
+ * archetype's on-screen node count, computed from the same layout and camera
+ * path the adapters use.
+ *
+ * Analytic on purpose: the harness's structural probe counts GPU draw calls, not
+ * nodes, and reading an engine's own culling statistics would make the figure
+ * arm-specific. This is neutral, so a test can pin an archetype's off-screen
+ * fraction as a property of the archetype rather than of whoever renders it.
+ */
+export const visibleLeafCount = (
+  spec: ArchetypeSpec,
+  nodeCount: number,
+  frame: number,
+  viewportWidth: number,
+  viewportHeight: number,
+  margin: number,
+  leafSize: number,
+): number => {
+  const world = worldExtent(spec, viewportWidth, viewportHeight);
+  const layout = gridLayout(nodeCount, world.width, world.height, margin);
+  const centre = cameraCenterAt(spec, frame, viewportWidth, viewportHeight);
+  const left = centre.x - viewportWidth / 2;
+  const top = centre.y - viewportHeight / 2;
+  const right = left + viewportWidth;
+  const bottom = top + viewportHeight;
+
+  let visible = 0;
+
+  for (let index = 0; index < nodeCount; index++) {
+    const position = gridPosition(index, layout, margin);
+
+    // Leaves anchor top-left (both adapters leave the anchor at its default),
+    // so the quad spans [x, x + leafSize) x [y, y + leafSize).
+    if (position.x < right && position.x + leafSize > left && position.y < bottom && position.y + leafSize > top) {
+      visible++;
+    }
+  }
+
+  return visible;
+};

--- a/packages/exojs-bench/test/scrolling-world.test.ts
+++ b/packages/exojs-bench/test/scrolling-world.test.ts
@@ -1,0 +1,150 @@
+import { ARCHETYPES, buildMatrix } from '../src/rendering/archetypes';
+import type { ArchetypeSpec, Backend, EngineAdapter } from '../src/rendering/EngineAdapter';
+import { cameraCenterAt, GRID_MARGIN, isScrolling, SPRITE_SIZE, VIEWPORT_HEIGHT, VIEWPORT_WIDTH, visibleLeafCount, worldExtent } from '../src/rendering/world';
+
+const scrollingWorld = ARCHETYPES.find(archetype => archetype.id === 'scrolling-world')!;
+
+/** Frames sampled across a long stretch of the camera path, including several reflections off the world edges. */
+const SAMPLE_FRAMES = [0, 1, 7, 60, 120, 199, 331, 512, 900, 1_337];
+
+describe('scrolling-world archetype', () => {
+  test('is the only archetype with off-screen content and a moving camera', () => {
+    const scrolling = ARCHETYPES.filter(isScrolling);
+    const culling = ARCHETYPES.filter(archetype => archetype.cullingEnabled);
+
+    expect(scrolling.map(archetype => archetype.id)).toEqual(['scrolling-world']);
+    expect(culling.map(archetype => archetype.id)).toEqual(['scrolling-world']);
+  });
+
+  test('lays its nodes out over four times the viewport area', () => {
+    const world = worldExtent(scrollingWorld, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+
+    expect(world.width).toBe(VIEWPORT_WIDTH * 2);
+    expect(world.height).toBe(VIEWPORT_HEIGHT * 2);
+    expect((world.width * world.height) / (VIEWPORT_WIDTH * VIEWPORT_HEIGHT)).toBe(4);
+  });
+
+  test('is otherwise identical to static-heavy, so the delta is the camera and the off-screen content', () => {
+    const staticHeavy = ARCHETYPES.find(archetype => archetype.id === 'static-heavy')!;
+
+    expect(scrollingWorld.nodeCounts).toEqual(staticHeavy.nodeCounts);
+    expect(scrollingWorld.nestingDepth).toBe(staticHeavy.nestingDepth);
+    expect(scrollingWorld.textureCount).toBe(staticHeavy.textureCount);
+    expect(scrollingWorld.mutationFraction).toBe(staticHeavy.mutationFraction);
+  });
+});
+
+describe('cameraCenterAt', () => {
+  test('is a closed form in the frame index, so repeated evaluation agrees', () => {
+    for (const frame of SAMPLE_FRAMES) {
+      expect(cameraCenterAt(scrollingWorld, frame, VIEWPORT_WIDTH, VIEWPORT_HEIGHT)).toEqual(
+        cameraCenterAt(scrollingWorld, frame, VIEWPORT_WIDTH, VIEWPORT_HEIGHT),
+      );
+    }
+  });
+
+  test('never lets the view leave the world', () => {
+    const world = worldExtent(scrollingWorld, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+
+    for (let frame = 0; frame < 2_000; frame++) {
+      const centre = cameraCenterAt(scrollingWorld, frame, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+
+      expect(centre.x - VIEWPORT_WIDTH / 2).toBeGreaterThanOrEqual(0);
+      expect(centre.y - VIEWPORT_HEIGHT / 2).toBeGreaterThanOrEqual(0);
+      expect(centre.x + VIEWPORT_WIDTH / 2).toBeLessThanOrEqual(world.width);
+      expect(centre.y + VIEWPORT_HEIGHT / 2).toBeLessThanOrEqual(world.height);
+    }
+  });
+
+  test('travels at the archetype rate, slowing only in the frame that crosses a wall', () => {
+    const speed = scrollingWorld.cameraSpeed!;
+
+    let atSpeed = 0;
+
+    for (let frame = 1; frame < 2_000; frame++) {
+      const previous = cameraCenterAt(scrollingWorld, frame - 1, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+      const current = cameraCenterAt(scrollingWorld, frame, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+      const step = Math.hypot(current.x - previous.x, current.y - previous.y);
+
+      // A reflection splits one frame's travel between two directions, so that
+      // frame's straight-line displacement is shorter; it can never be longer.
+      expect(step).toBeLessThanOrEqual(speed + 1e-9);
+
+      if (Math.abs(step - speed) < 1e-9) {
+        atSpeed++;
+      }
+    }
+
+    // Reflections are rare (a wall every ~160 or ~90 frames per axis), so the
+    // overwhelming majority of frames move at exactly the archetype's rate.
+    expect(atSpeed).toBeGreaterThan(1_900);
+  });
+
+  test('parks a non-scrolling archetype in the middle of its viewport-sized world', () => {
+    const staticHeavy = ARCHETYPES.find(archetype => archetype.id === 'static-heavy')!;
+
+    expect(cameraCenterAt(staticHeavy, 0, VIEWPORT_WIDTH, VIEWPORT_HEIGHT)).toEqual({ x: VIEWPORT_WIDTH / 2, y: VIEWPORT_HEIGHT / 2 });
+    expect(cameraCenterAt(staticHeavy, 500, VIEWPORT_WIDTH, VIEWPORT_HEIGHT)).toEqual({ x: VIEWPORT_WIDTH / 2, y: VIEWPORT_HEIGHT / 2 });
+  });
+});
+
+describe('off-screen fraction', () => {
+  test('keeps roughly three quarters of the world off-screen on every sampled frame', () => {
+    const nodeCount = 25_000;
+
+    for (const frame of SAMPLE_FRAMES) {
+      const visible = visibleLeafCount(scrollingWorld, nodeCount, frame, VIEWPORT_WIDTH, VIEWPORT_HEIGHT, GRID_MARGIN, SPRITE_SIZE);
+      const fraction = visible / nodeCount;
+
+      // The grid is inset by GRID_MARGIN and the view can reach the world edge,
+      // so the visible share sits slightly above the naive area ratio of 0.25
+      // near a wall. A band around it is the honest assertion; the point is that
+      // the majority of the scene is off-screen in every frame.
+      expect(fraction).toBeGreaterThan(0.2);
+      expect(fraction).toBeLessThan(0.32);
+    }
+  });
+
+  test('leaves nothing off-screen on a non-scrolling archetype', () => {
+    const staticHeavy = ARCHETYPES.find(archetype => archetype.id === 'static-heavy')!;
+    const nodeCount = 5_000;
+
+    expect(visibleLeafCount(staticHeavy, nodeCount, 0, VIEWPORT_WIDTH, VIEWPORT_HEIGHT, GRID_MARGIN, SPRITE_SIZE)).toBe(nodeCount);
+  });
+});
+
+describe('arm coverage', () => {
+  const fakeAdapter = (engine: string, config: string, coversArchetype?: (spec: ArchetypeSpec) => boolean): EngineAdapter =>
+    ({
+      engine,
+      config,
+      supports: (backend: Backend) => backend === 'webgl2',
+      ...(coversArchetype !== undefined && { coversArchetype }),
+      init: async () => undefined,
+      buildScene: () => undefined,
+      mutate: () => undefined,
+      renderFrame: () => undefined,
+      teardown: () => undefined,
+    }) satisfies EngineAdapter;
+
+  test('an arm without a coverage predicate is measured on every archetype', () => {
+    const cells = buildMatrix([fakeAdapter('exojs', 'current')], ['webgl2']);
+    const covered = new Set(cells.map(cell => cell.archetype));
+
+    expect(covered.size).toBe(ARCHETYPES.length);
+  });
+
+  test('the culled Pixi variant is measured only where culling can remove something', () => {
+    const cells = buildMatrix([fakeAdapter('pixi', 'culled', spec => spec.cullingEnabled)], ['webgl2']);
+
+    expect(new Set(cells.map(cell => cell.archetype))).toEqual(new Set(['scrolling-world']));
+    expect(cells.map(cell => cell.nodeCount)).toEqual([...scrollingWorld.nodeCounts]);
+  });
+
+  test('arms without a camera sit the scrolling archetypes out', () => {
+    const cells = buildMatrix([fakeAdapter('phaser', 'default', spec => !isScrolling(spec))], ['webgl2']);
+
+    expect(cells.some(cell => cell.archetype === 'scrolling-world')).toBe(false);
+    expect(cells.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Adds the `scrolling-world` archetype to the benchmark matrix.

## Why

Every existing archetype builds its scene fully on-screen under a static view, so the matrix has never measured what a scrolling map costs — the shape of practically every real 2D scene, and the case where per-child view culling forces a full re-collect on every frame.

## What it measures

`scrolling-world` lays `nodeCount` leaves over 4× the viewport's area (`worldSpan: 2`, ~75% off-screen at any moment) and moves the camera along the world diagonal at a fixed rate, reflecting off the world edges. The camera path is a closed form in the frame index, so warmup and timed frames see one continuous camera and every arm observes the identical centre without synchronising state. Otherwise identical to `static-heavy`, so the delta between the two rows is the camera and the off-screen content alone.

## Fairness

Grid layout and camera live in the new `rendering/world.ts` and are shared by the arms — the same construction `selectMutationIndices` already uses for the mutation set: one implementation means both arms place the identical leaf at the identical world position by construction. The module also exposes an analytic `visibleLeafCount` so a test can pin the archetype's off-screen fraction neutrally, without reading any engine's own culling statistics.

The camera mechanism differs per arm, idiomatically: ExoJS moves its `View` centre (the rect its culling and its retained-product validity key on), Pixi translates the world container under a fixed screen rect. Both show the identical content per frame; the report's Methodology discloses it.

## Culling arms

This is the first archetype with `cullingEnabled: true`, which the previous fairness note explicitly deferred until Pixi had a real culling path. It now runs on two Pixi arms instead:

- **pixi default** — stock Pixi, does not cull. It draws the off-screen content too: the out-of-the-box behaviour and the honest upper bound.
- **pixi culled** — adds the explicit per-frame `Culler.shared.cull` a Pixi app has to write itself.

Arms are gated by the new optional `EngineAdapter.coversArchetype`: `pixi culled` runs only where culling can remove something, and the Phaser/Excalibur arms sit the scrolling archetypes out rather than silently rendering a fixed, fully-visible scene under an id that promises off-screen content.
