### PR TITLE
refactor(rendering): commonize retained capture state and record pools

### DIFF
--- a/src/rendering/plan/CaptureThrashSuppressor.ts
+++ b/src/rendering/plan/CaptureThrashSuppressor.ts
@@ -1,0 +1,111 @@
+/**
+ * What a dirty frame should do with its snapshot.
+ * @internal
+ */
+export const enum CaptureVerdict {
+  /** Take the snapshot: nothing is wrong, or one wasted capture is being forgiven. */
+  Capture,
+  /** Thrash confirmed. The owner invalidates its product, opens the window, then skips the snapshot. */
+  InvalidateAndSuppress,
+  /** Already suppressed and the key is still moving: skip the snapshot. */
+  Suppress,
+}
+
+/**
+ * @internal
+ *
+ * The capture-thrash rule, written once for every tier that keeps a keyed
+ * snapshot: the {@link RetainedGroupFragment} a `RetainedContainer` owns, and
+ * the {@link RetainedRootRepresentation} a render root owns.
+ *
+ * A capture that is invalidated without ever having been replayed was pure
+ * waste. One is tolerated, because a lone mutation between two replays is
+ * exactly the one-shot case where recapturing immediately is the right answer.
+ * The SECOND consecutive wasted capture is evidence of per-frame thrash, and
+ * from then on dirty frames skip the snapshot entirely — a plain collect, the
+ * cheapest dirty frame there is — until the owner's key stops moving, at which
+ * point one full collect plus capture recovers the retained tier. One frame
+ * late, self-correcting, no tunables.
+ *
+ * The KEY that "stops moving" is deliberately NOT held here. It is the one part
+ * of this the two tiers genuinely disagree about: a group observes its content
+ * and structure revisions, a root observes those plus its transform revision and
+ * its view identity, because without the view in the tuple a panning camera over
+ * a partly culled scene alternates between suppressed and recovered forever
+ * instead of settling. Which channels a tier's clean-frame test spans is that
+ * tier's policy; how many wasted captures buy a suppression window is not.
+ */
+export class CaptureThrashSuppressor {
+  private _replayedSinceCapture = false;
+  private _wastedCaptures = 0;
+  private _suppressed = false;
+
+  /** `true` while capture is thrash-suppressed. */
+  public get suppressed(): boolean {
+    return this._suppressed;
+  }
+
+  /** The active capture was replayed at least once — it earned its keep. */
+  public markReplayed(): void {
+    this._replayedSinceCapture = true;
+  }
+
+  /** A fresh snapshot exists; it has not earned anything yet. */
+  public markCaptured(): void {
+    this._replayedSinceCapture = false;
+  }
+
+  /** The owner dropped its capture: no window, no debt, no waste on record. */
+  public reset(): void {
+    this._replayedSinceCapture = false;
+    this._wastedCaptures = 0;
+    this._suppressed = false;
+  }
+
+  /**
+   * Advance the machine for one DIRTY frame — the owner's clean-frame gate has
+   * already failed. Call exactly once per such frame, before collecting.
+   *
+   * `keyUnchanged` is only read on the suppressed branch, yet is passed by value
+   * rather than as a thunk: producing it is a handful of `===` compares against
+   * fields the owner already holds, and a closure per dirty frame would cost
+   * more than the compares it avoids.
+   */
+  public evaluate(hasCapture: boolean, keyUnchanged: boolean): CaptureVerdict {
+    if (hasCapture) {
+      if (this._replayedSinceCapture) {
+        this._wastedCaptures = 0;
+
+        return CaptureVerdict.Capture;
+      }
+
+      this._wastedCaptures++;
+
+      if (this._wastedCaptures < 2) {
+        // Grace: a single wasted capture recaptures immediately (the expected
+        // behaviour for a one-shot mutation).
+        return CaptureVerdict.Capture;
+      }
+
+      // Two consecutive captures invalidated without a single replay: thrash.
+      // The owner's invalidation runs {@link reset}, which is why the window is
+      // opened by a separate {@link suppress} call afterwards rather than here.
+      return CaptureVerdict.InvalidateAndSuppress;
+    }
+
+    if (this._suppressed && keyUnchanged) {
+      // The key stopped moving: this frame would have been clean if a capture
+      // existed. Recover the retained tier now.
+      this._suppressed = false;
+
+      return CaptureVerdict.Capture;
+    }
+
+    return this._suppressed ? CaptureVerdict.Suppress : CaptureVerdict.Capture;
+  }
+
+  /** Open the suppression window, after the owner has invalidated its product. */
+  public suppress(): void {
+    this._suppressed = true;
+  }
+}

