### PR TITLE
fix(webgpu): destroy devices deterministically

### DIFF
--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -955,6 +955,14 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   public destroy(): void {
+    // Captured before the teardown below nulls `_device`: the explicit
+    // `GPUDevice.destroy()` at the very end of this method is what actually
+    // hands the driver-side device (on D3D12: its command queue) back.
+    // Dropping the last JS reference only makes it eligible for garbage
+    // collection, and a driver has a hard ceiling on live devices that GC
+    // timing must not be trusted to stay under.
+    const device = this._device;
+
     this._destroyed = true;
     this._removeUncapturedErrorListener();
     this.onDeviceLost.destroy();
@@ -1034,6 +1042,16 @@ export class WebGpuBackend implements RenderBackend {
     this._renderTarget = this._rootRenderTarget;
     this._clearColor.destroy();
     this._rootRenderTarget.destroy();
+
+    // Last, so every buffer/texture destroy above still ran against a live
+    // device. The resulting device loss carries reason `'destroyed'`, and
+    // `_destroyed` was set at the top of this method — both the loss
+    // subscription and `_handleDeviceLoss` bail out on it, so this cannot
+    // start a recovery attempt. Guarded for the mock devices the jsdom suites
+    // hand the backend, which implement no `destroy`.
+    if (typeof device?.destroy === 'function') {
+      device.destroy();
+    }
   }
 
   public createColorAttachment(): GPURenderPassColorAttachment {
@@ -1796,28 +1814,43 @@ export class WebGpuBackend implements RenderBackend {
     // fails (a usable adapter but a failing requestDevice — e.g. a missing
     // backend library), which breaks the automatic WebGL2 fallback in
     // Application.
-    const context = this._canvas.getContext('webgpu');
-
-    if (context === null) {
-      throw new Error('Could not create WebGPU canvas context.');
-    }
-
-    const format = gpuNavigator.gpu.getPreferredCanvasFormat();
-
+    // From here on the device exists but is not yet owned by `this._device`,
+    // so a failure would strand it beyond the reach of `destroy()`. Every
+    // throw on this stretch releases it explicitly — the driver's live-device
+    // ceiling is low enough that a leak per failed initialization matters,
+    // and `Application`'s WebGPU→WebGL2 fallback walks exactly this path.
     try {
-      context.configure({
-        device,
-        format,
-        alphaMode: 'opaque',
-        // COPY_SRC is required by WebGpuBackdropBlendCompositor to capture
-        // the root-canvas backdrop via copyTextureToTexture.
-        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
-      });
+      const context = this._canvas.getContext('webgpu');
+
+      if (context === null) {
+        throw new Error('Could not create WebGPU canvas context.');
+      }
+
+      const format = gpuNavigator.gpu.getPreferredCanvasFormat();
+
+      try {
+        context.configure({
+          device,
+          format,
+          alphaMode: 'opaque',
+          // COPY_SRC is required by WebGpuBackdropBlendCompositor to capture
+          // the root-canvas backdrop via copyTextureToTexture.
+          usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+        });
+      } catch (error) {
+        throw this._createInitializationError('Failed to configure the WebGPU canvas context.', error);
+      }
+
+      this._context = context;
+      this._format = format;
     } catch (error) {
-      throw this._createInitializationError('Failed to configure the WebGPU canvas context.', error);
+      if (typeof device.destroy === 'function') {
+        device.destroy();
+      }
+
+      throw error;
     }
 
-    this._context = context;
     this._device = device;
 
     // Surface uncaptured GPU errors (validation / OOM / internal) through
@@ -1828,7 +1861,6 @@ export class WebGpuBackend implements RenderBackend {
       device.addEventListener('uncapturederror', this._onUncapturedError);
     }
 
-    this._format = format;
     this._hasPresentedFrame = false;
     this._subscribeToDeviceLoss();
     this.rendererRegistry.connect(this);
@@ -1840,7 +1872,7 @@ export class WebGpuBackend implements RenderBackend {
     // draw call of every blend mode does not have to block on synchronous
     // pipeline creation. Renderers without a prewarmPipelines method
     // continue to create pipelines lazily on first use.
-    const prewarmFormats: readonly GPUTextureFormat[] = [format, managedTextureFormat];
+    const prewarmFormats: readonly GPUTextureFormat[] = [this.format, managedTextureFormat];
 
     await this._prewarmRendererPipelines(prewarmFormats);
 

--- a/test/rendering/browser/webgpu-device-lifecycle.test.ts
+++ b/test/rendering/browser/webgpu-device-lifecycle.test.ts
@@ -1,0 +1,147 @@
+/**
+ * WebGPU device-lifecycle regression tests — real adapter, real devices.
+ *
+ * A `GPUDevice` is backed by a driver-side device (on D3D12: a command queue)
+ * and the driver keeps only a small number of them alive at once — measured at
+ * 64 on the Windows/D3D12 machine this regression was found on, after which
+ * `requestDevice()` rejects with
+ * `D3D12 create command queue failed with E_OUTOFMEMORY`. Dropping the last JS
+ * reference merely makes the wrapper collectable, so before `destroy()`
+ * released the device explicitly the whole browser lane depended on garbage
+ * collection running often enough — which is exactly why it failed
+ * intermittently across files while every file passed in isolation.
+ *
+ * The cycle test therefore keeps every device wrapper referenced: garbage
+ * collection is ruled out as the release mechanism, so completing more cycles
+ * than the driver has live device slots can only mean the teardown released
+ * them itself.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+
+import { describe, expect, test, vi } from 'vitest';
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { Graphics } from '#rendering/primitives/Graphics';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from './_coreRenderers';
+
+const canvasSize = 64;
+
+/**
+ * Comfortably above the 64 live devices the D3D12 driver granted before
+ * rejecting, and still only a few seconds of runtime.
+ */
+const cycles = 96;
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: { canvas: { width: canvasSize, height: canvasSize }, clearColor: Color.black },
+  }) as unknown as Application;
+
+const makeCanvas = (): HTMLCanvasElement => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = canvasSize;
+  canvas.height = canvasSize;
+
+  return canvas;
+};
+
+const buildScene = (): Container => {
+  const root = new Container();
+  const graphics = new Graphics();
+
+  graphics.fillStyle = Color.red;
+  graphics.drawRectangle(8, 8, 32, 32);
+  root.addChild(graphics);
+
+  return root;
+};
+
+const createBackend = async (): Promise<WebGpuBackend> => {
+  const backend = new WebGpuBackend(makeApp(makeCanvas()));
+
+  wireCoreRenderers(backend);
+
+  await backend.initialize();
+
+  return backend;
+};
+
+describe('WebGPU device lifecycle', () => {
+  test('destroy() releases the device without relying on garbage collection', { timeout: 300_000 }, async () => {
+    const scene = buildScene();
+    // Holding these is the point of the test — see the file header.
+    const devices: GPUDevice[] = [];
+
+    for (let cycle = 0; cycle < cycles; cycle++) {
+      let backend: WebGpuBackend;
+
+      try {
+        backend = await createBackend();
+      } catch (error) {
+        throw new Error(`Device acquisition failed after ${cycle} completed create/destroy cycles.`, { cause: error });
+      }
+
+      devices.push(backend.device);
+
+      backend.resetStats();
+      backend.clear(Color.black);
+      scene.render(backend);
+      backend.flush();
+      backend.destroy();
+    }
+
+    expect(devices).toHaveLength(cycles);
+
+    // Every device reports the intentional-teardown reason, which is what
+    // `destroy()` calling `GPUDevice.destroy()` produces.
+    const reasons = await Promise.all(devices.map(async device => (await device.lost).reason));
+
+    expect(new Set(reasons)).toStrictEqual(new Set(['destroyed']));
+  });
+
+  test('a destroyed backend does not attempt device recovery', { timeout: 60_000 }, async () => {
+    const backend = await createBackend();
+    const device = backend.device;
+    const restored = vi.fn();
+    const recoveryError = vi.fn();
+
+    backend.onDeviceRestored.add(restored);
+    backend.onRenderError.add(recoveryError);
+    backend.destroy();
+
+    expect((await device.lost).reason).toBe('destroyed');
+
+    // Recovery would re-request an adapter and dispatch onDeviceRestored (or,
+    // once every retry failed, an onRenderError) — neither may happen for a
+    // teardown the caller asked for.
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 250);
+    });
+
+    expect(restored).not.toHaveBeenCalled();
+    expect(recoveryError).not.toHaveBeenCalled();
+  });
+
+  test('a fresh backend initializes after a previous one was destroyed', { timeout: 60_000 }, async () => {
+    const first = await createBackend();
+    const firstDevice = first.device;
+
+    first.destroy();
+
+    const second = await createBackend();
+
+    try {
+      expect(second.device).toBeDefined();
+      expect(second.device).not.toBe(firstDevice);
+    } finally {
+      second.destroy();
+    }
+  });
+});

