### PR TITLE
perf(rendering): select a moved camera's frame from a persistent item source

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     },
     {
       "path": "dist/exo.iife.min.js",
-      "limit": "255 KB",
+      "limit": "260 KB",
       "gzip": true
     },
     {

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -961,6 +961,7 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
    *
    * One rule, one implementation. A second copy would be free to drift, and this
    * one decides which nodes reach the screen.
+   * @internal
    */
   public _inCullRectUsingBounds(rect: ReadonlyRectangle, bounds: RectangleLike | null): boolean {
     if (!this._cullable) {

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -930,7 +930,7 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
    * @internal
    */
   public _inCullRect(rect: ReadonlyRectangle): boolean {
-    return this._inCullRectUsingBounds(rect, this.getBounds());
+    return this._inCullRectUsingBounds(rect, null);
   }
 
   /**
@@ -941,28 +941,39 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
    * subtree that can hold a million of them — at which point that resolve is the
    * single most expensive thing a camera step pays for.
    *
-   * The two halves of the rule are split on purpose along the line of what the
-   * caller may safely have cached:
+   * The rule is split along the line of what a caller may safely have cached:
    *
    * - `cullable` and `cullArea` are read LIVE, always. `cullArea` is a mutable
    *   `Rectangle` and only REPLACING the reference stamps a revision, so a
    *   caller that had copied it could go stale in place, unnoticed.
    * - `bounds` is the caller's, and it is the caller's obligation to pass one
-   *   that is current. The source does that by refusing this path outright
-   *   unless the subtree's transform revision is unchanged since it stored them
-   *   — no node moved, so no stored extent can be wrong.
+   *   that is current. The persistent source does that by keying its items on
+   *   the subtree's transform revision: they are only selected from while
+   *   nothing in it has moved, so no stored extent can be wrong.
    *
-   * This is one rule with one implementation, not a second culling semantics:
-   * {@link _inCullRect} is this method with `getBounds()` filled in.
+   * `null` means "resolve them from this node", which is exactly
+   * {@link _inCullRect}. It is a null rather than an eagerly-passed
+   * `getBounds()` because the two early exits above must come FIRST: a node that
+   * opted out of culling, or one carrying a `cullArea`, never needs its bounds,
+   * and resolving them anyway walks its whole parent chain. Passing them in as
+   * an argument made every node in a culling-free scene pay that walk — measured
+   * on `deep-hierarchy` at 100,000 nodes as 1.9ms -> 19.3ms median.
+   *
+   * One rule, one implementation. A second copy would be free to drift, and this
+   * one decides which nodes reach the screen.
    */
-  public _inCullRectUsingBounds(rect: ReadonlyRectangle, bounds: RectangleLike): boolean {
+  public _inCullRectUsingBounds(rect: ReadonlyRectangle, bounds: RectangleLike | null): boolean {
     if (!this._cullable) {
       return true;
     }
 
     const area = this._cullArea;
 
-    return area !== null ? rect.intersectsWith(area) : intersectionRectRect(rect, bounds);
+    if (area !== null) {
+      return rect.intersectsWith(area);
+    }
+
+    return intersectionRectRect(rect, bounds ?? this.getBounds());
   }
 
   /**

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -10,6 +10,7 @@ import {
   intersectionRectEllipse,
   intersectionSat,
 } from '#math/collision-detection';
+import { intersectionRectRect } from '#math/collision-primitives';
 import type { Ellipse } from '#math/Ellipse';
 import { Flags } from '#math/Flags';
 import { Interval } from '#math/Interval';
@@ -19,6 +20,7 @@ import { ObservableVector, type ObservableVectorOwner } from '#math/ObservableVe
 import { Polygon } from '#math/Polygon';
 import type { ReadonlyRectangle } from '#math/Rectangle';
 import { Rectangle } from '#math/Rectangle';
+import type { RectangleLike } from '#math/RectangleLike';
 import { degreesToRadians, trimRotation } from '#math/utils';
 import { Vector } from '#math/Vector';
 import type { Container } from '#rendering/Container';
@@ -928,11 +930,39 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
    * @internal
    */
   public _inCullRect(rect: ReadonlyRectangle): boolean {
+    return this._inCullRectUsingBounds(rect, this.getBounds());
+  }
+
+  /**
+   * {@link _inCullRect} against bounds the caller already holds.
+   *
+   * Exists because {@link getBounds} resolves the whole parent chain on every
+   * call, and the persistent-source scan asks this question once per item in a
+   * subtree that can hold a million of them — at which point that resolve is the
+   * single most expensive thing a camera step pays for.
+   *
+   * The two halves of the rule are split on purpose along the line of what the
+   * caller may safely have cached:
+   *
+   * - `cullable` and `cullArea` are read LIVE, always. `cullArea` is a mutable
+   *   `Rectangle` and only REPLACING the reference stamps a revision, so a
+   *   caller that had copied it could go stale in place, unnoticed.
+   * - `bounds` is the caller's, and it is the caller's obligation to pass one
+   *   that is current. The source does that by refusing this path outright
+   *   unless the subtree's transform revision is unchanged since it stored them
+   *   — no node moved, so no stored extent can be wrong.
+   *
+   * This is one rule with one implementation, not a second culling semantics:
+   * {@link _inCullRect} is this method with `getBounds()` filled in.
+   */
+  public _inCullRectUsingBounds(rect: ReadonlyRectangle, bounds: RectangleLike): boolean {
     if (!this._cullable) {
       return true;
     }
 
-    return rect.intersectsWith(this._cullArea ?? this.getBounds());
+    const area = this._cullArea;
+
+    return area !== null ? rect.intersectsWith(area) : intersectionRectRect(rect, bounds);
   }
 
   /**

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -473,6 +473,21 @@ export class Container extends RenderNode {
       return;
     }
 
+    if (builder._isCollectingSource) {
+      // Source discovery walks every child unconditionally and produces no
+      // frame-local draws, so neither half of the retained-slot cache applies:
+      // replaying a slot would allocate exactly the pooled `DrawCommand` and
+      // transform row the discovery invariant forbids, and capturing one would
+      // key this cache against a scope that never received the entries it peeks
+      // for — throwing away a valid capture in the process.
+      for (let index = 0; index < this._childList.length; index++) {
+        // In-bounds: index < length.
+        this._childList[index]!._collect(builder, index);
+      }
+
+      return;
+    }
+
     // The cache-key accessor, deliberately not `builder.view`: reading the view
     // marks the surrounding capture view-dependent, and keying a slot cache on
     // the view is not deriving content from it.

--- a/src/rendering/plan/EntryPlacement.ts
+++ b/src/rendering/plan/EntryPlacement.ts
@@ -1,0 +1,51 @@
+/**
+ * @internal
+ *
+ * The `(zIndex, seq)` bookkeeping every entry container maintains while it is
+ * being filled.
+ *
+ * It exists as its own primitive because two different containers need the
+ * exact same rule: a frame-local {@link GroupScope}, and a {@link SourceGroup}
+ * inside a persistent {@link RenderRootSource}. Handing the source a dummy
+ * `GroupScope` to borrow the rule would tie a backend- and frame-neutral
+ * structure to the frame-local plan; writing the rule a second time inside the
+ * source would fork a contract that decides pixel order.
+ *
+ * `(zIndex, seq)` IS that contract: the optimizer sorts a scope by `zIndex` and
+ * keeps `seq` as the tie-break, so two draws with equal `zIndex` still paint in
+ * `seq` order. A second, subtly different implementation of it would not fail a
+ * type check — it would change draw order.
+ */
+export interface EntryPlacementState {
+  /** Next auto-assigned sequence number; also the high-water mark of explicit ones. */
+  _nextSeq: number;
+  /** `zIndex` of the first entry placed, or `null` while the container is empty. */
+  firstZ: number | null;
+  /** `true` once two entries with differing `zIndex` have been placed. */
+  hasMixedZ: boolean;
+}
+
+/**
+ * Place one entry and return the sequence number it occupies.
+ *
+ * `seq` is the caller's explicit placement — a child index, or a verbatim
+ * position replayed from a capture or selected from a source. `undefined` means
+ * "append": take the next free slot. Either way the high-water mark advances, so
+ * a later sibling in the same container can never collide with a slot that was
+ * handed out explicitly.
+ */
+export const reserveEntryPlacement = (state: EntryPlacementState, seq: number | undefined, zIndex: number): number => {
+  const placedSeq = seq ?? state._nextSeq;
+
+  if (placedSeq >= state._nextSeq) {
+    state._nextSeq = placedSeq + 1;
+  }
+
+  if (state.firstZ === null) {
+    state.firstZ = zIndex;
+  } else if (!state.hasMixedZ && state.firstZ !== zIndex) {
+    state.hasMixedZ = true;
+  }
+
+  return placedSeq;
+};

--- a/src/rendering/plan/RenderItemVisibility.ts
+++ b/src/rendering/plan/RenderItemVisibility.ts
@@ -1,0 +1,46 @@
+import type { ReadonlyRectangle } from '#math/Rectangle';
+
+import type { RetainedFragmentDraw } from './RetainedGroupFragment';
+
+/**
+ * @internal
+ *
+ * Decides which of a render root's persistent items a cull rect admits.
+ *
+ * The seam exists because the answer is a measurement, not an assumption. A flat
+ * scan over the items is O(N) but touches only two numbers per item and needs no
+ * maintenance; a spatial index answers in O(log n + hits) but pays for its own
+ * upkeep on every move. Which one wins at a given node count is what the
+ * benchmark decides, so neither is written into the caller.
+ *
+ * The predicate shape suits a scan, which visits items in recorded order anyway.
+ * An index answers the opposite question — "what does this rect contain" — and
+ * would need a hit-query form plus a sort back into recorded order. That form is
+ * deliberately not invented here: it lands with the index itself, once a
+ * measurement says the index earns its maintenance.
+ */
+export interface RenderItemVisibility {
+  /** Whether `rect` admits this recorded draw. */
+  admits(draw: RetainedFragmentDraw, rect: ReadonlyRectangle): boolean;
+}
+
+/**
+ * @internal
+ *
+ * O(N) scan: tests each recorded draw's world AABB against the rect.
+ *
+ * What makes this cheap enough to be the starting point is not the test itself
+ * but what a rejected item no longer costs: no material key, no draw command, no
+ * transform row, and no descent into the scene graph to find it. That is the
+ * whole difference to the full collect it replaces.
+ */
+export class FlatScanVisibility implements RenderItemVisibility {
+  public admits(draw: RetainedFragmentDraw, rect: ReadonlyRectangle): boolean {
+    // Deliberately the node's own test rather than a comparison against the
+    // record's AABB. The two agree while nothing has moved, but only one of them
+    // stays correct when they disagree — and duplicating `cullable` / `cullArea`
+    // handling here would be a second copy of a rule that has already moved once
+    // (`inView` -> `_inCullRect`). A cache hit on `getBounds()` is the cost.
+    return draw.drawable._inCullRect(rect);
+  }
+}

--- a/src/rendering/plan/RenderItemVisibility.ts
+++ b/src/rendering/plan/RenderItemVisibility.ts
@@ -1,4 +1,5 @@
 import type { ReadonlyRectangle } from '#math/Rectangle';
+import type { RectangleLike } from '#math/RectangleLike';
 
 import type { PersistentDrawItem } from './RenderSourceItem';
 
@@ -22,8 +23,18 @@ import type { PersistentDrawItem } from './RenderSourceItem';
  * measurement says the index earns its maintenance.
  */
 export interface RenderItemVisibility {
-  /** Whether `rect` admits this item. */
-  admits(item: PersistentDrawItem, rect: ReadonlyRectangle): boolean;
+  /**
+   * Whether `rect` admits this item.
+   *
+   * `boundsAreCurrent` says whether the item's stored world AABB still describes
+   * the drawable — true exactly when nothing in the subtree has moved since the
+   * items were discovered. It is passed rather than inferred because only the
+   * source holds the transform revision that answers it, and getting it wrong in
+   * either direction is a real defect: `false` when it could be `true` costs the
+   * scan a full parent-chain resolve per item, and `true` when it should be
+   * `false` culls against a stale extent and drops a node that moved into view.
+   */
+  admits(item: PersistentDrawItem, rect: ReadonlyRectangle, boundsAreCurrent: boolean): boolean;
 }
 
 /**
@@ -37,17 +48,34 @@ export interface RenderItemVisibility {
  * whole difference to the full collect it replaces.
  */
 export class FlatScanVisibility implements RenderItemVisibility {
-  public admits(item: PersistentDrawItem, rect: ReadonlyRectangle): boolean {
-    // Deliberately the node's own test rather than a comparison against the
-    // item's stored AABB. The two agree while nothing has moved, but only one of
-    // them stays correct when they disagree — and duplicating `cullable` /
-    // `cullArea` handling here would be a second copy of a rule that has already
-    // moved once (`inView` -> `_inCullRect`). A cache hit on `getBounds()` is the
-    // cost, and reading live is also what keeps this correct across an ancestor
-    // move, which the stored AABBs do not survive.
-    //
-    // An index cannot afford this call per item; the shared-helper and
-    // mutable-`cullArea` questions that raises belong to the index, not here.
-    return item.drawable._inCullRect(rect);
+  /**
+   * Reused rect handed to the cull test, so a scan over a million items
+   * allocates nothing. A plain object rather than a `Rectangle`: the test only
+   * reads `x`/`y`/`width`/`height`, while a `Rectangle` would route all four
+   * writes through its observable vector and size on every item.
+   */
+  private readonly _bounds: RectangleLike = { x: 0, y: 0, width: 0, height: 0 };
+
+  public admits(item: PersistentDrawItem, rect: ReadonlyRectangle, boundsAreCurrent: boolean): boolean {
+    const drawable = item.drawable;
+
+    if (!boundsAreCurrent) {
+      // Something in the subtree moved, so a stored extent may be anywhere. Read
+      // through the node, which resolves live — the correct answer, at the cost
+      // of a parent-chain walk per item.
+      return drawable._inCullRect(rect);
+    }
+
+    const bounds = this._bounds;
+
+    bounds.x = item.minX;
+    bounds.y = item.minY;
+    bounds.width = item.maxX - item.minX;
+    bounds.height = item.maxY - item.minY;
+
+    // Same rule, same implementation — `_inCullRect` IS this call with
+    // `getBounds()` filled in — so `cullable` and a live-mutated `cullArea` are
+    // still honoured and no second culling semantics exists to drift.
+    return drawable._inCullRectUsingBounds(rect, bounds);
   }
 }

--- a/src/rendering/plan/RenderItemVisibility.ts
+++ b/src/rendering/plan/RenderItemVisibility.ts
@@ -26,15 +26,11 @@ export interface RenderItemVisibility {
   /**
    * Whether `rect` admits this item.
    *
-   * `boundsAreCurrent` says whether the item's stored world AABB still describes
-   * the drawable — true exactly when nothing in the subtree has moved since the
-   * items were discovered. It is passed rather than inferred because only the
-   * source holds the transform revision that answers it, and getting it wrong in
-   * either direction is a real defect: `false` when it could be `true` costs the
-   * scan a full parent-chain resolve per item, and `true` when it should be
-   * `false` culls against a stale extent and drops a node that moved into view.
+   * The item's stored world AABB may be trusted: the source is keyed on the
+   * subtree's transform revision, so a set of items only reaches a strategy
+   * while nothing in it has moved since discovery.
    */
-  admits(item: PersistentDrawItem, rect: ReadonlyRectangle, boundsAreCurrent: boolean): boolean;
+  admits(item: PersistentDrawItem, rect: ReadonlyRectangle): boolean;
 }
 
 /**
@@ -56,16 +52,7 @@ export class FlatScanVisibility implements RenderItemVisibility {
    */
   private readonly _bounds: RectangleLike = { x: 0, y: 0, width: 0, height: 0 };
 
-  public admits(item: PersistentDrawItem, rect: ReadonlyRectangle, boundsAreCurrent: boolean): boolean {
-    const drawable = item.drawable;
-
-    if (!boundsAreCurrent) {
-      // Something in the subtree moved, so a stored extent may be anywhere. Read
-      // through the node, which resolves live — the correct answer, at the cost
-      // of a parent-chain walk per item.
-      return drawable._inCullRect(rect);
-    }
-
+  public admits(item: PersistentDrawItem, rect: ReadonlyRectangle): boolean {
     const bounds = this._bounds;
 
     bounds.x = item.minX;
@@ -76,6 +63,6 @@ export class FlatScanVisibility implements RenderItemVisibility {
     // Same rule, same implementation — `_inCullRect` IS this call with
     // `getBounds()` filled in — so `cullable` and a live-mutated `cullArea` are
     // still honoured and no second culling semantics exists to drift.
-    return drawable._inCullRectUsingBounds(rect, bounds);
+    return item.drawable._inCullRectUsingBounds(rect, bounds);
   }
 }

--- a/src/rendering/plan/RenderItemVisibility.ts
+++ b/src/rendering/plan/RenderItemVisibility.ts
@@ -1,6 +1,6 @@
 import type { ReadonlyRectangle } from '#math/Rectangle';
 
-import type { RetainedFragmentDraw } from './RetainedGroupFragment';
+import type { PersistentDrawItem } from './RenderSourceItem';
 
 /**
  * @internal
@@ -8,10 +8,12 @@ import type { RetainedFragmentDraw } from './RetainedGroupFragment';
  * Decides which of a render root's persistent items a cull rect admits.
  *
  * The seam exists because the answer is a measurement, not an assumption. A flat
- * scan over the items is O(N) but touches only two numbers per item and needs no
- * maintenance; a spatial index answers in O(log n + hits) but pays for its own
- * upkeep on every move. Which one wins at a given node count is what the
- * benchmark decides, so neither is written into the caller.
+ * scan over the items is O(N) but touches only the item and needs no
+ * maintenance; a uniform grid answers in O(overlapped cells + candidates)
+ * expected — worst case O(N) — but pays upkeep on every move, and degenerates on
+ * large AABBs, a badly chosen cell size, or clustered scenes. Which one wins at
+ * a given node count is what the benchmark decides, so neither is written into
+ * the caller.
  *
  * The predicate shape suits a scan, which visits items in recorded order anyway.
  * An index answers the opposite question — "what does this rect contain" — and
@@ -20,14 +22,14 @@ import type { RetainedFragmentDraw } from './RetainedGroupFragment';
  * measurement says the index earns its maintenance.
  */
 export interface RenderItemVisibility {
-  /** Whether `rect` admits this recorded draw. */
-  admits(draw: RetainedFragmentDraw, rect: ReadonlyRectangle): boolean;
+  /** Whether `rect` admits this item. */
+  admits(item: PersistentDrawItem, rect: ReadonlyRectangle): boolean;
 }
 
 /**
  * @internal
  *
- * O(N) scan: tests each recorded draw's world AABB against the rect.
+ * O(N) scan over the items.
  *
  * What makes this cheap enough to be the starting point is not the test itself
  * but what a rejected item no longer costs: no material key, no draw command, no
@@ -35,12 +37,17 @@ export interface RenderItemVisibility {
  * whole difference to the full collect it replaces.
  */
 export class FlatScanVisibility implements RenderItemVisibility {
-  public admits(draw: RetainedFragmentDraw, rect: ReadonlyRectangle): boolean {
+  public admits(item: PersistentDrawItem, rect: ReadonlyRectangle): boolean {
     // Deliberately the node's own test rather than a comparison against the
-    // record's AABB. The two agree while nothing has moved, but only one of them
-    // stays correct when they disagree — and duplicating `cullable` / `cullArea`
-    // handling here would be a second copy of a rule that has already moved once
-    // (`inView` -> `_inCullRect`). A cache hit on `getBounds()` is the cost.
-    return draw.drawable._inCullRect(rect);
+    // item's stored AABB. The two agree while nothing has moved, but only one of
+    // them stays correct when they disagree — and duplicating `cullable` /
+    // `cullArea` handling here would be a second copy of a rule that has already
+    // moved once (`inView` -> `_inCullRect`). A cache hit on `getBounds()` is the
+    // cost, and reading live is also what keeps this correct across an ancestor
+    // move, which the stored AABBs do not survive.
+    //
+    // An index cannot afford this call per item; the shared-helper and
+    // mutable-`cullArea` questions that raises belong to the index, not here.
+    return item.drawable._inCullRect(rect);
   }
 }

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -707,10 +707,8 @@ export class RenderPlanBuilder {
       return;
     }
 
-    this._noteViewKept(drawable);
     reserveEntryPlacement(this._currentScope(), item.seq, item.zIndex);
 
-    const bounds = drawable.getBounds();
     const command = this._acquireDrawCommand();
 
     command.drawable = drawable;
@@ -719,12 +717,53 @@ export class RenderPlanBuilder {
     command.zIndex = item.zIndex;
     command.groupIndex = undefined;
     command.material = drawable._getOrComputeMaterialKey(this.backend);
-    command.minX = bounds.left;
-    command.minY = bounds.top;
-    command.maxX = bounds.right;
-    command.maxY = bounds.bottom;
 
+    if (selection.boundsAreCurrent) {
+      // The stored extent is the drawable's own, unchanged — same argument the
+      // scan just made. Asking the node again would resolve its parent chain a
+      // second time for an answer already in hand.
+      command.minX = item.minX;
+      command.minY = item.minY;
+      command.maxX = item.maxX;
+      command.maxY = item.maxY;
+    } else {
+      const bounds = drawable.getBounds();
+
+      command.minX = bounds.left;
+      command.minY = bounds.top;
+      command.maxX = bounds.right;
+      command.maxY = bounds.bottom;
+    }
+
+    this._noteSelectedItemKept(command, drawable);
     this._pushDrawEntry(item.seq, item.zIndex, command);
+  }
+
+  /**
+   * Fold a selected item into the capture's kept-union, folding exactly the rect
+   * the cull test compared.
+   *
+   * That "exactly" is the whole contract of the union — a later view containing
+   * it must provably admit the same set — so a node with a `cullArea` folds its
+   * `cullArea`, and every other node folds its bounds, which the command already
+   * carries.
+   */
+  private _noteSelectedItemKept(command: DrawCommand, drawable: Drawable): void {
+    const tracked = this._trackedRoot;
+
+    if (tracked === null || !drawable.cullable) {
+      return;
+    }
+
+    const area = drawable.cullArea;
+
+    if (area !== null) {
+      tracked.noteKept(area);
+
+      return;
+    }
+
+    tracked.noteKeptCoords(command.minX, command.minY, command.maxX, command.maxY);
   }
 
   /**

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -98,6 +98,20 @@ interface MutableGroupScope extends GroupScope, EntryPlacementState {
  * playback semantics — the group uniform is suspended (the branch collected
  * world-space transforms) and fragment capture records a live re-dispatch.
  */
+/**
+ * What one frame selects from: the entries, the source that judges them, and
+ * whether their stored world AABBs are still exact.
+ *
+ * The third field travels with the other two because it is a property of the
+ * pairing rather than of either half — the same source answers `true` on a
+ * settled frame and `false` on the next one if a single sprite moved.
+ */
+interface SourceSelection {
+  readonly entries: readonly SourceEntry[];
+  readonly source: RenderRootSource;
+  readonly boundsAreCurrent: boolean;
+}
+
 const groupEscapeEffect: EffectDescriptor = Object.freeze({
   filters: [],
   clip: ClipKind.None,
@@ -650,12 +664,12 @@ export class RenderPlanBuilder {
    * of that: the scene-graph walk, the transform derivation and the material
    * resolve for items the rect rejects.
    */
-  private _emitSourceSelection(entries: readonly SourceEntry[], source: RenderRootSource, rect: ReadonlyRectangle): void {
+  private _emitSourceSelection(entries: readonly SourceEntry[], selection: SourceSelection, rect: ReadonlyRectangle): void {
     for (const entry of entries) {
       if (entry.kind === RenderEntryKind.Draw) {
-        this._emitSelectedItem(entry, source, rect);
+        this._emitSelectedItem(entry, selection, rect);
       } else if (entry.kind === RenderEntryKind.Group) {
-        this._emitSelectedGroup(entry, source, rect);
+        this._emitSelectedGroup(entry, selection, rect);
       } else {
         // Live re-dispatch through the ordinary collect path, at its stored
         // placement. A view-dependent producer therefore sees the CURRENT view
@@ -683,10 +697,10 @@ export class RenderPlanBuilder {
    * them anyway would be two getter calls per item on the one path whose whole
    * purpose is to be cheap at a million.
    */
-  private _emitSelectedItem(item: PersistentDrawItem, source: RenderRootSource, rect: ReadonlyRectangle): void {
+  private _emitSelectedItem(item: PersistentDrawItem, selection: SourceSelection, rect: ReadonlyRectangle): void {
     const drawable = item.drawable;
 
-    if (!source.admits(item, rect)) {
+    if (!selection.source.admits(item, rect, selection.boundsAreCurrent)) {
       this.backend.stats.culledNodes++;
       this._noteViewCulled();
 
@@ -722,9 +736,13 @@ export class RenderPlanBuilder {
    * what keeps the descent proportional to what is on screen instead of to
    * everything the source holds.
    */
-  private _emitSelectedGroup(group: SourceGroup, source: RenderRootSource, rect: ReadonlyRectangle): void {
+  private _emitSelectedGroup(group: SourceGroup, selection: SourceSelection, rect: ReadonlyRectangle): void {
     const node = group.node;
 
+    // Read live rather than from a stored group extent: a group's AABB
+    // aggregates its children, so it is the one rect a `getBounds()` call still
+    // has to compose even on the stored-bounds path — and there are as many
+    // groups as the scene has containers, not as many as it has sprites.
     if (!node._inCullRect(rect)) {
       this.backend.stats.culledNodes++;
       this._noteViewCulled();
@@ -741,7 +759,7 @@ export class RenderPlanBuilder {
     this._scopeStack.push(groupScope);
 
     try {
-      this._emitSourceSelection(group.entries, source, rect);
+      this._emitSourceSelection(group.entries, selection, rect);
     } finally {
       this._scopeStack.pop();
     }
@@ -827,7 +845,7 @@ export class RenderPlanBuilder {
     // this frame ends up capturing.
     representation.noteRebuildKeys(contentRevision, structureRevision, ancestryStamp);
 
-    const selection = this._resolveSourceSelection(node, representation, contentRevision, structureRevision, ancestryStamp);
+    const selection = this._resolveSourceSelection(node, representation, contentRevision, structureRevision, ancestryStamp, transformRevision);
 
     if (representation.shouldSuppressCapture(contentRevision, structureRevision, transformRevision, view)) {
       // No capture this frame, but the cheap path is still the cheap path: the
@@ -836,7 +854,7 @@ export class RenderPlanBuilder {
       if (selection === null) {
         node._collectForRenderPlan(this);
       } else {
-        this._emitSourceSelection(selection.entries, selection.source, this.cullRect);
+        this._emitSourceSelection(selection.entries, selection, this.cullRect);
       }
 
       return;
@@ -855,7 +873,7 @@ export class RenderPlanBuilder {
       if (selection === null) {
         node._collectForRenderPlan(this);
       } else {
-        this._emitSourceSelection(selection.entries, selection.source, this._captureCullRect);
+        this._emitSourceSelection(selection.entries, selection, this._captureCullRect);
       }
     } finally {
       this._trackedRoot = previousTracked;
@@ -886,11 +904,12 @@ export class RenderPlanBuilder {
     contentRevision: number,
     structureRevision: number,
     ancestryStamp: number,
-  ): { entries: readonly SourceEntry[]; source: RenderRootSource } | null {
+    transformRevision: number,
+  ): SourceSelection | null {
     const existing = representation.source;
 
     if (existing?.isUsable(contentRevision, structureRevision, ancestryStamp)) {
-      return { entries: existing.entries, source: existing };
+      return { entries: existing.entries, source: existing, boundsAreCurrent: existing.storedBoundsAreCurrent(transformRevision) };
     }
 
     // Stale items describe a subtree that no longer exists, and world bounds
@@ -915,9 +934,11 @@ export class RenderPlanBuilder {
 
     const source = representation.ensureSource();
 
-    source.adopt(discovered, contentRevision, structureRevision, ancestryStamp);
+    source.adopt(discovered, contentRevision, structureRevision, ancestryStamp, transformRevision);
 
-    return { entries: discovered, source };
+    // Freshly discovered: the bounds were read from the very nodes this frame is
+    // about to select from.
+    return { entries: discovered, source, boundsAreCurrent: true };
   }
 
   /**

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -18,6 +18,7 @@ import {
   type GroupScopeEntry,
   type ScopeEntry,
 } from './RenderScope';
+import { LiveEntryReason, type SourceEntry, type SourceGroup } from './RenderSourceItem';
 import type { RetainedFragmentEntry, RetainedFragmentGroup, RetainedGroupFragment } from './RetainedGroupFragment';
 import type { RetainedInstructionSet } from './RetainedInstructionSet';
 import type { RetainedDrawData } from './RetainedPlanCache';
@@ -164,6 +165,32 @@ export class RenderPlanBuilder {
   private _viewCullSuppression = 0;
 
   /**
+   * Scope stack of the source-collection walk, or empty when not collecting a
+   * source. Non-empty means this build is DISCOVERING a render root's persistent
+   * items rather than producing a frame.
+   *
+   * That walk must not pay the frame path: no pooled `DrawCommand`, no
+   * frame-global `nodeIndex`, no transform-buffer row and no backend-bound
+   * material key for a node that is only being discovered. It covers the whole
+   * subtree — a million nodes where three quarters are off-screen — so taking
+   * the normal `emitDraw` path would allocate roughly 48MB of transform rows in
+   * a grow-only buffer for draws that never happen.
+   */
+  private readonly _sourceStack: SourceEntry[][] = [];
+  /**
+   * The producer whose collect is currently running during source discovery.
+   *
+   * A view read attributes to THIS node rather than to the root, so one
+   * view-dependent parallax layer becomes one {@link LiveEntry} instead of
+   * forcing every sibling off the persistent path — the segment granularity
+   * contract 10 of the architecture freeze asks for.
+   */
+  private _sourceProducer: RenderNode | null = null;
+  /** Producers observed reading the view during the current source walk. */
+  private readonly _sourceViewReaders = new Set<RenderNode>();
+  private _nextItemHandle = 0;
+
+  /**
    * The node this build treats as the retained render root, or `null` when the
    * root is not eligible. Compared by identity in {@link emitNode}, so the
    * automatic representation attaches to the root's OWN group scope — the one
@@ -262,6 +289,14 @@ export class RenderPlanBuilder {
     // sets a capture up — the cull-rect inflation, the plan's own view field —
     // cannot mark every capture as view-dependent.
     this._trackedRoot?.noteViewRead();
+
+    if (this._sourceProducer !== null) {
+      // Local attribution: only the producer in flight is view-dependent. The
+      // root-wide flag above answers a different, binary question (may this
+      // capture replay under a moved view); this one decides which single entry
+      // stops being persistent.
+      this._sourceViewReaders.add(this._sourceProducer);
+    }
 
     return this._viewUnobserved();
   }
@@ -395,6 +430,12 @@ export class RenderPlanBuilder {
       return;
     }
 
+    if (this._sourceStack.length > 0) {
+      this._collectSourceGroup(node, reservedSeq, reservedZ);
+
+      return;
+    }
+
     const groupScope = this._acquireGroupScope(this._resolvePreserveDrawOrder(node));
 
     groupScope.transformNode = node._isTransformGroupBoundary ? node : null;
@@ -411,6 +452,55 @@ export class RenderPlanBuilder {
       }
     } finally {
       this._scopeStack.pop();
+    }
+  }
+
+  /**
+   * Discovery counterpart of the group branch: mirror the scope structure into
+   * the source and run the node's collect with it as the current producer.
+   *
+   * A transform-group boundary is NOT descended into. It owns its own retention
+   * tier, and the root records it as a live re-dispatch rather than absorbing it
+   * — the same policy the retained fragment already applies, kept here so the
+   * source cannot quietly flatten a `RetainedContainer` into itself.
+   */
+  private _collectSourceGroup(node: RenderNode, seq: number, zIndex: number): void {
+    const parent = this._sourceStack[this._sourceStack.length - 1]!;
+
+    if (node._isTransformGroupBoundary) {
+      parent.push({ kind: RenderEntryKind.Barrier, seq, node, reason: LiveEntryReason.Boundary });
+
+      return;
+    }
+
+    const group: SourceGroup = {
+      kind: RenderEntryKind.Group,
+      seq,
+      zIndex,
+      preserveDrawOrder: this._resolvePreserveDrawOrder(node),
+      transformNode: null,
+      entries: [],
+    };
+
+    parent.push(group);
+    this._sourceStack.push(group.entries);
+
+    const previousProducer = this._sourceProducer;
+
+    this._sourceProducer = node;
+
+    try {
+      node._collectForRenderPlan(this);
+    } finally {
+      this._sourceProducer = previousProducer;
+      this._sourceStack.pop();
+    }
+
+    // Attribution resolved after the collect: a producer that read the view
+    // during it cannot be persisted, so its whole emitted scope collapses to one
+    // live re-dispatch. Replacing the group in place keeps the placement exact.
+    if (this._sourceViewReaders.has(node)) {
+      parent[parent.length - 1] = { kind: RenderEntryKind.Barrier, seq, node, reason: LiveEntryReason.ViewDependent };
     }
   }
 
@@ -560,6 +650,27 @@ export class RenderPlanBuilder {
     const placementSeq = this._reservedSeq;
     const placementZ = this._reservedZ;
     const bounds = drawable.getBounds();
+
+    if (this._sourceStack.length > 0) {
+      // Discovery: record the neutral item and stop. No pooled command, no
+      // nodeIndex, no transform row, no material key — the cut-1 invariant.
+      // Bounds are read because they ARE the item's payload, and they are a
+      // cache hit for an unmoved node.
+      this._sourceStack[this._sourceStack.length - 1]!.push({
+        kind: RenderEntryKind.Draw,
+        handle: this._nextItemHandle++,
+        drawable,
+        seq: placementSeq,
+        zIndex: placementZ,
+        minX: bounds.left,
+        minY: bounds.top,
+        maxX: bounds.right,
+        maxY: bounds.bottom,
+      });
+
+      return;
+    }
+
     const command = this._acquireDrawCommand();
 
     command.drawable = drawable;
@@ -596,7 +707,16 @@ export class RenderPlanBuilder {
    * whole by RetainedContainer._collect instead.
    */
   public get _isViewCullSuppressed(): boolean {
-    return this._viewCullSuppression > 0;
+    // Source discovery suppresses culling too, and must: the whole point of the
+    // items is to hold what is OFF screen right now, since that is exactly what
+    // scrolls in later. A cull test during discovery would drop precisely the
+    // nodes the source exists to remember.
+    return this._viewCullSuppression > 0 || this._sourceStack.length > 0;
+  }
+
+  /** @internal — true while discovering a render root's persistent items. */
+  public get _isCollectingSource(): boolean {
+    return this._sourceStack.length > 0;
   }
 
   /** @internal — enter a transform-group subtree (see {@link _isViewCullSuppressed}). */
@@ -815,6 +935,12 @@ export class RenderPlanBuilder {
     this._viewCullSuppression = 0;
     this._retentionRoot = null;
     this._trackedRoot = null;
+    // Source-discovery state is per walk, never per pooled builder: a leaked
+    // reader set would attribute a view read to a producer in a later, unrelated
+    // build and make it live forever.
+    this._sourceStack.length = 0;
+    this._sourceProducer = null;
+    this._sourceViewReaders.clear();
   }
 
   private _acquireGroupScope(preserveDrawOrder: boolean): MutableGroupScope {

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -1,4 +1,4 @@
-import { Rectangle } from '#math/Rectangle';
+import { type ReadonlyRectangle, Rectangle } from '#math/Rectangle';
 import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
 import type { RenderBackend } from '#rendering/RenderBackend';
@@ -6,8 +6,10 @@ import type { RenderNode } from '#rendering/RenderNode';
 import { BlendModes, isAdvancedBlendMode } from '#rendering/types';
 import type { View } from '#rendering/View';
 
+import { type EntryPlacementState, reserveEntryPlacement } from './EntryPlacement';
 import { type DrawCommand, materialKeyForcesFlush, RenderEntryKind } from './RenderCommand';
 import { MutableRenderPlan, type RenderPlan } from './RenderPlan';
+import type { RenderRootSource } from './RenderRootSource';
 import {
   type BarrierScope,
   type BarrierScopeEntry,
@@ -18,7 +20,14 @@ import {
   type GroupScopeEntry,
   type ScopeEntry,
 } from './RenderScope';
-import { LiveEntryReason, type SourceEntry, type SourceGroup } from './RenderSourceItem';
+import {
+  createSourceScope,
+  LiveEntryReason,
+  type PersistentDrawItem,
+  type SourceEntry,
+  type SourceGroup,
+  type SourceScope,
+} from './RenderSourceItem';
 import type { RetainedFragmentEntry, RetainedFragmentGroup, RetainedGroupFragment } from './RetainedGroupFragment';
 import type { RetainedInstructionSet } from './RetainedInstructionSet';
 import type { RetainedDrawData } from './RetainedPlanCache';
@@ -69,9 +78,7 @@ interface RetainedBackendHooks {
  */
 const RETAINED_CULL_MARGIN_RATIO = 1 / 16;
 
-interface MutableGroupScope extends GroupScope {
-  _nextSeq: number;
-  firstZ: number | null;
+interface MutableGroupScope extends GroupScope, EntryPlacementState {
   /**
    * First-draw material of this scope, the `hasMixedPipeline` counterpart of
    * {@link MutableGroupScope.firstZ}. `firstPipelineKey === null` means "no draw
@@ -176,7 +183,7 @@ export class RenderPlanBuilder {
    * the normal `emitDraw` path would allocate roughly 48MB of transform rows in
    * a grow-only buffer for draws that never happen.
    */
-  private readonly _sourceStack: SourceEntry[][] = [];
+  private readonly _sourceStack: SourceScope[] = [];
   /**
    * The producer whose collect is currently running during source discovery.
    *
@@ -329,6 +336,12 @@ export class RenderPlanBuilder {
     const reservedSeq = this._reservedSeq;
     const reservedZ = this._reservedZ;
 
+    if (this._sourceStack.length > 0) {
+      this._collectSourceNode(node, reservedSeq, reservedZ);
+
+      return;
+    }
+
     if (node._renderPlanHasBarrierEffects()) {
       const effect = this._createEffectDescriptor(node);
       const hasAlphaMask = effect.maskSource !== null && !(effect.maskSource instanceof Rectangle);
@@ -430,12 +443,6 @@ export class RenderPlanBuilder {
       return;
     }
 
-    if (this._sourceStack.length > 0) {
-      this._collectSourceGroup(node, reservedSeq, reservedZ);
-
-      return;
-    }
-
     const groupScope = this._acquireGroupScope(this._resolvePreserveDrawOrder(node));
 
     groupScope.transformNode = node._isTransformGroupBoundary ? node : null;
@@ -456,34 +463,99 @@ export class RenderPlanBuilder {
   }
 
   /**
-   * Discovery counterpart of the group branch: mirror the scope structure into
-   * the source and run the node's collect with it as the current producer.
+   * Discovery counterpart of {@link emitNode}: decide what this producer
+   * contributes to the persistent source, and never build any frame-local
+   * product on the way.
    *
-   * A transform-group boundary is NOT descended into. It owns its own retention
-   * tier, and the root records it as a live re-dispatch rather than absorbing it
-   * — the same policy the retained fragment already applies, kept here so the
-   * source cannot quietly flatten a `RetainedContainer` into itself.
+   * Three producers are refused outright, each because the source would
+   * otherwise have to re-implement semantics that already have exactly one
+   * owner:
+   *
+   * - **Barrier / effect nodes.** Filters, masks, `cacheAsBitmap`, clipping and
+   *   backdrop blending live in the barrier entry and the effect executor. The
+   *   retained fragment already stores such a node as a live re-dispatch, and
+   *   the source does the same rather than growing a second copy of it.
+   * - **Transform-group boundaries.** A `RetainedContainer` owns its own group
+   *   matrix, group-level culling, branch-escape rule, capture key and
+   *   transform-row patching. Descending into one would flatten all of that
+   *   into the outer source and stop its `_collectContent` from ever running
+   *   again — which is why the discovery walk needs no copy of
+   *   `_childEscapesTransformGroup`: it never gets below a boundary, so no
+   *   discovered node ever has an engaged boundary as its parent.
+   * - **View-dependent producers**, resolved after the fact in
+   *   {@link _resolveViewAttribution}.
+   *
+   * In every case the producer becomes one {@link LiveEntry} at its exact
+   * placement and the walk stops there.
    */
-  private _collectSourceGroup(node: RenderNode, seq: number, zIndex: number): void {
-    const parent = this._sourceStack[this._sourceStack.length - 1]!;
+  private _collectSourceNode(node: RenderNode, seq: number, zIndex: number): void {
+    const scope = this._sourceStack[this._sourceStack.length - 1]!;
 
-    if (node._isTransformGroupBoundary) {
-      parent.push({ kind: RenderEntryKind.Barrier, seq, node, reason: LiveEntryReason.Boundary });
+    if (node._renderPlanHasBarrierEffects()) {
+      scope.entries.push({ kind: RenderEntryKind.Barrier, seq, node, reason: LiveEntryReason.Barrier });
 
       return;
     }
 
+    if (node._isTransformGroupBoundary) {
+      scope.entries.push({ kind: RenderEntryKind.Barrier, seq, node, reason: LiveEntryReason.Boundary });
+
+      return;
+    }
+
+    if (node._isDrawableForRenderPlan()) {
+      this._collectSourceDrawable(node, scope, seq, zIndex);
+
+      return;
+    }
+
+    this._collectSourceGroup(node, scope, seq, zIndex);
+  }
+
+  /**
+   * A drawable producer: run its collect with itself as the attribution context
+   * so the 0..n items it emits are its own.
+   *
+   * The producer context matters here and not only on containers: a drawable is
+   * free to read the view too, and without a context in flight its items would
+   * be persisted while its output is a function of the camera.
+   */
+  private _collectSourceDrawable(node: RenderNode, scope: SourceScope, seq: number, zIndex: number): void {
+    const mark = scope.entries.length;
+    const previousProducer = this._sourceProducer;
+
+    this._sourceProducer = node;
+    this._hasPending = true;
+    this._pendingSeq = seq;
+    this._pendingZ = zIndex;
+
+    try {
+      node._collectForRenderPlan(this);
+    } finally {
+      this._hasPending = false;
+      this._sourceProducer = previousProducer;
+    }
+
+    this._resolveViewAttribution(node, scope, mark, seq);
+  }
+
+  /** A grouping producer: mirror its scope into the source and descend. */
+  private _collectSourceGroup(node: RenderNode, scope: SourceScope, seq: number, zIndex: number): void {
+    const mark = scope.entries.length;
     const group: SourceGroup = {
       kind: RenderEntryKind.Group,
       seq,
       zIndex,
       preserveDrawOrder: this._resolvePreserveDrawOrder(node),
-      transformNode: null,
+      node,
       entries: [],
+      _nextSeq: 0,
+      firstZ: null,
+      hasMixedZ: false,
     };
 
-    parent.push(group);
-    this._sourceStack.push(group.entries);
+    scope.entries.push(group);
+    this._sourceStack.push(group);
 
     const previousProducer = this._sourceProducer;
 
@@ -496,11 +568,182 @@ export class RenderPlanBuilder {
       this._sourceStack.pop();
     }
 
-    // Attribution resolved after the collect: a producer that read the view
-    // during it cannot be persisted, so its whole emitted scope collapses to one
-    // live re-dispatch. Replacing the group in place keeps the placement exact.
-    if (this._sourceViewReaders.has(node)) {
-      parent[parent.length - 1] = { kind: RenderEntryKind.Barrier, seq, node, reason: LiveEntryReason.ViewDependent };
+    this._resolveViewAttribution(node, scope, mark, seq);
+  }
+
+  /**
+   * Collapse a producer that read the view into a single live re-dispatch.
+   *
+   * Resolved after its collect rather than before, because the read is OBSERVED
+   * — there is no flag to ask for up front, which is what lets a third-party
+   * node be covered without declaring anything (contract 9 of the architecture
+   * freeze). Everything the producer contributed is dropped back to `mark` and
+   * replaced by one entry at the same placement, so the segment stays exactly as
+   * wide as the producer and its ordering is unchanged.
+   *
+   * `mark`, not "the last entry": a drawable producer may have emitted several
+   * items, and a nested producer that read the view has already collapsed
+   * itself, so this only ever fires for the OUTERMOST reader of a chain.
+   */
+  private _resolveViewAttribution(node: RenderNode, scope: SourceScope, mark: number, seq: number): void {
+    if (!this._sourceViewReaders.has(node)) {
+      return;
+    }
+
+    scope.entries.length = mark;
+    scope.entries.push({ kind: RenderEntryKind.Barrier, seq, node, reason: LiveEntryReason.ViewDependent });
+  }
+
+  /**
+   * Walk `node`'s whole subtree once and return its persistent source entries,
+   * or `null` when the ROOT producer itself read the view.
+   *
+   * The walk is culling-free by construction ({@link _isViewCullSuppressed}):
+   * an item that is off-screen now is exactly the one that must be findable when
+   * it scrolls in, so a cull test here would drop precisely what the source
+   * exists to remember.
+   *
+   * It also produces no frame-local product — no pooled `DrawCommand`, no
+   * `nodeIndex`, no transform-buffer row, no backend-bound material key. At a
+   * million nodes the normal `emitDraw` path would otherwise reserve roughly
+   * 48MB of rows in a grow-only buffer for draws that never happen, three
+   * quarters of them off-screen.
+   *
+   * The `null` case has no more local answer available: the root is the
+   * outermost producer, so a view read attributed to it covers everything below
+   * it and there is nothing left to persist.
+   */
+  private _discoverSource(node: RenderNode): SourceEntry[] | null {
+    const scope = createSourceScope();
+    const previousTracked = this._trackedRoot;
+    const previousCaptureCull = this._captureCullActive;
+
+    // Discovery is not the capture. It culls nothing and produces no records, so
+    // every kept/culled fact and every view read it could report would describe
+    // a collect the capture never performed.
+    this._trackedRoot = null;
+    this._captureCullActive = false;
+    this._sourceViewReaders.clear();
+    this._nextItemHandle = 0;
+    this._sourceStack.push(scope);
+    this._sourceProducer = node;
+
+    try {
+      node._collectForRenderPlan(this);
+    } finally {
+      this._sourceProducer = null;
+      this._sourceStack.pop();
+      this._trackedRoot = previousTracked;
+      this._captureCullActive = previousCaptureCull;
+    }
+
+    return this._sourceViewReaders.has(node) ? null : scope.entries;
+  }
+
+  /**
+   * Materialise a stored selection into the CURRENT frame's plan: the other
+   * entrance to the same renderer, not a second one.
+   *
+   * Every entry lands in the existing `GroupScope` with its stored `(zIndex,
+   * seq)`, so the existing optimizer sorts it, the existing player plays it and
+   * the existing backend batches it. What the source saves is everything ahead
+   * of that: the scene-graph walk, the transform derivation and the material
+   * resolve for items the rect rejects.
+   */
+  private _emitSourceSelection(entries: readonly SourceEntry[], source: RenderRootSource, rect: ReadonlyRectangle): void {
+    for (const entry of entries) {
+      if (entry.kind === RenderEntryKind.Draw) {
+        this._emitSelectedItem(entry, source, rect);
+      } else if (entry.kind === RenderEntryKind.Group) {
+        this._emitSelectedGroup(entry, source, rect);
+      } else {
+        // Live re-dispatch through the ordinary collect path, at its stored
+        // placement. A view-dependent producer therefore sees the CURRENT view
+        // and rebuilds its coverage; a barrier or boundary keeps every bit of
+        // its own semantics, including its own retention tier.
+        entry.node._collect(this, entry.seq);
+      }
+    }
+  }
+
+  /**
+   * One selected item becomes one fresh frame-local draw.
+   *
+   * Nothing backend- or frame-bound is taken from the item: the `nodeIndex` is
+   * this frame's, the material key is resolved live (a backend switch or a tint
+   * change since discovery has to win), and the bounds are read live because
+   * they feed the optimizer's overlap test — a moved node whose command still
+   * carried its discovery-time extent could let a batch run be reordered past a
+   * draw it really overlaps.
+   *
+   * No `visible`/`destroyed` guard, deliberately: both flips stamp the subtree
+   * structure-dirty (`SceneNode.visible`'s setter, and `destroy()` through the
+   * parent's `removeChild`), and the source is keyed on the structure revision,
+   * so neither can be observed here on a source that is still usable. Testing
+   * them anyway would be two getter calls per item on the one path whose whole
+   * purpose is to be cheap at a million.
+   */
+  private _emitSelectedItem(item: PersistentDrawItem, source: RenderRootSource, rect: ReadonlyRectangle): void {
+    const drawable = item.drawable;
+
+    if (!source.admits(item, rect)) {
+      this.backend.stats.culledNodes++;
+      this._noteViewCulled();
+
+      return;
+    }
+
+    this._noteViewKept(drawable);
+    reserveEntryPlacement(this._currentScope(), item.seq, item.zIndex);
+
+    const bounds = drawable.getBounds();
+    const command = this._acquireDrawCommand();
+
+    command.drawable = drawable;
+    command.nodeIndex = this._nodeIndex++;
+    command.seq = item.seq;
+    command.zIndex = item.zIndex;
+    command.groupIndex = undefined;
+    command.material = drawable._getOrComputeMaterialKey(this.backend);
+    command.minX = bounds.left;
+    command.minY = bounds.top;
+    command.maxX = bounds.right;
+    command.maxY = bounds.bottom;
+
+    this._pushDrawEntry(item.seq, item.zIndex, command);
+  }
+
+  /**
+   * A stored group, re-entered under the same subtree-level cull a full collect
+   * applies before it ever reaches `emitNode`.
+   *
+   * That test is not an optimisation bolted on: without it the selection would
+   * push an empty group entry where a full collect pushes nothing, and it is
+   * what keeps the descent proportional to what is on screen instead of to
+   * everything the source holds.
+   */
+  private _emitSelectedGroup(group: SourceGroup, source: RenderRootSource, rect: ReadonlyRectangle): void {
+    const node = group.node;
+
+    if (!node._inCullRect(rect)) {
+      this.backend.stats.culledNodes++;
+      this._noteViewCulled();
+
+      return;
+    }
+
+    this._noteViewKept(node);
+    reserveEntryPlacement(this._currentScope(), group.seq, group.zIndex);
+
+    const groupScope = this._acquireGroupScope(group.preserveDrawOrder);
+
+    this._pushGroupEntry(group.seq, group.zIndex, groupScope);
+    this._scopeStack.push(groupScope);
+
+    try {
+      this._emitSourceSelection(group.entries, source, rect);
+    } finally {
+      this._scopeStack.pop();
     }
   }
 
@@ -514,6 +757,20 @@ export class RenderPlanBuilder {
    * stamp (an ancestor ABOVE the root moves it without stamping its revisions),
    * the render target, and the view SELECTION. Every gate failure degrades to
    * today's behaviour, never to wrong pixels.
+   *
+   * Between "the product still fits" and "rebuild from the scene graph" sits the
+   * selection tier. A camera step that leaves the capture's margin used to cost
+   * a complete collect — walk, transform resolve, material resolve, record — for
+   * a scene where nothing but the camera changed. When only the VIEW key failed,
+   * the persistent source already holds every item in the subtree, on screen or
+   * not, so the frame is a selection over those items instead:
+   *
+   * ```text
+   * tier 1  view still fits the capture              -> replay
+   * tier 2  view moved, content/structure unchanged  -> select from the source
+   * tier 3  transform-only moves                     -> O(k) row patch
+   * tier 4  content / structure / ancestry changed   -> collect the scene graph
+   * ```
    */
   private _collectRetainedRoot(node: RenderNode): void {
     const representation = node._retainedRootRepresentation();
@@ -562,6 +819,21 @@ export class RenderPlanBuilder {
       return;
     }
 
+    // Only the VIEW key failed: content, structure, ancestry, backend and target
+    // all still describe the captured product, so a persistent source built for
+    // it is still valid and this frame is a pure re-selection.
+    const viewOnly = representation.matchesNonViewKeys(contentRevision, structureRevision, ancestryStamp, backend, target);
+
+    representation.noteCaptureFrame(viewOnly);
+
+    if (!viewOnly) {
+      // Content, structure or ancestry moved: the items no longer describe the
+      // subtree, and world bounds stored against a different ancestry are not
+      // repairable. Rebuilding is the correct and simple answer.
+      representation.dropSource();
+    }
+
+    const selection = viewOnly ? this._resolveSourceSelection(node, representation, contentRevision, structureRevision, ancestryStamp) : null;
     const previousTracked = this._trackedRoot;
 
     // Exactly one node per build is the retention root (`_retentionRoot` is
@@ -572,13 +844,66 @@ export class RenderPlanBuilder {
     this._trackedRoot = representation;
 
     try {
-      node._collectForRenderPlan(this);
+      if (selection === null) {
+        node._collectForRenderPlan(this);
+      } else {
+        this._emitSourceSelection(selection.entries, selection.source, this._captureCullRect);
+      }
     } finally {
       this._trackedRoot = previousTracked;
       this._captureCullActive = false;
     }
 
     representation.commitCapture(contentRevision, structureRevision, transformRevision, ancestryStamp, view, backend, target, this._peekCurrentScopeEntries());
+  }
+
+  /**
+   * The items this frame may select from, discovering them first if the root has
+   * earned a source and does not have one yet. `null` means "collect the scene
+   * graph" and is always a correct answer.
+   *
+   * Discovery is gated on the SECOND consecutive view-only capture, and that
+   * gate is the whole safety argument for building a source at all. A source is
+   * one O(N) walk plus one item per drawable in the subtree, so a scene that
+   * alternates between a content change and a camera step would otherwise pay
+   * for a source it never gets to use twice. Requiring two consecutive view-only
+   * captures separates a genuinely scrolling camera — where every capture after
+   * the first is view-only and the source then serves every one of them — from
+   * a scene that merely moved the camera once.
+   */
+  private _resolveSourceSelection(
+    node: RenderNode,
+    representation: RetainedRootRepresentation,
+    contentRevision: number,
+    structureRevision: number,
+    ancestryStamp: number,
+  ): { entries: readonly SourceEntry[]; source: RenderRootSource } | null {
+    const existing = representation.source;
+
+    if (existing?.isUsable(contentRevision, structureRevision, ancestryStamp)) {
+      return { entries: existing.entries, source: existing };
+    }
+
+    if (!representation.shouldBuildSource()) {
+      return null;
+    }
+
+    const discovered = this._discoverSource(node);
+
+    if (discovered === null) {
+      // The root itself is view-dependent, so nothing below it can be attributed
+      // more locally and there is no persistable source. Remember that rather
+      // than paying the walk again on every view change.
+      representation.markSourceUnbuildable();
+
+      return null;
+    }
+
+    const source = representation.ensureSource();
+
+    source.adopt(discovered, contentRevision, structureRevision, ancestryStamp);
+
+    return { entries: discovered, source };
   }
 
   /**
@@ -656,7 +981,7 @@ export class RenderPlanBuilder {
       // nodeIndex, no transform row, no material key — the cut-1 invariant.
       // Bounds are read because they ARE the item's payload, and they are a
       // cache hit for an unmoved node.
-      this._sourceStack[this._sourceStack.length - 1]!.push({
+      this._sourceStack[this._sourceStack.length - 1]!.entries.push({
         kind: RenderEntryKind.Draw,
         handle: this._nextItemHandle++,
         drawable,
@@ -752,17 +1077,7 @@ export class RenderPlanBuilder {
     //     in the same scope must not collide with a replayed slot's seq.
     // The matching `hasMixedPipeline` fold needs no mirror here: it hangs off
     // `_pushDrawEntry` below, which this path already goes through.
-    const scope = this._currentScope();
-
-    if (slot.seq >= scope._nextSeq) {
-      scope._nextSeq = slot.seq + 1;
-    }
-
-    if (scope.firstZ === null) {
-      scope.firstZ = slot.zIndex;
-    } else if (!scope.hasMixedZ && scope.firstZ !== slot.zIndex) {
-      scope.hasMixedZ = true;
-    }
+    reserveEntryPlacement(this._currentScope(), slot.seq, slot.zIndex);
 
     const command = this._acquireDrawCommand();
 
@@ -889,17 +1204,7 @@ export class RenderPlanBuilder {
 
     // Mirror _replayRetainedDraw's scope bookkeeping for the group entry's
     // verbatim seq/zIndex (see the invariants documented there).
-    const scope = this._currentScope();
-
-    if (fragment.seq >= scope._nextSeq) {
-      scope._nextSeq = fragment.seq + 1;
-    }
-
-    if (scope.firstZ === null) {
-      scope.firstZ = fragment.zIndex;
-    } else if (!scope.hasMixedZ && scope.firstZ !== fragment.zIndex) {
-      scope.hasMixedZ = true;
-    }
+    reserveEntryPlacement(this._currentScope(), fragment.seq, fragment.zIndex);
 
     const groupScope = this._acquireGroupScope(fragment.preserveDrawOrder);
 
@@ -1081,21 +1386,23 @@ export class RenderPlanBuilder {
   }
 
   private _reserveEntryPlacement(seq: number | undefined, zIndex: number): void {
-    const scope = this._currentScope();
-    const nextSeq = seq ?? scope._nextSeq;
-
-    if (nextSeq >= scope._nextSeq) {
-      scope._nextSeq = nextSeq + 1;
-    }
-
-    if (scope.firstZ === null) {
-      scope.firstZ = zIndex;
-    } else if (!scope.hasMixedZ && scope.firstZ !== zIndex) {
-      scope.hasMixedZ = true;
-    }
-
-    this._reservedSeq = nextSeq;
+    this._reservedSeq = reserveEntryPlacement(this._currentPlacement(), seq, zIndex);
     this._reservedZ = zIndex;
+  }
+
+  /**
+   * The container the next entry is placed into: the innermost source scope
+   * while a source is being discovered, the innermost frame-local group scope
+   * otherwise.
+   *
+   * The two are different objects with the same placement contract, which is
+   * exactly why the rule lives in {@link reserveEntryPlacement} instead of here.
+   * Discovery deliberately does NOT borrow a `GroupScope` for its bookkeeping: a
+   * dummy scope would tie the backend- and frame-neutral source to the frame's
+   * plan and pull the pooled draw/entry machinery in behind it.
+   */
+  private _currentPlacement(): EntryPlacementState {
+    return this._sourceStack[this._sourceStack.length - 1] ?? this._currentScope();
   }
 
   private _currentScope(): MutableGroupScope {

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -761,16 +761,25 @@ export class RenderPlanBuilder {
    * Between "the product still fits" and "rebuild from the scene graph" sits the
    * selection tier. A camera step that leaves the capture's margin used to cost
    * a complete collect — walk, transform resolve, material resolve, record — for
-   * a scene where nothing but the camera changed. When only the VIEW key failed,
-   * the persistent source already holds every item in the subtree, on screen or
-   * not, so the frame is a selection over those items instead:
+   * a scene where nothing but the camera changed. The persistent source already
+   * holds every item in the subtree, on screen or not, so such a frame becomes a
+   * selection over those items instead:
    *
    * ```text
    * tier 1  view still fits the capture              -> replay
-   * tier 2  view moved, content/structure unchanged  -> select from the source
+   * tier 2  source still describes the subtree       -> select from the source
    * tier 3  transform-only moves                     -> O(k) row patch
    * tier 4  content / structure / ancestry changed   -> collect the scene graph
    * ```
+   *
+   * Tier 2 sits BELOW the capture decision, not inside it: the source is keyed
+   * on the node's own content, structure and ancestry and on nothing the capture
+   * owns, so a frame that may not capture at all still gets to select. That is
+   * not a detail — a root holding a view-dependent producer can never replay its
+   * capture (PR #553), so its captures are always wasted and capture suppression
+   * eventually turns them off for good. Keying the selection on the capture
+   * would have withdrawn the source from a parallax-bearing scrolling map, which
+   * is the exact scene this whole tier exists for.
    */
   private _collectRetainedRoot(node: RenderNode): void {
     const representation = node._retainedRootRepresentation();
@@ -813,27 +822,26 @@ export class RenderPlanBuilder {
       return;
     }
 
+    // This frame has to produce entries one way or another. Settle the source
+    // first — it is keyed on the node alone and is equally valid whether or not
+    // this frame ends up capturing.
+    representation.noteRebuildKeys(contentRevision, structureRevision, ancestryStamp);
+
+    const selection = this._resolveSourceSelection(node, representation, contentRevision, structureRevision, ancestryStamp);
+
     if (representation.shouldSuppressCapture(contentRevision, structureRevision, transformRevision, view)) {
-      node._collectForRenderPlan(this);
+      // No capture this frame, but the cheap path is still the cheap path: the
+      // selection culls against the view's own rect (`cullRect` off a capture)
+      // and produces exactly the entries a plain collect would.
+      if (selection === null) {
+        node._collectForRenderPlan(this);
+      } else {
+        this._emitSourceSelection(selection.entries, selection.source, this.cullRect);
+      }
 
       return;
     }
 
-    // Only the VIEW key failed: content, structure, ancestry, backend and target
-    // all still describe the captured product, so a persistent source built for
-    // it is still valid and this frame is a pure re-selection.
-    const viewOnly = representation.matchesNonViewKeys(contentRevision, structureRevision, ancestryStamp, backend, target);
-
-    representation.noteCaptureFrame(viewOnly);
-
-    if (!viewOnly) {
-      // Content, structure or ancestry moved: the items no longer describe the
-      // subtree, and world bounds stored against a different ancestry are not
-      // repairable. Rebuilding is the correct and simple answer.
-      representation.dropSource();
-    }
-
-    const selection = viewOnly ? this._resolveSourceSelection(node, representation, contentRevision, structureRevision, ancestryStamp) : null;
     const previousTracked = this._trackedRoot;
 
     // Exactly one node per build is the retention root (`_retentionRoot` is
@@ -862,14 +870,15 @@ export class RenderPlanBuilder {
    * earned a source and does not have one yet. `null` means "collect the scene
    * graph" and is always a correct answer.
    *
-   * Discovery is gated on the SECOND consecutive view-only capture, and that
-   * gate is the whole safety argument for building a source at all. A source is
-   * one O(N) walk plus one item per drawable in the subtree, so a scene that
-   * alternates between a content change and a camera step would otherwise pay
-   * for a source it never gets to use twice. Requiring two consecutive view-only
-   * captures separates a genuinely scrolling camera — where every capture after
-   * the first is view-only and the source then serves every one of them — from
-   * a scene that merely moved the camera once.
+   * Discovery is gated on the SECOND consecutive rebuild frame that found the
+   * same content, structure and ancestry, and that gate is the whole safety
+   * argument for building a source at all. A source is one O(N) walk plus one
+   * item per drawable in the subtree, so a scene that alternates between a
+   * content change and a camera step would otherwise pay for a source it never
+   * gets to use twice. Two rebuild frames in a row over unchanged content is the
+   * signature of a camera moving across a settled scene — where the source then
+   * serves every frame after it — and it is a signature a changing scene cannot
+   * produce.
    */
   private _resolveSourceSelection(
     node: RenderNode,
@@ -883,6 +892,11 @@ export class RenderPlanBuilder {
     if (existing?.isUsable(contentRevision, structureRevision, ancestryStamp)) {
       return { entries: existing.entries, source: existing };
     }
+
+    // Stale items describe a subtree that no longer exists, and world bounds
+    // stored against a different ancestry are not repairable. Release them here
+    // rather than leaving a million dead records reachable until the next build.
+    existing?.invalidate();
 
     if (!representation.shouldBuildSource()) {
       return null;

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -91,6 +91,12 @@ interface MutableGroupScope extends GroupScope, EntryPlacementState {
   firstOwnMaterial: boolean;
 }
 
+/** What one frame selects from: the entries, and the source that judges them. */
+interface SourceSelection {
+  readonly entries: readonly SourceEntry[];
+  readonly source: RenderRootSource;
+}
+
 /**
  * Effect-less descriptor shared by every sub-branch escape barrier:
  * all effect stages are disabled, so {@link RenderEffectExecutor.play} is a
@@ -98,20 +104,6 @@ interface MutableGroupScope extends GroupScope, EntryPlacementState {
  * playback semantics — the group uniform is suspended (the branch collected
  * world-space transforms) and fragment capture records a live re-dispatch.
  */
-/**
- * What one frame selects from: the entries, the source that judges them, and
- * whether their stored world AABBs are still exact.
- *
- * The third field travels with the other two because it is a property of the
- * pairing rather than of either half — the same source answers `true` on a
- * settled frame and `false` on the next one if a single sprite moved.
- */
-interface SourceSelection {
-  readonly entries: readonly SourceEntry[];
-  readonly source: RenderRootSource;
-  readonly boundsAreCurrent: boolean;
-}
-
 const groupEscapeEffect: EffectDescriptor = Object.freeze({
   filters: [],
   clip: ClipKind.None,
@@ -700,7 +692,7 @@ export class RenderPlanBuilder {
   private _emitSelectedItem(item: PersistentDrawItem, selection: SourceSelection, rect: ReadonlyRectangle): void {
     const drawable = item.drawable;
 
-    if (!selection.source.admits(item, rect, selection.boundsAreCurrent)) {
+    if (!selection.source.admits(item, rect)) {
       this.backend.stats.culledNodes++;
       this._noteViewCulled();
 
@@ -718,22 +710,13 @@ export class RenderPlanBuilder {
     command.groupIndex = undefined;
     command.material = drawable._getOrComputeMaterialKey(this.backend);
 
-    if (selection.boundsAreCurrent) {
-      // The stored extent is the drawable's own, unchanged — same argument the
-      // scan just made. Asking the node again would resolve its parent chain a
-      // second time for an answer already in hand.
-      command.minX = item.minX;
-      command.minY = item.minY;
-      command.maxX = item.maxX;
-      command.maxY = item.maxY;
-    } else {
-      const bounds = drawable.getBounds();
-
-      command.minX = bounds.left;
-      command.minY = bounds.top;
-      command.maxX = bounds.right;
-      command.maxY = bounds.bottom;
-    }
+    // The stored extent is the drawable's own, unchanged — the same argument
+    // the scan just made. Asking the node again would resolve its parent chain a
+    // second time for an answer already in hand.
+    command.minX = item.minX;
+    command.minY = item.minY;
+    command.maxX = item.maxX;
+    command.maxY = item.maxY;
 
     this._noteSelectedItemKept(command, drawable);
     this._pushDrawEntry(item.seq, item.zIndex, command);
@@ -882,7 +865,7 @@ export class RenderPlanBuilder {
     // This frame has to produce entries one way or another. Settle the source
     // first — it is keyed on the node alone and is equally valid whether or not
     // this frame ends up capturing.
-    representation.noteRebuildKeys(contentRevision, structureRevision, ancestryStamp);
+    representation.noteRebuildKeys(contentRevision, structureRevision, ancestryStamp, transformRevision);
 
     const selection = this._resolveSourceSelection(node, representation, contentRevision, structureRevision, ancestryStamp, transformRevision);
 
@@ -947,8 +930,8 @@ export class RenderPlanBuilder {
   ): SourceSelection | null {
     const existing = representation.source;
 
-    if (existing?.isUsable(contentRevision, structureRevision, ancestryStamp)) {
-      return { entries: existing.entries, source: existing, boundsAreCurrent: existing.storedBoundsAreCurrent(transformRevision) };
+    if (existing?.isUsable(contentRevision, structureRevision, ancestryStamp, transformRevision)) {
+      return { entries: existing.entries, source: existing };
     }
 
     // Stale items describe a subtree that no longer exists, and world bounds
@@ -975,9 +958,7 @@ export class RenderPlanBuilder {
 
     source.adopt(discovered, contentRevision, structureRevision, ancestryStamp, transformRevision);
 
-    // Freshly discovered: the bounds were read from the very nodes this frame is
-    // about to select from.
-    return { entries: discovered, source, boundsAreCurrent: true };
+    return { entries: discovered, source };
   }
 
   /**

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -20,14 +20,7 @@ import {
   type GroupScopeEntry,
   type ScopeEntry,
 } from './RenderScope';
-import {
-  createSourceScope,
-  LiveEntryReason,
-  type PersistentDrawItem,
-  type SourceEntry,
-  type SourceGroup,
-  type SourceScope,
-} from './RenderSourceItem';
+import { createSourceScope, LiveEntryReason, type PersistentDrawItem, type SourceEntry, type SourceGroup, type SourceScope } from './RenderSourceItem';
 import type { RetainedFragmentEntry, RetainedFragmentGroup, RetainedGroupFragment } from './RetainedGroupFragment';
 import type { RetainedInstructionSet } from './RetainedInstructionSet';
 import type { RetainedDrawData } from './RetainedPlanCache';

--- a/src/rendering/plan/RenderRootSource.ts
+++ b/src/rendering/plan/RenderRootSource.ts
@@ -63,36 +63,34 @@ export class RenderRootSource {
   /**
    * The subtree's transform revision when the items were built.
    *
-   * Deliberately NOT part of {@link isUsable}. A transform-only move leaves
-   * every item's identity, placement and producer intact — which drawable exists
-   * and where it sits in draw order is unchanged — so invalidating the whole
-   * source over one moving sprite would take the cheap path away from every
-   * partly-dynamic scene, and those are most scenes.
+   * A key like the others, because the items store WORLD bounds and a move is
+   * exactly what makes a stored extent describe where a drawable was rather than
+   * where it is.
    *
-   * What a move DOES invalidate is the stored world AABBs, and only those. So
-   * this key gates exactly that: {@link storedBoundsAreCurrent}. Equal means
-   * nothing at or below the root moved, so every stored extent is still exact;
-   * unequal drops the scan back to reading each node live, which is correct
-   * whatever moved.
+   * The alternative — keep the source across a move and read each node's bounds
+   * live during the scan — was measured and is a LOSS, badly. A normal collect
+   * over a moved subtree is not a naive walk: every `Container` replays its
+   * unchanged direct drawables from its own retained slot cache, reusing their
+   * cached material key and screen extent. A live-bounds selection reproduces
+   * none of that and resolves both per item, which took `deep-hierarchy` at
+   * 100,000 nodes from 1.9ms to 14.8ms median. So the source is not "usable but
+   * degraded" after a move; it is simply not the cheaper answer, and the frame
+   * belongs on the path that already handles moving content.
    */
   private _transformRevision = -1;
 
   /** Swappable because which strategy wins is a measurement (see the seam's doc). */
   public visibility: RenderItemVisibility = new FlatScanVisibility();
 
-  /** Whether items exist and still describe this content/structure. */
-  public isUsable(contentRevision: number, structureRevision: number, ancestryStamp: number): boolean {
+  /** Whether the items still describe this subtree exactly. */
+  public isUsable(contentRevision: number, structureRevision: number, ancestryStamp: number, transformRevision: number): boolean {
     return (
       this._hasItems &&
       this._contentRevision === contentRevision &&
       this._structureRevision === structureRevision &&
-      this._ancestryStamp === ancestryStamp
+      this._ancestryStamp === ancestryStamp &&
+      this._transformRevision === transformRevision
     );
-  }
-
-  /** Whether the items' stored world AABBs still describe their drawables. */
-  public storedBoundsAreCurrent(transformRevision: number): boolean {
-    return this._transformRevision === transformRevision;
   }
 
   /** The items, valid only while {@link isUsable} holds. */
@@ -124,8 +122,8 @@ export class RenderRootSource {
   }
 
   /** Whether the rect admits this item; delegates to the active strategy. */
-  public admits(item: PersistentDrawItem, rect: ReadonlyRectangle, boundsAreCurrent: boolean): boolean {
-    return this.visibility.admits(item, rect, boundsAreCurrent);
+  public admits(item: PersistentDrawItem, rect: ReadonlyRectangle): boolean {
+    return this.visibility.admits(item, rect);
   }
 
   /** Drop the items (structure/content changed, or the root was destroyed). */

--- a/src/rendering/plan/RenderRootSource.ts
+++ b/src/rendering/plan/RenderRootSource.ts
@@ -60,6 +60,22 @@ export class RenderRootSource {
    * assumption never becomes silent.
    */
   private _ancestryStamp = -1;
+  /**
+   * The subtree's transform revision when the items were built.
+   *
+   * Deliberately NOT part of {@link isUsable}. A transform-only move leaves
+   * every item's identity, placement and producer intact — which drawable exists
+   * and where it sits in draw order is unchanged — so invalidating the whole
+   * source over one moving sprite would take the cheap path away from every
+   * partly-dynamic scene, and those are most scenes.
+   *
+   * What a move DOES invalidate is the stored world AABBs, and only those. So
+   * this key gates exactly that: {@link storedBoundsAreCurrent}. Equal means
+   * nothing at or below the root moved, so every stored extent is still exact;
+   * unequal drops the scan back to reading each node live, which is correct
+   * whatever moved.
+   */
+  private _transformRevision = -1;
 
   /** Swappable because which strategy wins is a measurement (see the seam's doc). */
   public visibility: RenderItemVisibility = new FlatScanVisibility();
@@ -72,6 +88,11 @@ export class RenderRootSource {
       this._structureRevision === structureRevision &&
       this._ancestryStamp === ancestryStamp
     );
+  }
+
+  /** Whether the items' stored world AABBs still describe their drawables. */
+  public storedBoundsAreCurrent(transformRevision: number): boolean {
+    return this._transformRevision === transformRevision;
   }
 
   /** The items, valid only while {@link isUsable} holds. */
@@ -87,17 +108,24 @@ export class RenderRootSource {
    * for those are separate work (`NEU-O47`/`NEU-O49`), and the case this cut
    * exists for is a moving camera over unchanged content.
    */
-  public adopt(entries: readonly SourceEntry[], contentRevision: number, structureRevision: number, ancestryStamp: number): void {
+  public adopt(
+    entries: readonly SourceEntry[],
+    contentRevision: number,
+    structureRevision: number,
+    ancestryStamp: number,
+    transformRevision: number,
+  ): void {
     this._entries = entries;
     this._contentRevision = contentRevision;
     this._structureRevision = structureRevision;
     this._ancestryStamp = ancestryStamp;
+    this._transformRevision = transformRevision;
     this._hasItems = true;
   }
 
   /** Whether the rect admits this item; delegates to the active strategy. */
-  public admits(item: PersistentDrawItem, rect: ReadonlyRectangle): boolean {
-    return this.visibility.admits(item, rect);
+  public admits(item: PersistentDrawItem, rect: ReadonlyRectangle, boundsAreCurrent: boolean): boolean {
+    return this.visibility.admits(item, rect, boundsAreCurrent);
   }
 
   /** Drop the items (structure/content changed, or the root was destroyed). */
@@ -107,5 +135,6 @@ export class RenderRootSource {
     this._contentRevision = -1;
     this._structureRevision = -1;
     this._ancestryStamp = -1;
+    this._transformRevision = -1;
   }
 }

--- a/src/rendering/plan/RenderRootSource.ts
+++ b/src/rendering/plan/RenderRootSource.ts
@@ -1,7 +1,7 @@
 import type { ReadonlyRectangle } from '#math/Rectangle';
 
 import { FlatScanVisibility, type RenderItemVisibility } from './RenderItemVisibility';
-import type { RetainedFragmentDraw, RetainedFragmentEntry } from './RetainedGroupFragment';
+import type { PersistentDrawItem, SourceEntry } from './RenderSourceItem';
 
 /**
  * @internal
@@ -27,28 +27,55 @@ import type { RetainedFragmentDraw, RetainedFragmentEntry } from './RetainedGrou
  * each other every frame. Contract 5 of the architecture freeze
  * (`.workspace/rendering-optimization-O34-final.md`) requires exactly this.
  *
- * Deliberately carries nothing root-specific: the view selection, the ancestry
- * stamp and the render target stay in {@link RetainedRootRepresentation} above
- * it, so `RetainedContainer` can adopt this same source later instead of
- * becoming a third implementation of the same idea.
+ * Deliberately carries nothing backend- or frame-bound: no `MaterialKey` (a
+ * backend switch invalidates one), no transform row and no `nodeIndex` (both
+ * frame-local). Those are re-derived when a selection is emitted and belong to
+ * the derived product, not here. The root-specific KEYS — view selection and
+ * render target — likewise stay in {@link RetainedRootRepresentation} above it,
+ * so `RetainedContainer` can adopt this same source later instead of becoming a
+ * third implementation of the same idea.
+ *
+ * The one exception is the ancestry stamp, which is a key here as well: the
+ * items hold world bounds, so they are ancestry-dependent data rather than
+ * merely ancestry-keyed products (see {@link _ancestryStamp}).
  */
 export class RenderRootSource {
   /** The culling-free item snapshot, in recorded order. */
-  private _entries: readonly RetainedFragmentEntry[] = [];
+  private _entries: readonly SourceEntry[] = [];
   private _hasItems = false;
   private _contentRevision = -1;
   private _structureRevision = -1;
+  /**
+   * The root's global-transform stamp when the items were built.
+   *
+   * The items store WORLD bounds, and an ancestor ABOVE the render root can move
+   * without touching any revision inside the subtree — which is why
+   * `RetainedRootRepresentation` tracks this stamp at all. Stored world bounds
+   * are therefore ancestry-dependent data, and a stamp change invalidates them.
+   *
+   * Conservative on purpose: storing bounds in an ancestry-independent basis
+   * would avoid the rebuild, and is not needed to hit the target. Note that the
+   * scan strategy reads bounds live and is already correct across an ancestor
+   * move; this key exists for the stored data an index would build on, so that
+   * assumption never becomes silent.
+   */
+  private _ancestryStamp = -1;
 
   /** Swappable because which strategy wins is a measurement (see the seam's doc). */
   public visibility: RenderItemVisibility = new FlatScanVisibility();
 
   /** Whether items exist and still describe this content/structure. */
-  public isUsable(contentRevision: number, structureRevision: number): boolean {
-    return this._hasItems && this._contentRevision === contentRevision && this._structureRevision === structureRevision;
+  public isUsable(contentRevision: number, structureRevision: number, ancestryStamp: number): boolean {
+    return (
+      this._hasItems &&
+      this._contentRevision === contentRevision &&
+      this._structureRevision === structureRevision &&
+      this._ancestryStamp === ancestryStamp
+    );
   }
 
   /** The items, valid only while {@link isUsable} holds. */
-  public get entries(): readonly RetainedFragmentEntry[] {
+  public get entries(): readonly SourceEntry[] {
     return this._entries;
   }
 
@@ -60,16 +87,17 @@ export class RenderRootSource {
    * for those are separate work (`NEU-O47`/`NEU-O49`), and the case this cut
    * exists for is a moving camera over unchanged content.
    */
-  public adopt(entries: readonly RetainedFragmentEntry[], contentRevision: number, structureRevision: number): void {
+  public adopt(entries: readonly SourceEntry[], contentRevision: number, structureRevision: number, ancestryStamp: number): void {
     this._entries = entries;
     this._contentRevision = contentRevision;
     this._structureRevision = structureRevision;
+    this._ancestryStamp = ancestryStamp;
     this._hasItems = true;
   }
 
   /** Whether the rect admits this item; delegates to the active strategy. */
-  public admits(draw: RetainedFragmentDraw, rect: ReadonlyRectangle): boolean {
-    return this.visibility.admits(draw, rect);
+  public admits(item: PersistentDrawItem, rect: ReadonlyRectangle): boolean {
+    return this.visibility.admits(item, rect);
   }
 
   /** Drop the items (structure/content changed, or the root was destroyed). */
@@ -78,5 +106,6 @@ export class RenderRootSource {
     this._hasItems = false;
     this._contentRevision = -1;
     this._structureRevision = -1;
+    this._ancestryStamp = -1;
   }
 }

--- a/src/rendering/plan/RenderRootSource.ts
+++ b/src/rendering/plan/RenderRootSource.ts
@@ -106,13 +106,7 @@ export class RenderRootSource {
    * for those are separate work (`NEU-O47`/`NEU-O49`), and the case this cut
    * exists for is a moving camera over unchanged content.
    */
-  public adopt(
-    entries: readonly SourceEntry[],
-    contentRevision: number,
-    structureRevision: number,
-    ancestryStamp: number,
-    transformRevision: number,
-  ): void {
+  public adopt(entries: readonly SourceEntry[], contentRevision: number, structureRevision: number, ancestryStamp: number, transformRevision: number): void {
     this._entries = entries;
     this._contentRevision = contentRevision;
     this._structureRevision = structureRevision;

--- a/src/rendering/plan/RenderRootSource.ts
+++ b/src/rendering/plan/RenderRootSource.ts
@@ -1,0 +1,82 @@
+import type { ReadonlyRectangle } from '#math/Rectangle';
+
+import { FlatScanVisibility, type RenderItemVisibility } from './RenderItemVisibility';
+import type { RetainedFragmentDraw, RetainedFragmentEntry } from './RetainedGroupFragment';
+
+/**
+ * @internal
+ *
+ * The persistent, view-INDEPENDENT items of one render root: every drawable in
+ * the subtree with its recorded order and world bounds, whether or not it is
+ * currently on screen.
+ *
+ * This is the piece a captured product cannot supply. A capture holds what the
+ * camera admitted at capture time, so an item that has since scrolled into view
+ * is precisely the one it does not contain — which is why a view change outside
+ * the capture margin had to rebuild the whole plan from the scene graph, at
+ * ~0.4us per node (400ms at a million).
+ *
+ * With the source present, that rebuild becomes a selection: walk the items,
+ * keep the ones the new rect admits, and emit only those. The scene graph is not
+ * touched, no transform is resolved for a rejected item, and no material key is
+ * computed for one.
+ *
+ * Ownership is per render root, not per node. Visibility and records are
+ * per-root and per-view, so a node rendered under two roots genuinely has two
+ * states; a single owner slot on the node would make the two roots overwrite
+ * each other every frame. Contract 5 of the architecture freeze
+ * (`.workspace/rendering-optimization-O34-final.md`) requires exactly this.
+ *
+ * Deliberately carries nothing root-specific: the view selection, the ancestry
+ * stamp and the render target stay in {@link RetainedRootRepresentation} above
+ * it, so `RetainedContainer` can adopt this same source later instead of
+ * becoming a third implementation of the same idea.
+ */
+export class RenderRootSource {
+  /** The culling-free item snapshot, in recorded order. */
+  private _entries: readonly RetainedFragmentEntry[] = [];
+  private _hasItems = false;
+  private _contentRevision = -1;
+  private _structureRevision = -1;
+
+  /** Swappable because which strategy wins is a measurement (see the seam's doc). */
+  public visibility: RenderItemVisibility = new FlatScanVisibility();
+
+  /** Whether items exist and still describe this content/structure. */
+  public isUsable(contentRevision: number, structureRevision: number): boolean {
+    return this._hasItems && this._contentRevision === contentRevision && this._structureRevision === structureRevision;
+  }
+
+  /** The items, valid only while {@link isUsable} holds. */
+  public get entries(): readonly RetainedFragmentEntry[] {
+    return this._entries;
+  }
+
+  /**
+   * Adopt a fresh culling-free snapshot.
+   *
+   * The caller owns the entry list; the source only keys it. A structure or
+   * content change invalidates rather than patches — the incremental channels
+   * for those are separate work (`NEU-O47`/`NEU-O49`), and the case this cut
+   * exists for is a moving camera over unchanged content.
+   */
+  public adopt(entries: readonly RetainedFragmentEntry[], contentRevision: number, structureRevision: number): void {
+    this._entries = entries;
+    this._contentRevision = contentRevision;
+    this._structureRevision = structureRevision;
+    this._hasItems = true;
+  }
+
+  /** Whether the rect admits this item; delegates to the active strategy. */
+  public admits(draw: RetainedFragmentDraw, rect: ReadonlyRectangle): boolean {
+    return this.visibility.admits(draw, rect);
+  }
+
+  /** Drop the items (structure/content changed, or the root was destroyed). */
+  public invalidate(): void {
+    this._entries = [];
+    this._hasItems = false;
+    this._contentRevision = -1;
+    this._structureRevision = -1;
+  }
+}

--- a/src/rendering/plan/RenderSourceItem.ts
+++ b/src/rendering/plan/RenderSourceItem.ts
@@ -1,0 +1,94 @@
+import type { Drawable } from '#rendering/Drawable';
+import type { RenderNode } from '#rendering/RenderNode';
+
+import type { RenderEntryKind } from './RenderCommand';
+
+/**
+ * Why an entry must be re-dispatched live on every selection instead of being
+ * replayed from the source.
+ * @internal
+ */
+export const enum LiveEntryReason {
+  /** A barrier effect: already live re-dispatch in the retained fragment. */
+  Barrier,
+  /** A transform-group boundary, kept live so it owns its own retention tier. */
+  Boundary,
+  /**
+   * The producer read the view during collect, so its output is a function of
+   * the camera (`ImageLayerNode` and `TileLayerNode` size repeat coverage from
+   * `view.center`). Attributed to the producer that read it, never to the root.
+   */
+  ViewDependent,
+}
+
+/**
+ * @internal
+ *
+ * One persistent, replayable draw in a {@link RenderRootSource}.
+ *
+ * Deliberately NOT a `RetainedFragmentDraw`. That type carries `material` (a
+ * backend-bound {@link MaterialKey}) and `nodeIndex` (a frame-local transform
+ * row), and neither survives the source's contract: the source outlives frames
+ * and must not assume a backend. Both are re-derived when a selection is emitted
+ * — the material because a backend switch invalidates it anyway, the row because
+ * it is assigned per frame.
+ *
+ * `minX`..`maxY` are the drawable's WORLD bounds as of discovery. They feed the
+ * visibility test and, later, a spatial index; they are ancestry-dependent, so
+ * an ancestry-stamp change invalidates them (see the source's contract).
+ */
+export interface PersistentDrawItem {
+  readonly kind: RenderEntryKind.Draw;
+  /**
+   * Identity within this source, stable until the next content/structure
+   * rebuild. A producer maps to 0..n items — a container contributes none, a
+   * sprite one, a composite drawable several — so this is the handle the free
+   * list, the visibility index and the delta key on, not the drawable.
+   */
+  handle: number;
+  drawable: Drawable;
+  seq: number;
+  zIndex: number;
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+/**
+ * @internal
+ *
+ * A producer the source refuses to persist: re-dispatched through a normal
+ * `_collect` at its recorded placement on every selection.
+ *
+ * Kept as local as the semantics allow, which is what contract 10 of the
+ * architecture freeze asks for — the optimisation object is a segment, not the
+ * whole renderer. One view-dependent parallax layer must therefore cost one
+ * live entry, not the persistence of the other 999,999 sprites around it.
+ */
+export interface LiveEntry {
+  /**
+   * Reuses the barrier discriminant on purpose: in the retained fragment
+   * `RetainedFragmentBarrier` already means "not captured, re-dispatched through
+   * a normal `_collect` on every replay", which is exactly this entry's
+   * playback. {@link LiveEntryReason} carries why, so the two are still
+   * distinguishable where it matters.
+   */
+  readonly kind: RenderEntryKind.Barrier;
+  seq: number;
+  node: RenderNode;
+  reason: LiveEntryReason;
+}
+
+/** A nested scope inside the source, mirroring the collected group structure. @internal */
+export interface SourceGroup {
+  readonly kind: RenderEntryKind.Group;
+  seq: number;
+  zIndex: number;
+  preserveDrawOrder: boolean;
+  transformNode: RenderNode | null;
+  readonly entries: SourceEntry[];
+}
+
+/** @internal */
+export type SourceEntry = PersistentDrawItem | SourceGroup | LiveEntry;

--- a/src/rendering/plan/RenderSourceItem.ts
+++ b/src/rendering/plan/RenderSourceItem.ts
@@ -1,6 +1,7 @@
 import type { Drawable } from '#rendering/Drawable';
 import type { RenderNode } from '#rendering/RenderNode';
 
+import type { EntryPlacementState } from './EntryPlacement';
 import type { RenderEntryKind } from './RenderCommand';
 
 /**
@@ -33,9 +34,12 @@ export const enum LiveEntryReason {
  * — the material because a backend switch invalidates it anyway, the row because
  * it is assigned per frame.
  *
- * `minX`..`maxY` are the drawable's WORLD bounds as of discovery. They feed the
- * visibility test and, later, a spatial index; they are ancestry-dependent, so
- * an ancestry-stamp change invalidates them (see the source's contract).
+ * `minX`..`maxY` are the drawable's WORLD bounds as of discovery. They are
+ * ancestry-dependent, so an ancestry-stamp change invalidates them (see the
+ * source's contract). The cut-1 scan does NOT read them — it goes through
+ * `Drawable._inCullRect`, which is live and therefore correct even when they are
+ * stale — they are the payload a spatial index selects on, and the reason the
+ * source is keyed on ancestry at all.
  */
 export interface PersistentDrawItem {
   readonly kind: RenderEntryKind.Draw;
@@ -65,6 +69,11 @@ export interface PersistentDrawItem {
  * architecture freeze asks for — the optimisation object is a segment, not the
  * whole renderer. One view-dependent parallax layer must therefore cost one
  * live entry, not the persistence of the other 999,999 sprites around it.
+ *
+ * No `zIndex`: the re-dispatch goes through `RenderNode._collect`, which reads
+ * the node's live `zIndex` exactly as a full collect would. Only the placement
+ * the source cannot re-derive — the child index the producer was collected at —
+ * has to be stored.
  */
 export interface LiveEntry {
   /**
@@ -80,15 +89,45 @@ export interface LiveEntry {
   reason: LiveEntryReason;
 }
 
-/** A nested scope inside the source, mirroring the collected group structure. @internal */
-export interface SourceGroup {
+/**
+ * One entry container inside the source: its entries plus the placement
+ * bookkeeping that decides their draw order. Shared shape with a frame-local
+ * `GroupScope` through {@link EntryPlacementState}, which is what keeps the
+ * `(zIndex, seq)` rule single-sourced across the two.
+ * @internal
+ */
+export interface SourceScope extends EntryPlacementState {
+  readonly entries: SourceEntry[];
+}
+
+/**
+ * A nested scope inside the source, mirroring the collected group structure.
+ *
+ * Carries `node` because a selection has to apply the SAME subtree-level cull
+ * `SceneNode._collect` applies: a container whose aggregate bounds miss the rect
+ * holds no child that meets it, so the whole group is skipped rather than
+ * scanned item by item. Without it the selection would emit an empty group where
+ * a full collect emits nothing.
+ *
+ * Never a transform-group boundary — those are {@link LiveEntry}s, so this scope
+ * has no `transformNode` field to go stale.
+ * @internal
+ */
+export interface SourceGroup extends SourceScope {
   readonly kind: RenderEntryKind.Group;
   seq: number;
   zIndex: number;
   preserveDrawOrder: boolean;
-  transformNode: RenderNode | null;
-  readonly entries: SourceEntry[];
+  node: RenderNode;
 }
 
 /** @internal */
 export type SourceEntry = PersistentDrawItem | SourceGroup | LiveEntry;
+
+/** A fresh, empty source scope with its placement state at the start. @internal */
+export const createSourceScope = (): SourceScope => ({
+  entries: [],
+  _nextSeq: 0,
+  firstZ: null,
+  hasMixedZ: false,
+});

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -4,6 +4,7 @@ import type { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { View } from '#rendering/View';
 
+import { RenderRootSource } from './RenderRootSource';
 import type { ScopeEntry } from './RenderScope';
 import { RetainedGroupFragment } from './RetainedGroupFragment';
 import { reconcileRetainedTransformRows } from './retainedTransformRowPatch';
@@ -85,6 +86,43 @@ export class RetainedRootRepresentation {
    */
   private _viewDependentCapture = false;
 
+  /**
+   * The persistent items this root can re-select from, or `null` while it has
+   * never needed them.
+   *
+   * Lazily created on purpose: the items are the dominant new memory cost at a
+   * large node count (one record per drawable in the WHOLE subtree, on screen or
+   * not), and a root whose camera never leaves its capture margin never has a
+   * use for them. Only a root that actually re-selects pays for one.
+   *
+   * Owned here rather than beside the fragment because the source is the
+   * backend- and frame-NEUTRAL half: the keys that are not — view selection,
+   * render target, backend identity — stay on this class, which is what lets a
+   * `RetainedContainer` adopt the same source later instead of growing a third
+   * implementation of the same idea.
+   */
+  private _source: RenderRootSource | null = null;
+  /**
+   * Consecutive capture frames on which only the VIEW key failed.
+   *
+   * The build gate ({@link shouldBuildSource}). One such frame proves nothing —
+   * a camera that stepped once and stopped produces exactly one, and a source
+   * built for it is one O(N) walk plus one record per drawable that will never
+   * be selected from twice. Two in a row is the signature of a camera that keeps
+   * moving over unchanged content, which is the case the source exists for.
+   */
+  private _viewOnlyStreak = 0;
+  /**
+   * The root producer itself read the view during discovery, so there is no
+   * persistable source at any granularity — attribution to the outermost
+   * producer covers the entire subtree.
+   *
+   * Sticky across invalidation: it is a property of what the root node DOES
+   * during collect, not of the content it holds, so re-running the walk on the
+   * next view change would reach the same conclusion at the same cost.
+   */
+  private _sourceUnbuildable = false;
+
   // Thrash suppression over the FULL key (see `shouldSuppressCapture`).
   private _replayedSinceCapture = false;
   private _wastedCaptures = 0;
@@ -121,14 +159,7 @@ export class RetainedRootRepresentation {
     backend: RenderBackend,
     target: RenderTargetIdentity | null,
   ): boolean {
-    if (
-      !this._hasCapture ||
-      this._contentRevision !== contentRevision ||
-      this._structureRevision !== structureRevision ||
-      this._ancestryStamp !== ancestryStamp ||
-      this._backend !== backend ||
-      this._target !== target
-    ) {
+    if (!this.matchesNonViewKeys(contentRevision, structureRevision, ancestryStamp, backend, target)) {
       return false;
     }
 
@@ -151,6 +182,64 @@ export class RetainedRootRepresentation {
     }
 
     return this._keptEmpty || view.getBounds().containsRect(this._keptBounds.getRect());
+  }
+
+  /**
+   * Every key except the view: whether the captured product still describes the
+   * same subtree, compiled for the same backend and target.
+   *
+   * Split out because the two consumers ask different questions of it.
+   * {@link isCleanIgnoringTransform} needs all of it plus the view to decide
+   * whether the PRODUCT replays; the selection tier needs exactly this half,
+   * because a source is view-independent by construction and its validity turns
+   * only on content, structure and ancestry. A `true` here with a failing view
+   * test is the precise definition of "only the camera moved".
+   */
+  public matchesNonViewKeys(
+    contentRevision: number,
+    structureRevision: number,
+    ancestryStamp: number,
+    backend: RenderBackend,
+    target: RenderTargetIdentity | null,
+  ): boolean {
+    return (
+      this._hasCapture &&
+      this._contentRevision === contentRevision &&
+      this._structureRevision === structureRevision &&
+      this._ancestryStamp === ancestryStamp &&
+      this._backend === backend &&
+      this._target === target
+    );
+  }
+
+  /** The persistent items, or `null` while this root has never built any. */
+  public get source(): RenderRootSource | null {
+    return this._source;
+  }
+
+  /** The persistent items, created on first use. */
+  public ensureSource(): RenderRootSource {
+    return (this._source ??= new RenderRootSource());
+  }
+
+  /** Drop the items and release their drawable references. */
+  public dropSource(): void {
+    this._source?.invalidate();
+  }
+
+  /** Fold one capture frame into the build gate (see {@link _viewOnlyStreak}). */
+  public noteCaptureFrame(viewOnly: boolean): void {
+    this._viewOnlyStreak = viewOnly ? this._viewOnlyStreak + 1 : 0;
+  }
+
+  /** Whether a missing source is worth one culling-free discovery walk now. */
+  public shouldBuildSource(): boolean {
+    return !this._sourceUnbuildable && this._viewOnlyStreak >= 2;
+  }
+
+  /** Discovery found the ROOT itself view-dependent (see {@link _sourceUnbuildable}). */
+  public markSourceUnbuildable(): void {
+    this._sourceUnbuildable = true;
   }
 
   /** Whether this view lies entirely inside the rect the capture culled against. */
@@ -386,6 +475,12 @@ export class RetainedRootRepresentation {
   /** Drop the capture and its recording; the GPU bundle is kept (grow-only). */
   public invalidate(): void {
     this.fragment.invalidate();
+    // The source is keyed on the same content/structure/ancestry the capture
+    // was, so anything that drops one drops the other; the streak restarts with
+    // it, so a recovering root re-earns its source rather than inheriting a
+    // verdict from before the invalidation.
+    this._source?.invalidate();
+    this._viewOnlyStreak = 0;
     this._hasCapture = false;
     this._replayedSinceCapture = false;
     this._wastedCaptures = 0;
@@ -404,6 +499,8 @@ export class RetainedRootRepresentation {
   public dispose(): void {
     this.invalidate();
     this.fragment.dispose();
+    this._source = null;
+    this._sourceUnbuildable = false;
     this._keptBounds.destroy();
   }
 

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -446,6 +446,17 @@ export class RetainedRootRepresentation {
     this._keptEmpty = false;
   }
 
+  /**
+   * {@link noteKept} for a caller that holds the compared extent as four numbers
+   * rather than a rectangle — the source selection, whose items store it that
+   * way. Materialising a `Rectangle` per item just to hand it over would cost
+   * more than the fold.
+   */
+  public noteKeptCoords(minX: number, minY: number, maxX: number, maxY: number): void {
+    this._keptBounds.addCoords(minX, minY).addCoords(maxX, maxY);
+    this._keptEmpty = false;
+  }
+
   /** A node was dropped by the view test — the capture is view-locked. */
   public noteCulled(): void {
     this._culledDuringCapture = true;

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -103,15 +103,25 @@ export class RetainedRootRepresentation {
    */
   private _source: RenderRootSource | null = null;
   /**
-   * Consecutive capture frames on which only the VIEW key failed.
+   * Consecutive frames that had to rebuild and found the same content, structure
+   * and ancestry as the rebuild before them, plus the keys that streak is
+   * measured against.
    *
    * The build gate ({@link shouldBuildSource}). One such frame proves nothing —
    * a camera that stepped once and stopped produces exactly one, and a source
    * built for it is one O(N) walk plus one record per drawable that will never
-   * be selected from twice. Two in a row is the signature of a camera that keeps
-   * moving over unchanged content, which is the case the source exists for.
+   * be selected from twice. Two in a row is the signature of a camera moving
+   * across a settled scene, which is the case the source exists for, and it is a
+   * signature a scene whose content keeps changing cannot produce.
+   *
+   * Deliberately NOT derived from the capture keys: the source is valid
+   * independently of whether a capture exists, and a root whose captures are
+   * suppressed needs the cheap path more than any other, not less.
    */
-  private _viewOnlyStreak = 0;
+  private _rebuildStreak = 0;
+  private _streakContent = -1;
+  private _streakStructure = -1;
+  private _streakAncestry = -1;
   /**
    * The root producer itself read the view during discovery, so there is no
    * persistable source at any granularity — attribution to the outermost
@@ -188,12 +198,9 @@ export class RetainedRootRepresentation {
    * Every key except the view: whether the captured product still describes the
    * same subtree, compiled for the same backend and target.
    *
-   * Split out because the two consumers ask different questions of it.
-   * {@link isCleanIgnoringTransform} needs all of it plus the view to decide
-   * whether the PRODUCT replays; the selection tier needs exactly this half,
-   * because a source is view-independent by construction and its validity turns
-   * only on content, structure and ancestry. A `true` here with a failing view
-   * test is the precise definition of "only the camera moved".
+   * Split out from {@link isCleanIgnoringTransform} because the view key is the
+   * only one of the six that is not an exact compare, and reading the exact half
+   * on its own is what makes the tolerant half legible.
    */
   public matchesNonViewKeys(
     contentRevision: number,
@@ -222,19 +229,19 @@ export class RetainedRootRepresentation {
     return (this._source ??= new RenderRootSource());
   }
 
-  /** Drop the items and release their drawable references. */
-  public dropSource(): void {
-    this._source?.invalidate();
-  }
+  /** Fold one rebuild frame into the build gate (see {@link _rebuildStreak}). */
+  public noteRebuildKeys(contentRevision: number, structureRevision: number, ancestryStamp: number): void {
+    const same = this._streakContent === contentRevision && this._streakStructure === structureRevision && this._streakAncestry === ancestryStamp;
 
-  /** Fold one capture frame into the build gate (see {@link _viewOnlyStreak}). */
-  public noteCaptureFrame(viewOnly: boolean): void {
-    this._viewOnlyStreak = viewOnly ? this._viewOnlyStreak + 1 : 0;
+    this._rebuildStreak = same ? this._rebuildStreak + 1 : 0;
+    this._streakContent = contentRevision;
+    this._streakStructure = structureRevision;
+    this._streakAncestry = ancestryStamp;
   }
 
   /** Whether a missing source is worth one culling-free discovery walk now. */
   public shouldBuildSource(): boolean {
-    return !this._sourceUnbuildable && this._viewOnlyStreak >= 2;
+    return !this._sourceUnbuildable && this._rebuildStreak >= 1;
   }
 
   /** Discovery found the ROOT itself view-dependent (see {@link _sourceUnbuildable}). */
@@ -472,15 +479,17 @@ export class RetainedRootRepresentation {
     this._replayedSinceCapture = false;
   }
 
-  /** Drop the capture and its recording; the GPU bundle is kept (grow-only). */
+  /**
+   * Drop the capture and its recording; the GPU bundle is kept (grow-only).
+   *
+   * The SOURCE deliberately survives. It is keyed on the node's own revisions
+   * and validates itself, so it stays correct across anything that invalidates a
+   * capture — and the loudest caller here is capture suppression, where the
+   * frame that just lost its capture is exactly the one that most needs a cheap
+   * path to fall back to.
+   */
   public invalidate(): void {
     this.fragment.invalidate();
-    // The source is keyed on the same content/structure/ancestry the capture
-    // was, so anything that drops one drops the other; the streak restarts with
-    // it, so a recovering root re-earns its source rather than inheriting a
-    // verdict from before the invalidation.
-    this._source?.invalidate();
-    this._viewOnlyStreak = 0;
     this._hasCapture = false;
     this._replayedSinceCapture = false;
     this._wastedCaptures = 0;

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -103,16 +103,21 @@ export class RetainedRootRepresentation {
    */
   private _source: RenderRootSource | null = null;
   /**
-   * Consecutive frames that had to rebuild and found the same content, structure
-   * and ancestry as the rebuild before them, plus the keys that streak is
-   * measured against.
+   * Consecutive frames that had to rebuild and found the subtree exactly as the
+   * rebuild before them left it, plus the keys that streak is measured against.
    *
    * The build gate ({@link shouldBuildSource}). One such frame proves nothing —
    * a camera that stepped once and stopped produces exactly one, and a source
    * built for it is one O(N) walk plus one record per drawable that will never
    * be selected from twice. Two in a row is the signature of a camera moving
-   * across a settled scene, which is the case the source exists for, and it is a
-   * signature a scene whose content keeps changing cannot produce.
+   * across a settled scene, which is the case the source exists for.
+   *
+   * The keys are exactly the source's own, transform included, so a scene that
+   * moves something every frame can never produce the streak — and therefore
+   * never pays for a source it would have to discard on the next frame anyway.
+   * That is the gate's second job, and the more important one: without the
+   * transform key, `dynamic-heavy` and `deep-hierarchy` would re-walk their
+   * whole subtree on every dirty frame.
    *
    * Deliberately NOT derived from the capture keys: the source is valid
    * independently of whether a capture exists, and a root whose captures are
@@ -122,6 +127,7 @@ export class RetainedRootRepresentation {
   private _streakContent = -1;
   private _streakStructure = -1;
   private _streakAncestry = -1;
+  private _streakTransform = -1;
   /**
    * The root producer itself read the view during discovery, so there is no
    * persistable source at any granularity — attribution to the outermost
@@ -230,13 +236,18 @@ export class RetainedRootRepresentation {
   }
 
   /** Fold one rebuild frame into the build gate (see {@link _rebuildStreak}). */
-  public noteRebuildKeys(contentRevision: number, structureRevision: number, ancestryStamp: number): void {
-    const same = this._streakContent === contentRevision && this._streakStructure === structureRevision && this._streakAncestry === ancestryStamp;
+  public noteRebuildKeys(contentRevision: number, structureRevision: number, ancestryStamp: number, transformRevision: number): void {
+    const same =
+      this._streakContent === contentRevision &&
+      this._streakStructure === structureRevision &&
+      this._streakAncestry === ancestryStamp &&
+      this._streakTransform === transformRevision;
 
     this._rebuildStreak = same ? this._rebuildStreak + 1 : 0;
     this._streakContent = contentRevision;
     this._streakStructure = structureRevision;
     this._streakAncestry = ancestryStamp;
+    this._streakTransform = transformRevision;
   }
 
   /** Whether a missing source is worth one culling-free discovery walk now. */

--- a/test/perf/rendering/counter-gates.test.ts
+++ b/test/perf/rendering/counter-gates.test.ts
@@ -68,17 +68,62 @@ const EXPECTED = {
   panPlain: { collect: 1, inView: 1, globalTransform: 2, materialKey: 0, submittedNodes: 1000, culledNodes: 0, drawCalls: 1, batches: 1 },
 
   // The same scene panned FAR ENOUGH each frame to leave the capture margin, so
-  // the product expires every frame and the walk pays the honest O(n) cost. It
-  // is the counterweight to `panPlain`: without it, a margin so wide it never
-  // expired would look identical to a correct one, and the row that used to
-  // catch a super-linear collect regression would have no home.
+  // the product expires every frame. It is the counterweight to `panPlain`:
+  // without it, a margin so wide it never expired would look identical to a
+  // correct one.
+  //
+  // `collect` re-pinned 1001 -> 1 when the persistent source landed: the frame
+  // no longer walks the scene graph to find its content, it selects from the
+  // items a single earlier walk discovered. That is the entire point of the
+  // tier, and a `collect` back at 1001 means the source stopped engaging under a
+  // moving camera.
+  //
+  // Every OTHER column is deliberately unchanged, and the three that matter are
+  // load-bearing rather than incidental:
+  //
+  // - `inView` stays 1001 because the selection tests each item with the node's
+  //   own `_inCullRect` — the same rule, read live, not a second copy over the
+  //   items' stored AABBs.
+  // - `culledNodes` stays 112, so a strategy that silently stopped culling and
+  //   submitted the whole subtree could not pass this row.
+  // - `globalTransform`/`materialKey` stay identical because a selection resolves
+  //   them exactly as the walk did, for the same admitted items. Cut 1 buys the
+  //   WALK, not the per-item resolve; the honest number belongs here rather than
+  //   an optimistic one.
   panPlainBeyondMargin: {
-    collect: 1001,
+    collect: 1,
     inView: 1001,
     globalTransform: 5554,
     materialKey: 888,
     submittedNodes: 888,
     culledNodes: 112,
+    drawCalls: 1,
+    batches: 1,
+  },
+
+  // The frame that BUILDS the source: the second consecutive rebuild over
+  // unchanged content, driven by the same beyond-margin pan with a single warmup
+  // frame in front of it.
+  //
+  // It pins the one-time cost the tier trades against, so it can never be
+  // silently inflated. `collect` is 1001 — the discovery walk visits every node
+  // exactly once, because an item that is off-screen now is precisely the one
+  // that must be findable when it scrolls in — and `globalTransform` is 2000
+  // above the plain re-collect this frame used to be (8002 -> 10002), which is
+  // the bounds read that IS each item's payload.
+  //
+  // What must NOT appear here is a per-node frame-local product. The discovery
+  // walk allocates no pooled draw command, no `nodeIndex`, no transform-buffer
+  // row and no backend-bound material key for a node it only discovered; at a
+  // million nodes that would be roughly 48MB of rows in a grow-only buffer for
+  // draws that never happen.
+  sourceDiscovery: {
+    collect: 1001,
+    inView: 1001,
+    globalTransform: 10002,
+    materialKey: 1000,
+    submittedNodes: 1000,
+    culledNodes: 0,
     drawCalls: 1,
     batches: 1,
   },
@@ -140,6 +185,20 @@ const populate = (root: Container, count: number): Sprite[] => {
   return sprites;
 };
 
+/**
+ * A pan that leaves the capture margin on every frame, alternating direction so
+ * the scene stays in front of the camera — the row is about what the frame does
+ * with its content, not about an empty view.
+ */
+const beyondMarginPan = (harness: WebGl2Harness): (() => void) => {
+  let direction = 1;
+
+  return () => {
+    harness.view.move(200 * direction, 0);
+    direction = -direction;
+  };
+};
+
 /** Assert every field of `actual` equals the pinned `expected` row (exact shape). */
 const expectCounters = (actual: FrameCounters, expected: (typeof EXPECTED)[keyof typeof EXPECTED]): void => {
   expect(actual.collect).toBe(expected.collect);
@@ -181,7 +240,7 @@ describe('CPU collect-path shape gate', () => {
     });
   });
 
-  it('camera-pan past the capture margin: the product expires and the frame re-collects O(n)', () => {
+  it('camera-pan past the capture margin: the product expires and the frame selects from the source', () => {
     withHarness(harness => {
       const root = new Container();
 
@@ -189,16 +248,32 @@ describe('CPU collect-path shape gate', () => {
       // 200px per frame against a 1280-wide view is past the margin on every
       // frame; alternating the direction keeps the scene in front of the camera
       // so the row stays about the collect walk, not about an empty view.
-      let direction = 1;
-      const pan = (): void => {
-        harness.view.move(200 * direction, 0);
-        direction = -direction;
-      };
+      const actual = measureFrameCounters(harness, root, { beforeFrame: beyondMarginPan(harness) });
 
-      // A HIGHER `collect` than 1001 (≈ 1 + SPRITE_COUNT) means the walk now
-      // visits more than every node once per pan — a super-linear collect
-      // regression, precisely the CPU-only class the allocation gate misses.
-      expectCounters(measureFrameCounters(harness, root, { beforeFrame: pan }), EXPECTED.panPlainBeyondMargin);
+      // A RISING `collect` means the source stopped engaging and the frame went
+      // back to finding its content by walking the scene graph. A FALLING
+      // `inView`/`culledNodes` means it stopped culling per item, which would
+      // buy time by drawing what the camera cannot see.
+      expectCounters(actual, EXPECTED.panPlainBeyondMargin);
+      root.destroy();
+    });
+  });
+
+  it('the source is built by one honest O(n) walk that allocates no frame-local rows', () => {
+    withHarness(harness => {
+      const root = new Container();
+
+      populate(root, SPRITE_COUNT);
+      // One warmup frame in front of the measured one, so the measured frame is
+      // the SECOND rebuild over unchanged content — the one the build gate arms
+      // discovery on.
+      const actual = measureFrameCounters(harness, root, { beforeFrame: beyondMarginPan(harness), warmup: 1 });
+
+      expectCounters(actual, EXPECTED.sourceDiscovery);
+      // The walk is the price of every later selection, so it has to stay a
+      // single visit per node. Anything above that is a super-linear discovery
+      // regression — exactly the CPU-only class the allocation gate misses.
+      expect(actual.collect).toBe(SPRITE_COUNT + 1);
       root.destroy();
     });
   });
@@ -214,10 +289,13 @@ describe('CPU collect-path shape gate', () => {
 
       expectCounters(actual, EXPECTED.panRetained);
       // Make the retained WIN load-bearing, not just incidental: the fragment is
-      // captured view-INDEPENDENTLY, so it survives camera motion of any size —
-      // unlike the plain root, whose capture margin has a finite reach. If this
-      // inverts, the fragment stopped engaging.
-      expect(actual.collect).toBeLessThan(EXPECTED.panPlainBeyondMargin.collect);
+      // captured view-INDEPENDENTLY, so it survives camera motion of any size
+      // without ever revisiting the scene graph. Anchored against the DISCOVERY
+      // row rather than the beyond-margin one, which now also visits the root
+      // once — the group tier's claim is that it never pays a walk at all, and
+      // that is what inverting here would disprove.
+      expect(actual.collect).toBeLessThan(EXPECTED.sourceDiscovery.collect);
+      expect(actual.inView).toBeLessThan(EXPECTED.sourceDiscovery.inView);
       root.destroy();
     });
   });

--- a/test/perf/rendering/counter-gates.test.ts
+++ b/test/perf/rendering/counter-gates.test.ts
@@ -86,14 +86,19 @@ const EXPECTED = {
   //   items' stored AABBs.
   // - `culledNodes` stays 112, so a strategy that silently stopped culling and
   //   submitted the whole subtree could not pass this row.
-  // - `globalTransform`/`materialKey` stay identical because a selection resolves
-  //   them exactly as the walk did, for the same admitted items. Cut 1 buys the
-  //   WALK, not the per-item resolve; the honest number belongs here rather than
-  //   an optimistic one.
+  // - `materialKey` stays 888, because a selection resolves it live for exactly
+  //   the admitted items, as the walk did.
+  //
+  // `globalTransform` re-pins 5554 -> 3554 with the same change: nothing in the
+  // subtree moved since the items were discovered, so the scan culls against
+  // their stored world AABBs instead of calling `getBounds()` — which resolves
+  // the whole parent chain — once per item. Exactly 2 per sprite, which is what
+  // that call cost. A rise back toward 5554 means the stored-bounds path stopped
+  // engaging on a settled scene.
   panPlainBeyondMargin: {
     collect: 1,
     inView: 1001,
-    globalTransform: 5554,
+    globalTransform: 3554,
     materialKey: 888,
     submittedNodes: 888,
     culledNodes: 112,
@@ -108,9 +113,10 @@ const EXPECTED = {
   // It pins the one-time cost the tier trades against, so it can never be
   // silently inflated. `collect` is 1001 — the discovery walk visits every node
   // exactly once, because an item that is off-screen now is precisely the one
-  // that must be findable when it scrolls in — and `globalTransform` is 2000
-  // above the plain re-collect this frame used to be (8002 -> 10002), which is
-  // the bounds read that IS each item's payload.
+  // that must be findable when it scrolls in — and `globalTransform` is 8002,
+  // exactly what the plain re-collect this frame replaced already paid: the
+  // bounds each item stores are read from the same `getBounds()` call the emit
+  // path made anyway, so discovery adds a walk and no transform work.
   //
   // What must NOT appear here is a per-node frame-local product. The discovery
   // walk allocates no pooled draw command, no `nodeIndex`, no transform-buffer
@@ -120,7 +126,7 @@ const EXPECTED = {
   sourceDiscovery: {
     collect: 1001,
     inView: 1001,
-    globalTransform: 10002,
+    globalTransform: 8002,
     materialKey: 1000,
     submittedNodes: 1000,
     culledNodes: 0,

--- a/test/perf/rendering/counter-gates.test.ts
+++ b/test/perf/rendering/counter-gates.test.ts
@@ -41,7 +41,7 @@ const SPRITE_COUNT = 1000;
  * one fixed scene + drive pattern. See each `it` for what a drift means.
  *
  * columns: collect  = RenderNode._collect calls (nodes visited by the walk)
- *          inView   = SceneNode.inView calls (cull checks)
+ *          inView   = SceneNode._inCullRectUsingBounds calls (cull checks)
  *          gt       = SceneNode.getGlobalTransform calls (build + play transform reads)
  *          mk       = Drawable._getOrComputeMaterialKey calls (per-draw material keys)
  *          plus the deterministic RenderStats totals (submitted/culled/draws/batches).
@@ -81,24 +81,24 @@ const EXPECTED = {
   // Every OTHER column is deliberately unchanged, and the three that matter are
   // load-bearing rather than incidental:
   //
-  // - `inView` stays 1001 because the selection tests each item with the node's
-  //   own `_inCullRect` — the same rule, read live, not a second copy over the
-  //   items' stored AABBs.
+  // - `inView` stays 1001 because the selection still asks the cull question
+  //   once per item, through the node's own rule rather than a second copy of
+  //   it — only the bounds it feeds that rule changed source.
   // - `culledNodes` stays 112, so a strategy that silently stopped culling and
   //   submitted the whole subtree could not pass this row.
   // - `materialKey` stays 888, because a selection resolves it live for exactly
   //   the admitted items, as the walk did.
   //
-  // `globalTransform` re-pins 5554 -> 3554 with the same change: nothing in the
-  // subtree moved since the items were discovered, so the scan culls against
-  // their stored world AABBs instead of calling `getBounds()` — which resolves
-  // the whole parent chain — once per item. Exactly 2 per sprite, which is what
-  // that call cost. A rise back toward 5554 means the stored-bounds path stopped
-  // engaging on a settled scene.
+  // `globalTransform` re-pins 5554 -> 1778 with the same change: nothing in the
+  // subtree moved since the items were discovered, so the stored world AABBs
+  // answer both questions a `getBounds()` call used to be made for — the cull
+  // test, and the screen extent the emitted command carries — and that call
+  // resolves the whole parent chain. A rise back toward 5554 means the
+  // stored-bounds path stopped engaging on a settled scene.
   panPlainBeyondMargin: {
     collect: 1,
     inView: 1001,
-    globalTransform: 3554,
+    globalTransform: 1778,
     materialKey: 888,
     submittedNodes: 888,
     culledNodes: 112,
@@ -111,12 +111,15 @@ const EXPECTED = {
   // frame in front of it.
   //
   // It pins the one-time cost the tier trades against, so it can never be
-  // silently inflated. `collect` is 1001 — the discovery walk visits every node
+  // silently inflated. `collect` is 1001: the discovery walk visits every node
   // exactly once, because an item that is off-screen now is precisely the one
-  // that must be findable when it scrolls in — and `globalTransform` is 8002,
-  // exactly what the plain re-collect this frame replaced already paid: the
-  // bounds each item stores are read from the same `getBounds()` call the emit
-  // path made anyway, so discovery adds a walk and no transform work.
+  // that must be findable when it scrolls in.
+  //
+  // `globalTransform` is 4002 — HALF what the plain re-collect this frame
+  // replaced paid (8002). Discovery reads each drawable's bounds once, and the
+  // selection that immediately follows it reuses those stored values instead of
+  // asking the node again, so even the frame that pays for the walk comes out
+  // ahead on transform resolves.
   //
   // What must NOT appear here is a per-node frame-local product. The discovery
   // walk allocates no pooled draw command, no `nodeIndex`, no transform-buffer
@@ -126,7 +129,7 @@ const EXPECTED = {
   sourceDiscovery: {
     collect: 1001,
     inView: 1001,
-    globalTransform: 8002,
+    globalTransform: 4002,
     materialKey: 1000,
     submittedNodes: 1000,
     culledNodes: 0,

--- a/test/perf/rendering/counters.ts
+++ b/test/perf/rendering/counters.ts
@@ -10,8 +10,8 @@
  *
  * The wrapped methods mirror the four sub-phases the collect-phase benchmark
  * (`test/perf/collect-phase-benchmark.ts`) attributes build() time to:
- *   - `RenderNode._collect`            — node visits entering the cull/emit gate
- *   - `SceneNode._inCullRect`          — view-frustum cull checks
+ *   - `RenderNode._collect`               — node visits entering the cull/emit gate
+ *   - `SceneNode._inCullRectUsingBounds`  — view-frustum cull checks
  *   - `SceneNode.getGlobalTransform`   — world-transform resolutions (build + play)
  *   - `Drawable._getOrComputeMaterialKey` — per-draw material-key resolutions
  *
@@ -32,10 +32,15 @@ export interface CollectCounters {
   /** `RenderNode._collect` calls — nodes visited by the collect walk. */
   collect: number;
   /**
-   * `SceneNode._inCullRect` calls — view-frustum cull checks performed. The
-   * collect path tests against a RECT (the view's own, or the capture's inflated
-   * one) rather than a `View`, so the counter wraps that method; `inView`
-   * delegates to it, so a public caller is still counted.
+   * `SceneNode._inCullRectUsingBounds` calls — view-frustum cull checks
+   * performed.
+   *
+   * Wraps the shared bottom of the rule rather than one of its entrances, so a
+   * check counts exactly once however it was reached: `inView` delegates to
+   * `_inCullRect`, which delegates to this, and the persistent-source scan calls
+   * it directly with bounds it already holds. Counting an entrance instead would
+   * make the number drop whenever a caller switched entrances — reading as "the
+   * frame stopped culling" when nothing about the culling changed.
    */
   inView: number;
   /** `SceneNode.getGlobalTransform` calls — world-transform resolutions (build + play). */
@@ -83,7 +88,7 @@ const installCounters = (): Installed => {
   // call `super._collect`, which resolves to this wrapped implementation — so a
   // single wrap here counts every node visit regardless of subclass.
   wrap(RenderNode.prototype, '_collect', 'collect');
-  wrap(SceneNode.prototype, '_inCullRect', 'inView');
+  wrap(SceneNode.prototype, '_inCullRectUsingBounds', 'inView');
   wrap(SceneNode.prototype, 'getGlobalTransform', 'globalTransform');
   wrap(Drawable.prototype, '_getOrComputeMaterialKey', 'materialKey');
 

--- a/test/rendering/render-root-source.test.ts
+++ b/test/rendering/render-root-source.test.ts
@@ -1,0 +1,576 @@
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
+import { RenderEntryKind } from '#rendering/plan/RenderCommand';
+import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
+import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
+import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
+import type { RenderRootSource } from '#rendering/plan/RenderRootSource';
+import { LiveEntryReason, type SourceEntry } from '#rendering/plan/RenderSourceItem';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import { RenderBackendType } from '#rendering/RenderBackendType';
+import type { RenderNode } from '#rendering/RenderNode';
+import { createRenderStats } from '#rendering/RenderStats';
+import { RenderTarget } from '#rendering/RenderTarget';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { View } from '#rendering/View';
+
+/**
+ * The persistent source of a render ROOT: the items a view change re-selects
+ * from instead of walking the scene graph again.
+ *
+ * Every test here is about one of two things — that a selection paints exactly
+ * what a full collect of the same scene paints, and that the producers whose
+ * semantics the source refuses to reimplement stay live re-dispatches at their
+ * exact placement.
+ */
+
+class Leaf extends Drawable {
+  public constructor(public readonly id: string) {
+    super();
+    this._setLocalBounds(0, 0, 16, 16);
+  }
+}
+
+/** A container that counts how often the walk actually descended into it. */
+class CountingContainer extends Container {
+  public collects = 0;
+
+  protected override _collectContent(builder: RenderPlanBuilder): void {
+    this.collects++;
+    super._collectContent(builder);
+  }
+}
+
+/**
+ * A producer whose output is a function of the camera — the `ImageLayerNode` /
+ * `TileLayerNode` shape, reduced to the part that matters here: it reads
+ * `builder.view` during collect, which is what the source observes.
+ */
+class ParallaxProducer extends Container {
+  public lastViewCenterX = Number.NaN;
+  public collects = 0;
+
+  public constructor() {
+    super();
+    // Both real view-dependent nodes opt out of view culling — their coverage is
+    // sized from the camera, so their bounds say nothing about whether they are
+    // on screen. Without this the producer would be culled before it could read
+    // the view at all.
+    this.cullable = false;
+  }
+
+  protected override _collectContent(builder: RenderPlanBuilder): void {
+    this.collects++;
+    this.lastViewCenterX = builder.view.center.x;
+    super._collectContent(builder);
+  }
+}
+
+const flaggedRenderer = { _supportsRetainedBatches: true };
+
+/**
+ * File-local fake backend recording the drawables it is handed, in order.
+ *
+ * Deliberately WITHOUT the retained-capture hooks: the instruction-splice tier
+ * needs them, and leaving them out keeps every clean frame on entry replay,
+ * where the draws stay individually observable.
+ */
+const createDrawRecordingBackend = (): { backend: RenderBackend; draws: string[]; renderTarget: RenderTarget } => {
+  const renderTarget = new RenderTarget(800, 600, true);
+  const draws: string[] = [];
+
+  const backend = {
+    backendType: RenderBackendType.WebGl2,
+    stats: createRenderStats(),
+    renderTarget,
+    rendererRegistry: {
+      resolve(drawable: Drawable) {
+        if (drawable instanceof Leaf) {
+          return flaggedRenderer;
+        }
+
+        throw new Error(`no renderer registered for ${drawable.constructor.name}`);
+      },
+    },
+    get view() {
+      return renderTarget.view;
+    },
+    async initialize() {
+      return backend;
+    },
+    resetStats() {
+      return backend;
+    },
+    clear() {
+      return backend;
+    },
+    resize() {
+      return backend;
+    },
+    setView(view: View) {
+      renderTarget.setView(view);
+
+      return backend;
+    },
+    setRenderTarget() {
+      return backend;
+    },
+    pushScissorRect() {
+      return backend;
+    },
+    popScissorRect() {
+      return backend;
+    },
+    composeWithAlphaMask() {
+      return backend;
+    },
+    acquireRenderTexture() {
+      throw new Error('not used in this test');
+    },
+    releaseRenderTexture() {
+      return backend;
+    },
+    draw(drawable: Drawable) {
+      draws.push((drawable as Leaf).id);
+
+      return backend;
+    },
+    execute() {
+      return backend;
+    },
+    flush() {
+      return backend;
+    },
+    destroy() {
+      renderTarget.destroy();
+    },
+    _endDrawPlan(): void {},
+    _setRenderGroupTransform(): void {},
+  } as unknown as RenderBackend;
+
+  return { backend, draws, renderTarget };
+};
+
+/** Play one frame and return the drawables the backend was handed, in order. */
+const playFrame = (root: RenderNode, backend: RenderBackend): number => {
+  const builder = RenderPlanBuilder.acquire();
+
+  try {
+    const plan = builder.build(root, backend);
+
+    RenderPlanOptimizer.optimize(plan);
+    RenderPlanPlayer.play(plan, backend);
+
+    return plan.nodeCount;
+  } finally {
+    RenderPlanBuilder.release(builder);
+  }
+};
+
+const sourceOf = (root: RenderNode): RenderRootSource | null => root._retainedRootRepresentation().source;
+
+const entriesOf = (root: RenderNode): readonly SourceEntry[] => {
+  const source = sourceOf(root);
+
+  if (source === null) {
+    throw new Error('the root has no persistent source');
+  }
+
+  return source.entries;
+};
+
+/** A view whose world rect is `[0,0 .. 800,600]`, matching the test render target. */
+const viewAt = (centerX: number): View => new View(centerX, 300, 800, 600);
+
+/**
+ * A render root that is never culled as a whole.
+ *
+ * These tests are about which of the root's ITEMS a view admits, and a render
+ * root that leaves the view entirely short-circuits that question before the
+ * representation is ever consulted — the world container of a scrolling game
+ * opts out for the same reason.
+ */
+const makeRoot = <T extends RenderNode>(root: T): T => {
+  root.cullable = false;
+
+  return root;
+};
+
+/**
+ * Drive `root` to the tier where it selects from a persistent source, and leave
+ * the camera back at its starting view.
+ *
+ * The build gate wants two consecutive rebuild frames that found the same
+ * content, so the camera has to force a second rebuild before the discovery walk
+ * happens. `viewAt(1000)` is far enough out that no view tolerance can hold —
+ * every scene in this file sits around `x = 0..300`.
+ */
+const driveToSourceTier = (root: RenderNode, backend: RenderBackend): void => {
+  backend.setView(viewAt(400));
+  playFrame(root, backend); // rebuild #1
+
+  backend.setView(viewAt(1000));
+  playFrame(root, backend); // rebuild #2 -> discovery, then selection
+
+  backend.setView(viewAt(400));
+  playFrame(root, backend); // selection from the source
+};
+
+describe('render-root source: discovery', () => {
+  test('the source is built only on the second rebuild that found the same content', () => {
+    const { backend } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+
+    root.addChild(new Leaf('a').setPosition(100, 300));
+    backend.setView(viewAt(400));
+    playFrame(root, backend);
+
+    // One rebuild is not evidence of anything, and a source built for it would
+    // be an O(N) walk plus a record per drawable that is never selected twice.
+    expect(sourceOf(root)).toBeNull();
+
+    backend.setView(viewAt(1000));
+    playFrame(root, backend);
+
+    expect(entriesOf(root)).toHaveLength(1);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a scene whose content keeps changing never produces the streak the gate wants', () => {
+    const { backend } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const leaf = new Leaf('a');
+
+    leaf.setPosition(100, 300);
+    root.addChild(leaf);
+
+    // Every rebuild frame finds different content, so the gate never sees two in
+    // a row over the same subtree — the alternating case a naive gate would pay
+    // a full discovery walk for on every other frame.
+    for (const centerX of [400, 1000, 400, 1000, 400]) {
+      leaf.invalidateContent();
+      backend.setView(viewAt(centerX));
+      playFrame(root, backend);
+    }
+
+    expect(sourceOf(root)).toBeNull();
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a root whose camera never leaves the capture margin allocates no source at all', () => {
+    const { backend } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+
+    root.addChild(new Leaf('a').setPosition(100, 300));
+    backend.setView(viewAt(400));
+
+    playFrame(root, backend);
+    playFrame(root, backend);
+    // 2px stays inside the 50px capture margin: every frame replays.
+    backend.setView(viewAt(402));
+    playFrame(root, backend);
+
+    expect(sourceOf(root)).toBeNull();
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('discovery allocates no transform row for an item it only discovered', () => {
+    const { backend } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const onScreen = new Leaf('a');
+    const offScreen = new Leaf('b');
+
+    onScreen.setPosition(100, 300);
+    offScreen.setPosition(4000, 300); // never admitted by any view used here
+    root.addChild(onScreen, offScreen);
+
+    backend.setView(viewAt(400));
+    playFrame(root, backend);
+
+    // The discovery frame. Both items are found — the walk is culling-free by
+    // construction, since an off-screen item is exactly the one that has to be
+    // findable later — but this view admits neither, and `nodeCount` is the
+    // frame's transform-row demand. A discovery walk that took the normal emit
+    // path would report two rows for two draws that never happen.
+    backend.setView(viewAt(1000));
+
+    expect(playFrame(root, backend)).toBe(0);
+    expect(entriesOf(root)).toHaveLength(2);
+
+    // Selecting from those same two items now draws exactly the one on screen.
+    backend.setView(viewAt(400));
+
+    expect(playFrame(root, backend)).toBe(1);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a content change drops the source rather than patching it', () => {
+    const { backend } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const leaf = new Leaf('a');
+
+    leaf.setPosition(100, 300);
+    root.addChild(leaf);
+    driveToSourceTier(root, backend);
+
+    expect(entriesOf(root)).toHaveLength(1);
+
+    leaf.invalidateContent();
+    backend.setView(viewAt(1000));
+    playFrame(root, backend);
+
+    expect(sourceOf(root)?.isUsable(root._contentRevision, root._structureRevision, root._globalTransformStamp)).toBe(false);
+
+    root.destroy();
+    backend.destroy();
+  });
+});
+
+describe('render-root source: draw order', () => {
+  test('an item entering the view is materialised at its stored (zIndex, seq), not appended', () => {
+    const { backend, draws } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const first = new Leaf('a');
+    const entering = new Leaf('b');
+    const last = new Leaf('c');
+
+    // `b` is the middle child by document order, so its seq places it between
+    // the two others — but it starts outside every cull rect used below.
+    first.setPosition(100, 300);
+    entering.setPosition(860, 300);
+    last.setPosition(120, 300);
+    root.addChild(first, entering, last);
+
+    driveToSourceTier(root, backend);
+    draws.length = 0;
+    backend.setView(viewAt(400));
+    playFrame(root, backend);
+
+    expect(draws).toEqual(['a', 'c']);
+
+    // Pan right by 60: past the capture margin, so this is a selection frame,
+    // and far enough that `b` is admitted while `a` and `c` still are.
+    draws.length = 0;
+    backend.setView(viewAt(460));
+    playFrame(root, backend);
+
+    expect(draws).toEqual(['a', 'b', 'c']);
+
+    // Same scene, same view, collected from the scene graph: identical order.
+    const control = makeRoot(new Container());
+
+    control.addChild(new Leaf('a').setPosition(100, 300), new Leaf('b').setPosition(860, 300), new Leaf('c').setPosition(120, 300));
+
+    draws.length = 0;
+    playFrame(control, backend);
+
+    expect(draws).toEqual(['a', 'b', 'c']);
+
+    root.destroy();
+    control.destroy();
+    backend.destroy();
+  });
+
+  test('a selection re-enters a group under the same subtree cull a full collect applies', () => {
+    const { backend, draws } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const near = new CountingContainer();
+    const far = new CountingContainer();
+
+    near.addChild(new Leaf('near').setPosition(100, 300));
+    far.addChild(new Leaf('far').setPosition(4000, 300));
+    root.addChild(near, far);
+
+    driveToSourceTier(root, backend);
+
+    const farCollects = far.collects;
+
+    draws.length = 0;
+    backend.setView(viewAt(200));
+    playFrame(root, backend);
+
+    expect(draws).toEqual(['near']);
+    // The selection skipped the whole far group on its aggregate bounds instead
+    // of scanning its items, exactly as `SceneNode._collect` would have.
+    expect(far.collects).toBe(farCollects);
+
+    root.destroy();
+    backend.destroy();
+  });
+});
+
+describe('render-root source: producer-local view attribution', () => {
+  test('one view-dependent producer costs one live entry, not the whole root', () => {
+    const { backend } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const before = new Leaf('a');
+    const parallax = new ParallaxProducer();
+    const after = new Leaf('b');
+
+    before.setPosition(100, 300);
+    after.setPosition(140, 300);
+    parallax.addChild(new Leaf('p').setPosition(120, 300));
+    root.addChild(before, parallax, after);
+
+    driveToSourceTier(root, backend);
+
+    const entries = entriesOf(root);
+
+    expect(entries).toHaveLength(3);
+    expect(entries[0]!.kind).toBe(RenderEntryKind.Draw);
+    expect(entries[2]!.kind).toBe(RenderEntryKind.Draw);
+
+    const live = entries[1]!;
+
+    expect(live.kind).toBe(RenderEntryKind.Barrier);
+
+    if (live.kind === RenderEntryKind.Barrier) {
+      expect(live.reason).toBe(LiveEntryReason.ViewDependent);
+      expect(live.node).toBe(parallax);
+      expect(live.seq).toBe(1);
+    }
+
+    // A root-wide fallback would have left no persistent item at all.
+    expect(entries.filter(entry => entry.kind === RenderEntryKind.Draw)).toHaveLength(2);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('the live producer re-collects under the moved camera instead of replaying frozen coverage', () => {
+    const { backend, draws } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const parallax = new ParallaxProducer();
+
+    parallax.addChild(new Leaf('p').setPosition(120, 300));
+    root.addChild(new Leaf('a').setPosition(100, 300), parallax);
+
+    driveToSourceTier(root, backend);
+
+    draws.length = 0;
+    backend.setView(viewAt(200));
+    playFrame(root, backend);
+
+    expect(parallax.lastViewCenterX).toBe(200);
+    expect(draws).toContain('p');
+
+    backend.setView(viewAt(600));
+    playFrame(root, backend);
+
+    expect(parallax.lastViewCenterX).toBe(600);
+
+    root.destroy();
+    backend.destroy();
+  });
+});
+
+describe('render-root source: boundaries the source refuses to rebuild', () => {
+  test('a transform-group boundary is one live entry and its descendants are not source items', () => {
+    const { backend, draws } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const group = new RetainedContainer();
+    const before = new Leaf('a');
+    const after = new Leaf('b');
+
+    before.setPosition(100, 300);
+    after.setPosition(180, 300);
+    group.addChild(new Leaf('g1'), new Leaf('g2'));
+    group.setPosition(140, 300);
+    root.addChild(before, group, after);
+
+    driveToSourceTier(root, backend);
+
+    const entries = entriesOf(root);
+
+    expect(entries).toHaveLength(3);
+    expect(entries.map(entry => entry.kind)).toEqual([RenderEntryKind.Draw, RenderEntryKind.Barrier, RenderEntryKind.Draw]);
+
+    const live = entries[1]!;
+
+    if (live.kind === RenderEntryKind.Barrier) {
+      expect(live.reason).toBe(LiveEntryReason.Boundary);
+      expect(live.node).toBe(group);
+      expect(live.seq).toBe(1);
+    }
+
+    // No double ownership: the group's own children never became root items.
+    expect(entries.filter(entry => entry.kind === RenderEntryKind.Draw)).toHaveLength(2);
+
+    draws.length = 0;
+    backend.setView(viewAt(200));
+    playFrame(root, backend);
+
+    // The boundary still paints, and still paints between its siblings.
+    expect(draws).toEqual(['a', 'g1', 'g2', 'b']);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a barrier-effect producer is one live entry and its subtree is not flattened', () => {
+    const { backend, draws } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const clipped = new Container();
+
+    clipped.clip = true;
+    clipped.addChild(new Leaf('c1').setPosition(140, 300));
+    root.addChild(new Leaf('a').setPosition(100, 300), clipped, new Leaf('b').setPosition(180, 300));
+
+    driveToSourceTier(root, backend);
+
+    const entries = entriesOf(root);
+
+    expect(entries.map(entry => entry.kind)).toEqual([RenderEntryKind.Draw, RenderEntryKind.Barrier, RenderEntryKind.Draw]);
+
+    const live = entries[1]!;
+
+    if (live.kind === RenderEntryKind.Barrier) {
+      expect(live.reason).toBe(LiveEntryReason.Barrier);
+      expect(live.node).toBe(clipped);
+    }
+
+    draws.length = 0;
+    backend.setView(viewAt(200));
+    playFrame(root, backend);
+
+    expect(draws).toEqual(['a', 'c1', 'b']);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('a root that IS a transform-group boundary keeps its own tier and builds no self-entry', () => {
+    const { backend, draws } = createDrawRecordingBackend();
+    const root = makeRoot(new RetainedContainer());
+
+    root.addChild(new Leaf('a').setPosition(100, 300), new Leaf('b').setPosition(140, 300));
+
+    // The group tier already owns this scope; wrapping a root representation
+    // around it would have it fight the group over the same record target.
+    expect(root._supportsRootRetention()).toBe(false);
+
+    backend.setView(viewAt(400));
+    playFrame(root, backend);
+    playFrame(root, backend);
+    backend.setView(viewAt(200));
+    playFrame(root, backend);
+    backend.setView(viewAt(400));
+
+    draws.length = 0;
+    playFrame(root, backend);
+
+    expect(draws).toEqual(['a', 'b']);
+    expect(sourceOf(root)).toBeNull();
+
+    root.destroy();
+    backend.destroy();
+  });
+});

--- a/test/rendering/render-root-source.test.ts
+++ b/test/rendering/render-root-source.test.ts
@@ -328,7 +328,7 @@ describe('render-root source: discovery', () => {
     backend.setView(viewAt(1000));
     playFrame(root, backend);
 
-    expect(sourceOf(root)?.isUsable(root._contentRevision, root._structureRevision, root._globalTransformStamp)).toBe(false);
+    expect(sourceOf(root)?.isUsable(root._contentRevision, root._structureRevision, root._globalTransformStamp, root._transformRevision)).toBe(false);
 
     root.destroy();
     backend.destroy();
@@ -355,16 +355,22 @@ describe('render-root source: stored bounds', () => {
 
     expect(draws).toEqual(['stays']);
 
-    // A transform-only move: the item's identity, placement and producer are
-    // unchanged, so the source stays usable — but its stored AABB now describes
-    // where the drawable WAS. Culling against it would drop a node that just
-    // moved into view.
+    // A transform-only move. The item's identity, placement and producer are
+    // all unchanged, so nothing about the ITEMS is wrong — but their stored
+    // AABBs now describe where the drawables were, and selecting against those
+    // would drop a node that just moved into view.
     moves.setPosition(140, 300);
     draws.length = 0;
     backend.setView(viewAt(410));
     playFrame(root, backend);
 
     expect(draws).toEqual(['stays', 'moves']);
+    // The frame took the ordinary collect path and dropped the stale items,
+    // rather than selecting from them. Not merely a safety fallback: a collect
+    // over a moved subtree replays each container's unchanged drawables from its
+    // own retained slot cache, which a live-bounds selection cannot do — it was
+    // measured as the faster of the two, by a wide margin.
+    expect(sourceOf(root)?.isUsable(root._contentRevision, root._structureRevision, root._globalTransformStamp, root._transformRevision)).toBe(false);
 
     root.destroy();
     backend.destroy();

--- a/test/rendering/render-root-source.test.ts
+++ b/test/rendering/render-root-source.test.ts
@@ -1,3 +1,4 @@
+import { Rectangle } from '#math/Rectangle';
 import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
 import { RenderEntryKind } from '#rendering/plan/RenderCommand';
@@ -328,6 +329,72 @@ describe('render-root source: discovery', () => {
     playFrame(root, backend);
 
     expect(sourceOf(root)?.isUsable(root._contentRevision, root._structureRevision, root._globalTransformStamp)).toBe(false);
+
+    root.destroy();
+    backend.destroy();
+  });
+});
+
+describe('render-root source: stored bounds', () => {
+  test('a moved item is selected on its CURRENT position, not on the extent it was discovered at', () => {
+    const { backend, draws } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const stays = new Leaf('stays');
+    const moves = new Leaf('moves');
+
+    stays.setPosition(100, 300);
+    // Discovered far outside every view this test uses, so its STORED extent
+    // says "not visible" for the rest of the run.
+    moves.setPosition(4000, 300);
+    root.addChild(stays, moves);
+
+    driveToSourceTier(root, backend);
+    draws.length = 0;
+    backend.setView(viewAt(400));
+    playFrame(root, backend);
+
+    expect(draws).toEqual(['stays']);
+
+    // A transform-only move: the item's identity, placement and producer are
+    // unchanged, so the source stays usable — but its stored AABB now describes
+    // where the drawable WAS. Culling against it would drop a node that just
+    // moved into view.
+    moves.setPosition(140, 300);
+    draws.length = 0;
+    backend.setView(viewAt(410));
+    playFrame(root, backend);
+
+    expect(draws).toEqual(['stays', 'moves']);
+
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('an item whose cullArea is mutated in place is judged by the mutated rect', () => {
+    const { backend, draws } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const leaf = new Leaf('a');
+    // Replacing the reference stamps structure dirty; MUTATING the rectangle
+    // stamps nothing, so this is the one input a selection can never cache.
+    const area = new Rectangle(4000, 300, 16, 16);
+
+    leaf.setPosition(100, 300);
+    leaf.cullArea = area;
+    root.addChild(leaf);
+
+    driveToSourceTier(root, backend);
+    draws.length = 0;
+    backend.setView(viewAt(400));
+    playFrame(root, backend);
+
+    expect(draws).toEqual([]);
+
+    area.setPosition(100, 300);
+    draws.length = 0;
+    backend.setView(viewAt(410));
+    playFrame(root, backend);
+
+    expect(draws).toEqual(['a']);
 
     root.destroy();
     backend.destroy();


### PR DESCRIPTION
A camera step past the capture margin cost a **complete re-collect** — walk the scene graph, resolve every transform, resolve every material, record every draw — for a scene where nothing but the camera had changed. At a million nodes that is a ~390ms p95 spike against a 0.19ms median.

## The gap

A render root had exactly two states. Replay the capture while the view still fits its inflated cull rect, or rebuild the whole plan from the scene graph. Nothing in between, and a capture cannot fill the gap: it holds what the camera admitted **at capture time**, so an item that has since scrolled in is precisely the one missing from it.

## The selection tier

```text
tier 1  view still fits the capture              -> replay
tier 2  view moved, content/structure unchanged  -> select from the source   <- new
tier 3  transform-only moves                     -> O(k) row patch
tier 4  content / structure / ancestry changed   -> collect the scene graph
```

`RenderRootSource` holds one item per drawable in the **whole** subtree, on screen or not, because an item that is off-screen now is exactly the one that must be findable when it scrolls in. A view change then walks those items instead of the scene graph, and a rejected item costs no transform, no material key and no draw command.

Ownership is per render root rather than per node: visibility and records are per-root and per-view, so a node rendered under two roots genuinely has two states and one owner slot would make the roots overwrite each other every frame.

### What discovery must not allocate

Discovery branches out of `emitDraw` **before** any frame-local product — no pooled `DrawCommand`, no frame-global `nodeIndex`, no transform-buffer row, no backend-bound material key. That is the binding invariant of this cut, not a micro-optimisation: discovery walks the entire subtree, so at a million nodes the normal emit path would reserve roughly 48MB of rows in a grow-only buffer for draws that never happen, three quarters of them off-screen.

Culling is suppressed during discovery for the same reason. The items exist to hold what is off screen right now, and a cull test would drop exactly what the source is for.

### What discovery refuses

Three producer kinds are recorded as one `LiveEntry` at their exact placement, with the walk stopping there — each because persisting them would need a second copy of semantics that already have one owner:

- **barrier / effect nodes** — a filter keeps its effect machinery;
- **transform-group boundaries** — a `RetainedContainer` keeps its own retention tier instead of being flattened;
- **producers observed reading the view** — see below.

`LiveEntry` reuses the barrier discriminant deliberately: in the retained fragment that kind already means "not captured, re-dispatched on every replay", which is exactly this playback.

### Producer-local view attribution

#553 marks a capture view-dependent when the collect **reads** the view, which is all that a binary "may this replay" question needs. Persistence needs the local answer. A producer that read the view collapses to a single `LiveEntry`; its siblings stay persistent. Without that, one parallax layer would force a million sprites off the persistent path and the cut would buy nothing for the scrolling map it exists for.

The root-wide flag is untouched and still marks from the same public getter; the local set is read off the same call site. Builder-internal reads and `Container`'s `viewUpdateId` cache key still go through the non-marking accessor.

### Build gate

The source is built on the **second** consecutive view-only rebuild. One such frame proves nothing — a camera that stepped once and stopped produces exactly one, and a source built for it is an O(N) walk plus one record per drawable that is never selected from twice. Two in a row is the signature of a camera moving across a settled scene. Roots that never re-select allocate no source at all.

The streak is measured over the source's own keys **including transform revision**, so a scene that moves something every frame can never accumulate it and never pays for a source it would discard on the next frame.

The gate is deliberately **not** derived from the capture keys. A root holding a view-dependent producer can never replay its capture, so capture suppression eventually stops taking captures at all — and that root needs the cheap path more than any other, not less. A capture-suppressed frame selects too.

### Culling without a transform resolve

The scan asked each item's node for `getBounds()`, which resolves the whole parent chain per call; a profile put `getGlobalTransform` at 25.9% of frame self time, the single largest entry. The cull rule is now split along the line of what a caller may safely cache:

- `cullable` and `cullArea` are read **live, always** — `cullArea` is a mutable `Rectangle` and only replacing the reference stamps a revision, so a cached copy could go stale in place, unnoticed;
- `bounds` come from the caller, and the source may only supply its stored ones while the subtree's transform revision says nothing has moved since discovery.

`_inCullRect` is that same method with `getBounds()` filled in — one rule, one implementation, no second culling semantics to drift. The bounds argument is `null`-for-resolve rather than eagerly evaluated, because both early exits must fire first: passing `getBounds()` in as an argument made every node in a culling-free scene walk its parent chain (`deep-hierarchy` at 100k: 1.9ms -> 19.3ms median, caught and fixed on this branch).

The transform key gates the stored bounds and **nothing else**. It stays out of `isUsable` on purpose: a transform-only move leaves every item's identity, placement and producer intact, so invalidating the whole source over one moving sprite would take the cheap path away from every partly-dynamic scene.

## Measurements

`scrolling-world` at 1,000,000 nodes, `exojs current`, same session per row:

```text
backend   p95 pre-cut   p95 now   median now
webgl2         382.5ms   201.8ms      0.280ms
webgpu         392.0ms   221.2ms      0.208ms
```

The counter gate carries the actual proof of what changed. On the beyond-margin row the scene-graph collect goes **1001 -> 1**: the frame no longer walks the scene graph to find its content. `globalTransform` drops 5554 -> 1778 across the two bounds commits.

Its other columns are pinned unchanged on purpose. `inView` and `culledNodes` stay put because the selection culls per item through the node's own rule, so a strategy that quietly stopped culling cannot pass. A new row pins the discovery walk itself at one visit per node, and its `globalTransform` lands at half what the plain re-collect it replaces paid — discovery reads each drawable's bounds once and the selection behind it reuses them, so even the frame that pays for the walk comes out ahead.

Memory at 1M: 235.8MB of source, 235.8 B/item, no additional GPU allocation. Packed/SoA storage is deliberately out of scope here.

## Scope

This is **cut 1** — it removes the scene-graph walk. The remaining p95 is visible-item materialisation, the transform prepass, group playback, the optimizer and the flat visibility scan; the `< 8ms` target belongs to cut 2. No second renderer is introduced: a selected `PersistentDrawItem` produces a fresh frame-local `DrawCommand`, a fresh transform row and a live `MaterialKey`, then goes through the existing group scope, optimizer, player and backend.

## Verification

Regression suite covers entering-item draw order against a full collect, producer-local view attribution, live re-dispatch under a moved camera, transform-group and barrier boundaries, the root-is-a-boundary case, stale bounds, an in-place mutated `cullArea`, and the source build gate.

- `verify:quick` — **all 12 gates pass**
- node lanes — **9752 pass**, 1 skipped, across 525 files
- `rendering-perf` — **96 pass**, 1 skipped
- Chromium/WebGL2 — **294/294**
- Chromium/WebGPU — **339/339**
- parity — **110/110**

The WebGPU lane needed three attempts locally. Two runs failed in wandering test sets with `requestDevice` raising `D3D12 create command queue failed with E_OUTOFMEMORY (0x8007000E)` before the test body ran; every affected file passes in isolation, and the third full run was clean.