--- a/src/rendering/plan/DerivedRootProduct.ts
+++ b/src/rendering/plan/DerivedRootProduct.ts
@@ -61,9 +61,11 @@ const popcount = (value: number): number => {
  * backend- and view-NEUTRAL description of what the subtree contains; membership
  * is a function of the camera and of the target the root is drawn into, and
  * folding it into the source would make a root rendered through two views
- * overwrite its own answer every frame. Keeping the split explicit is also what
- * lets `RetainedContainer` adopt the same source later (cut 3) without
- * inheriting a view it does not have.
+ * overwrite its own answer every frame.
+ *
+ * Per render root, and nothing else: a `RetainedContainer` is culled as a whole
+ * and never asks which of its children a rect admits, so it holds no membership
+ * of any kind (see {@link RenderRootSource}).
  *
  * Membership is one bit per item, held per scope so a scope's bits are a plain
  * index range over its contiguous item store. That shape is the point: the delta

--- a/src/rendering/plan/RenderCommand.ts
+++ b/src/rendering/plan/RenderCommand.ts
@@ -3,7 +3,7 @@ import type { Material } from '#rendering/material/Material';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
-import type { BlendModes } from '#rendering/types';
+import { BlendModes } from '#rendering/types';
 
 /** @internal */
 export const enum RenderEntryKind {
@@ -223,6 +223,26 @@ export const makeMaterialKey = (drawable: Drawable, backend: RenderBackend | nul
     drawable,
     backend,
   );
+
+/**
+ * A material key in its neutral, pre-derivation state, for a pooled record that
+ * owns its key object and rewrites it in place (`copyMaterialKeyInto`) rather
+ * than replacing it.
+ *
+ * The neutral values are not arbitrary: `-1` is "no such id" for the texture and
+ * shader channels, which `getTextureId`/`getShaderId` also return, so a key that
+ * has never been written groups with nothing rather than with texture 0.
+ * @internal
+ */
+export const createEmptyMaterialKey = (): MaterialKey => ({
+  rendererId: 0,
+  blendMode: BlendModes.Normal,
+  textureId: -1,
+  shaderId: -1,
+  pipelineKey: 0,
+  bindKey: 0,
+  ownMaterial: false,
+});
 
 /**
  * In-place variant of {@link makeMaterialKey}: derives the same material key but

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -25,7 +25,7 @@ import {
 import { createSourceScope, LiveEntryReason, type SourceGroup, type SourceOther, type SourceScope } from './RenderSourceItem';
 import type { RetainedFragmentEntry, RetainedFragmentGroup, RetainedGroupFragment } from './RetainedGroupFragment';
 import type { RetainedInstructionSet } from './RetainedInstructionSet';
-import type { RetainedDrawData } from './RetainedPlanCache';
+import type { RetainedDrawData } from './RetainedRecordPool';
 import type { RetainedRootRepresentation } from './RetainedRootRepresentation';
 
 /**

--- a/src/rendering/plan/RenderRootSource.ts
+++ b/src/rendering/plan/RenderRootSource.ts
@@ -30,9 +30,17 @@ import { finalizeSourceScopes, type SourceScope } from './RenderSourceItem';
  * frame-local), and no membership (per view — see {@link DerivedRootProduct}).
  * Those are re-derived when a selection is emitted and belong to the derived
  * product, not here. The root-specific KEYS — view selection and render target —
- * likewise stay in {@link RetainedRootRepresentation} above it, so
- * `RetainedContainer` can adopt this same source later instead of becoming a
- * third implementation of the same idea.
+ * likewise stay in {@link RetainedRootRepresentation} above it, which is what
+ * keeps this half describable without a camera.
+ *
+ * This is a RENDER ROOT's structure and stays one. A `RetainedContainer` was
+ * once expected to adopt it; it must not, because the boundary suppresses
+ * per-child culling (`RenderNode._collectForRenderPlan`), so a selection inside
+ * a transform group can only ever return every item. It would pay the discovery
+ * walk, the item store and the index for no selectivity, and trade an
+ * O(batches) instruction replay for an O(items) emit. What the two tiers really
+ * do share is the layer below — {@link RetainedGroupFragment}'s pooled records
+ * and {@link CaptureThrashSuppressor} — and they share it already.
  *
  * The one exception is the ancestry stamp, which is a key here as well: the
  * items hold world bounds, so they are ancestry-dependent data rather than

--- a/src/rendering/plan/RetainedGroupFragment.ts
+++ b/src/rendering/plan/RetainedGroupFragment.ts
@@ -3,6 +3,7 @@ import type { RenderBackend } from '#rendering/RenderBackend';
 import type { RenderNode } from '#rendering/RenderNode';
 import { BlendModes } from '#rendering/types';
 
+import { CaptureThrashSuppressor, CaptureVerdict } from './CaptureThrashSuppressor';
 import { copyMaterialKeyInto, type MaterialKey, RenderEntryKind } from './RenderCommand';
 import type { ScopeEntry } from './RenderScope';
 import { isRetainedFragmentRecordable, RetainedInstructionSet } from './RetainedInstructionSet';
@@ -109,18 +110,11 @@ export class RetainedGroupFragment {
   private readonly _barrierPool: RetainedFragmentBarrier[] = [];
   private _barrierCursor = 0;
 
-  // Thrash suppression: a capture that is invalidated without
-  // ever having been replayed was pure waste. One wasted capture is tolerated
-  // (a lone mutation between replays keeps the recapture-immediately
-  // behavior); the SECOND consecutive wasted capture is evidence of
-  // per-frame thrash — from then on dirty frames skip the snapshot entirely
-  // (plain collect, cheapest possible dirty frame) until the revisions
-  // observed on consecutive dirty frames stop moving, at which point one full
-  // collect + capture recovers the retained tier (one frame late,
-  // self-correcting, no tunables).
-  private _replayedSinceCapture = false;
-  private _suppressed = false;
-  private _wastedCaptures = 0;
+  // Thrash suppression. The state machine is shared with the render-root
+  // representation ({@link CaptureThrashSuppressor}); what stays here is this
+  // tier's KEY — the content and structure revisions, and nothing else, because
+  // a group's clean-frame test spans exactly those two channels.
+  private readonly _thrash = new CaptureThrashSuppressor();
   private _observedContent = -1;
   private _observedStructure = -1;
 
@@ -301,12 +295,12 @@ export class RetainedGroupFragment {
 
   /** `true` while capture is thrash-suppressed. */
   public get captureSuppressed(): boolean {
-    return this._suppressed;
+    return this._thrash.suppressed;
   }
 
   /** The active capture was replayed (spliced) at least once — it earned its keep. */
   public markReplayed(): void {
-    this._replayedSinceCapture = true;
+    this._thrash.markReplayed();
   }
 
   /**
@@ -316,46 +310,21 @@ export class RetainedGroupFragment {
    * `true` to skip the capture.
    */
   public shouldSuppressCapture(contentRevision: number, structureRevision: number): boolean {
-    if (this._hasCapture) {
-      if (this._replayedSinceCapture) {
-        this._wastedCaptures = 0;
+    const verdict = this._thrash.evaluate(this._hasCapture, this._observedContent === contentRevision && this._observedStructure === structureRevision);
 
-        return false;
-      }
+    if (verdict === CaptureVerdict.Capture) {
+      return false;
+    }
 
-      this._wastedCaptures++;
-
-      if (this._wastedCaptures < 2) {
-        // Grace: a single wasted capture recaptures immediately
-        // (the expected behavior for one-shot mutations).
-        return false;
-      }
-
-      // Two consecutive captures invalidated without a single replay: thrash.
+    if (verdict === CaptureVerdict.InvalidateAndSuppress) {
       this.invalidate();
-      this._suppressed = true;
-      this._observedContent = contentRevision;
-      this._observedStructure = structureRevision;
-
-      return true;
+      this._thrash.suppress();
     }
 
-    if (this._suppressed) {
-      if (this._observedContent === contentRevision && this._observedStructure === structureRevision) {
-        // The revisions stopped moving: this frame would have been clean if a
-        // capture existed. Recover the retained tier now.
-        this._suppressed = false;
+    this._observedContent = contentRevision;
+    this._observedStructure = structureRevision;
 
-        return false;
-      }
-
-      this._observedContent = contentRevision;
-      this._observedStructure = structureRevision;
-
-      return true;
-    }
-
-    return false;
+    return true;
   }
 
   public get entries(): readonly RetainedFragmentEntry[] {
@@ -400,7 +369,7 @@ export class RetainedGroupFragment {
     this._structureRevision = structureRevision;
     this._backend = backend;
     this._hasCapture = true;
-    this._replayedSinceCapture = false;
+    this._thrash.markCaptured();
     // The subtree changed: any recorded batches and the cached recordability
     // verdict are stale. The instruction set keeps its GPU bundle (grow-only)
     // and re-records from the next clean playback.
@@ -414,9 +383,7 @@ export class RetainedGroupFragment {
     this._entries.length = 0;
     this._rowMap = null;
     this.clearDirtyTransformRows();
-    this._replayedSinceCapture = false;
-    this._suppressed = false;
-    this._wastedCaptures = 0;
+    this._thrash.reset();
     this._recordableFor = null;
     this._instructions?.invalidate();
   }

--- a/src/rendering/plan/RetainedGroupFragment.ts
+++ b/src/rendering/plan/RetainedGroupFragment.ts
@@ -1,12 +1,12 @@
 import type { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { RenderNode } from '#rendering/RenderNode';
-import { BlendModes } from '#rendering/types';
 
 import { CaptureThrashSuppressor, CaptureVerdict } from './CaptureThrashSuppressor';
-import { copyMaterialKeyInto, type MaterialKey, RenderEntryKind } from './RenderCommand';
+import { createEmptyMaterialKey, RenderEntryKind } from './RenderCommand';
 import type { ScopeEntry } from './RenderScope';
 import { isRetainedFragmentRecordable, RetainedInstructionSet } from './RetainedInstructionSet';
+import { copyRetainedDrawData, type MutableRetainedDrawData, releasePooledDrawables, RetainedRecordPool } from './RetainedRecordPool';
 
 /**
  * A captured draw: replayed verbatim with a fresh frame-local nodeIndex.
@@ -15,9 +15,8 @@ import { isRetainedFragmentRecordable, RetainedInstructionSet } from './Retained
  * the readonly {@link RetainedDrawData} contract consumers replay from.
  * @internal
  */
-export interface RetainedFragmentDraw {
+export interface RetainedFragmentDraw extends MutableRetainedDrawData {
   readonly kind: RenderEntryKind.Draw;
-  drawable: Drawable;
   /**
    * The shared frame-buffer transform row this draw was captured on.
    * A group-local row is `nodeIndex - bundle.transformRowBase`; the fast patch
@@ -26,14 +25,6 @@ export interface RetainedFragmentDraw {
    * captured index equals the recorded one.
    */
   nodeIndex: number;
-  seq: number;
-  zIndex: number;
-  /** Pooled key object, rewritten in place on recapture — never replaced. */
-  readonly material: MaterialKey;
-  minX: number;
-  minY: number;
-  maxX: number;
-  maxY: number;
 }
 
 /** A captured nested group scope (a plain or retained Container below the group). @internal */
@@ -100,15 +91,12 @@ export class RetainedGroupFragment {
   private _backend: RenderBackend | null = null;
   private _hasCapture = false;
 
-  // Grow-only record pools. Cursors reset per capture; the backing
-  // records survive and are mutated in place. Each pooled group record owns
-  // its own entries array, reused the same way.
-  private readonly _drawPool: RetainedFragmentDraw[] = [];
-  private _drawCursor = 0;
-  private readonly _groupPool: RetainedFragmentGroup[] = [];
-  private _groupCursor = 0;
-  private readonly _barrierPool: RetainedFragmentBarrier[] = [];
-  private _barrierCursor = 0;
+  // Grow-only record pools. Rewound per capture; the backing records survive
+  // and are mutated in place. Each pooled group record owns its own entries
+  // array, reused the same way.
+  private readonly _drawPool = new RetainedRecordPool(createFragmentDraw);
+  private readonly _groupPool = new RetainedRecordPool(createFragmentGroup);
+  private readonly _barrierPool = new RetainedRecordPool(createFragmentBarrier);
 
   // Thrash suppression. The state machine is shared with the render-root
   // representation ({@link CaptureThrashSuppressor}); what stays here is this
@@ -354,9 +342,9 @@ export class RetainedGroupFragment {
     // Not clean while the snapshot is being (re)written: an exception
     // mid-snapshot must not leave a half-updated capture looking valid.
     this._hasCapture = false;
-    this._drawCursor = 0;
-    this._groupCursor = 0;
-    this._barrierCursor = 0;
+    this._drawPool.rewind();
+    this._groupPool.rewind();
+    this._barrierPool.rewind();
     this._entries.length = 0;
     this._rowMap = null;
     // A full (re)capture reads every child's current transform: any queued
@@ -378,7 +366,7 @@ export class RetainedGroupFragment {
   }
 
   public invalidate(): void {
-    this._releaseDrawableRefs();
+    releasePooledDrawables(this._drawPool);
     this._hasCapture = false;
     this._entries.length = 0;
     this._rowMap = null;
@@ -386,18 +374,6 @@ export class RetainedGroupFragment {
     this._thrash.reset();
     this._recordableFor = null;
     this._instructions?.invalidate();
-  }
-
-  /**
-   * Drop the grow-only draw pool's strong references to their drawables so an
-   * evicted/destroyed drawable can be garbage-collected. The pooled
-   * record objects survive and their `drawable` is rewritten in place on the
-   * next capture, so pool reuse is unaffected.
-   */
-  private _releaseDrawableRefs(): void {
-    for (let index = 0; index < this._drawCursor; index++) {
-      this._drawPool[index]!.drawable = undefined as unknown as Drawable;
-    }
   }
 
   /**
@@ -413,17 +389,10 @@ export class RetainedGroupFragment {
     for (const entry of entries) {
       if (entry.kind === RenderEntryKind.Draw) {
         const command = entry.command;
-        const record = this._acquireDraw();
+        const record = this._drawPool.acquire();
 
-        record.drawable = command.drawable;
+        copyRetainedDrawData(record, command);
         record.nodeIndex = command.nodeIndex;
-        record.seq = command.seq;
-        record.zIndex = command.zIndex;
-        copyMaterialKeyInto(record.material, command.material);
-        record.minX = command.minX;
-        record.minY = command.minY;
-        record.maxX = command.maxX;
-        record.maxY = command.maxY;
         target.push(record);
       } else if (entry.kind === RenderEntryKind.Group) {
         // A snapshot that DEFERS transform groups (the automatic render-root
@@ -438,7 +407,7 @@ export class RetainedGroupFragment {
         // runs) — it stays on the entry-replay tier, which is what an outer
         // scope full of nested groups would replay anyway.
         if (this._deferTransformGroups && entry.scope.transformNode !== null) {
-          const deferred = this._acquireBarrier();
+          const deferred = this._barrierPool.acquire();
 
           deferred.seq = entry.seq;
           deferred.node = entry.scope.transformNode;
@@ -447,7 +416,7 @@ export class RetainedGroupFragment {
           continue;
         }
 
-        const record = this._acquireGroup();
+        const record = this._groupPool.acquire();
 
         record.seq = entry.seq;
         record.zIndex = entry.zIndex;
@@ -459,7 +428,7 @@ export class RetainedGroupFragment {
         this._snapshotInto(record.entries, entry.scope.entries);
         target.push(record);
       } else {
-        const record = this._acquireBarrier();
+        const record = this._barrierPool.acquire();
 
         record.seq = entry.seq;
         record.node = entry.scope.node;
@@ -467,78 +436,36 @@ export class RetainedGroupFragment {
       }
     }
   }
-
-  private _acquireDraw(): RetainedFragmentDraw {
-    const pooled = this._drawPool[this._drawCursor];
-
-    if (pooled !== undefined) {
-      this._drawCursor++;
-
-      return pooled;
-    }
-
-    const record: RetainedFragmentDraw = {
-      kind: RenderEntryKind.Draw,
-      drawable: undefined as unknown as Drawable,
-      nodeIndex: 0,
-      seq: 0,
-      zIndex: 0,
-      material: { rendererId: 0, blendMode: BlendModes.Normal, textureId: -1, shaderId: -1, pipelineKey: 0, bindKey: 0, ownMaterial: false },
-      minX: 0,
-      minY: 0,
-      maxX: 0,
-      maxY: 0,
-    };
-
-    this._drawPool[this._drawCursor] = record;
-    this._drawCursor++;
-
-    return record;
-  }
-
-  private _acquireGroup(): RetainedFragmentGroup {
-    const pooled = this._groupPool[this._groupCursor];
-
-    if (pooled !== undefined) {
-      this._groupCursor++;
-
-      return pooled;
-    }
-
-    const record: RetainedFragmentGroup = {
-      kind: RenderEntryKind.Group,
-      seq: 0,
-      zIndex: 0,
-      preserveDrawOrder: false,
-      transformNode: null,
-      retainedInstructions: null,
-      entries: [],
-    };
-
-    this._groupPool[this._groupCursor] = record;
-    this._groupCursor++;
-
-    return record;
-  }
-
-  private _acquireBarrier(): RetainedFragmentBarrier {
-    const pooled = this._barrierPool[this._barrierCursor];
-
-    if (pooled !== undefined) {
-      this._barrierCursor++;
-
-      return pooled;
-    }
-
-    const record: RetainedFragmentBarrier = {
-      kind: RenderEntryKind.Barrier,
-      seq: 0,
-      node: undefined as unknown as RenderNode,
-    };
-
-    this._barrierPool[this._barrierCursor] = record;
-    this._barrierCursor++;
-
-    return record;
-  }
 }
+
+// Record factories, one per pool. Written out field by field at a single site
+// each — see the hidden-class note on `RetainedRecordPool`.
+
+const createFragmentDraw = (): RetainedFragmentDraw => ({
+  kind: RenderEntryKind.Draw,
+  drawable: undefined as unknown as Drawable,
+  nodeIndex: 0,
+  seq: 0,
+  zIndex: 0,
+  material: createEmptyMaterialKey(),
+  minX: 0,
+  minY: 0,
+  maxX: 0,
+  maxY: 0,
+});
+
+const createFragmentGroup = (): RetainedFragmentGroup => ({
+  kind: RenderEntryKind.Group,
+  seq: 0,
+  zIndex: 0,
+  preserveDrawOrder: false,
+  transformNode: null,
+  retainedInstructions: null,
+  entries: [],
+});
+
+const createFragmentBarrier = (): RetainedFragmentBarrier => ({
+  kind: RenderEntryKind.Barrier,
+  seq: 0,
+  node: undefined as unknown as RenderNode,
+});

--- a/src/rendering/plan/RetainedPlanCache.ts
+++ b/src/rendering/plan/RetainedPlanCache.ts
@@ -1,27 +1,8 @@
 import type { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
-import { BlendModes } from '#rendering/types';
 
-import { copyMaterialKeyInto, type DrawCommand, type MaterialKey } from './RenderCommand';
-
-/**
- * The replayable payload of one previously-collected draw: everything
- * `RenderPlanBuilder.emitDraw` computed for it (material key, bounds in the
- * capture's space convention, seq/zIndex placement). Base shape shared by the
- * per-child {@link RetainedDrawSlot} and the whole-fragment
- * {@link RetainedFragmentDraw}.
- * @internal
- */
-export interface RetainedDrawData {
-  readonly drawable: Drawable;
-  readonly seq: number;
-  readonly zIndex: number;
-  readonly material: MaterialKey;
-  readonly minX: number;
-  readonly minY: number;
-  readonly maxX: number;
-  readonly maxY: number;
-}
+import { createEmptyMaterialKey, type DrawCommand } from './RenderCommand';
+import { copyRetainedDrawData, type MutableRetainedDrawData, releasePooledDrawables, type RetainedDrawData, RetainedRecordPool } from './RetainedRecordPool';
 
 /**
  * @internal
@@ -41,17 +22,21 @@ export interface RetainedDrawSlot extends RetainedDrawData {
  * recapture of a same-shaped child list allocates zero objects. Structurally
  * satisfies the readonly {@link RetainedDrawSlot} contract consumers read.
  */
-interface MutableRetainedDrawSlot {
+interface MutableRetainedDrawSlot extends MutableRetainedDrawData {
   childIndex: number;
-  drawable: Drawable;
-  seq: number;
-  zIndex: number;
-  readonly material: MaterialKey;
-  minX: number;
-  minY: number;
-  maxX: number;
-  maxY: number;
 }
+
+const createSlot = (): MutableRetainedDrawSlot => ({
+  childIndex: 0,
+  drawable: undefined as unknown as Drawable,
+  seq: 0,
+  zIndex: 0,
+  material: createEmptyMaterialKey(),
+  minX: 0,
+  minY: 0,
+  maxX: 0,
+  maxY: 0,
+});
 
 /**
  * Per-`Container` fragment cache for the static-subtree-skip. Lazily
@@ -80,8 +65,7 @@ export class RetainedPlanCache {
   /** Active slot list, reused across captures (pointer pushes only). */
   private readonly _slots: MutableRetainedDrawSlot[] = [];
   /** Grow-only record pool; `_slots` holds a cursor-ordered prefix of it. */
-  private readonly _slotPool: MutableRetainedDrawSlot[] = [];
-  private _poolCursor = 0;
+  private readonly _slotPool = new RetainedRecordPool(createSlot);
   private _contentRevision = -1;
   private _structureRevision = -1;
   private _transformRevision = -1;
@@ -120,7 +104,7 @@ export class RetainedPlanCache {
   public _beginCapture(): void {
     this._hasCapture = false;
     this._slots.length = 0;
-    this._poolCursor = 0;
+    this._slotPool.rewind();
   }
 
   /**
@@ -129,17 +113,10 @@ export class RetainedPlanCache {
    * pool has grown to the child count).
    */
   public _appendSlot(childIndex: number, command: DrawCommand): void {
-    const slot = this._acquireSlot();
+    const slot = this._slotPool.acquire();
 
     slot.childIndex = childIndex;
-    slot.drawable = command.drawable;
-    slot.seq = command.seq;
-    slot.zIndex = command.zIndex;
-    copyMaterialKeyInto(slot.material, command.material);
-    slot.minX = command.minX;
-    slot.minY = command.minY;
-    slot.maxX = command.maxX;
-    slot.maxY = command.maxY;
+    copyRetainedDrawData(slot, command);
     this._slots.push(slot);
   }
 
@@ -154,48 +131,9 @@ export class RetainedPlanCache {
   }
 
   public invalidate(): void {
-    this._releaseDrawableRefs();
+    releasePooledDrawables(this._slotPool);
     this._hasCapture = false;
     this._slots.length = 0;
-    this._poolCursor = 0;
-  }
-
-  /**
-   * Drop the grow-only slot pool's strong references to their drawables so an
-   * evicted/destroyed drawable can be garbage-collected. The pooled slot
-   * objects survive and their `drawable` is rewritten in place on the next
-   * capture, so pool reuse is unaffected.
-   */
-  private _releaseDrawableRefs(): void {
-    for (let index = 0; index < this._poolCursor; index++) {
-      this._slotPool[index]!.drawable = undefined as unknown as Drawable;
-    }
-  }
-
-  private _acquireSlot(): MutableRetainedDrawSlot {
-    const pooled = this._slotPool[this._poolCursor];
-
-    if (pooled !== undefined) {
-      this._poolCursor++;
-
-      return pooled;
-    }
-
-    const slot: MutableRetainedDrawSlot = {
-      childIndex: 0,
-      drawable: undefined as unknown as Drawable,
-      seq: 0,
-      zIndex: 0,
-      material: { rendererId: 0, blendMode: BlendModes.Normal, textureId: -1, shaderId: -1, pipelineKey: 0, bindKey: 0, ownMaterial: false },
-      minX: 0,
-      minY: 0,
-      maxX: 0,
-      maxY: 0,
-    };
-
-    this._slotPool[this._poolCursor] = slot;
-    this._poolCursor++;
-
-    return slot;
+    this._slotPool.rewind();
   }
 }

--- a/src/rendering/plan/RetainedRecordPool.ts
+++ b/src/rendering/plan/RetainedRecordPool.ts
@@ -1,0 +1,139 @@
+import type { Drawable } from '#rendering/Drawable';
+
+import { copyMaterialKeyInto, type DrawCommand, type MaterialKey } from './RenderCommand';
+
+/**
+ * The replayable payload of one previously-collected draw: everything
+ * `RenderPlanBuilder.emitDraw` computed for it (material key, bounds in the
+ * capture's space convention, seq/zIndex placement). Base shape shared by the
+ * per-child {@link RetainedDrawSlot} and the whole-fragment
+ * {@link RetainedFragmentDraw}.
+ * @internal
+ */
+export interface RetainedDrawData {
+  readonly drawable: Drawable;
+  readonly seq: number;
+  readonly zIndex: number;
+  readonly material: MaterialKey;
+  readonly minX: number;
+  readonly minY: number;
+  readonly maxX: number;
+  readonly maxY: number;
+}
+
+/**
+ * The writable half of {@link RetainedDrawData}: what a pooled record exposes to
+ * the code that fills it. `material` stays readonly here on purpose — the key
+ * object is pooled with its record and rewritten field by field
+ * ({@link copyRetainedDrawData}), never replaced.
+ * @internal
+ */
+export interface MutableRetainedDrawData {
+  drawable: Drawable;
+  seq: number;
+  zIndex: number;
+  readonly material: MaterialKey;
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+/**
+ * @internal
+ *
+ * A grow-only pool of records that are rewritten in place, and the one
+ * implementation of that idiom for every retained capture that keeps one: the
+ * draw, group and barrier records of a {@link RetainedGroupFragment}, and the
+ * per-child slots of a {@link RetainedPlanCache}.
+ *
+ * The contract is what makes a steady-state recapture allocation-free.
+ * {@link rewind} declares the previous capture's records reusable without
+ * dropping them, and {@link acquire} hands the next one back — constructing one
+ * only the first time a capture ever reaches that depth. So a subtree that keeps
+ * its shape allocates on its first capture and never again, however often it is
+ * invalidated and re-taken.
+ *
+ * `_create` is a factory rather than a shape descriptor because the records are
+ * deliberately NOT built by spreading a shared base: each pool's records are
+ * created at exactly one site with every field present in a fixed order, which
+ * is what keeps one hidden class per record type on the hottest path the
+ * renderer has.
+ */
+export class RetainedRecordPool<T> {
+  private readonly _records: T[] = [];
+  private _cursor = 0;
+
+  public constructor(private readonly _create: () => T) {}
+
+  /** How many records the capture in progress has taken. */
+  public get used(): number {
+    return this._cursor;
+  }
+
+  /** Record `index` of the capture in progress; callers hold `index < used`. */
+  public at(index: number): T {
+    return this._records[index]!;
+  }
+
+  /** Begin a capture: every record the previous one took becomes reusable. */
+  public rewind(): void {
+    this._cursor = 0;
+  }
+
+  /** The next record of this capture, constructed only if the pool never grew this far. */
+  public acquire(): T {
+    const pooled = this._records[this._cursor];
+
+    if (pooled !== undefined) {
+      this._cursor++;
+
+      return pooled;
+    }
+
+    const record = this._create();
+
+    this._records[this._cursor] = record;
+    this._cursor++;
+
+    return record;
+  }
+}
+
+/**
+ * Drop a draw pool's strong references to their drawables so an evicted or
+ * destroyed drawable can be garbage-collected. The pooled record objects
+ * survive and their `drawable` is rewritten in place on the next capture, so
+ * pool reuse is unaffected.
+ *
+ * Only the records the last capture actually took are cleared: beyond `used`
+ * the pool holds records whose `drawable` was already cleared by an earlier
+ * pass or never written at all.
+ * @internal
+ */
+export const releasePooledDrawables = <T extends { drawable: Drawable }>(pool: RetainedRecordPool<T>): void => {
+  for (let index = 0; index < pool.used; index++) {
+    pool.at(index).drawable = undefined as unknown as Drawable;
+  }
+};
+
+/**
+ * Copy the eight fields every captured draw shares — the drawable, its
+ * `(zIndex, seq)` placement, its material key and its snapshotted screen AABB —
+ * out of a live command into a pooled record.
+ *
+ * One function rather than two identical field lists, because these are the
+ * fields a replay reads back verbatim: a copy that silently skipped one would
+ * not fail a type check, it would paint the previous capture's value.
+ * @internal
+ */
+export const copyRetainedDrawData = (target: MutableRetainedDrawData, command: DrawCommand): void => {
+  target.drawable = command.drawable;
+  target.seq = command.seq;
+  target.zIndex = command.zIndex;
+  copyMaterialKeyInto(target.material, command.material);
+  target.minX = command.minX;
+  target.minY = command.minY;
+  target.maxX = command.maxX;
+  target.maxY = command.maxY;
+};

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -106,9 +106,13 @@ export class RetainedRootRepresentation {
    *
    * Owned here rather than beside the fragment because the source is the
    * backend- and frame-NEUTRAL half: the keys that are not — view selection,
-   * render target, backend identity — stay on this class, which is what lets a
-   * `RetainedContainer` adopt the same source later instead of growing a third
-   * implementation of the same idea.
+   * render target, backend identity — stay on this class.
+   *
+   * Root-only, and not for want of a second consumer: a `RetainedContainer`
+   * suppresses per-child culling inside its boundary, so it has no re-selection
+   * to make and holds none of this (see {@link RenderRootSource}). The layer the
+   * two tiers do share is the one below — the fragment's pooled records and the
+   * capture-thrash rule.
    */
   private _source: RenderRootSource | null = null;
   /**

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -4,6 +4,7 @@ import type { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { View } from '#rendering/View';
 
+import { CaptureThrashSuppressor, CaptureVerdict } from './CaptureThrashSuppressor';
 import { DerivedRootProduct } from './DerivedRootProduct';
 import {
   type PersistentSlotBackend,
@@ -165,10 +166,10 @@ export class RetainedRootRepresentation {
    */
   private _sourceUnbuildable = false;
 
-  // Thrash suppression over the FULL key (see `shouldSuppressCapture`).
-  private _replayedSinceCapture = false;
-  private _wastedCaptures = 0;
-  private _suppressed = false;
+  // Thrash suppression over the FULL key (see `shouldSuppressCapture`). The
+  // state machine is shared with a group's fragment; only the key is this
+  // tier's own, and it is the wider of the two.
+  private readonly _thrash = new CaptureThrashSuppressor();
   private _observedContent = -1;
   private _observedStructure = -1;
   private _observedTransform = -1;
@@ -530,7 +531,7 @@ export class RetainedRootRepresentation {
 
   /** The active capture was replayed at least once — it earned its keep. */
   public markReplayed(): void {
-    this._replayedSinceCapture = true;
+    this._thrash.markReplayed();
     this.fragment.markReplayed();
   }
 
@@ -545,49 +546,26 @@ export class RetainedRootRepresentation {
    * suppressed and recovered forever instead of settling.
    */
   public shouldSuppressCapture(contentRevision: number, structureRevision: number, transformRevision: number, view: View): boolean {
-    if (this._hasCapture) {
-      if (this._replayedSinceCapture) {
-        this._wastedCaptures = 0;
+    const keyUnchanged =
+      this._observedContent === contentRevision &&
+      this._observedStructure === structureRevision &&
+      this._observedTransform === transformRevision &&
+      this._observedView === view &&
+      this._observedViewUpdateId === view.updateId;
+    const verdict = this._thrash.evaluate(this._hasCapture, keyUnchanged);
 
-        return false;
-      }
+    if (verdict === CaptureVerdict.Capture) {
+      return false;
+    }
 
-      this._wastedCaptures++;
-
-      if (this._wastedCaptures < 2) {
-        // Grace: a single wasted capture recaptures immediately (the expected
-        // behaviour for a one-shot mutation).
-        return false;
-      }
-
+    if (verdict === CaptureVerdict.InvalidateAndSuppress) {
       this.invalidate();
-      this._suppressed = true;
-      this._observe(contentRevision, structureRevision, transformRevision, view);
-
-      return true;
+      this._thrash.suppress();
     }
 
-    if (this._suppressed) {
-      if (
-        this._observedContent === contentRevision &&
-        this._observedStructure === structureRevision &&
-        this._observedTransform === transformRevision &&
-        this._observedView === view &&
-        this._observedViewUpdateId === view.updateId
-      ) {
-        // The key stopped moving: this frame would have been clean if a capture
-        // existed. Recover the retained tier now.
-        this._suppressed = false;
+    this._observe(contentRevision, structureRevision, transformRevision, view);
 
-        return false;
-      }
-
-      this._observe(contentRevision, structureRevision, transformRevision, view);
-
-      return true;
-    }
-
-    return false;
+    return true;
   }
 
   /**
@@ -660,7 +638,7 @@ export class RetainedRootRepresentation {
     this._backend = backend;
     this._target = target;
     this._hasCapture = true;
-    this._replayedSinceCapture = false;
+    this._thrash.markCaptured();
   }
 
   /**
@@ -675,9 +653,7 @@ export class RetainedRootRepresentation {
   public invalidate(): void {
     this.fragment.invalidate();
     this._hasCapture = false;
-    this._replayedSinceCapture = false;
-    this._wastedCaptures = 0;
-    this._suppressed = false;
+    this._thrash.reset();
     this._keptBounds.reset();
     this._keptEmpty = true;
     this._culledDuringCapture = true;

--- a/test/rendering/capture-thrash-suppressor.test.ts
+++ b/test/rendering/capture-thrash-suppressor.test.ts
@@ -1,0 +1,154 @@
+/**
+ * The capture-thrash rule itself, exercised directly rather than through one of
+ * its two owners.
+ *
+ * Both a `RetainedContainer`'s fragment and a render root's representation drive
+ * this machine, and each pins its own behaviour end to end. What neither can pin
+ * is the machine in isolation: an edit that changes a transition here changes it
+ * for both tiers at once, so the transitions get their own coverage.
+ *
+ * The owner's contract, reproduced by `drive` below: call `evaluate` exactly
+ * once per DIRTY frame; on `InvalidateAndSuppress`, invalidate the product
+ * (which runs `reset`) and then `suppress`.
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import { CaptureThrashSuppressor, CaptureVerdict } from '#rendering/plan/CaptureThrashSuppressor';
+
+interface Frame {
+  hasCapture: boolean;
+  keyUnchanged: boolean;
+}
+
+/** Run one dirty frame through the owner-side protocol; `true` = capture skipped. */
+const drive = (suppressor: CaptureThrashSuppressor, frame: Frame): boolean => {
+  const verdict = suppressor.evaluate(frame.hasCapture, frame.keyUnchanged);
+
+  if (verdict === CaptureVerdict.Capture) {
+    return false;
+  }
+
+  if (verdict === CaptureVerdict.InvalidateAndSuppress) {
+    suppressor.reset();
+    suppressor.suppress();
+  }
+
+  return true;
+};
+
+describe('CaptureThrashSuppressor', () => {
+  test('a fresh machine never suppresses', () => {
+    const suppressor = new CaptureThrashSuppressor();
+
+    expect(suppressor.suppressed).toBe(false);
+    expect(drive(suppressor, { hasCapture: false, keyUnchanged: false })).toBe(false);
+    expect(suppressor.suppressed).toBe(false);
+  });
+
+  test('a capture that WAS replayed clears the waste counter, however often it repeats', () => {
+    const suppressor = new CaptureThrashSuppressor();
+
+    for (let frame = 0; frame < 10; frame++) {
+      suppressor.markCaptured();
+      suppressor.markReplayed();
+
+      expect(drive(suppressor, { hasCapture: true, keyUnchanged: false })).toBe(false);
+    }
+
+    expect(suppressor.suppressed).toBe(false);
+  });
+
+  test('one wasted capture is forgiven; the second opens the window', () => {
+    const suppressor = new CaptureThrashSuppressor();
+
+    suppressor.markCaptured();
+
+    // Waste #1: the one-shot-mutation case, recaptured immediately.
+    expect(drive(suppressor, { hasCapture: true, keyUnchanged: false })).toBe(false);
+    expect(suppressor.suppressed).toBe(false);
+
+    suppressor.markCaptured();
+
+    // Waste #2: thrash.
+    expect(drive(suppressor, { hasCapture: true, keyUnchanged: false })).toBe(true);
+    expect(suppressor.suppressed).toBe(true);
+  });
+
+  test('a replay between two wasted captures resets the count, so the window never opens', () => {
+    const suppressor = new CaptureThrashSuppressor();
+
+    suppressor.markCaptured();
+    drive(suppressor, { hasCapture: true, keyUnchanged: false }); // waste #1
+
+    suppressor.markCaptured();
+    suppressor.markReplayed();
+    drive(suppressor, { hasCapture: true, keyUnchanged: false }); // earned its keep
+
+    suppressor.markCaptured();
+
+    expect(drive(suppressor, { hasCapture: true, keyUnchanged: false })).toBe(false);
+    expect(suppressor.suppressed).toBe(false);
+  });
+
+  test('a moving key keeps the window open indefinitely', () => {
+    const suppressor = new CaptureThrashSuppressor();
+
+    suppressor.markCaptured();
+    drive(suppressor, { hasCapture: true, keyUnchanged: false });
+    suppressor.markCaptured();
+    drive(suppressor, { hasCapture: true, keyUnchanged: false });
+
+    for (let frame = 0; frame < 50; frame++) {
+      expect(drive(suppressor, { hasCapture: false, keyUnchanged: false })).toBe(true);
+    }
+
+    expect(suppressor.suppressed).toBe(true);
+  });
+
+  test('a key that stopped moving closes the window, and the recovery frame captures', () => {
+    const suppressor = new CaptureThrashSuppressor();
+
+    suppressor.markCaptured();
+    drive(suppressor, { hasCapture: true, keyUnchanged: false });
+    suppressor.markCaptured();
+    drive(suppressor, { hasCapture: true, keyUnchanged: false });
+
+    expect(suppressor.suppressed).toBe(true);
+
+    // The frame that would have been clean if a capture still existed.
+    expect(drive(suppressor, { hasCapture: false, keyUnchanged: true })).toBe(false);
+    expect(suppressor.suppressed).toBe(false);
+  });
+
+  test('an unchanged key does NOT recover a machine that never entered the window', () => {
+    const suppressor = new CaptureThrashSuppressor();
+
+    suppressor.markCaptured();
+
+    // Waste #1 with a settled key: still the grace frame, not a recovery.
+    expect(drive(suppressor, { hasCapture: true, keyUnchanged: true })).toBe(false);
+    expect(suppressor.suppressed).toBe(false);
+  });
+
+  test('reset clears the window, the waste count and the replay flag', () => {
+    const suppressor = new CaptureThrashSuppressor();
+
+    suppressor.markCaptured();
+    drive(suppressor, { hasCapture: true, keyUnchanged: false });
+    suppressor.markCaptured();
+    drive(suppressor, { hasCapture: true, keyUnchanged: false });
+
+    expect(suppressor.suppressed).toBe(true);
+
+    suppressor.reset();
+
+    expect(suppressor.suppressed).toBe(false);
+
+    // The waste count went with it: the next capture gets its grace frame back.
+    suppressor.markCaptured();
+
+    expect(drive(suppressor, { hasCapture: true, keyUnchanged: false })).toBe(false);
+    expect(suppressor.suppressed).toBe(false);
+  });
+});

--- a/test/rendering/material-grouping.test.ts
+++ b/test/rendering/material-grouping.test.ts
@@ -4,7 +4,7 @@ import { type DrawCommand, type MaterialKey, RenderEntryKind } from '#rendering/
 import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
 import type { GroupScope } from '#rendering/plan/RenderScope';
-import type { RetainedDrawData } from '#rendering/plan/RetainedPlanCache';
+import type { RetainedDrawData } from '#rendering/plan/RetainedRecordPool';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import { createRenderStats, resetRenderStats } from '#rendering/RenderStats';

--- a/test/rendering/render-root-source.test.ts
+++ b/test/rendering/render-root-source.test.ts
@@ -7,6 +7,7 @@ import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
 import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
 import type { RenderRootSource } from '#rendering/plan/RenderRootSource';
 import { LiveEntryReason, type SourceOther, type SourceScope } from '#rendering/plan/RenderSourceItem';
+import type { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import type { RenderNode } from '#rendering/RenderNode';
@@ -169,6 +170,8 @@ const playFrame = (root: RenderNode, backend: RenderBackend): number => {
 };
 
 const sourceOf = (root: RenderNode): RenderRootSource | null => root._retainedRootRepresentation().source;
+
+const fragmentOf = (group: RetainedContainer): RetainedGroupFragment => (group as unknown as { _fragment: RetainedGroupFragment })._fragment;
 
 /**
  * One entry of the root scope in RECORDED order — the shape the source used to
@@ -673,6 +676,100 @@ describe('render-root source: boundaries the source refuses to rebuild', () => {
     expect(draws).toEqual(['a', 'b']);
     expect(sourceOf(root)).toBeNull();
 
+    root.destroy();
+    backend.destroy();
+  });
+});
+
+describe('render-root source: a transform group pays for none of the root machinery', () => {
+  /**
+   * The two tiers share their capture layer — the pooled records, the thrash
+   * rule, the transform-row reconcile — and share nothing above it. A source is
+   * a spatial index plus one packed item per drawable, built so a MOVED CAMERA
+   * can re-select what it admits; inside a transform group there is no such
+   * question to answer, because `RenderNode._collectForRenderPlan` suppresses
+   * per-child culling at the boundary and the group is culled as a whole.
+   *
+   * So a group would pay the walk, the item store and the index for a selection
+   * that can only ever return everything, and would trade its own O(batches)
+   * replay for an O(items) emit. These tests exist to make that stay a decision
+   * rather than an omission.
+   */
+  test('a group under a selecting root builds no source, no membership and no representation of its own', () => {
+    const { backend, draws } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const group = new RetainedContainer();
+    const inside = new Leaf('g1');
+
+    inside.setPosition(140, 300);
+    group.addChild(inside);
+    root.addChild(new Leaf('a').setPosition(100, 300), group);
+
+    driveToSourceTier(root, backend);
+
+    // The root reached the tier this is all about...
+    expect(sourceOf(root)).not.toBeNull();
+
+    // ...and the group under it holds none of it. Read through the private
+    // field rather than `_retainedRootRepresentation()`, which would CREATE the
+    // very thing being asserted absent.
+    const groupRoot = (group as unknown as { _retainedRoot: unknown })._retainedRoot;
+
+    expect(groupRoot).toBeNull();
+
+    // Its own tier still carries it across camera steps: the group fragment's
+    // key omits `View.updateId` on purpose — the group is culled as a whole, so
+    // its capture is view-independent — and that is exactly what a root-style
+    // per-child re-selection inside the group would take away.
+    const captureSpy = vi.spyOn(fragmentOf(group), 'capture');
+
+    for (const centerX of [420, 440, 460, 380]) {
+      draws.length = 0;
+      backend.setView(viewAt(centerX));
+      playFrame(root, backend);
+
+      expect(draws).toEqual(['a', 'g1']);
+    }
+
+    expect(captureSpy).not.toHaveBeenCalled();
+    expect((group as unknown as { _retainedRoot: unknown })._retainedRoot).toBeNull();
+
+    captureSpy.mockRestore();
+    root.destroy();
+    backend.destroy();
+  });
+
+  test('moving the group is one matrix: the root source survives it and the group re-collects nothing', () => {
+    const { backend, draws } = createDrawRecordingBackend();
+    const root = makeRoot(new Container());
+    const group = new RetainedContainer();
+    const inside = new Leaf('g1');
+
+    group.addChild(inside);
+    group.setPosition(140, 300);
+    root.addChild(new Leaf('a').setPosition(100, 300), group);
+
+    driveToSourceTier(root, backend);
+
+    const source = sourceOf(root);
+
+    expect(source).not.toBeNull();
+
+    const captureSpy = vi.spyOn(fragmentOf(group), 'capture');
+
+    group.setPosition(160, 300);
+    draws.length = 0;
+    playFrame(root, backend);
+
+    // A group move stamps no revision inside the group, so its fragment stays
+    // clean; and the group is a live entry in the root's source rather than a
+    // set of items, so the root's stored world bounds do not describe it and
+    // its move cannot invalidate them.
+    expect(draws).toEqual(['a', 'g1']);
+    expect(captureSpy).not.toHaveBeenCalled();
+    expect(sourceOf(root)).toBe(source);
+
+    captureSpy.mockRestore();
     root.destroy();
     backend.destroy();
   });

--- a/test/rendering/retained-group-fragment.test.ts
+++ b/test/rendering/retained-group-fragment.test.ts
@@ -5,6 +5,7 @@ import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
 import type { DrawScopeEntry, GroupScope } from '#rendering/plan/RenderScope';
 import { type RetainedFragmentEntry, RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import type { RetainedRecordPool } from '#rendering/plan/RetainedRecordPool';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import { createRenderStats } from '#rendering/RenderStats';
@@ -36,15 +37,19 @@ const makeScopeDrawEntry = (drawable: Drawable, nodeIndex = 0): DrawScopeEntry =
 });
 
 interface DrawPoolCarrier {
-  _drawPool: Array<{ drawable: Drawable | undefined }>;
-  _drawCursor: number;
+  _drawPool: RetainedRecordPool<{ drawable: Drawable | undefined }>;
 }
 
 /** The live prefix of the fragment's grow-only draw pool, as raw references. */
 const pooledDrawables = (fragment: RetainedGroupFragment): Array<Drawable | undefined> => {
-  const carrier = fragment as unknown as DrawPoolCarrier;
+  const pool = (fragment as unknown as DrawPoolCarrier)._drawPool;
+  const drawables: Array<Drawable | undefined> = [];
 
-  return carrier._drawPool.slice(0, carrier._drawCursor).map(record => record.drawable);
+  for (let index = 0; index < pool.used; index++) {
+    drawables.push(pool.at(index).drawable);
+  }
+
+  return drawables;
 };
 
 describe('RetainedGroupFragment', () => {

--- a/test/rendering/retained-plan-cache.test.ts
+++ b/test/rendering/retained-plan-cache.test.ts
@@ -129,6 +129,34 @@ describe('RetainedPlanCache', () => {
 
     drawable.destroy();
   });
+
+  test('invalidate() releases the pooled strong reference to drawables so they can GC', () => {
+    const cache = new RetainedPlanCache();
+    const drawable = new Drawable();
+
+    captureOne(cache, drawable, 1, 1, 1, 1, fakeBackendA);
+
+    const pooledSlot = cache.slots[0]!;
+
+    expect(pooledSlot.drawable).toBe(drawable);
+
+    cache.invalidate();
+
+    // The pooled record survives for reuse; only its drawable reference is
+    // dropped, so a child evicted from the container is not kept alive by a
+    // cache that no longer describes it. Same contract the fragment's draw pool
+    // has — both go through `releasePooledDrawables` now.
+    expect(pooledSlot.drawable).toBeUndefined();
+
+    cache._beginCapture();
+    cache._appendSlot(0, makeCommand(drawable));
+    cache._commitCapture(2, 1, 1, 1, fakeBackendA);
+
+    expect(cache.slots[0]).toBe(pooledSlot);
+    expect(cache.slots[0]!.drawable).toBe(drawable);
+
+    drawable.destroy();
+  });
 });
 
 class ProbeContainer extends Container {

--- a/test/rendering/retained-record-pool.test.ts
+++ b/test/rendering/retained-record-pool.test.ts
@@ -1,0 +1,141 @@
+/**
+ * The pooled-record primitive both retained captures are built on.
+ *
+ * Its whole job is to make a steady-state recapture allocate nothing, and the
+ * two ways that can quietly break are the ones pinned here: a rewind that hands
+ * back a FRESH record instead of the previous one (allocation per capture, and a
+ * consumer holding the old reference sees a frozen draw), and a copy that misses
+ * a field (the record then replays the previous capture's value, which renders
+ * plausibly and is wrong).
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import type { Drawable } from '#rendering/Drawable';
+import { type DrawCommand, type MaterialKey, RenderEntryKind } from '#rendering/plan/RenderCommand';
+import { copyRetainedDrawData, type MutableRetainedDrawData, releasePooledDrawables, RetainedRecordPool } from '#rendering/plan/RetainedRecordPool';
+
+const drawableA = { id: 'a' } as unknown as Drawable;
+const drawableB = { id: 'b' } as unknown as Drawable;
+
+const neutralKey = (): MaterialKey => ({ rendererId: 0, blendMode: 0, textureId: -1, shaderId: -1, pipelineKey: 0, bindKey: 0, ownMaterial: false });
+
+const createRecord = (): MutableRetainedDrawData => ({
+  drawable: undefined as unknown as Drawable,
+  seq: 0,
+  zIndex: 0,
+  material: neutralKey(),
+  minX: 0,
+  minY: 0,
+  maxX: 0,
+  maxY: 0,
+});
+
+const command = (drawable: Drawable, seq: number, zIndex: number, minX: number): DrawCommand =>
+  ({
+    kind: RenderEntryKind.Draw,
+    drawable,
+    nodeIndex: 7,
+    seq,
+    zIndex,
+    material: { rendererId: 3, blendMode: 1, textureId: 5, shaderId: 6, pipelineKey: 11, bindKey: 12, ownMaterial: true },
+    groupIndex: undefined,
+    minX,
+    minY: minX + 1,
+    maxX: minX + 2,
+    maxY: minX + 3,
+  }) as DrawCommand;
+
+describe('RetainedRecordPool', () => {
+  test('acquire constructs on first use and hands the same records back after a rewind', () => {
+    let constructed = 0;
+    const pool = new RetainedRecordPool(() => {
+      constructed++;
+
+      return createRecord();
+    });
+
+    const first = pool.acquire();
+    const second = pool.acquire();
+
+    expect(constructed).toBe(2);
+    expect(pool.used).toBe(2);
+    expect(second).not.toBe(first);
+
+    pool.rewind();
+
+    expect(pool.used).toBe(0);
+    expect(pool.acquire()).toBe(first);
+    expect(pool.acquire()).toBe(second);
+    expect(constructed).toBe(2);
+  });
+
+  test('a capture shorter than its predecessor leaves the surplus records pooled, not dropped', () => {
+    const pool = new RetainedRecordPool(createRecord);
+    const first = pool.acquire();
+    const second = pool.acquire();
+
+    pool.rewind();
+    pool.acquire();
+
+    expect(pool.used).toBe(1);
+
+    // The second record is beyond `used` and therefore not part of this capture,
+    // but it is still pooled: the next capture that reaches depth two gets it
+    // back rather than allocating.
+    pool.rewind();
+    pool.acquire();
+
+    expect(pool.acquire()).toBe(second);
+    expect(pool.at(0)).toBe(first);
+  });
+
+  test('releasePooledDrawables clears exactly the capture in progress', () => {
+    const pool = new RetainedRecordPool(createRecord);
+    const kept = pool.acquire();
+    const dropped = pool.acquire();
+
+    kept.drawable = drawableA;
+    dropped.drawable = drawableB;
+
+    // Shrink the live capture to one record, then release: the record beyond
+    // `used` is not this capture's and is left alone.
+    pool.rewind();
+    pool.acquire();
+    releasePooledDrawables(pool);
+
+    expect(kept.drawable).toBeUndefined();
+    expect(dropped.drawable).toBe(drawableB);
+  });
+});
+
+describe('copyRetainedDrawData', () => {
+  test('copies every replayed field and rewrites the pooled key in place', () => {
+    const record = createRecord();
+    const pooledKey = record.material;
+
+    copyRetainedDrawData(record, command(drawableA, 4, 9, 100));
+
+    expect(record.drawable).toBe(drawableA);
+    expect(record.seq).toBe(4);
+    expect(record.zIndex).toBe(9);
+    expect(record.minX).toBe(100);
+    expect(record.minY).toBe(101);
+    expect(record.maxX).toBe(102);
+    expect(record.maxY).toBe(103);
+
+    // The key object is the record's own, never the command's: the command is
+    // pooled per frame and would be rewritten under the capture.
+    expect(record.material).toBe(pooledKey);
+    expect(record.material).toEqual({ rendererId: 3, blendMode: 1, textureId: 5, shaderId: 6, pipelineKey: 11, bindKey: 12, ownMaterial: true });
+  });
+
+  test('a second copy leaves nothing of the first behind', () => {
+    const record = createRecord();
+
+    copyRetainedDrawData(record, command(drawableA, 4, 9, 100));
+    copyRetainedDrawData(record, command(drawableB, 1, 2, 3));
+
+    expect(record).toMatchObject({ drawable: drawableB, seq: 1, zIndex: 2, minX: 3, minY: 4, maxX: 5, maxY: 6 });
+  });
+});


### PR DESCRIPTION
## What

Two retention mechanisms that existed in duplicate are now shared:

- **`CaptureThrashSuppressor`** — one state machine for replayed/wasted capture accounting, grace, suppression and recovery. Each owner supplies its own keys; the suppressor owns only the transitions.
- **`RetainedRecordPool`** — one grow-only record pool with the cursor/release mechanics used by retained draw records.
- Shared helpers `copyRetainedDrawData` and `createEmptyMaterialKey` replace the per-owner copies.

Root and container retention **policies stay separate**. Nothing about visibility selection, culling scope or escape semantics was unified.

## Why

Both mechanisms were duplicated across `RetainedRootRepresentation` and `RetainedGroupFragment`. Both are correctness-sensitive: a thrash-suppression rule that drifts on one side produces a capture that replays stale content, and a pool cursor that drifts produces record aliasing. Neither divergence is something TypeScript would catch — the two copies had no shared type surface, so they could drift silently and stay green.

## Why `RetainedContainer` does NOT adopt `RenderRootSource`

The original O46 spec proposed that `RetainedContainer` adopt `RenderRootSource` directly. That was rejected after reading the implementation, and this PR deliberately does not do it.

`RetainedContainer` suppresses per-child view culling inside its transform boundary and culls as a group. It already replays clean content at `O(batches)`, works group-local, and carries branch-escape semantics. A root-style source would add a discovery walk, one source record per drawable, and a spatial index — `O(items)` discovery and storage — while gaining no visibility selectivity, because the container does not select per child in the first place. In the worst case it would replace a better `O(batches)` replay path with an `O(items)` one.

Cut 3 therefore shares only the retention mechanisms that are actually identical: **commonize mechanism, not semantics.**

## Performance

No performance improvement is claimed. This is a deduplication change.

- `scrolling-world @1M`: main vs HEAD practically unchanged.
- Renderer sweep: 0 structural diffs.
- No relevant regression observed.

## Memory

- No root-only arrays are allocated per `RetainedContainer`.
- Only a few small control/pool objects per retained capture.
- Nothing added is item-proportional.

## Size

| | bundle |
|---|---|
| main | ~268.69 KB |
| HEAD | ~268.71 KB |
| delta | +0.02 KB |

The existing 275 KB budget is unchanged.

## Verification

- `verify:quick` — 12/12
- unit — 9807 passed, 1 skipped
- WebGL2 — 305/305
- WebGPU serial — 349/349
- parity — 110/110
- rendering-perf — 96 passed, 1 skipped
- size — green
- diff-check — clean

The WebGPU parallel lane flake reproduces on `main` as well; it is a resource-contention issue in the test infrastructure, not a code change in this PR.

## Out of scope

- New root-selection features
- New `RetainedContainer` features
- Allocation/GC audit
- Any further O46 cuts
