### PR TITLE
fix(rendering): stop replaying a view-dependent capture under a moved camera

### DIFF
--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -473,7 +473,10 @@ export class Container extends RenderNode {
       return;
     }
 
-    const viewUpdateId = builder.view.updateId;
+    // The cache-key accessor, deliberately not `builder.view`: reading the view
+    // marks the surrounding capture view-dependent, and keying a slot cache on
+    // the view is not deriving content from it.
+    const viewUpdateId = builder.viewUpdateId;
 
     // A captured slot can no longer outlive its drawable: `SceneNode.destroy`
     // unlinks the node, and the removal stamps this container structure-dirty,

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -193,7 +193,7 @@ export class RenderPlanBuilder {
    * @internal
    */
   public get cullRect(): Rectangle {
-    return this._captureCullActive ? this._captureCullRect : this.view.getBounds();
+    return this._captureCullActive ? this._captureCullRect : this._viewUnobserved().getBounds();
   }
 
   public build(root: RenderNode, backend: RenderBackend): RenderPlan {
@@ -237,7 +237,7 @@ export class RenderPlanBuilder {
     if (rootScope.entries.length > 0) {
       this._plan.passes.push({
         target: null,
-        view: this.view,
+        view: this._viewUnobserved(),
         clearColor: null,
         root: rootScope,
       });
@@ -249,6 +249,39 @@ export class RenderPlanBuilder {
   }
 
   public get view(): View {
+    // A collect that reads the view produces view-DEPENDENT content, and the
+    // capture running around it must then not be replayed under a different
+    // view. `ImageLayerNode` and `TileLayerNode` do exactly this (both read
+    // `view.center` to place repeat coverage, and both opt out of view culling
+    // so no cull rect records the dependency for them), and contract 9 of the
+    // architecture freeze reserves the right for any node. Noting the read here
+    // rather than asking nodes to declare a flag covers third-party nodes too,
+    // and costs one null check on a path that already resolves a getter.
+    //
+    // Builder-internal reads go through `_viewUnobserved` so the machinery that
+    // sets a capture up — the cull-rect inflation, the plan's own view field —
+    // cannot mark every capture as view-dependent.
+    this._trackedRoot?.noteViewRead();
+
+    return this._viewUnobserved();
+  }
+
+  /**
+   * The view's identity for CACHE KEYS, without recording a view dependency.
+   *
+   * Keying a cache on the view and deriving content from the view are different
+   * things, and only the second one makes a capture unreplayable under a moved
+   * camera. `Container._collectContent` does the first — it keys its retained
+   * child slots on `updateId` — and must not be mistaken for the second, or
+   * every capture would be view-locked and root retention would be dead for
+   * every scene.
+   */
+  public get viewUpdateId(): number {
+    return this._viewUnobserved().updateId;
+  }
+
+  /** The view without recording a dependency — builder-internal reads only. */
+  private _viewUnobserved(): View {
     if (this._view === null) {
       this._view = this.backend.view;
     }
@@ -394,7 +427,7 @@ export class RenderPlanBuilder {
    */
   private _collectRetainedRoot(node: RenderNode): void {
     const representation = node._retainedRootRepresentation();
-    const view = this.view;
+    const view = this._viewUnobserved();
     const backend = this.backend;
     const target = backend.renderTarget;
     const contentRevision = node._contentRevision;

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -70,6 +70,20 @@ export class RetainedRootRepresentation {
    */
   private readonly _captureCullRect = new Rectangle();
   private _hasCaptureCullRect = false;
+  /**
+   * Whether the capturing collect READ the view — i.e. produced content that is
+   * a function of the camera, not merely positioned by it.
+   *
+   * Such a capture may only be replayed under the very same view. Both view
+   * tolerances below reason about the SELECTION of nodes (what a cull test would
+   * have dropped), and that reasoning is sound only while each node's recorded
+   * draw is what a fresh collect would produce again. A node that rebuilds its
+   * geometry from `view.center` breaks that premise: replaying it paints the
+   * camera position it was captured at. `ImageLayerNode` and `TileLayerNode` do
+   * exactly this, and contract 9 of the architecture freeze reserves the right
+   * for any node, which is why this is observed rather than declared.
+   */
+  private _viewDependentCapture = false;
 
   // Thrash suppression over the FULL key (see `shouldSuppressCapture`).
   private _replayedSinceCapture = false;
@@ -120,6 +134,12 @@ export class RetainedRootRepresentation {
 
     if (this._view === view && this._viewUpdateId === view.updateId) {
       return true;
+    }
+
+    if (this._viewDependentCapture) {
+      // The view moved and the capture is a function of it: neither tolerance
+      // applies, because both only argue about which nodes a cull test admits.
+      return false;
     }
 
     if (this._viewFitsCaptureCullRect(view)) {
@@ -310,8 +330,18 @@ export class RetainedRootRepresentation {
     this._keptBounds.reset();
     this._keptEmpty = true;
     this._culledDuringCapture = false;
+    this._viewDependentCapture = false;
     this._captureCullRect.set(cullRect.x, cullRect.y, cullRect.width, cullRect.height);
     this._hasCaptureCullRect = true;
+  }
+
+  /**
+   * The collect being captured read the view (see {@link _viewDependentCapture}).
+   * Called from `RenderPlanBuilder`'s public view getter, so it fires for any
+   * node — engine or third-party — without one having to declare itself.
+   */
+  public noteViewRead(): void {
+    this._viewDependentCapture = true;
   }
 
   /** A node passed the view test; `rect` is exactly what `inView` compared. */
@@ -363,6 +393,7 @@ export class RetainedRootRepresentation {
     this._keptBounds.reset();
     this._keptEmpty = true;
     this._culledDuringCapture = true;
+    this._viewDependentCapture = false;
     this._hasCaptureCullRect = false;
     this._view = null;
     this._backend = null;

--- a/test/rendering/retained-root-representation.test.ts
+++ b/test/rendering/retained-root-representation.test.ts
@@ -500,3 +500,55 @@ describe('automatic render-root representation: nested RetainedContainer', () =>
     backend.destroy();
   });
 });
+
+/**
+ * Contract 9 of the architecture freeze: view-dependent content may derive its
+ * product live, and `TileLayerNode`/`ImageLayerNode` do exactly that — they read
+ * `builder.view.center` inside their collect and both opt out of view culling.
+ *
+ * Root retention must therefore never replay a capture over a view the
+ * view-dependent node has not seen, or its content freezes while the camera
+ * moves.
+ */
+class ViewDependentLayer extends Container {
+  public collects = 0;
+  public lastCenterX = Number.NaN;
+
+  public constructor() {
+    super();
+    this.cullable = false;
+  }
+
+  protected override _collectContent(builder: RenderPlanBuilder): void {
+    this.collects++;
+    this.lastCenterX = builder.view.center.x;
+    super._collectContent(builder);
+  }
+}
+
+describe('automatic render-root representation: view-dependent content', () => {
+  test('a camera move inside the capture margin still runs a view-dependent collect', () => {
+    const { backend } = createRecordingBackend();
+    const root = new Container();
+    const layer = new ViewDependentLayer();
+
+    layer.addChild(new RecordableLeaf('a'));
+    root.addChild(layer);
+    backend.setView(defaultView());
+
+    playFrame(root, backend);
+    playFrame(root, backend);
+
+    const before = layer.collects;
+
+    // Pan by 2px: far inside the 1/16 capture margin, so the capture survives.
+    backend.setView(new View(402, 300, 800, 600));
+    playFrame(root, backend);
+
+    expect(layer.lastCenterX).toBe(402);
+    expect(layer.collects).toBeGreaterThan(before);
+
+    root.destroy();
+    backend.destroy();
+  });
+});


### PR DESCRIPTION
A render root whose collect **read** the view could be replayed under a different view, freezing content that is a function of the camera.

## The bug

`ImageLayerNode` and `TileLayerNode` both read `view.center` to place their repeat coverage, and both opt out of view culling — so nothing about them appeared in the capture's cull reasoning, and a camera pan left their geometry pinned at the position it was captured at. A parallax background stops moving while the camera does. Contract 9 of the architecture freeze reserves this right for any node, so third-party content is affected too.

Both view tolerances on a capture argue about **selection** — which nodes a cull test would have dropped. That argument is sound only while each kept node's recorded draw is what a fresh collect would produce again, which is exactly what a view-dependent node breaks.

Attribution, read off the code rather than bisected: the tolerance that admits any view containing every kept node arrived with the automatic root retention (#548). The one that admits any view inside the capture's inflated cull rect (#551) widened it considerably, because captures that culled something became view-tolerant too.

## The fix

The dependency is **observed, not declared**. `RenderPlanBuilder`'s public view getter marks the capture in flight, so a node that reads the view is covered without announcing itself — including third-party nodes that the engine cannot enumerate. The builder's own reads (cull-rect inflation, the plan's view field) go through a private accessor that does not mark.

Keying a cache on the view is not the same as deriving content from it, and conflating the two would view-lock every capture and kill root retention outright. `Container._collectContent` keys its retained child slots on `view.updateId`, so it moves to a new `viewUpdateId` accessor that carries the identity without recording a dependency.

## Verification

The regression test drives a container whose `_collectContent` reads `builder.view.center` — the `ImageLayerNode` pattern — under a retained root, then pans 2px, far inside the 1/16 capture margin. Before the fix it observes centre 400 after the camera moved to 402.

- Node lanes **9735 pass**; the 2 `production-stripping` failures are pre-existing against a stale dev `dist/`.
- Chromium/WebGL2 **294/294**, Chromium/WebGPU **339/339**.
- `lint` and `typecheck` green.

The retention win is untouched: `scrolling-world` 100k/WebGPU stays at **0.235 ms** median against 34.428 ms before the inflated cull rect, and `static-heavy` 100k is unchanged at 0.235 ms. The benchmark scene does not read the view, so it keeps the tolerant path.
