### PR TITLE
perf(rendering): remove recurring WebGL2 allocation churn

### DIFF
--- a/site/src/content/api/data-texture-dirty-region.json
+++ b/site/src/content/api/data-texture-dirty-region.json
@@ -1,6 +1,6 @@
 {
   "title": "DataTextureDirtyRegion",
-  "description": "A region of the buffer marked for upload by the next backend sync. Bounds are pixel coordinates with origin at the top-left.",
+  "description": "A region of the buffer marked for upload by the next backend sync. Bounds are pixel coordinates with origin at the top-left. The instance DataTexture._consumeDirtyRegion hands out is the texture's own long-lived record, reused across consume cycles — read it inside the sync pass that consumed it and do not retain it.",
   "symbol": "DataTextureDirtyRegion",
   "kind": "interface",
   "subsystem": "rendering",
@@ -19,7 +19,8 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "A region of the buffer marked for upload by the next backend sync. Bounds are pixel coordinates with origin at the top-left."
+        "A region of the buffer marked for upload by the next backend sync. Bounds are pixel coordinates with origin at the top-left.",
+        "The instance DataTexture._consumeDirtyRegion hands out is the texture's own long-lived record, reused across consume cycles — read it inside the sync pass that consumed it and do not retain it."
       ],
       "importLine": "import { DataTextureDirtyRegion } from '@codexo/exojs'",
       "sourceLink": null