--- a/test/rendering/webgpu-backend.test.ts
+++ b/test/rendering/webgpu-backend.test.ts
@@ -67,6 +67,8 @@ interface MockWebGpuEnvironment {
   readonly pipelineDescriptors: GPURenderPipelineDescriptor[];
   readonly buffers: Array<{ destroy: MockInstance }>;
   readonly textures: Array<{ destroy: MockInstance; createView: MockInstance }>;
+  /** `GPUDevice.destroy` — resolves `device.lost` with reason `'destroyed'`, as the platform does. */
+  readonly destroyDevice: MockInstance;
   /** Resolve this to simulate the GPU device being lost. */
   simulateDeviceLost(info?: Partial<GPUDeviceLostInfo>): void;
   restore(): void;
@@ -161,7 +163,14 @@ const createMockWebGpuEnvironment = (): MockWebGpuEnvironment => {
       ...info,
     } as GPUDeviceLostInfo);
   };
+  // Mirrors the platform contract: destroying a device resolves its `lost`
+  // promise with reason `'destroyed'`, which is what distinguishes an
+  // intentional teardown from a driver-side loss.
+  const destroyDevice = vi.fn(() => {
+    _resolveLost?.({ reason: 'destroyed' as GPUDeviceLostReason, message: 'device destroyed' } as GPUDeviceLostInfo);
+  });
   const device = {
+    destroy: destroyDevice,
     createShaderModule: vi.fn(() => ({}) as GPUShaderModule),
     createBindGroupLayout,
     createPipelineLayout: vi.fn(() => ({}) as GPUPipelineLayout),
@@ -255,6 +264,7 @@ const createMockWebGpuEnvironment = (): MockWebGpuEnvironment => {
     pipelineDescriptors,
     buffers,
     textures,
+    destroyDevice,
     simulateDeviceLost,
     restore: (): void => {
       if (previousGpu) {
@@ -2339,6 +2349,161 @@ describe('WebGpuBackend', () => {
       // teardown so it cannot keep running against a torn-down/replaced
       // navigator.gpu mock in a later test.
       manager?.destroy();
+      environment.restore();
+    }
+  });
+
+  test('destroy releases the GPUDevice explicitly instead of leaving it to garbage collection', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const app = {
+        canvas: environment.canvas,
+        options: { canvas: { width: 128, height: 128 }, clearColor: Color.black },
+      } as unknown as Application;
+      const manager = new WebGpuBackend(app);
+
+      installCoreAndParticleRenderers(manager);
+
+      await manager.initialize();
+
+      expect(environment.destroyDevice).not.toHaveBeenCalled();
+
+      manager.destroy();
+
+      expect(environment.destroyDevice).toHaveBeenCalledTimes(1);
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('destroy releases the device only after the resources it owns', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const app = {
+        canvas: environment.canvas,
+        options: { canvas: { width: 128, height: 128 }, clearColor: Color.black },
+      } as unknown as Application;
+      const manager = new WebGpuBackend(app);
+
+      installCoreAndParticleRenderers(manager);
+
+      await manager.initialize();
+
+      const order: string[] = [];
+
+      for (const buffer of environment.buffers) {
+        buffer.destroy.mockImplementation(() => order.push('buffer'));
+      }
+
+      environment.destroyDevice.mockImplementation(() => order.push('device'));
+
+      manager.destroy();
+
+      // Buffer/texture teardown must still run against a live device: once the
+      // device is destroyed every handle it owns is already invalid.
+      expect(order.at(-1)).toBe('device');
+      expect(order.indexOf('buffer')).toBeGreaterThanOrEqual(0);
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('an intentional destroy does not start a device-recovery attempt', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      const app = {
+        canvas: environment.canvas,
+        options: { canvas: { width: 128, height: 128 }, clearColor: Color.black },
+      } as unknown as Application;
+      const manager = new WebGpuBackend(app);
+
+      installCoreAndParticleRenderers(manager);
+
+      await manager.initialize();
+
+      const restored = vi.fn();
+      const lost = vi.fn();
+
+      manager.onDeviceRestored.add(restored);
+      manager.onDeviceLost.add(lost);
+
+      const requestsBeforeDestroy = (navigator.gpu.requestAdapter as unknown as MockInstance).mock.calls.length;
+
+      manager.destroy();
+
+      // The `lost` promise resolves a microtask later, and a recovery attempt
+      // would show up as a fresh requestAdapter() call.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect((navigator.gpu.requestAdapter as unknown as MockInstance).mock.calls.length).toBe(requestsBeforeDestroy);
+      expect(restored).not.toHaveBeenCalled();
+      expect(lost).not.toHaveBeenCalled();
+    } finally {
+      environment.restore();
+    }
+  });
+
+  test('an unintentional device loss still recovers after the explicit-destroy guard', async () => {
+    const environment = createMockWebGpuEnvironment();
+    let manager: WebGpuBackend | null = null;
+
+    try {
+      const app = {
+        canvas: environment.canvas,
+        options: { canvas: { width: 128, height: 128 }, clearColor: Color.black },
+      } as unknown as Application;
+
+      manager = new WebGpuBackend(app);
+      installCoreAndParticleRenderers(manager);
+
+      await manager.initialize();
+
+      const restored = vi.fn();
+
+      manager.onDeviceRestored.add(restored);
+
+      environment.simulateDeviceLost({ message: 'gpu removed' });
+
+      await vi.waitFor(
+        () => {
+          expect(restored).toHaveBeenCalledTimes(1);
+        },
+        { timeout: 5000, interval: 25 },
+      );
+
+      expect(manager.deviceLost).toBe(false);
+    } finally {
+      manager?.destroy();
+      environment.restore();
+    }
+  });
+
+  test('a failure after device acquisition releases the device instead of stranding it', async () => {
+    const environment = createMockWebGpuEnvironment();
+
+    try {
+      // The canvas hands out no WebGPU context: initialization fails at a point
+      // where the device exists but `destroy()` cannot reach it any more.
+      Object.defineProperty(environment.canvas, 'getContext', {
+        configurable: true,
+        value: vi.fn(() => null),
+      });
+
+      const app = {
+        canvas: environment.canvas,
+        options: { canvas: { width: 128, height: 128 }, clearColor: Color.black },
+      } as unknown as Application;
+      const manager = new WebGpuBackend(app);
+
+      installCoreAndParticleRenderers(manager);
+
+      await expect(manager.initialize()).rejects.toThrow('Could not create WebGPU canvas context.');
+      expect(environment.destroyDevice).toHaveBeenCalledTimes(1);
+    } finally {
       environment.restore();
     }
   });


### PR DESCRIPTION
## Root cause

`WebGpuBackend.destroy()` released every ExoJS-side structure it owned and then set `_device = null`, but **never called `GPUDevice.destroy()`** — no codepath in `src/` or `packages/` did. Handing the driver-side device (on D3D12: its command queue) back was left entirely to garbage collection of the wrapper.

## Evidence

Real adapter, Windows/D3D12, one browser context, serial create → initialize → render → destroy cycles:

```text
no teardown                  -> fails at device 64
old backend.destroy + refs   -> fails at device 64
device.destroy + refs        -> 300 cycles green
```

Row 2 is the proof: the previous teardown ran in full, with only the `GPUDevice` wrapper deliberately kept referenced so GC could not step in — and it hit the identical limit as no teardown at all. The failure is always:

```text
requestDevice: D3D12 create command queue failed with E_OUTOFMEMORY (0x8007000E)
```

The driver grants 64 live devices on this machine. The WebGPU browser lane constructs devices at 261 sites, so staying under that ceiling depended purely on GC timing — which is exactly the observed pattern: a file green in isolation, the full lane red intermittently, a repeat run often green.

This also settles the older parallelism hypothesis. A **serial** repro fails at the same 64, so worker-count reduction only moved how many uncollected devices piled up at once. No worker tuning in this PR.

## Fix

- `destroy()` releases the device explicitly, as the **last** step — after every buffer/texture teardown, so those still run against a live device.
- `_initialize()` releases the device on its failure path after a successful `requestDevice()`. A null canvas context or a throwing `configure()` used to strand a device beyond the reach of `destroy()`, and that is exactly the path `Application`'s WebGPU→WebGL2 fallback walks.

## Device-loss semantics

Unchanged, now covered by tests: an intentional destroy starts no recovery (`_destroyed` is set before the release, and the `reason === 'destroyed'` branch guards it a second time), while an unintentional loss still recovers.

## Tests

- `test/rendering/browser/webgpu-device-lifecycle.test.ts` — 96 cycles above the 64-device ceiling with every device reference **held**, so GC is ruled out as the release mechanism; every `lost.reason` is `'destroyed'`; no recovery after an intentional destroy; a fresh backend initializes afterwards.
- `test/rendering/webgpu-backend.test.ts` — the mock device gained a spec-faithful `destroy()` (resolves `lost` with `'destroyed'`), plus five contract tests: device released, released *after* its child resources, no recovery on intent, recovery on a real loss, released on the init failure path.

## Verification

| Gate | Result |
|---|---|
| WebGPU lane before, 3 runs | `E_OUTOFMEMORY` present |
| WebGPU lane after, 3 runs | absent, 0 occurrences |
| WebGL2 lane | 53 files / 305 tests green |
| `pnpm test` | 9821 green |
| parity matrix | green |
| `pnpm verify:quick` | all 12 gates green |

## Deliberately out of scope

- `webgpu-video.test.ts` flakes on a `video.play()` decode timeout — different signature, present before and after, unrelated to the device lifecycle.
- `webgpu-render-to-texture.test.ts` and `webgpu-smoke.test.ts` construct backends without a `finally`. Hygiene, and proven *not* the root cause — kept separate.

https://claude.ai/code/session_01KQKgUaCnC2acS9TUQ1suGv
