### PR TITLE
perf(rendering): cull captures against an inflated rect so a moving camera replays

### DIFF
--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -915,13 +915,24 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   public inView(view: View): boolean {
+    return this._inCullRect(view.getBounds());
+  }
+
+  /**
+   * The view test against an explicit rect rather than a view's own bounds.
+   *
+   * A capturing collect culls against a rect slightly LARGER than the view so
+   * the resulting retained product survives a camera that moves (see
+   * `RenderPlanBuilder.cullRect`); everything else passes the view's own rect
+   * and gets exactly {@link inView}.
+   * @internal
+   */
+  public _inCullRect(rect: ReadonlyRectangle): boolean {
     if (!this._cullable) {
       return true;
     }
 
-    const bounds = this._cullArea ?? this.getBounds();
-
-    return view.getBounds().intersectsWith(bounds);
+    return rect.intersectsWith(this._cullArea ?? this.getBounds());
   }
 
   /**

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -419,7 +419,7 @@ export abstract class RenderNode extends SceneNode {
     }
 
     if (!builder._isViewCullSuppressed) {
-      if (!this.inView(builder.view)) {
+      if (!this._inCullRect(builder.cullRect)) {
         builder.backend.stats.culledNodes++;
         builder._noteViewCulled();
 

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -55,6 +55,19 @@ interface RetainedBackendHooks {
   _validateRetainedInstructionSet?(set: RetainedInstructionSet): boolean;
 }
 
+/**
+ * How far a capturing collect's cull rect reaches beyond the view, per side, as
+ * a fraction of that view axis. Each axis therefore grows by twice this, and the
+ * camera may travel that fraction of an axis before the captured product
+ * expires.
+ *
+ * A start value, not a tuned one: the trade is band area (nodes captured once,
+ * then replayed for free) against re-collect frequency (which falls roughly
+ * linearly with margin / camera speed). The `scrolling-world` benchmark
+ * archetype exists to sweep it.
+ */
+const RETAINED_CULL_MARGIN_RATIO = 1 / 16;
+
 interface MutableGroupScope extends GroupScope {
   _nextSeq: number;
   firstZ: number | null;
@@ -164,6 +177,24 @@ export class RenderPlanBuilder {
    * at one null check on every other frame.
    */
   private _trackedRoot: RetainedRootRepresentation | null = null;
+  /**
+   * The INFLATED rect a capturing collect culls against (see
+   * {@link RETAINED_CULL_MARGIN_RATIO}), live only while {@link _trackedRoot} is
+   * set. Off a capture, {@link cullRect} falls back to the view's own rect, so a
+   * frame that will not be retained culls exactly as tightly as it always has.
+   */
+  private readonly _captureCullRect = new Rectangle();
+  private _captureCullActive = false;
+
+  /**
+   * The rect the view test compares against for this collect: the view's own
+   * bounds normally, the capture's inflated rect while a render root is being
+   * captured.
+   * @internal
+   */
+  public get cullRect(): Rectangle {
+    return this._captureCullActive ? this._captureCullRect : this.view.getBounds();
+  }
 
   public build(root: RenderNode, backend: RenderBackend): RenderPlan {
     this.backend = backend;
@@ -178,6 +209,7 @@ export class RenderPlanBuilder {
     this._viewCullSuppression = 0;
     this._retentionRoot = root._supportsRootRetention() ? root : null;
     this._trackedRoot = null;
+    this._captureCullActive = false;
     // Base this plan's node indices after whatever earlier render() calls already
     // wrote into the frame-scoped transform buffer, so every draw across all
     // render() calls in the frame references a distinct slot and can batch.
@@ -409,16 +441,49 @@ export class RenderPlanBuilder {
 
     const previousTracked = this._trackedRoot;
 
-    representation.beginCapture();
+    // Exactly one node per build is the retention root (`_retentionRoot` is
+    // compared by identity in `emitNode`), so the capture cull rect needs no
+    // stack — it is armed here and disarmed below.
+    this._inflateCaptureCullRect(view);
+    representation.beginCapture(this._captureCullRect);
     this._trackedRoot = representation;
 
     try {
       node._collectForRenderPlan(this);
     } finally {
       this._trackedRoot = previousTracked;
+      this._captureCullActive = false;
     }
 
     representation.commitCapture(contentRevision, structureRevision, transformRevision, ancestryStamp, view, backend, target, this._peekCurrentScopeEntries());
+  }
+
+  /**
+   * Arm {@link _captureCullRect} as the view's rect grown by
+   * {@link RETAINED_CULL_MARGIN_RATIO} on every side.
+   *
+   * The margin is what lets a capture outlive a moving camera. Culling against
+   * the tight view rect makes the resulting product valid for that rect and
+   * nothing else — every camera step invalidates it, which is why a scene with
+   * off-screen content used to re-collect every single frame. Culling against a
+   * rect that ENCLOSES the view instead makes the product valid for every view
+   * still inside that rect: whatever was dropped was outside a rect containing
+   * today's view, so it is still correctly not drawn, and whatever was kept but
+   * has since left the view is drawn off-screen and clipped. Same pixels, one
+   * O(1) rect test instead of a re-collect.
+   *
+   * The price is the extra nodes in the band, which are captured once and then
+   * replayed for free. Growing each axis by twice the ratio, a uniformly dense
+   * scene gains `(1 + 2r)^2 - 1` nodes — about 27% at the current ratio — while
+   * the camera may travel a full `r` of each axis before the product expires.
+   */
+  private _inflateCaptureCullRect(view: View): void {
+    const rect = view.getBounds();
+    const marginX = rect.width * RETAINED_CULL_MARGIN_RATIO;
+    const marginY = rect.height * RETAINED_CULL_MARGIN_RATIO;
+
+    this._captureCullRect.set(rect.x - marginX, rect.y - marginY, rect.width + 2 * marginX, rect.height + 2 * marginY);
+    this._captureCullActive = true;
   }
 
   /**

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -1,5 +1,6 @@
 import { Bounds } from '#core/Bounds';
-import type { ReadonlyRectangle } from '#math/Rectangle';
+import { type ReadonlyRectangle, Rectangle } from '#math/Rectangle';
+import type { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { View } from '#rendering/View';
 
@@ -52,14 +53,23 @@ export class RetainedRootRepresentation {
   /**
    * Whether the capturing collect dropped at least one node on the view test.
    * A capture that culled nothing can be replayed under any view that still
-   * contains {@link _keptBounds}; a capture that culled something cannot,
-   * because a previously-culled node may have entered the new view and no index
-   * exists to find it.
+   * contains {@link _keptBounds}; a capture that culled something can only be
+   * replayed under a view inside {@link _captureCullRect}, because outside that
+   * rect a previously-culled node may have entered the view and no index exists
+   * to find it.
    */
   private _culledDuringCapture = true;
-  /** Union of the rects `inView` tested for every kept, cullable node. */
+  /** Union of the rects the view test compared for every kept, cullable node. */
   private readonly _keptBounds = new Bounds();
   private _keptEmpty = true;
+  /**
+   * The rect the capturing collect actually culled against — the view rect grown
+   * by the capture margin (`RenderPlanBuilder.cullRect`). Every node the capture
+   * dropped lies outside it, so any view still INSIDE it selects the same nodes
+   * and the product replays unchanged.
+   */
+  private readonly _captureCullRect = new Rectangle();
+  private _hasCaptureCullRect = false;
 
   // Thrash suppression over the FULL key (see `shouldSuppressCapture`).
   private _replayedSinceCapture = false;
@@ -74,12 +84,20 @@ export class RetainedRootRepresentation {
   /**
    * Whether the captured product can be replayed as-is this frame.
    *
-   * The revision/identity keys are exact compares. The view key is not: a
-   * capture whose collect culled nothing stays valid under ANY view that
-   * contains every kept node's cull rect, because then the same set of nodes
-   * passes `inView` and the captured records — world-space bounds, material
-   * keys, baked transform rows — carry no view state of their own (the recorded
-   * batches resolve projection live at replay).
+   * The revision/identity keys are exact compares. The view key is not, and it
+   * has two independent ways to pass, because the captured records — world-space
+   * bounds, material keys, baked transform rows — carry no view state of their
+   * own (the recorded batches resolve projection live at replay):
+   *
+   * - **The view still fits the capture's cull rect.** Every node the capture
+   *   dropped was outside that rect, hence outside this view too; every node it
+   *   kept is still drawn, and any that no longer meets the view is clipped
+   *   rather than wrong. This is the case that survives a moving camera over a
+   *   scene with off-screen content — the margin exists to make it common.
+   * - **Nothing was culled and the view still contains every kept node.** Then
+   *   the selection is trivially the whole subtree and stays that way. This one
+   *   also covers a view that GREW past the capture rect (a zoom-out), which the
+   *   first test cannot.
    */
   public isCleanIgnoringTransform(
     contentRevision: number,
@@ -104,11 +122,20 @@ export class RetainedRootRepresentation {
       return true;
     }
 
+    if (this._viewFitsCaptureCullRect(view)) {
+      return true;
+    }
+
     if (this._culledDuringCapture) {
       return false;
     }
 
     return this._keptEmpty || view.getBounds().containsRect(this._keptBounds.getRect());
+  }
+
+  /** Whether this view lies entirely inside the rect the capture culled against. */
+  private _viewFitsCaptureCullRect(view: View): boolean {
+    return this._hasCaptureCullRect && this._captureCullRect.containsRect(view.getBounds());
   }
 
   /**
@@ -128,17 +155,9 @@ export class RetainedRootRepresentation {
    * frame earlier, a scene that moves something every frame would never reach the
    * clean frame it has to record on.
    *
-   * Two guards make that sound against per-child view culling, which a group
-   * does not have to face (it suppresses culling inside itself and is culled as
-   * a whole):
-   *
-   * - **A capture that culled something is never patched.** A culled node is not
-   *   in the fragment, so a move that brings it back into view could not be
-   *   noticed at all. Such a capture keeps the plain re-collect behaviour.
-   * - **A moved node that left the view fails the reconcile.** Replaying would
-   *   keep drawing it. Its new rect is also folded into the kept-union, so a
-   *   later view change is judged against where the nodes are now, not where
-   *   they were at capture.
+   * The guards that make that sound against per-child view culling — which a
+   * group does not have to face, since it suppresses culling inside itself and
+   * is culled as a whole — live in {@link _canReconcileMovedNodes}.
    */
   public reconcileTransform(transformRevision: number, view: View, backend: RenderBackend): boolean {
     if (!this.fragment.hasDirtyTransformRows()) {
@@ -148,7 +167,7 @@ export class RetainedRootRepresentation {
       return this._transformRevision === transformRevision;
     }
 
-    if (this._culledDuringCapture || !this._foldMovedNodesIntoKeptBounds(view)) {
+    if (!this._canReconcileMovedNodes(view)) {
       this._dropRecording();
 
       return false;
@@ -164,15 +183,34 @@ export class RetainedRootRepresentation {
   }
 
   /**
-   * Grow the kept-union by every queued node's CURRENT cull rect, rejecting the
-   * reconcile if one of them no longer meets the view — it would have been
-   * dropped by a real collect, and replaying it would draw a node that is no
-   * longer selected.
+   * Whether every queued move can be applied to the captured product, growing
+   * the kept-union by each moved node's CURRENT cull rect on the way.
+   *
+   * Two rejections, one per direction a move can break the selection:
+   *
+   * - **A moved node the capture never recorded, on a capture that culled.** It
+   *   is not in the product, so it may be one of the culled ones — and it may
+   *   have just moved INTO the view, which replay would silently omit. Patching
+   *   cannot help: there is no row to patch. (On the recorded tier the row patch
+   *   would catch this too, but the entry-replay tier has no such check, and
+   *   this must hold on both.) When the capture culled nothing, every visible
+   *   node is in the product and no such node exists.
+   * - **A moved node that left the view, when only the kept-union rule is
+   *   carrying validity.** Replaying would keep drawing it where a real collect
+   *   would have dropped it — which matters because that rule's whole premise is
+   *   that nothing was culled. Under the capture-rect rule the premise is
+   *   different and this cannot go wrong: an out-of-view node that is still
+   *   drawn is clipped, not wrong.
    */
-  private _foldMovedNodesIntoKeptBounds(view: View): boolean {
+  private _canReconcileMovedNodes(view: View): boolean {
     const viewRect = view.getBounds();
+    const insideCaptureRect = this._viewFitsCaptureCullRect(view);
 
     for (const node of this.fragment.dirtyTransformRows) {
+      if (this._culledDuringCapture && this.fragment.recordedDraw(node as unknown as Drawable) === undefined) {
+        return false;
+      }
+
       if (!node.cullable) {
         // Never culled: its position cannot change the selection.
         continue;
@@ -180,7 +218,7 @@ export class RetainedRootRepresentation {
 
       const rect = node.cullArea ?? node.getBounds();
 
-      if (!viewRect.intersectsWith(rect)) {
+      if (!insideCaptureRect && !viewRect.intersectsWith(rect)) {
         return false;
       }
 
@@ -263,11 +301,17 @@ export class RetainedRootRepresentation {
     return false;
   }
 
-  /** Arm cull-union accumulation for the collect that is about to run. */
-  public beginCapture(): void {
+  /**
+   * Arm cull-union accumulation for the collect that is about to run, and record
+   * the rect that collect will cull against — the view's rect plus the capture
+   * margin, which is what later lets a moved view be judged in O(1).
+   */
+  public beginCapture(cullRect: ReadonlyRectangle): void {
     this._keptBounds.reset();
     this._keptEmpty = true;
     this._culledDuringCapture = false;
+    this._captureCullRect.set(cullRect.x, cullRect.y, cullRect.width, cullRect.height);
+    this._hasCaptureCullRect = true;
   }
 
   /** A node passed the view test; `rect` is exactly what `inView` compared. */
@@ -319,6 +363,7 @@ export class RetainedRootRepresentation {
     this._keptBounds.reset();
     this._keptEmpty = true;
     this._culledDuringCapture = true;
+    this._hasCaptureCullRect = false;
     this._view = null;
     this._backend = null;
     this._target = null;

--- a/test/perf/rendering/counter-gates.test.ts
+++ b/test/perf/rendering/counter-gates.test.ts
@@ -58,23 +58,30 @@ const EXPECTED = {
   // toward 2001, the root's instruction tier stopped engaging on a static frame.
   staticPlain: { collect: 1, inView: 1, globalTransform: 2, materialKey: 0, submittedNodes: 1000, culledNodes: 0, drawCalls: 1, batches: 1 },
 
-  // Plain Container with the camera panning every frame. A pan changes which
-  // nodes pass the view test, so the frame takes a FULL re-collect: 1 root +
-  // 1000 children visited, 1001 cull checks, 1000 material keys. This is the
-  // O(n) collect cost — the row that catches "the collect walk regressed to
-  // touch every node again". A LOWER number here is an improvement; a HIGHER one
-  // (e.g. 2× the visits) is the exact CPU regression that merges silently.
-  //
-  // The root representation does NOT save this frame: its view-reuse test asks
-  // whether every kept node's cull rect still lies inside the new view rect, and
-  // a scene filling the viewport fails that after a single pixel of pan. Closing
-  // it needs a captured, inflated cull rect — recorded as `NEU-O45`. Until then
-  // this row stays the honest O(n) cost of a panning camera.
-  //
-  // globalTransform re-pinned 6001 -> 6002: the root resolves its own global
-  // transform once per build, to observe ancestry-derived moves its revisions do
-  // not see.
-  panPlain: { collect: 1001, inView: 1001, globalTransform: 6002, materialKey: 1000, submittedNodes: 1000, culledNodes: 0, drawCalls: 1, batches: 1 },
+  // Plain Container with the camera panning one pixel every frame. Re-pinned
+  // from a full re-collect (collect 1001 / inView 1001 / gt 6002 / mk 1000) to
+  // the static row exactly: the capture now culls against the view grown by a
+  // margin and stays valid for every view still inside that rect, so a slow pan
+  // is absorbed and the frame replays. This row is the headline of the capture
+  // margin — if it climbs back toward 1001, the margin stopped engaging and
+  // every scrolling scene regressed to a per-frame rebuild.
+  panPlain: { collect: 1, inView: 1, globalTransform: 2, materialKey: 0, submittedNodes: 1000, culledNodes: 0, drawCalls: 1, batches: 1 },
+
+  // The same scene panned FAR ENOUGH each frame to leave the capture margin, so
+  // the product expires every frame and the walk pays the honest O(n) cost. It
+  // is the counterweight to `panPlain`: without it, a margin so wide it never
+  // expired would look identical to a correct one, and the row that used to
+  // catch a super-linear collect regression would have no home.
+  panPlainBeyondMargin: {
+    collect: 1001,
+    inView: 1001,
+    globalTransform: 5554,
+    materialKey: 888,
+    submittedNodes: 888,
+    culledNodes: 112,
+    drawCalls: 1,
+    batches: 1,
+  },
 
   // RetainedContainer with the camera panning every frame. The retained fragment
   // is captured view-independently (deliberately omits View.updateId
@@ -159,17 +166,39 @@ describe('CPU collect-path shape gate', () => {
     });
   });
 
-  it('camera-pan plain container: cache busts → full O(n) re-collect', () => {
+  it('camera-pan plain container: the capture margin absorbs the pan and the frame replays', () => {
     withHarness(harness => {
       const root = new Container();
 
       populate(root, SPRITE_COUNT);
       const pan = (): void => void harness.view.move(1, 0);
 
+      // A RISING `collect` here means the captured cull rect stopped covering
+      // the panned view — the margin is the only thing keeping this frame off
+      // the O(n) path below.
+      expectCounters(measureFrameCounters(harness, root, { beforeFrame: pan }), EXPECTED.panPlain);
+      root.destroy();
+    });
+  });
+
+  it('camera-pan past the capture margin: the product expires and the frame re-collects O(n)', () => {
+    withHarness(harness => {
+      const root = new Container();
+
+      populate(root, SPRITE_COUNT);
+      // 200px per frame against a 1280-wide view is past the margin on every
+      // frame; alternating the direction keeps the scene in front of the camera
+      // so the row stays about the collect walk, not about an empty view.
+      let direction = 1;
+      const pan = (): void => {
+        harness.view.move(200 * direction, 0);
+        direction = -direction;
+      };
+
       // A HIGHER `collect` than 1001 (≈ 1 + SPRITE_COUNT) means the walk now
       // visits more than every node once per pan — a super-linear collect
       // regression, precisely the CPU-only class the allocation gate misses.
-      expectCounters(measureFrameCounters(harness, root, { beforeFrame: pan }), EXPECTED.panPlain);
+      expectCounters(measureFrameCounters(harness, root, { beforeFrame: pan }), EXPECTED.panPlainBeyondMargin);
       root.destroy();
     });
   });
@@ -184,10 +213,11 @@ describe('CPU collect-path shape gate', () => {
       const actual = measureFrameCounters(harness, root, { beforeFrame: pan });
 
       expectCounters(actual, EXPECTED.panRetained);
-      // Make the retained WIN load-bearing, not just incidental: under identical
-      // camera motion the retained tier must visit dramatically fewer nodes than
-      // the plain container. If this inverts, the fragment stopped engaging.
-      expect(actual.collect).toBeLessThan(EXPECTED.panPlain.collect);
+      // Make the retained WIN load-bearing, not just incidental: the fragment is
+      // captured view-INDEPENDENTLY, so it survives camera motion of any size —
+      // unlike the plain root, whose capture margin has a finite reach. If this
+      // inverts, the fragment stopped engaging.
+      expect(actual.collect).toBeLessThan(EXPECTED.panPlainBeyondMargin.collect);
       root.destroy();
     });
   });

--- a/test/perf/rendering/counters.ts
+++ b/test/perf/rendering/counters.ts
@@ -11,7 +11,7 @@
  * The wrapped methods mirror the four sub-phases the collect-phase benchmark
  * (`test/perf/collect-phase-benchmark.ts`) attributes build() time to:
  *   - `RenderNode._collect`            — node visits entering the cull/emit gate
- *   - `SceneNode.inView`               — view-frustum cull checks
+ *   - `SceneNode._inCullRect`          — view-frustum cull checks
  *   - `SceneNode.getGlobalTransform`   — world-transform resolutions (build + play)
  *   - `Drawable._getOrComputeMaterialKey` — per-draw material-key resolutions
  *
@@ -31,7 +31,12 @@ import type { WebGl2Harness } from './harness';
 export interface CollectCounters {
   /** `RenderNode._collect` calls — nodes visited by the collect walk. */
   collect: number;
-  /** `SceneNode.inView` calls — view-frustum cull checks performed. */
+  /**
+   * `SceneNode._inCullRect` calls — view-frustum cull checks performed. The
+   * collect path tests against a RECT (the view's own, or the capture's inflated
+   * one) rather than a `View`, so the counter wraps that method; `inView`
+   * delegates to it, so a public caller is still counted.
+   */
   inView: number;
   /** `SceneNode.getGlobalTransform` calls — world-transform resolutions (build + play). */
   globalTransform: number;
@@ -78,7 +83,7 @@ const installCounters = (): Installed => {
   // call `super._collect`, which resolves to this wrapped implementation — so a
   // single wrap here counts every node visit regardless of subclass.
   wrap(RenderNode.prototype, '_collect', 'collect');
-  wrap(SceneNode.prototype, 'inView', 'inView');
+  wrap(SceneNode.prototype, '_inCullRect', 'inView');
   wrap(SceneNode.prototype, 'getGlobalTransform', 'globalTransform');
   wrap(Drawable.prototype, '_getOrComputeMaterialKey', 'materialKey');
 

--- a/test/rendering/retained-root-representation.test.ts
+++ b/test/rendering/retained-root-representation.test.ts
@@ -363,7 +363,7 @@ describe('automatic render-root representation: view dependence', () => {
     backend.destroy();
   });
 
-  test('a capture that culled something is view-locked: any view change re-collects', () => {
+  test('a capture that culled something still replays while the view stays inside the capture margin', () => {
     const { backend, events } = createRecordingBackend();
     const root = new Container();
     const visible = new RecordableLeaf('a');
@@ -380,13 +380,68 @@ describe('automatic render-root representation: view dependence', () => {
 
     expect(events).toContain('replay:a');
 
-    // A pan the containment test alone would have accepted — but a node WAS
-    // culled, so the selection cannot be proven unchanged without an index.
+    // The capture culled against the view rect grown by 1/16 of each axis, i.e.
+    // [-50,-37.5 .. 850,637.5]. A 2px pan stays well inside that, so every node
+    // the capture dropped is provably still outside the view.
     events.length = 0;
     backend.setView(new View(402, 300, 800, 600));
     playFrame(root, backend);
 
+    expect(events).toEqual(['replay:a']);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a capture that culled something re-collects once the view leaves the capture margin', () => {
+    const { backend, events } = createRecordingBackend();
+    const root = new Container();
+    const visible = new RecordableLeaf('a');
+    const offscreen = new RecordableLeaf('b');
+
+    visible.setPosition(400, 300);
+    offscreen.setPosition(5000, 5000);
+    root.addChild(visible, offscreen);
+    backend.setView(defaultView());
+
+    playFrame(root, backend);
+    playFrame(root, backend);
+    playFrame(root, backend);
+
+    expect(events).toContain('replay:a');
+
+    // 60px on x is past the 50px margin, so the view now reaches world the
+    // capture never tested — a previously-culled node could be in there and
+    // nothing in the product would point at it.
+    events.length = 0;
+    backend.setView(new View(460, 300, 800, 600));
+    playFrame(root, backend);
+
     expect(events).not.toContain('replay:a');
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('the capture margin admits the band around the view, so a node just off-screen is captured', () => {
+    const { backend, events } = createRecordingBackend();
+    const root = new Container();
+    const visible = new RecordableLeaf('a');
+    const inBand = new RecordableLeaf('b');
+
+    visible.setPosition(400, 300);
+    // Outside the [0,0 .. 800,600] view rect but inside the grown one, so the
+    // capture keeps it: that is what a later pan gets to replay for free.
+    inBand.setPosition(820, 300);
+    root.addChild(visible, inBand);
+    backend.setView(defaultView());
+
+    playFrame(root, backend);
+
+    // Without the margin the first collect would have dropped `b` and flushed
+    // `a` alone; with it the band node is in the product from the start, which
+    // is what a later pan gets to replay for free.
+    expect(events).toContain('flush:a,b');
 
     root.destroy();
     backend.destroy();

--- a/test/rendering/retained-transform-row-patch.test.ts
+++ b/test/rendering/retained-transform-row-patch.test.ts
@@ -295,7 +295,7 @@ describe('automatic render-root representation: incremental transform rows', () 
     harness.backend.destroy();
   });
 
-  test('a capture that culled something never patches — a culled node could move back into view unseen', () => {
+  test('a capture that culled something still patches a RECORDED node that moves', () => {
     const harness = createPatchingBackend();
     const root = new Container();
     const visible = new RecordableLeaf('a');
@@ -311,29 +311,67 @@ describe('automatic render-root representation: incremental transform rows', () 
     visible.setPosition(410, 300);
     playFrame(root, harness.backend);
 
-    expect(harness.patches).toEqual([]);
-    expect(harness.events).toContain('flush:a'); // full re-collect
+    // The moved node is in the product, so its row is patchable; the culled one
+    // is irrelevant to this move. Off-screen content no longer costs the whole
+    // subtree its recorded tier.
+    expect(harness.patches).toHaveLength(1);
+    expect(harness.events).not.toContain('flush:a');
 
     root.destroy();
     harness.backend.destroy();
   });
 
-  test('a moved node that leaves the view forces a re-collect instead of a stale replay', () => {
+  test('a node the capture culled cannot be patched when it moves — the frame re-collects and draws it', () => {
     const harness = createPatchingBackend();
     const root = new Container();
-    const leaf = new RecordableLeaf('a');
+    const visible = new RecordableLeaf('a');
+    const offscreen = new RecordableLeaf('b');
 
-    leaf.setPosition(400, 300);
-    root.addChild(leaf);
+    visible.setPosition(400, 300);
+    offscreen.setPosition(5000, 5000);
+    root.addChild(visible, offscreen);
     harness.backend.setView(new View(400, 300, 800, 600));
 
     reachSpliceTier(root, harness);
 
-    leaf.setPosition(5000, 5000);
+    // The one direction the capture rect cannot answer: a node that is in NO
+    // record moves into the view. There is no row to patch and nothing in the
+    // product points at it, so the frame must fall back to a real collect.
+    harness.events.length = 0;
+    offscreen.setPosition(400, 300);
     playFrame(root, harness.backend);
 
     expect(harness.patches).toEqual([]);
-    expect(harness.events).not.toContain('replay:a');
+    expect(harness.events).toContain('flush:a,b');
+
+    root.destroy();
+    harness.backend.destroy();
+  });
+
+  test('a moved node that leaves the view replays clipped instead of forcing a re-collect', () => {
+    const harness = createPatchingBackend();
+    const root = new Container();
+    const anchor = new RecordableLeaf('a');
+    const leaver = new RecordableLeaf('b');
+
+    // `anchor` keeps the ROOT itself inside the view; without it the root's own
+    // bounds would follow the leaver off-screen and the whole subtree would be
+    // culled, which is a different thing than the case under test.
+    anchor.setPosition(400, 300);
+    leaver.setPosition(420, 300);
+    root.addChild(anchor, leaver);
+    harness.backend.setView(new View(400, 300, 800, 600));
+
+    reachSpliceTier(root, harness);
+
+    leaver.setPosition(5000, 5000);
+    playFrame(root, harness.backend);
+
+    // Drawing a node that has left the view is not a pixel error — it lands
+    // outside the viewport and is clipped — so the cheap answer is the correct
+    // one: patch the row and keep replaying.
+    expect(harness.patches).toHaveLength(1);
+    expect(harness.events).toContain('replay:a,b');
 
     root.destroy();
     harness.backend.destroy();

--- a/test/rendering/video.test.ts
+++ b/test/rendering/video.test.ts
@@ -2,6 +2,7 @@ import type { MockInstance } from 'vitest';
 
 import { getAudioContext } from '#audio/audio-context';
 import { AudioBus } from '#audio/AudioBus';
+import type { Rectangle } from '#math/Rectangle';
 import type { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { Video } from '#rendering/video/Video';
 import { View } from '#rendering/View';
@@ -108,18 +109,26 @@ const createMockVideoElement = (options: MockVideoElementOptions = {}): MockVide
 /** A minimal `RenderPlanBuilder` fake — just enough surface for `RenderNode._collect`. */
 const createBuilder = (): {
   view: View;
+  cullRect: Rectangle;
   backend: { stats: { culledNodes: number } };
   emitNode: MockInstance;
   _noteViewKept: MockInstance;
   _noteViewCulled: MockInstance;
-} => ({
-  view: new View(0, 0, 1000, 1000),
-  backend: { stats: { culledNodes: 0 } },
-  emitNode: vi.fn(),
-  // View-selection bookkeeping for the automatic render-root representation.
-  _noteViewKept: vi.fn(),
-  _noteViewCulled: vi.fn(),
-});
+} => {
+  const view = new View(0, 0, 1000, 1000);
+
+  return {
+    view,
+    // What `_collect` actually tests against: the view's own rect off a capture,
+    // the capture's inflated rect while a render root is being captured.
+    cullRect: view.getBounds(),
+    backend: { stats: { culledNodes: 0 } },
+    emitNode: vi.fn(),
+    // View-selection bookkeeping for the automatic render-root representation.
+    _noteViewKept: vi.fn(),
+    _noteViewCulled: vi.fn(),
+  };
+};
 
 describe('Video', () => {
   // Video defers its audio-node setup until the AudioContext exists. Since AU2,


### PR DESCRIPTION
A recording collect now culls against the view rect inflated by 1/16 per side and stores that rect on the capture. The captured product stays valid as long as the current view is contained in it — an O(1) rectangle test, no spatial index.

## Why this is pixel-identical

Culled nodes lay outside a rectangle that *encloses* today's view, so they cannot be visible now. Kept nodes that have since scrolled out are clipped by the GPU. Same pixels.

## Price

About +27% captured nodes, paid once per capture and then replayed for free. What it buys is 1/16 of an axis of camera travel per capture. The ratio is a starting value, not a calibrated one.

## The moving-node edge case

Previously a node that left the view forced a re-collect. That is now handled narrowly instead of broadly: reconcile rejects exactly one case — a moved node with no draw record on a culled capture. A scrolling scene therefore keeps its recorded tier even when something inside it moves, and a node leaving the view no longer forces a re-collect on its own.

## Mechanics

The cull test moves from `SceneNode.inView(view)` to `SceneNode._inCullRect(rect)`; `inView` delegates to it, so public behaviour is unchanged.

## Measurements

`exojs current`, `scrolling-world`, CPU ms median, same session:

| n | WebGPU before | after | WebGL2 before | after |
| --- | --- | --- | --- | --- |
| 1 000 | 0.600 | 0.205 | 0.445 | 0.115 |
| 25 000 | 8.795 | 0.175 | 8.240 | 0.108 |
| 100 000 | 34.428 | 0.248 | 31.780 | 0.125 |

At 100k/WebGPU that is a factor of 139, level with the `retained` arm of the same session (0.197 ms). No regressions elsewhere: static-heavy 25k 0.125 / 100k 0.183, deep-hierarchy 25k 0.513, dynamic-heavy 25k 2.705 (noise).

## Known limit this does not fix

The median above is amortised. The inflated rect reduces how *often* the O(n) collect runs; it does not reduce its cost. A follow-up 1M run measured p95 alongside the median:

| n | backend | cpu median | cpu p95 |
| --- | --- | --- | --- |
| 100 000 | webgl2 | 0.140 | 36.100 |
| 100 000 | webgpu | 0.187 | 35.180 |
| 1 000 000 | webgl2 | 0.260 | 392.475 |
| 1 000 000 | webgpu | 0.190 | 400.155 |

The re-collect spike scales linearly with node count and is unchanged by this patch — it simply happens roughly every tenth frame instead of every frame. The explicit `retained` arm has no such spike (1M p95: 0.500 webgl2 / 0.230 webgpu) because it never re-collects. Removing the spike needs an incremental re-capture of the cull-set delta, which is deliberately out of scope here.

## Gates

`pnpm test` 9734 green, `lint` green, `docs:api:check` in sync, WebGL2 browser lane 294/294. The counter gates are re-pinned: `camera-pan plain` drops from collect 1001 to 1, plus a new row that pans past the margin every frame — without it an over-wide margin would look identical to a correct one and the O(n) path would have no gate left.