--- a/src/rendering/texture/DataTexture.ts
+++ b/src/rendering/texture/DataTexture.ts
@@ -36,6 +36,10 @@ const bytesPerChannelForFormat: Record<DataTextureFormat, number> = {
 /**
  * A region of the buffer marked for upload by the next backend sync.
  * Bounds are pixel coordinates with origin at the top-left.
+ *
+ * The instance {@link DataTexture._consumeDirtyRegion} hands out is the
+ * texture's own long-lived record, reused across consume cycles — read it
+ * inside the sync pass that consumed it and do not retain it.
  */
 export interface DataTextureDirtyRegion {
   /** Whether the whole texture should be re-uploaded (covers initial alloc and full {@link DataTexture.commit}). */
@@ -44,6 +48,15 @@ export interface DataTextureDirtyRegion {
   readonly y: number;
   readonly width: number;
   readonly height: number;
+}
+
+/** The writable view of {@link DataTextureDirtyRegion} the owning texture mutates. @internal */
+interface MutableDataTextureDirtyRegion {
+  full: boolean;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 }
 
 /** Construction options for {@link DataTexture}. */
@@ -116,7 +129,19 @@ export class DataTexture<F extends DataTextureFormat = DataTextureFormat> extend
   public readonly format: F;
   public readonly buffer: DataTextureBuffer<F>;
 
-  private _dirty: DataTextureDirtyRegion | null = null;
+  /**
+   * The one dirty-region record this texture ever owns. `commit`/`commitRect`
+   * rewrite it in place and `_dirtyPending` says whether it currently describes
+   * anything, so marking a region dirty allocates nothing — the transform and
+   * tint stores commit a rect per moved node per frame, which previously cost
+   * one record per commit and a second one per union.
+   *
+   * Reuse is safe because every consumer reads the region synchronously inside
+   * the sync pass that consumed it (`_syncTexture` on both backends) and none
+   * holds it beyond that.
+   */
+  private readonly _dirty: MutableDataTextureDirtyRegion = { full: false, x: 0, y: 0, width: 0, height: 0 };
+  private _dirtyPending = false;
 
   public constructor(options: DataTextureOptions & { format: F }) {
     super(null, { ...DataTexture.defaultSamplerOptions, ...options.samplerOptions });
@@ -167,7 +192,17 @@ export class DataTexture<F extends DataTextureFormat = DataTextureFormat> extend
     this.setSize(width, height);
 
     // Mark fully dirty so the first sync uploads the whole buffer.
-    this._dirty = { full: true, x: 0, y: 0, width, height };
+    this._markFullyDirty();
+  }
+
+  /** Point the record at the whole texture. Shared by construction and {@link commit}. */
+  private _markFullyDirty(): void {
+    this._dirty.full = true;
+    this._dirty.x = 0;
+    this._dirty.y = 0;
+    this._dirty.width = this.width;
+    this._dirty.height = this.height;
+    this._dirtyPending = true;
   }
 
   /**
@@ -183,7 +218,7 @@ export class DataTexture<F extends DataTextureFormat = DataTextureFormat> extend
    * mutating `buffer` contents to flush changes to the GPU.
    */
   public commit(): this {
-    this._dirty = { full: true, x: 0, y: 0, width: this.width, height: this.height };
+    this._markFullyDirty();
     this.setSize(this.width, this.height);
     // setSize is a no-op when dimensions don't change; force version bump for sync detection.
     this._bumpVersion();
@@ -210,19 +245,28 @@ export class DataTexture<F extends DataTextureFormat = DataTextureFormat> extend
       throw new Error(`DataTexture commitRect (${x}, ${y}, ${width}, ${height}) is out of bounds for ${this.width}x${this.height}.`);
     }
 
-    if (this._dirty === null) {
-      this._dirty = { full: false, x, y, width, height };
-    } else if (this._dirty.full) {
-      // Already pending full upload — region is subsumed.
-    } else {
-      // Union with the existing pending region.
-      const minX = Math.min(this._dirty.x, x);
-      const minY = Math.min(this._dirty.y, y);
-      const maxX = Math.max(this._dirty.x + this._dirty.width, x + width);
-      const maxY = Math.max(this._dirty.y + this._dirty.height, y + height);
+    const dirty = this._dirty;
 
-      this._dirty = { full: false, x: minX, y: minY, width: maxX - minX, height: maxY - minY };
+    if (!this._dirtyPending) {
+      dirty.full = false;
+      dirty.x = x;
+      dirty.y = y;
+      dirty.width = width;
+      dirty.height = height;
+      this._dirtyPending = true;
+    } else if (!dirty.full) {
+      // Union with the existing pending region, in place.
+      const minX = Math.min(dirty.x, x);
+      const minY = Math.min(dirty.y, y);
+      const maxX = Math.max(dirty.x + dirty.width, x + width);
+      const maxY = Math.max(dirty.y + dirty.height, y + height);
+
+      dirty.x = minX;
+      dirty.y = minY;
+      dirty.width = maxX - minX;
+      dirty.height = maxY - minY;
     }
+    // Pending and already full: the region is subsumed, nothing to record.
 
     this._bumpVersion();
 
@@ -234,13 +278,20 @@ export class DataTexture<F extends DataTextureFormat = DataTextureFormat> extend
    * `null` when there is nothing pending. Backends call this once per sync
    * pass to plan their texSubImage2D / writeTexture operations.
    *
+   * The returned object is the texture's own record and is rewritten by the
+   * next {@link commit}/{@link commitRect} — read it within the sync pass, do
+   * not store it.
+   *
    * @internal
    */
   public _consumeDirtyRegion(): DataTextureDirtyRegion | null {
-    const region = this._dirty;
-    this._dirty = null;
+    if (!this._dirtyPending) {
+      return null;
+    }
 
-    return region;
+    this._dirtyPending = false;
+
+    return this._dirty;
   }
 }
 

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -2586,20 +2586,48 @@ interface WebGl2DataTextureFormatInfo {
   readonly bytesPerPixel: number;
 }
 
+type WebGl2DataTextureFormatTable = Readonly<Record<DataTextureFormat | ColorTextureFormat, WebGl2DataTextureFormatInfo>>;
+
+/**
+ * The descriptor table, built once and handed out by reference. `_syncTexture`
+ * resolves a format for every dirty texture in every frame, so returning a fresh
+ * object literal per call meant one descriptor allocation per texture sync.
+ *
+ * Built on first use rather than at module scope: the enum values are read off
+ * the `WebGL2RenderingContext` global, which a plain Node import of the engine
+ * does not have. `formatTableSource` keys the cache on the global's identity, so
+ * a scope that installs (or replaces) the class after the first lookup still
+ * gets a table built from it.
+ */
+let formatTableSource: unknown = null;
+let formatTable: WebGl2DataTextureFormatTable | null = null;
+
+// Only the descriptors are frozen — they are what leaves this module, so they
+// are what a call site could otherwise mutate. The table holding them stays a
+// plain object: `Object.freeze` on the container buys nothing here (it never
+// escapes) and would only risk pushing the per-call keyed lookup out of V8's
+// fast property path.
+function buildWebgl2DataTextureFormatTable(gl: typeof WebGL2RenderingContext): WebGl2DataTextureFormatTable {
+  return {
+    [TextureFormat.R8]: Object.freeze({ internalFormat: gl.R8, format: gl.RED, type: gl.UNSIGNED_BYTE, channels: 1, bytesPerPixel: 1 }),
+    [TextureFormat.R32F]: Object.freeze({ internalFormat: gl.R32F, format: gl.RED, type: gl.FLOAT, channels: 1, bytesPerPixel: 4 }),
+    [TextureFormat.Rgba8]: Object.freeze({ internalFormat: gl.RGBA8, format: gl.RGBA, type: gl.UNSIGNED_BYTE, channels: 4, bytesPerPixel: 4 }),
+    [TextureFormat.Rgba16F]: Object.freeze({ internalFormat: gl.RGBA16F, format: gl.RGBA, type: gl.HALF_FLOAT, channels: 4, bytesPerPixel: 8 }),
+    [TextureFormat.Rgba32F]: Object.freeze({ internalFormat: gl.RGBA32F, format: gl.RGBA, type: gl.FLOAT, channels: 4, bytesPerPixel: 16 }),
+  };
+}
+
 // Handles both DataTexture (single- and four-channel) and RenderTexture
 // (four-channel color attachment) formats — the four-channel entries overlap.
 function webgl2DataTextureFormat(format: DataTextureFormat | ColorTextureFormat): WebGl2DataTextureFormatInfo {
   const gl = WebGL2RenderingContext;
-  switch (format) {
-    case TextureFormat.R8:
-      return { internalFormat: gl.R8, format: gl.RED, type: gl.UNSIGNED_BYTE, channels: 1, bytesPerPixel: 1 };
-    case TextureFormat.R32F:
-      return { internalFormat: gl.R32F, format: gl.RED, type: gl.FLOAT, channels: 1, bytesPerPixel: 4 };
-    case TextureFormat.Rgba8:
-      return { internalFormat: gl.RGBA8, format: gl.RGBA, type: gl.UNSIGNED_BYTE, channels: 4, bytesPerPixel: 4 };
-    case TextureFormat.Rgba16F:
-      return { internalFormat: gl.RGBA16F, format: gl.RGBA, type: gl.HALF_FLOAT, channels: 4, bytesPerPixel: 8 };
-    case TextureFormat.Rgba32F:
-      return { internalFormat: gl.RGBA32F, format: gl.RGBA, type: gl.FLOAT, channels: 4, bytesPerPixel: 16 };
+  let table = formatTable;
+
+  if (table === null || formatTableSource !== gl) {
+    table = buildWebgl2DataTextureFormatTable(gl);
+    formatTableSource = gl;
+    formatTable = table;
   }
+
+  return table[format];
 }

--- a/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
+++ b/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
@@ -351,13 +351,18 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
 
   /**
    * Fast patch: overwrite one group-local transform row in place with
-   * `floats` (8 = 2 rgba32f texels, the {@link TransformBuffer} row layout)
-   * and mark ONLY that row's sub-range for upload. Deliberately does NOT bump
-   * the generation — the recorded instance bytes reference this row by index
-   * and stay valid; only the transform behind the index moved. Tint is not
+   * `floats` and mark ONLY that row's sub-range for upload. Deliberately does
+   * NOT bump the generation — the recorded instance bytes reference this row by
+   * index and stay valid; only the transform behind the index moved. Tint is not
    * touched (a moved node's tint doesn't change — see
    * {@link RetainedContainer._tryPatchTransformRow}). Out-of-range rows are
    * ignored (a stale queue entry after a recapture shrank the store).
+   *
+   * `floats` is exactly one row — `TRANSFORM_FLOATS_PER_ROW` (8 = 2 rgba32f
+   * texels, the {@link TransformBuffer} row layout) — so it is copied whole. It
+   * is deliberately NOT narrowed with `subarray()` first: this runs once per
+   * moved node per frame, and a view per patch was the single largest per-node
+   * allocation on the transform-patch path.
    */
   public _patchTransformRow(localRow: number, floats: Float32Array): void {
     if (
@@ -375,7 +380,7 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
     // upload size.
     const rect = transformTextureRect(this._transformLayout, localRow, 1, this._rectScratch);
 
-    this._transformFloats.set(floats.subarray(0, transformFloatsPerRow), localRow * transformFloatsPerRow);
+    this._transformFloats.set(floats, localRow * transformFloatsPerRow);
     this._transformTexture.commitRect(rect.x, rect.y, rect.width, rect.height);
   }
 

--- a/test/perf/rendering/fakeWebGl2.ts
+++ b/test/perf/rendering/fakeWebGl2.ts
@@ -508,7 +508,10 @@ export const installFakeWebGl2Globals = (): void => {
 
   const stub: Record<string, number> = {};
 
-  for (const name of ['R8', 'R32F', 'RGBA8', 'RGBA32F', 'RED', 'RGBA', 'UNSIGNED_BYTE', 'FLOAT']) {
+  // Every constant the backend's format table reads — it builds all five format
+  // descriptors in one go, so a missing name would put `undefined` in an entry
+  // rather than only failing if that format were ever requested.
+  for (const name of ['R8', 'R32F', 'RGBA8', 'RGBA16F', 'RGBA32F', 'RED', 'RGBA', 'UNSIGNED_BYTE', 'HALF_FLOAT', 'FLOAT']) {
     stub[name] = constantFor(name);
   }
 

--- a/test/rendering/data-texture.test.ts
+++ b/test/rendering/data-texture.test.ts
@@ -174,13 +174,71 @@ describe('DataTexture', () => {
       expect(region).toEqual({ full: false, x: 2, y: 2, width: 10, height: 10 });
     });
 
-    test('commitRect() after commit() keeps the full flag', () => {
+    test('commitRect() unions overlapping pending regions to their bounding box', () => {
+      const tex = new DataTexture({ width: 16, height: 16, format: TextureFormat.R8 });
+      tex._consumeDirtyRegion(); // clear initial
+      tex.commitRect(2, 2, 6, 6); // (2,2)..(8,8)
+      tex.commitRect(5, 4, 6, 2); // (5,4)..(11,6) — overlaps on x and y
+      const region = tex._consumeDirtyRegion();
+      expect(region).toEqual({ full: false, x: 2, y: 2, width: 9, height: 6 });
+    });
+
+    test('commitRect() keeps a fully contained region inside the pending one', () => {
+      const tex = new DataTexture({ width: 16, height: 16, format: TextureFormat.R8 });
+      tex._consumeDirtyRegion(); // clear initial
+      tex.commitRect(2, 2, 8, 8);
+      tex.commitRect(4, 4, 2, 2); // strictly inside — must not shrink the union
+      expect(tex._consumeDirtyRegion()).toEqual({ full: false, x: 2, y: 2, width: 8, height: 8 });
+    });
+
+    test('commitRect() after commit() keeps the full flag and the full extent', () => {
       const tex = new DataTexture({ width: 16, height: 16, format: TextureFormat.R8 });
       tex._consumeDirtyRegion();
       tex.commit();
       tex.commitRect(2, 2, 4, 4);
       const region = tex._consumeDirtyRegion();
-      expect(region?.full).toBe(true);
+      expect(region).toEqual({ full: true, x: 0, y: 0, width: 16, height: 16 });
+    });
+
+    test('a partial commit after a consume starts a fresh region, not a union with the consumed one', () => {
+      const tex = new DataTexture({ width: 16, height: 16, format: TextureFormat.R8 });
+      tex._consumeDirtyRegion(); // clear initial full dirty
+
+      tex.commitRect(0, 0, 2, 2);
+      expect(tex._consumeDirtyRegion()).toEqual({ full: false, x: 0, y: 0, width: 2, height: 2 });
+
+      tex.commitRect(12, 12, 4, 4);
+      expect(tex._consumeDirtyRegion()).toEqual({ full: false, x: 12, y: 12, width: 4, height: 4 });
+    });
+
+    test('a partial commit after a consumed FULL region drops the full flag', () => {
+      const tex = new DataTexture({ width: 16, height: 16, format: TextureFormat.R8 });
+      tex.commit();
+      tex._consumeDirtyRegion(); // consume the full region
+
+      tex.commitRect(3, 3, 2, 2);
+      expect(tex._consumeDirtyRegion()).toEqual({ full: false, x: 3, y: 3, width: 2, height: 2 });
+    });
+
+    test('the consumed region is a reused record — valid for the consuming sync pass, rewritten by the next commit', () => {
+      const tex = new DataTexture({ width: 16, height: 16, format: TextureFormat.R8 });
+      tex._consumeDirtyRegion(); // clear initial
+
+      tex.commitRect(1, 1, 2, 2);
+
+      const first = tex._consumeDirtyRegion();
+
+      // A synchronous consumer reads correct values for the region it consumed.
+      expect(first).toEqual({ full: false, x: 1, y: 1, width: 2, height: 2 });
+
+      tex.commitRect(9, 9, 3, 3);
+
+      const second = tex._consumeDirtyRegion();
+
+      // Same object handed out again (no per-commit allocation), carrying the
+      // new region — which is why a consumer must not hold it across a sync.
+      expect(second).toBe(first);
+      expect(second).toEqual({ full: false, x: 9, y: 9, width: 3, height: 3 });
     });
 
     test('commitRect() throws on out-of-bounds coords', () => {


### PR DESCRIPTION
Removes three per-frame allocation sources on the WebGL2 sync and retained-patch paths. Scope is exactly the three low-risk points from the allocation audit — **NEU-Q3 / A1**, **NEU-Q4 / A2**, **NEU-Q5 / A3**. No other allocation finding is touched.

## Headline results

| Scenario | Δ allocation |
|---|---:|
| `sprite/1000 moving` | **−80 %** (221.06 → 43.45 KB/frame) |
| `sprite/10000 transform-only 1%` | **−49 %** (35.82 → 18.23 KB/frame) |
| `filtered/100` | **−14 %** (856.77 → 735.67 KB/frame) |
| `scrolling-world/1000000` steady state | **−83 %** (15.24 → 2.54 KB/frame) |

The 1M **cold/bootstrap** figure remains ~770 MB (773.1 → 770.6) and is tracked separately as `NEU-Q12`; this PR does not claim to address it. A1–A3 are steady-state optimizations, and the unchanged bootstrap is the expected outcome, not a shortfall.

## NEU-Q3 / A1 — WebGL2 texture-format descriptors

`webgl2DataTextureFormat` returned a fresh `{ internalFormat, format, type, channels, bytesPerPixel }` literal per call — once per changed texture per frame. It now resolves through a table of five frozen descriptors.

Two deliberate deviations from the audit's suggested fix:

- The descriptors are **not** module constants. Their values are read off the `WebGL2RenderingContext` global, which a plain Node import of the engine does not have, so module evaluation would die with a `ReferenceError`. The table is built on first use and the cache is keyed on that global's **identity**, so a scope that installs or replaces the class later (the perf harness stub, `fakeWebGl2.ts`) gets a table built from it instead of one frozen full of `undefined`.
- Only the descriptors are frozen — they are what leaves the module. The container stays a plain object: freezing it buys nothing (it never escapes) and measurably cost CPU. With the container frozen, `mesh/1000` read ~2 % slower reproducibly across three passes.

**Measured, and it contradicts the audit's expectation:** the predicted large win in batch-/flush-heavy scenes does not appear. `blend/1000 alternating` 235.81 → 235.60 and `mesh/1000` 575.40 → 574.34 KB/frame are both noise. The only measurable gain is `filtered/100`, 856.77 → 782.76 (−8.6 %). The cost scales with the number of *changed textures* per frame, not with batches. The allocation was real and is gone; its magnitude in the audit was not.

## NEU-Q4 / A2 — retained transform-row view churn

`WebGl2RetainedGroupResources._patchTransformRow` narrowed its argument with `subarray(0, transformFloatsPerRow)` before copying it — one throwaway view per moved node per frame.

The contract was re-checked against `main` and is **exact**: `patchRowScratch` (`retainedTransformRowPatch.ts`) is `new Float32Array(TRANSFORM_FLOATS_PER_ROW)`, and every test caller passes `Float32Array(8)`. The `subarray` is therefore removed outright rather than replaced with a copy loop, and the exact-length contract is now documented on the method. The WebGPU counterpart was already allocation-free (`writeBuffer` with a `byteOffset`) and is unchanged.

Isolated: `sprite/1000 moving` 221.06 → 120.98 (−45 %), `sprite/10000 transform-only 1%` 35.82 → 25.60 (−29 %), `deep-hierarchy/1000 d16 1%` 4.63 → 3.42.

**Not included:** the row-per-`subarray` in the rectangular sub-region upload (`WebGl2Backend.ts`, the partial glyph-atlas path) that the audit carried under this point. It belongs to the `NEU-Q6` fix class (cached upload views) and is explicitly left open.

## NEU-Q5 / A3 — `DataTexture.commitRect`

All three audit facts were re-verified against `main` and hold: the fields are `width`/`height`, the union branch replaced the record instead of mutating it, and both consumers read synchronously.

The texture now owns **one** long-lived `_dirty` record, rewritten in place, plus a separate `_dirtyPending` flag carrying the emptiness that `null` carried before. `commit()` and construction share `_markFullyDirty()`. No pool. `DataTextureDirtyRegion` and `_consumeDirtyRegion` now document the reuse contract explicitly.

Isolated: `sprite/1000 moving` 221.06 → 144.33 (−35 %), `sprite/10000 transform-only 1%` 35.82 → 28.24, `filtered/100` 856.77 → 810.95.

Eight cases pinned in `test/rendering/data-texture.test.ts`: first partial commit, several commits before consume, overlapping regions, a fully contained region (must not shrink the union), disjoint regions, `commit()`/full including extent, consume/reset, a partial commit after consume — including after a consumed *full* region, where the flag must drop — and the aliasing case, which records that the same object comes back and is overwritten by the next commit.

## CPU

Three passes per side, median-of-medians over 400 frames:

| Scenario | median before | median after | p95 before | p95 after |
|---|---:|---:|---:|---:|
| `sprite/1000 moving` | 0.5565 ms | 0.4966 ms | 0.6011 | 0.5226 |
| `sprite/10000 transform-only 1%` | 0.7554 ms | 0.6784 ms | 1.2584 | 1.1095 |
| `deep-hierarchy/1000 d16 1%` | 0.0539 ms | 0.0501 ms | 0.0592 | 0.0556 |
| `mesh/1000` | 3.293–3.306 | 3.303–3.342 | — | — |
| `filtered/100` | 3.552–3.598 | 3.558–3.712 | — | — |
| `blend/1000 alternating` | 2.277–2.303 | 2.270–2.386 | — | — |

The two transform-heavy scenes gain ~10 % median; every untouched scene overlaps its own before-spread. No structural regression.

## Gate budgets

**No budget was relaxed or re-baselined.** They were frozen for this slice on purpose. All five budgeted cells now sit well under budget, so the gates are correspondingly looser than documented — the whole-table re-measurement `NEU-Q2` asks for is still due, as a unit, once `NEU-Q6`–`NEU-Q8` have landed.

## Verification

`pnpm verify:quick` 12/12 gates · `pnpm typecheck:test` 623 files, within budget · `pnpm test` 9816 passed · `--project=rendering-perf` 100 passed (allocation gates unchanged) · WebGL2 browser lane 305 passed · WebGPU browser lane 349 passed · parity 110 passed · `pnpm size` 268.83/275 kB IIFE · `git diff --check` clean.

One note: the WebGPU lane first failed 5 tests with `requestDevice: D3D12 create command queue failed with E_OUTOFMEMORY`. Reproduced in isolation: 49/49 passed, and a full lane re-run passed 349/349. Environment pressure after the preceding lanes, not the change.

Measurement environment: Node v24.14.1, win32/x64, harness from #559.
