### PR TITLE
perf(rendering): stop recording retained groups that always poison

### DIFF
--- a/packages/exojs-particles/src/renderers/WebGl2ParticleRenderer.ts
+++ b/packages/exojs-particles/src/renderers/WebGl2ParticleRenderer.ts
@@ -6,7 +6,7 @@ import type { WebGl2Backend } from '@codexo/exojs/renderer-sdk';
 import { BufferTypes, BufferUsage, RenderingPrimitives } from '@codexo/exojs/renderer-sdk';
 import { Shader } from '@codexo/exojs/renderer-sdk';
 import { AbstractWebGl2Renderer } from '@codexo/exojs/renderer-sdk';
-import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from '@codexo/exojs/renderer-sdk';
+import { uploadBufferRange, uploadBufferStore, WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from '@codexo/exojs/renderer-sdk';
 import { createWebGl2ShaderProgram } from '@codexo/exojs/renderer-sdk';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from '@codexo/exojs/renderer-sdk';
 
@@ -464,17 +464,16 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
       },
       upload: (buffer, offset): void => {
         const gl = connection.gl;
-        const data = buffer.data;
         const state = connection.buffers.get(buffer);
 
         gl.bindBuffer(buffer.type, handle);
 
-        if (state && state.dataByteLength >= data.byteLength) {
-          gl.bufferSubData(buffer.type, offset, data);
-          state.dataByteLength = data.byteLength;
+        if (state && state.dataByteLength >= buffer.uploadByteLength) {
+          uploadBufferRange(gl, buffer, offset);
+          state.dataByteLength = buffer.uploadByteLength;
         } else {
-          gl.bufferData(buffer.type, data, buffer.usage);
-          connection.buffers.set(buffer, { handle, dataByteLength: data.byteLength });
+          uploadBufferStore(gl, buffer);
+          connection.buffers.set(buffer, { handle, dataByteLength: buffer.uploadByteLength });
         }
       },
       destroy: (buffer): void => {

--- a/packages/exojs-tilemap/src/webgl2/WebGl2TileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgl2/WebGl2TileChunkRenderer.ts
@@ -19,6 +19,8 @@ import {
   RenderingPrimitives,
   Shader,
   TRANSFORM_TEXTURE_GLSL_INCLUDE,
+  uploadBufferRange,
+  uploadBufferStore,
   WebGl2RenderBuffer,
   WebGl2VertexArrayObject,
 } from '@codexo/exojs/renderer-sdk';
@@ -584,17 +586,16 @@ export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNod
       },
       upload: (buffer, offset): void => {
         const gl = connection.gl;
-        const data = buffer.data;
         const state = connection.buffers.get(buffer);
 
         gl.bindBuffer(buffer.type, handle);
 
-        if (state && state.dataByteLength >= data.byteLength) {
-          gl.bufferSubData(buffer.type, offset, data);
-          state.dataByteLength = data.byteLength;
+        if (state && state.dataByteLength >= buffer.uploadByteLength) {
+          uploadBufferRange(gl, buffer, offset);
+          state.dataByteLength = buffer.uploadByteLength;
         } else {
-          gl.bufferData(buffer.type, data, buffer.usage);
-          connection.buffers.set(buffer, { handle, dataByteLength: data.byteLength });
+          uploadBufferStore(gl, buffer);
+          connection.buffers.set(buffer, { handle, dataByteLength: buffer.uploadByteLength });
         }
       },
       destroy: (buffer): void => {

--- a/src/renderer-sdk.ts
+++ b/src/renderer-sdk.ts
@@ -43,7 +43,7 @@ export { AbstractWebGl2BatchedRenderer } from '#rendering/webgl2/AbstractWebGl2B
 export { AbstractWebGl2Renderer } from '#rendering/webgl2/AbstractWebGl2Renderer';
 export { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
 export type { WebGl2RenderBufferRuntime } from '#rendering/webgl2/WebGl2RenderBuffer';
-export { WebGl2RenderBuffer } from '#rendering/webgl2/WebGl2RenderBuffer';
+export { uploadBufferRange, uploadBufferStore, WebGl2RenderBuffer } from '#rendering/webgl2/WebGl2RenderBuffer';
 export type {
   WebGl2RetainedBatchPayload,
   WebGl2RetainedBatchReplayer,

--- a/src/rendering/plan/RetainedInstructionSet.ts
+++ b/src/rendering/plan/RetainedInstructionSet.ts
@@ -251,6 +251,31 @@ export interface RetainedBatchCapableRenderer {
   readonly _supportsRetainedBatches?: boolean;
   /** Opt an own-material drawable into retained recording. @internal */
   _canRecordRetainedDrawable?(drawable: Drawable): boolean;
+  /**
+   * Veto a drawable this renderer cannot record REGARDLESS of its material,
+   * because the drawable's own storage or draw path is not the one
+   * `_supportsRetainedBatches` promises. Consulted for every draw entry, before
+   * the own-material hook; an absent implementation means the renderer records
+   * anything it is handed on its default path.
+   *
+   * A renderer that already poisons an open capture from a non-recordable draw
+   * path belongs here: without the veto the fragment is admitted, opens a
+   * capture, records, and gets poisoned again on every single frame — the
+   * group ends up on the same (correct) entry-replay tier either way, but pays
+   * for a recording it can never use. The poison call stays as the safety net
+   * its own contract describes.
+   *
+   * CONTRACT for implementers: this answer is cached per capture (see
+   * `RetainedGroupFragment.isRecordable`) and only re-taken when the capture is
+   * re-keyed, so it must read state that either is immutable for the drawable's
+   * lifetime or, when mutated, bumps the node's content revision. Otherwise a
+   * `recordable → non-recordable` flip would leave the group replaying a capture
+   * its own renderer can no longer honour. Both current implementations read
+   * immutable state: mesh geometry storage and a repeating sprite's resolved
+   * strategy are fixed at construction.
+   * @internal
+   */
+  _admitsRetainedRecording?(drawable: Drawable): boolean;
 }
 
 interface BackendWithRendererRegistry {
@@ -261,7 +286,11 @@ interface BackendWithRendererRegistry {
 
 /**
  * A captured fragment can be recorded as an instruction set iff every draw's
- * renderer opts in via {@link RetainedBatchCapableRenderer}; own-material
+ * renderer opts in via {@link RetainedBatchCapableRenderer}; no draw is vetoed
+ * by its renderer's per-drawable
+ * {@link RetainedBatchCapableRenderer._admitsRetainedRecording} check (a mesh
+ * without static geometry, a shader-path repeating sprite — draws whose
+ * renderer would otherwise poison the capture on every frame); own-material
  * draws additionally pass that renderer's live-state capability check; and no
  * barrier record exists anywhere in the fragment (barriers re-dispatch live
  * per frame and cannot interleave with cached batch runs). Nested
@@ -307,6 +336,10 @@ const entriesRecordable = (entries: readonly RetainedFragmentEntry[], registry: 
     }
 
     if (renderer === null || typeof renderer !== 'object' || renderer._supportsRetainedBatches !== true) {
+      return false;
+    }
+
+    if (renderer._admitsRetainedRecording?.(drawable) === false) {
       return false;
     }
 

--- a/src/rendering/webgl2/AbstractWebGl2BatchedRenderer.ts
+++ b/src/rendering/webgl2/AbstractWebGl2BatchedRenderer.ts
@@ -9,7 +9,7 @@ import type { View } from '#rendering/View';
 
 import { AbstractWebGl2Renderer } from './AbstractWebGl2Renderer';
 import type { WebGl2Backend } from './WebGl2Backend';
-import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import { uploadBufferRange, uploadBufferStore, WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
 import { createWebGl2ShaderProgram } from './WebGl2ShaderProgram';
 import type { WebGl2VertexArrayObject, WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
 
@@ -173,17 +173,16 @@ export abstract class AbstractWebGl2BatchedRenderer extends AbstractWebGl2Render
       },
       upload: (buffer: WebGl2RenderBuffer, offset: number): void => {
         const gl = connection.gl;
-        const data = buffer.data;
         const state = connection.buffers.get(buffer);
 
         gl.bindBuffer(buffer.type, handle);
 
-        if (state && state.dataByteLength >= data.byteLength) {
-          gl.bufferSubData(buffer.type, offset, data);
-          state.dataByteLength = data.byteLength;
+        if (state && state.dataByteLength >= buffer.uploadByteLength) {
+          uploadBufferRange(gl, buffer, offset);
+          state.dataByteLength = buffer.uploadByteLength;
         } else {
-          gl.bufferData(buffer.type, data, buffer.usage);
-          connection.buffers.set(buffer, { handle, dataByteLength: data.byteLength });
+          uploadBufferStore(gl, buffer);
+          connection.buffers.set(buffer, { handle, dataByteLength: buffer.uploadByteLength });
         }
       },
       destroy: (buffer: WebGl2RenderBuffer): void => {

--- a/src/rendering/webgl2/WebGl2BackdropBlendCompositor.ts
+++ b/src/rendering/webgl2/WebGl2BackdropBlendCompositor.ts
@@ -6,7 +6,7 @@ import { BlendModes, BufferTypes, BufferUsage } from '#rendering/types';
 import fragmentSource from './glsl/backdrop-blend.frag';
 import vertexSource from './glsl/backdrop-blend.vert';
 import type { WebGl2Backend } from './WebGl2Backend';
-import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import { uploadBufferStore, WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
 import { createWebGl2ShaderProgram } from './WebGl2ShaderProgram';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
 
@@ -227,10 +227,8 @@ export class WebGl2BackdropBlendCompositor {
         gl.bindBuffer(buffer.type, handle);
       },
       upload: (buffer: WebGl2RenderBuffer): void => {
-        const data = buffer.data;
-
         gl.bindBuffer(buffer.type, handle);
-        gl.bufferData(buffer.type, data, buffer.usage);
+        uploadBufferStore(gl, buffer);
         handles.set(buffer, handle);
       },
       destroy: (buffer: WebGl2RenderBuffer): void => {

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -1602,8 +1602,24 @@ export class WebGl2Backend implements RenderBackend {
    * Invalidate every open capture window by appending an instruction whose
    * recorded generation can never match its bundle — the resulting sets fail
    * collect-time validation forever and the group stays on the (correct)
-   * entry-replay tier. Belt-and-braces for draws the recordability predicate
-   * should have excluded; never expected on a healthy path.
+   * entry-replay tier.
+   *
+   * Most callers are belt-and-braces for draws the collect-time recordability
+   * predicate already excluded, and those never fire on a healthy frame — a
+   * renderer whose non-recordable draws are decidable PER DRAWABLE states that
+   * through `_admitsRetainedRecording` so the capture is never opened at all
+   * (mesh geometry storage, the repeating sprite's shader path).
+   *
+   * One caller is not defensive and DOES fire on healthy frames: the Text
+   * renderer poisons when a flush is not a single recordable batch, or when a
+   * SECOND Text flush lands in the same window. Neither is a property of any
+   * one drawable — both depend on how the frame's draws compose into flushes —
+   * so no per-drawable predicate can pre-empt them, and a perfectly ordinary
+   * scene reaches this (two overlapping Text nodes split by a sprite in between
+   * force two Text flushes into one window, on every frame). Such a group
+   * re-records and re-poisons per frame; the tier it lands on is correct, the
+   * repeated recording is the waste, and a cheaper form (a veto flag on the set
+   * instead of one appended instruction per open capture) is the open follow-up.
    * @internal
    */
   public _poisonRetainedCaptures(): void {

--- a/src/rendering/webgl2/WebGl2MaskCompositor.ts
+++ b/src/rendering/webgl2/WebGl2MaskCompositor.ts
@@ -7,7 +7,7 @@ import { BufferTypes, BufferUsage } from '#rendering/types';
 import fragmentSource from './glsl/mask-compose.frag';
 import vertexSource from './glsl/mask-compose.vert';
 import type { WebGl2Backend } from './WebGl2Backend';
-import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import { uploadBufferStore, WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
 import { createWebGl2ShaderProgram } from './WebGl2ShaderProgram';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
 
@@ -187,10 +187,8 @@ export class WebGl2MaskCompositor {
         gl.bindBuffer(buffer.type, handle);
       },
       upload: (buffer: WebGl2RenderBuffer): void => {
-        const data = buffer.data;
-
         gl.bindBuffer(buffer.type, handle);
-        gl.bufferData(buffer.type, data, buffer.usage);
+        uploadBufferStore(gl, buffer);
         handles.set(buffer, handle);
       },
       destroy: (buffer: WebGl2RenderBuffer): void => {

--- a/src/rendering/webgl2/WebGl2MeshRenderer.ts
+++ b/src/rendering/webgl2/WebGl2MeshRenderer.ts
@@ -1,4 +1,5 @@
 import { Matrix } from '#math/Matrix';
+import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
 import type { Material, UniformValue } from '#rendering/material/Material';
 import type { Mesh } from '#rendering/mesh/Mesh';
@@ -13,7 +14,7 @@ import { AbstractWebGl2Renderer } from './AbstractWebGl2Renderer';
 import fragmentSource from './glsl/mesh.frag';
 import vertexSource from './glsl/mesh.vert';
 import type { WebGl2Backend } from './WebGl2Backend';
-import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import { uploadBufferRange, uploadBufferStore, WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
 import type { WebGl2RetainedBatchPayload, WebGl2RetainedBatchReplayer, WebGl2RetainedNodeIndexRange } from './WebGl2RetainedGroupResources';
 import { createWebGl2ShaderProgram } from './WebGl2ShaderProgram';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
@@ -80,10 +81,35 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
    * Retained-batch opt-in: the default-path static
    * instanced draw ({@link _drawStaticBatch}) is a flush-level batch the group
    * recorder can capture and replay. Custom-material and dynamic-geometry
-   * meshes never take that path — they poison any open capture instead (see
-   * {@link _drawDynamicInstancedSingle}) so the group degrades to entry replay.
+   * meshes never take that path; both are excluded at collect time (own
+   * material by the predicate's own-material rule, geometry storage by
+   * {@link _admitsRetainedRecording}), so no capture opens around them.
    */
   public readonly _supportsRetainedBatches = true;
+
+  /**
+   * Only a mesh backed by SHARED, STATIC {@link Geometry} is recordable: that is
+   * the one form whose vertex/index buffers are the persistent objects a
+   * retained batch references. An array-vertex mesh (`geometry === null`) and a
+   * `dynamic`/`stream` geometry both re-pack into the renderer's own scratch
+   * buffers every frame, so they take {@link _drawDynamicInstancedSingle} and
+   * poison the capture there. Vetoing them at collect time is what keeps that
+   * poison the dead safety net its contract describes — without it a group of
+   * array meshes records and re-poisons on every single frame.
+   *
+   * The verdict is cached per capture, so it would go stale if this answer could
+   * flip under a live capture. It cannot for any mesh that can appear in one:
+   * `Geometry.usage` is readonly, and `Mesh._geometry` is written once in the
+   * constructor. The one subclass that rewrites it, the pooled `ImmediateMesh`,
+   * is submitted straight to the backend by `RenderingContext.drawGeometry` /
+   * `drawBatch` and never enters the scene graph, so it is never a captured
+   * fragment entry.
+   * @internal
+   */
+  public _admitsRetainedRecording(drawable: Drawable): boolean {
+    return (drawable as Mesh).geometry?.usage === 'static';
+  }
+
   /** Reusable single-slot texture list handed to the recorder (avoids a per-batch array). */
   private readonly _retainedTextureScratch: [Texture | RenderTexture] = [Texture.white];
 
@@ -110,7 +136,7 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
   private _indexData: Uint16Array = new Uint16Array(initialIndexCapacity);
   private _nodeIndexData: Uint32Array = new Uint32Array(initialNodeIndexCapacity);
   // Initial (empty) backing data for the shared divisor-1 instance buffer; a
-  // draw uploads a subarray of the RenderBatch's own storage directly.
+  // draw uploads the packed prefix of the RenderBatch's own storage directly.
   private readonly _instanceAttributeData: Float32Array = new Float32Array(0);
 
   // Frame-persistent pool of pending-draw slots. `render()` fills slots front to
@@ -241,12 +267,12 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
 
     this._bindInstancedShaderState(shader, texture, material, backend, maxNodeIndex);
     backend.bindVertexArrayObject(vao);
-    connection.dynamicNodeIndexBuffer.upload(this._nodeIndexData.subarray(0, count));
+    connection.dynamicNodeIndexBuffer.upload(this._nodeIndexData, 0, count);
 
     if (instances !== null) {
       // Upload exactly the packed instances, not the batch's whole (over-grown)
       // storage — the VAO reads `count` strides from offset 0.
-      connection.dynamicInstanceBuffer.upload(instances.data.subarray(0, count * instances.strideFloats));
+      connection.dynamicInstanceBuffer.upload(instances.data, 0, count * instances.strideFloats);
     }
 
     this._bindBaseTextureSampler(backend, material);
@@ -412,12 +438,12 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
   }
 
   private _drawDynamicInstancedSingle(draw: PendingMeshDraw, backend: WebGl2Backend, connection: MeshRendererConnection): void {
-    // A dynamic-geometry (non-static) mesh cannot be recorded — its geometry
-    // is not the shared, persistent buffer a retained batch references. The
-    // recordability predicate admits it (material === null, snap none),
-    // so poison any open capture: the group's set never validates and it stays
-    // on the correct entry-replay tier. Belt-and-braces, mirroring the sprite
-    // renderer's custom-material poison.
+    // A dynamic-geometry (non-static) mesh cannot be recorded — its geometry is
+    // not the shared, persistent buffer a retained batch references, which is
+    // why _admitsRetainedRecording keeps such a mesh from ever opening a
+    // capture. A mesh's geometry cannot change after that verdict was cached
+    // (see _admitsRetainedRecording), so this poison is unreachable through the
+    // public API and stays only as a structural safety net.
     if (backend._isRetainedCapturing) {
       backend._poisonRetainedCaptures();
     }
@@ -447,9 +473,9 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
     this._nodeIndexData[0] = nodeIndex >>> 0;
 
     backend.bindVertexArrayObject(connection.dynamicVao);
-    connection.dynamicVertexBuffer.upload(this._float32View.subarray(0, draw.mesh.vertexCount * vertexStrideWords));
-    connection.dynamicIndexBuffer.upload(this._indexData.subarray(0, draw.mesh.indexCount));
-    connection.dynamicNodeIndexBuffer.upload(this._nodeIndexData.subarray(0, 1));
+    connection.dynamicVertexBuffer.upload(this._float32View, 0, draw.mesh.vertexCount * vertexStrideWords);
+    connection.dynamicIndexBuffer.upload(this._indexData, 0, draw.mesh.indexCount);
+    connection.dynamicNodeIndexBuffer.upload(this._nodeIndexData, 0, 1);
     connection.dynamicVao.drawInstanced(draw.mesh.indexCount, 0, 1, RenderingPrimitives.Triangles);
 
     backend.stats.batches++;
@@ -491,7 +517,7 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
 
     this._bindInstancedShaderState(first.shader, first.texture, first.material, backend, maxNodeIndex);
     backend.bindVertexArrayObject(vao);
-    connection.dynamicNodeIndexBuffer.upload(this._nodeIndexData.subarray(0, count));
+    connection.dynamicNodeIndexBuffer.upload(this._nodeIndexData, 0, count);
     this._bindBaseTextureSampler(backend, first.material);
     vao.drawInstanced(cacheEntry.indexCount, 0, count, RenderingPrimitives.Triangles);
     this._unbindBaseTextureSampler(backend, first.material);
@@ -561,8 +587,8 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
 
     shader.sync();
     backend.bindVertexArrayObject(connection.dynamicVao);
-    connection.dynamicVertexBuffer.upload(this._float32View.subarray(0, mesh.vertexCount * vertexStrideWords));
-    connection.dynamicIndexBuffer.upload(this._indexData.subarray(0, mesh.indexCount));
+    connection.dynamicVertexBuffer.upload(this._float32View, 0, mesh.vertexCount * vertexStrideWords);
+    connection.dynamicIndexBuffer.upload(this._indexData, 0, mesh.indexCount);
     this._bindBaseTextureSampler(backend, draw.material);
     connection.dynamicVao.draw(mesh.indexCount, 0, RenderingPrimitives.Triangles);
     this._unbindBaseTextureSampler(backend, draw.material);
@@ -1115,16 +1141,14 @@ export class WebGl2MeshRenderer extends AbstractWebGl2Renderer<Mesh> implements 
       },
       upload: (buffer: WebGl2RenderBuffer, offset: number): void => {
         const state = buffers.get(buffer);
-        const data = buffer.data;
-
         gl.bindBuffer(buffer.type, handle);
 
-        if (state && state.dataByteLength >= data.byteLength) {
-          gl.bufferSubData(buffer.type, offset, data);
-          state.dataByteLength = data.byteLength;
+        if (state && state.dataByteLength >= buffer.uploadByteLength) {
+          uploadBufferRange(gl, buffer, offset);
+          state.dataByteLength = buffer.uploadByteLength;
         } else {
-          gl.bufferData(buffer.type, data, buffer.usage);
-          buffers.set(buffer, { handle, dataByteLength: data.byteLength });
+          uploadBufferStore(gl, buffer);
+          buffers.set(buffer, { handle, dataByteLength: buffer.uploadByteLength });
         }
       },
       destroy: (buffer: WebGl2RenderBuffer): void => {

--- a/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
@@ -10,7 +10,7 @@ import type { View } from '#rendering/View';
 
 import { AbstractWebGl2Renderer } from './AbstractWebGl2Renderer';
 import type { WebGl2Backend } from './WebGl2Backend';
-import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import { uploadBufferRange, uploadBufferStore, WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
 import type { WebGl2RetainedBatchPayload, WebGl2RetainedBatchReplayer, WebGl2RetainedNodeIndexRange } from './WebGl2RetainedGroupResources';
 import { createWebGl2ShaderProgram } from './WebGl2ShaderProgram';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
@@ -552,17 +552,16 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
       },
       upload: (buffer, offset): void => {
         const gl = connection.gl;
-        const data = buffer.data;
         const state = connection.buffers.get(buffer);
 
         gl.bindBuffer(buffer.type, handle);
 
-        if (state && state.dataByteLength >= data.byteLength) {
-          gl.bufferSubData(buffer.type, offset, data);
-          state.dataByteLength = data.byteLength;
+        if (state && state.dataByteLength >= buffer.uploadByteLength) {
+          uploadBufferRange(gl, buffer, offset);
+          state.dataByteLength = buffer.uploadByteLength;
         } else {
-          gl.bufferData(buffer.type, data, buffer.usage);
-          connection.buffers.set(buffer, { handle, dataByteLength: data.byteLength });
+          uploadBufferStore(gl, buffer);
+          connection.buffers.set(buffer, { handle, dataByteLength: buffer.uploadByteLength });
         }
       },
       destroy: (buffer): void => {

--- a/src/rendering/webgl2/WebGl2RenderBuffer.ts
+++ b/src/rendering/webgl2/WebGl2RenderBuffer.ts
@@ -11,6 +11,56 @@ export interface WebGl2RenderBufferRuntime {
   destroy(buffer: WebGl2RenderBuffer): void;
 }
 
+/** `elementCount` value meaning "upload all of `data`". @internal */
+const wholeBuffer = -1;
+
+/**
+ * Byte size of one element of `data`. `BYTES_PER_ELEMENT` is present on every
+ * typed array; a `DataView` or raw buffer has no element type, so a partial
+ * upload from one is counted in bytes.
+ */
+const bytesPerElementOf = (data: DataContainer): number => (data as { BYTES_PER_ELEMENT?: number }).BYTES_PER_ELEMENT ?? 1;
+
+/**
+ * Issue the buffer's pending upload as an in-place `bufferSubData` at
+ * `byteOffset`. Honours a partial {@link WebGl2RenderBuffer.upload} range via
+ * WebGL2's `(srcData, srcOffset, length)` overload, so a caller that uploads
+ * the filled prefix of a persistent scratch array does not have to materialize
+ * a `subarray()` view to express the length. Every runtime must go through this
+ * (and {@link uploadBufferStore}) rather than calling `gl` directly — a direct
+ * call would silently upload the whole array for a partial range.
+ * @internal
+ */
+export const uploadBufferRange = (gl: WebGL2RenderingContext, buffer: WebGl2RenderBuffer, byteOffset: number): void => {
+  const { data, uploadElementCount } = buffer;
+
+  if (uploadElementCount === wholeBuffer) {
+    gl.bufferSubData(buffer.type, byteOffset, data as ArrayBuffer);
+
+    return;
+  }
+
+  gl.bufferSubData(buffer.type, byteOffset, data as ArrayBufferView, 0, uploadElementCount);
+};
+
+/**
+ * (Re)allocate the buffer's GPU store from its pending upload — the orphaning
+ * `bufferData` counterpart to {@link uploadBufferRange}. The store is sized to
+ * the uploaded RANGE, exactly as a `subarray()` argument used to size it.
+ * @internal
+ */
+export const uploadBufferStore = (gl: WebGL2RenderingContext, buffer: WebGl2RenderBuffer): void => {
+  const { data, uploadElementCount } = buffer;
+
+  if (uploadElementCount === wholeBuffer) {
+    gl.bufferData(buffer.type, data as ArrayBuffer, buffer.usage);
+
+    return;
+  }
+
+  gl.bufferData(buffer.type, data as ArrayBufferView, buffer.usage, 0, uploadElementCount);
+};
+
 /**
  * Backend-agnostic GPU buffer descriptor. Holds the buffer type
  * (`ArrayBuffer` / `ElementArrayBuffer`), usage hint
@@ -24,6 +74,14 @@ export class WebGl2RenderBuffer {
   private readonly _usage: BufferUsage;
   private _runtime: WebGl2RenderBufferRuntime | null = null;
   private _data: DataContainer = emptyArrayBuffer;
+  /**
+   * Elements of {@link _data} the pending upload covers, counted from index 0,
+   * or {@link wholeBuffer} for all of it. Lets a caller upload the filled prefix
+   * of a persistent scratch array without allocating a `subarray()` view per
+   * upload just to carry the length.
+   */
+  private _uploadElementCount = wholeBuffer;
+  private _uploadByteLength = 0;
   private _version = 0;
   private _accountant: GpuResourceAccountant | null = null;
   /**
@@ -55,6 +113,25 @@ export class WebGl2RenderBuffer {
     return this._data;
   }
 
+  /**
+   * Elements of {@link data} the pending upload covers, counted from index 0.
+   * `-1` means all of it. Read by {@link uploadBufferRange} /
+   * {@link uploadBufferStore}; runtimes never need it directly.
+   */
+  public get uploadElementCount(): number {
+    return this._uploadElementCount;
+  }
+
+  /**
+   * Bytes the pending upload covers — {@link data}'s `byteLength` for a whole
+   * upload, the range's byte length for a partial one. This, not
+   * `data.byteLength`, is what a runtime must compare its GPU store against and
+   * what the accountant books.
+   */
+  public get uploadByteLength(): number {
+    return this._uploadByteLength;
+  }
+
   public get version(): number {
     return this._version;
   }
@@ -63,7 +140,7 @@ export class WebGl2RenderBuffer {
     this._runtime = runtime;
     this._accountant = accountant ?? null;
 
-    if (this._data.byteLength > 0) {
+    if (this._uploadByteLength > 0) {
       runtime.upload(this, 0);
       this._bookUpload();
     }
@@ -77,8 +154,22 @@ export class WebGl2RenderBuffer {
     return this;
   }
 
-  public upload(data: DataContainer, offset = 0): void {
+  /**
+   * Stage `data` and issue the GPU upload at destination byte offset `offset`.
+   *
+   * `elementCount` uploads only the first `elementCount` ELEMENTS of `data`
+   * (elements of the view's own type — floats for a `Float32Array`, not bytes),
+   * which is what a renderer wants when it holds one grown-once scratch array
+   * and fills a different prefix of it every flush. Passing the count is
+   * equivalent to passing `data.subarray(0, elementCount)` in every observable
+   * way — same GPU bytes, same accounted traffic, same store size — but does not
+   * allocate a view per upload. Requires `data` to be an `ArrayBufferView`;
+   * omit it (the default) to upload all of `data`.
+   */
+  public upload(data: DataContainer, offset = 0, elementCount = wholeBuffer): void {
     this._data = data;
+    this._uploadElementCount = elementCount;
+    this._uploadByteLength = elementCount === wholeBuffer ? data.byteLength : elementCount * bytesPerElementOf(data);
     this._version++;
 
     this._runtime?.upload(this, offset);
@@ -111,7 +202,7 @@ export class WebGl2RenderBuffer {
       return;
     }
 
-    const byteLength = this._data.byteLength;
+    const byteLength = this._uploadByteLength;
 
     accountant.recordBufferUpload(byteLength);
 

--- a/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
@@ -1,4 +1,5 @@
 import { packedGroupChanged } from '#rendering/affinePacking';
+import type { Drawable } from '#rendering/Drawable';
 import { Shader } from '#rendering/shader/Shader';
 import { TRANSFORM_TEXTURE_GLSL_INCLUDE } from '#rendering/shader/transformTextureLayout';
 import type { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
@@ -10,7 +11,7 @@ import { BlendModes, BufferTypes, BufferUsage, RenderingPrimitives, ScaleModes, 
 
 import { AbstractWebGl2Renderer } from './AbstractWebGl2Renderer';
 import type { WebGl2Backend } from './WebGl2Backend';
-import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import { uploadBufferRange, uploadBufferStore, WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
 import type { WebGl2RetainedBatchPayload, WebGl2RetainedBatchReplayer, WebGl2RetainedNodeIndexRange } from './WebGl2RetainedGroupResources';
 import { createWebGl2ShaderProgram } from './WebGl2ShaderProgram';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
@@ -289,6 +290,23 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
    */
   public readonly _supportsRetainedBatches = true;
 
+  /**
+   * Veto the SHADER path at collect time. `resolvedStrategy` is derived from the
+   * source type alone, so it is decidable per drawable — and a shader-path draw
+   * would otherwise poison the capture on every frame, leaving the group on the
+   * entry-replay tier it can reach for free.
+   *
+   * The verdict is cached per capture, so it would go stale if this answer could
+   * flip under a live capture. It cannot: `resolvedStrategy` reads a private,
+   * readonly source assigned once in the constructor, so a sprite's strategy is
+   * fixed for its lifetime. The poison in {@link render} is therefore
+   * unreachable through the public API and kept only as a structural safety net.
+   * @internal
+   */
+  public _admitsRetainedRecording(drawable: Drawable): boolean {
+    return (drawable as RepeatingSprite).resolvedStrategy !== 'shader';
+  }
+
   private readonly _shaderPathShader: Shader;
   private readonly _geoPathShader: Shader;
   private readonly _batchSize: number;
@@ -375,12 +393,15 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
 
     const backend = this.getBackend();
 
-    // Retained recording: only the geometry path is
-    // replayable. A shader-path draw inside an active capture cannot be replayed
-    // from group-owned resources, so poison the window — the group falls back to
-    // entry replay (correct, never stale) rather than replaying an incomplete or
-    // wrap-less instruction stream. Both pixel-snap modes are resolved in-shader
-    // and stay recordable.
+    // Retained recording: only the geometry path is replayable, and
+    // _admitsRetainedRecording keeps a shader-path sprite from opening a capture
+    // at all. A sprite's strategy cannot change after that verdict was cached
+    // (readonly source), so this poison is unreachable through the public API
+    // and stays only as a structural safety net: were it to fire, the window
+    // cannot be replayed from group-owned resources, so the group falls back to
+    // entry replay (correct, never stale) rather than replaying a wrap-less
+    // instruction stream. Both pixel-snap modes are resolved in-shader and stay
+    // recordable.
     if (backend._isRetainedCapturing && strategy === 'shader') {
       backend._poisonRetainedCaptures();
     }
@@ -907,16 +928,15 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
       },
       upload: (buffer, offset): void => {
         const gl = conn.gl;
-        const data = buffer.data;
         const state = conn.buffers.get(buffer);
 
         gl.bindBuffer(buffer.type, handle);
-        if (state && state.dataByteLength >= data.byteLength) {
-          gl.bufferSubData(buffer.type, offset, data);
-          state.dataByteLength = data.byteLength;
+        if (state && state.dataByteLength >= buffer.uploadByteLength) {
+          uploadBufferRange(gl, buffer, offset);
+          state.dataByteLength = buffer.uploadByteLength;
         } else {
-          gl.bufferData(buffer.type, data, buffer.usage);
-          conn.buffers.set(buffer, { handle, dataByteLength: data.byteLength });
+          uploadBufferStore(gl, buffer);
+          conn.buffers.set(buffer, { handle, dataByteLength: buffer.uploadByteLength });
         }
       },
       destroy: (buffer): void => {

--- a/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
+++ b/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
@@ -14,7 +14,7 @@ import type { Texture } from '#rendering/texture/Texture';
 import { TRANSFORM_FLOATS_PER_ROW, TRANSFORM_TINT_BYTES_PER_ROW } from '#rendering/TransformBuffer';
 import { type BlendModes, BufferTypes, BufferUsage, RenderingPrimitives, TextureFormat } from '#rendering/types';
 
-import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import { uploadBufferRange, uploadBufferStore, WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
 
 const transformFloatsPerRow = TRANSFORM_FLOATS_PER_ROW;
@@ -532,15 +532,13 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
         gl.bindBuffer(buffer.type, handle);
       },
       upload: (buffer, offset): void => {
-        const data = buffer.data;
-
         gl.bindBuffer(buffer.type, handle);
 
-        if (allocatedBytes >= data.byteLength && allocatedBytes > 0) {
-          gl.bufferSubData(buffer.type, offset, data as ArrayBufferView);
+        if (allocatedBytes >= buffer.uploadByteLength && allocatedBytes > 0) {
+          uploadBufferRange(gl, buffer, offset);
         } else {
-          gl.bufferData(buffer.type, data as ArrayBufferView, buffer.usage);
-          allocatedBytes = data.byteLength;
+          uploadBufferStore(gl, buffer);
+          allocatedBytes = buffer.uploadByteLength;
         }
       },
       destroy: (buffer): void => {

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -25,7 +25,7 @@ import vertexSource from './glsl/sprite.vert';
 import indexedVertexSource from './glsl/sprite-indexed.vert';
 import type { WebGl2Backend } from './WebGl2Backend';
 import { WebGl2PersistentSlotStore } from './WebGl2PersistentSlotStore';
-import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import { uploadBufferRange, uploadBufferStore, WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
 import type { WebGl2RetainedBatchPayload, WebGl2RetainedBatchReplayer, WebGl2RetainedNodeIndexRange } from './WebGl2RetainedGroupResources';
 import { createWebGl2ShaderProgram } from './WebGl2ShaderProgram';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
@@ -975,17 +975,16 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
       },
       upload: (buffer, offset): void => {
         const gl = connection.gl;
-        const data = buffer.data;
         const state = connection.buffers.get(buffer);
 
         gl.bindBuffer(buffer.type, handle);
 
-        if (state && state.dataByteLength >= data.byteLength) {
-          gl.bufferSubData(buffer.type, offset, data);
-          state.dataByteLength = data.byteLength;
+        if (state && state.dataByteLength >= buffer.uploadByteLength) {
+          uploadBufferRange(gl, buffer, offset);
+          state.dataByteLength = buffer.uploadByteLength;
         } else {
-          gl.bufferData(buffer.type, data, buffer.usage);
-          connection.buffers.set(buffer, { handle, dataByteLength: data.byteLength });
+          uploadBufferStore(gl, buffer);
+          connection.buffers.set(buffer, { handle, dataByteLength: buffer.uploadByteLength });
         }
       },
       destroy: (buffer): void => {

--- a/src/rendering/webgl2/WebGl2StencilClipper.ts
+++ b/src/rendering/webgl2/WebGl2StencilClipper.ts
@@ -7,7 +7,7 @@ import { BufferTypes, BufferUsage, RenderingPrimitives } from '#rendering/types'
 import fragmentSource from './glsl/stencil-clip.frag';
 import vertexSource from './glsl/stencil-clip.vert';
 import type { WebGl2Backend } from './WebGl2Backend';
-import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import { uploadBufferStore, WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
 import { createWebGl2ShaderProgram } from './WebGl2ShaderProgram';
 import { WebGl2VertexArrayObject, type WebGl2VertexArrayObjectRuntime } from './WebGl2VertexArrayObject';
 
@@ -178,7 +178,7 @@ export class WebGl2StencilClipper {
       },
       upload: (buffer: WebGl2RenderBuffer): void => {
         gl.bindBuffer(buffer.type, handle);
-        gl.bufferData(buffer.type, buffer.data, buffer.usage);
+        uploadBufferStore(gl, buffer);
       },
       destroy: (buffer: WebGl2RenderBuffer): void => {
         gl.deleteBuffer(handle);

--- a/src/rendering/webgl2/WebGl2TextRenderer.ts
+++ b/src/rendering/webgl2/WebGl2TextRenderer.ts
@@ -16,7 +16,7 @@ import textColorFragSource from './glsl/text-color.frag';
 import textMsdfFragSource from './glsl/text-msdf.frag';
 import textSdfFragSource from './glsl/text-sdf.frag';
 import type { WebGl2Backend } from './WebGl2Backend';
-import { WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
+import { uploadBufferRange, uploadBufferStore, WebGl2RenderBuffer, type WebGl2RenderBufferRuntime } from './WebGl2RenderBuffer';
 import {
   type WebGl2RetainedBatchPayload,
   type WebGl2RetainedBatchReplayer,
@@ -1001,14 +1001,13 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       },
       upload: (buf, offset): void => {
         const state = buffers.get(buf);
-        const data = buf.data;
         gl.bindBuffer(buf.type, handle);
-        if (state && state.dataByteLength >= data.byteLength) {
-          gl.bufferSubData(buf.type, offset, data);
-          state.dataByteLength = data.byteLength;
+        if (state && state.dataByteLength >= buf.uploadByteLength) {
+          uploadBufferRange(gl, buf, offset);
+          state.dataByteLength = buf.uploadByteLength;
         } else {
-          gl.bufferData(buf.type, data, buf.usage);
-          buffers.set(buf, { handle, dataByteLength: data.byteLength });
+          uploadBufferStore(gl, buf);
+          buffers.set(buf, { handle, dataByteLength: buf.uploadByteLength });
         }
       },
       destroy: (buf): void => {

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -1570,11 +1570,23 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   /**
-   * Mark every active capture window as unreplayable (defensive, see
-   * {@link WebGpuRetainedCaptureFrame.poisoned}). The recordability predicate
-   * makes this unreachable; if it ever fires, the produced sets are vetoed in
-   * `_validateRetainedInstructionSet` so the group stays on the (correct)
-   * entry-replay tier instead of replaying incomplete instruction streams.
+   * Mark every active capture window as unreplayable (see
+   * {@link WebGpuRetainedCaptureFrame.poisoned}). A poisoned window's set is
+   * vetoed in `_validateRetainedInstructionSet`, so the group stays on the
+   * (correct) entry-replay tier instead of replaying an incomplete instruction
+   * stream.
+   *
+   * Most callers are defensive and the collect-time recordability predicate
+   * keeps them unreachable — a renderer whose non-recordable draws are decidable
+   * PER DRAWABLE states that through `_admitsRetainedRecording` so no capture is
+   * opened for them at all. Two callers do fire on healthy frames and cannot be
+   * pre-empted per drawable, because both are properties of how a frame's draws
+   * compose into flushes rather than of any one drawable: the Text renderer's
+   * multi-batch / second-flush-per-window guard, and this backend's own
+   * single-mesh default path (the recordable mesh draw needs a RUN of ≥2
+   * same-geometry meshes, so a lone static-geometry mesh inside a capture
+   * poisons it). Both leave the group re-recording and re-poisoning per frame on
+   * the correct tier; a cheaper veto form is the open follow-up.
    * @internal
    */
   public _poisonActiveRetainedCaptures(): void {

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -2,6 +2,7 @@
 
 import { Matrix } from '#math/Matrix';
 import { packAffineMat3Std140 } from '#rendering/affinePacking';
+import type { Drawable } from '#rendering/Drawable';
 import type { Geometry } from '#rendering/geometry/Geometry';
 import type { Material } from '#rendering/material/Material';
 import type { Mesh } from '#rendering/mesh/Mesh';
@@ -357,11 +358,40 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
   /**
    * Retained-batch opt-in: the default static
    * INSTANCED draw (runs of ≥2 same-geometry meshes) is a recordable
-   * flush-level batch. Single meshes take the CPU-baked default path (view
-   * baked into vertices — uncacheable) and custom-material meshes their own
-   * path; both poison any open capture so the group degrades to entry replay.
+   * flush-level batch. Custom-material meshes and meshes without shared static
+   * geometry are excluded at collect time and never open a capture. A LONE
+   * static-geometry mesh still can: it takes the CPU-baked default path (view
+   * baked into vertices — uncacheable) and poisons the window from there,
+   * because run length is only known at flush time.
    */
   public readonly _supportsRetainedBatches = true;
+
+  /**
+   * Only a mesh backed by SHARED, STATIC {@link Geometry} can reach the
+   * recordable instanced path at all — an array-vertex mesh
+   * (`geometry === null`) and a `dynamic`/`stream` geometry re-pack into this
+   * renderer's own scratch buffers every frame and always take the CPU-baked
+   * default path. Vetoing them at collect time stops a group of array meshes
+   * from recording and re-poisoning on every frame.
+   *
+   * NOT sufficient on this backend, deliberately: the instanced path also needs
+   * a RUN of ≥2 same-geometry meshes (see `_getStaticBatchLength`), which is a
+   * flush-time property no per-drawable predicate can decide. A group of static
+   * meshes that never form a run therefore still records and poisons per frame.
+   *
+   * The verdict is cached per capture, so it would go stale if this answer could
+   * flip under a live capture. It cannot for any mesh that can appear in one:
+   * `Geometry.usage` is readonly, and `Mesh._geometry` is written once in the
+   * constructor. The one subclass that rewrites it, the pooled `ImmediateMesh`,
+   * is submitted straight to the backend by `RenderingContext.drawGeometry` /
+   * `drawBatch` and never enters the scene graph, so it is never a captured
+   * fragment entry.
+   * @internal
+   */
+  public _admitsRetainedRecording(drawable: Drawable): boolean {
+    return (drawable as Mesh).geometry?.usage === 'static';
+  }
+
   /** Reusable single-slot texture list handed to the recorder (avoids a per-batch array). */
   private readonly _retainedTextureScratch: [Texture | RenderTexture] = [TextureClass.white];
 

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -2,6 +2,7 @@
 
 import { Matrix } from '#math/Matrix';
 import { affineMat4FloatCount, packAffineMat4, packedGroupChanged } from '#rendering/affinePacking';
+import type { Drawable } from '#rendering/Drawable';
 import type { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
 import { computeShaderTiling, type RepeatingSpriteQuad } from '#rendering/sprite/repeatingSpritePlan';
 import { DataTexture } from '#rendering/texture/DataTexture';
@@ -253,6 +254,23 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
    */
   public readonly _supportsRetainedBatches = true;
 
+  /**
+   * Veto the SHADER path at collect time — `resolvedStrategy` is derived from
+   * the source type alone, so it is decidable per drawable, and a shader-path
+   * draw would otherwise poison the capture on every frame for a recording the
+   * group can never use.
+   *
+   * The verdict is cached per capture, so it would go stale if this answer could
+   * flip under a live capture. It cannot: `resolvedStrategy` reads a private,
+   * readonly source assigned once in the constructor, so a sprite's strategy is
+   * fixed for its lifetime. The poison in {@link render} is therefore
+   * unreachable through the public API and kept only as a structural safety net.
+   * @internal
+   */
+  public _admitsRetainedRecording(drawable: Drawable): boolean {
+    return (drawable as RepeatingSprite).resolvedStrategy !== 'shader';
+  }
+
   private readonly _projData = new Float32Array(projectionByteLength / Float32Array.BYTES_PER_ELEMENT);
   // Projection-uniform skip state: a matching (view identity, view.updateId,
   // group-matrix content) triple means the shared UBO already holds this
@@ -426,12 +444,16 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     const modeX = sprite.modeX;
     const modeY = sprite.modeY;
 
-    // Retained recording: only the geometry path is
-    // replayable (see _supportsRetainedBatches). A shader-path draw inside an
-    // active capture window cannot be replayed from group-owned resources, so
-    // poison the window — the group falls back to entry replay (correct, never
-    // stale) instead of a replay missing the wrap-mode sampler. Both pixel-snap
-    // modes are resolved in-shader and stay recordable.
+    // Retained recording: only the geometry path is replayable (see
+    // _supportsRetainedBatches), and _admitsRetainedRecording keeps a
+    // shader-path sprite from opening a capture at all. A sprite's strategy
+    // cannot change after that verdict was cached (readonly source), so this is
+    // unreachable through the public API and stays only as a structural safety
+    // net: were it to fire, a shader-path draw inside an active capture window
+    // cannot be replayed from group-owned resources, so poison the window — the
+    // group falls back to entry replay (correct, never stale) instead of a
+    // replay missing the wrap-mode sampler. Both pixel-snap modes are resolved
+    // in-shader and stay recordable.
     if (strategy === 'shader' && backend._retainedCaptureActive) {
       backend._poisonActiveRetainedCaptures();
     }

--- a/test/core/__snapshots__/renderer-sdk-snapshot.test.ts.snap
+++ b/test/core/__snapshots__/renderer-sdk-snapshot.test.ts.snap
@@ -37,5 +37,7 @@ exports[`renderer-sdk export surface snapshot > sorted runtime export names matc
   "reflectComputeBindings",
   "retainedGroupUniformBytes",
   "stencilContentDepthStencilState",
+  "uploadBufferRange",
+  "uploadBufferStore",
 ]
 `;

--- a/test/perf/rendering/fakeWebGl2.ts
+++ b/test/perf/rendering/fakeWebGl2.ts
@@ -189,6 +189,14 @@ const byteLengthOf = (data: unknown): number => {
   return 0;
 };
 
+/**
+ * Bytes a `bufferData`/`bufferSubData` call actually uploads. `length` (in
+ * elements of `data`'s own type) is the WebGL2 range overload's count; absent,
+ * the whole view is uploaded.
+ */
+const uploadedBytes = (data: unknown, _srcOffset: number | undefined, length: number | undefined): number =>
+  length === undefined ? byteLengthOf(data) : length * elementBytesOf(data);
+
 /** Bytes per typed-array element, for sizing an upload expressed as an element offset. */
 const elementBytesOf = (data: unknown): number => (ArrayBuffer.isView(data) ? ((data as { BYTES_PER_ELEMENT?: number }).BYTES_PER_ELEMENT ?? 1) : 1);
 
@@ -356,15 +364,19 @@ export const createFakeWebGl2Context = (recorder: GlRecorder): WebGL2RenderingCo
     drawElements: (): void => {
       recorder.drawCalls++;
     },
-    bufferData: (_target: number, data: unknown, _usage: number): void => {
-      const bytes = typeof data === 'number' ? data : byteLengthOf(data);
+    // The WebGL2 `(srcData, srcOffset, length)` overloads upload a RANGE of the
+    // view, not all of it — `length` is in elements. Ignoring the extra
+    // arguments would over-count every partial upload (the mesh renderer's
+    // per-draw vertex/index/node-index uploads are all partial).
+    bufferData: (_target: number, data: unknown, _usage: number, srcOffset?: number, length?: number): void => {
+      const bytes = typeof data === 'number' ? data : uploadedBytes(data, srcOffset, length);
 
       recorder.bufferUploads++;
       recorder.bufferReallocations++;
       recorder.bufferUploadBytes += bytes;
     },
-    bufferSubData: (_target: number, _offset: number, data: unknown): void => {
-      const bytes = byteLengthOf(data);
+    bufferSubData: (_target: number, _offset: number, data: unknown, srcOffset?: number, length?: number): void => {
+      const bytes = uploadedBytes(data, srcOffset, length);
 
       recorder.bufferUploads++;
       recorder.bufferSubUpdates++;

--- a/test/perf/rendering/retained-recording-admission-webgl2.test.ts
+++ b/test/perf/rendering/retained-recording-admission-webgl2.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Structural gates for the COLLECT-TIME admission predicate that decides
+ * whether a retained group's fragment is recorded at all
+ * (`isRetainedFragmentRecordable` ->
+ * `RetainedBatchCapableRenderer._admitsRetainedRecording`).
+ *
+ * The predicate used to look only at the renderer's capability flag, so it
+ * admitted draws whose renderer then had to POISON the open capture from inside
+ * its draw path — a mesh without static geometry and a shader-path repeating
+ * sprite both did. That combination is stable but wasteful: the group opens a
+ * capture, records into it, poisons it, fails validation, and re-arms on the
+ * next clean frame — every frame, forever, for a recording it can never replay.
+ * The poison itself stays in place as the safety net its contract describes;
+ * these cells pin that a healthy scene no longer reaches it.
+ *
+ * What these pin, per draw class:
+ * - array-vertex and non-`static` geometry meshes are NOT admitted: no capture
+ *   opens, no poison instruction is appended, and the group keeps rendering off
+ *   the (correct) entry-replay tier across mutation,
+ * - a shared-`static`-geometry mesh IS still admitted and still records/replays,
+ * - a shader-path repeating sprite is NOT admitted; a geometry-path one is,
+ * - one non-admitted draw vetoes the WHOLE fragment (the predicate is all-or-
+ *   nothing per group, which is what the poison used to achieve at draw time).
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { Container } from '#rendering/Container';
+import { Geometry } from '#rendering/geometry/Geometry';
+import { Mesh } from '#rendering/mesh/Mesh';
+import type { RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import { RetainedContainer } from '#rendering/RetainedContainer';
+import { RepeatingSprite } from '#rendering/sprite/RepeatingSprite';
+import { Sprite } from '#rendering/sprite/Sprite';
+import type { Texture } from '#rendering/texture/Texture';
+
+import { makeRegion, makeTextures } from './fixtures';
+import { createWebGl2Harness, measureFrame, type WebGl2Harness } from './harness';
+
+interface FragmentCarrier {
+  _fragment: RetainedGroupFragment;
+}
+
+const fragmentOf = (group: RetainedContainer): RetainedGroupFragment => (group as unknown as FragmentCarrier)._fragment;
+
+const withHarness = (fn: (harness: WebGl2Harness) => void): void => {
+  const harness = createWebGl2Harness();
+
+  try {
+    fn(harness);
+  } finally {
+    harness.destroy();
+  }
+};
+
+const quadVertices = new Float32Array([0, 0, 16, 0, 16, 16, 0, 16]);
+const quadIndices = new Uint16Array([0, 1, 2, 0, 2, 3]);
+const quadUvs = new Float32Array([0, 0, 1, 0, 1, 1, 0, 1]);
+
+/** Interleaved position+texcoord+color quad, in the layout the mesh renderer's default shader reads. */
+const createQuadGeometry = (usage: 'static' | 'dynamic'): Geometry => {
+  const stride = 20;
+  const buffer = new ArrayBuffer(4 * stride);
+  const view = new DataView(buffer);
+
+  [
+    [0, 0, 0, 0],
+    [16, 0, 1, 0],
+    [16, 16, 1, 1],
+    [0, 16, 0, 1],
+  ].forEach((vertex, index) => {
+    const base = index * stride;
+
+    view.setFloat32(base + 0, vertex[0]!, true);
+    view.setFloat32(base + 4, vertex[1]!, true);
+    view.setFloat32(base + 8, vertex[2]!, true);
+    view.setFloat32(base + 12, vertex[3]!, true);
+    view.setUint32(base + 16, 0xffffffff, true);
+  });
+
+  return new Geometry({
+    attributes: [
+      { name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 },
+      { name: 'a_texcoord', size: 2, type: 'f32', normalized: false, offset: 8 },
+      { name: 'a_color', size: 4, type: 'u8', normalized: true, offset: 16 },
+    ],
+    vertexData: buffer,
+    stride,
+    indices: quadIndices,
+    usage,
+  });
+};
+
+/**
+ * A live sprite OUTSIDE (and before) the group, so the group is never the whole
+ * frame and a vetoed group still has to interleave correctly with live work.
+ */
+const buildGroupScene = (texture: Texture, fill: (group: RetainedContainer) => void) => {
+  const root = new Container();
+  const outside = new Sprite(texture);
+  const group = new RetainedContainer();
+
+  outside.setPosition(600, 300);
+  root.addChild(outside);
+
+  fill(group);
+  group.setPosition(100, 100);
+  root.addChild(group);
+
+  return { root, group };
+};
+
+/**
+ * Drive four frames — capture, first clean frame (where recording is armed),
+ * and two steady frames — and report what the retained machinery did.
+ */
+const runLadder = (harness: WebGl2Harness, root: Container) => {
+  const beginSpy = vi.spyOn(harness.backend, '_beginRetainedCapture');
+  const poisonSpy = vi.spyOn(harness.backend, '_poisonRetainedCaptures');
+  const replaySpy = vi.spyOn(harness.backend, '_replayRetainedBatch');
+  const frames = [measureFrame(harness, root), measureFrame(harness, root), measureFrame(harness, root), measureFrame(harness, root)];
+
+  return {
+    frames,
+    captures: beginSpy.mock.calls.length,
+    poisons: poisonSpy.mock.calls.length,
+    replays: replaySpy.mock.calls.length,
+  };
+};
+
+describe('WebGL2 retained recording admission: draws their renderer would poison are never recorded', () => {
+  it('does not admit an array-vertex mesh — no capture, no poison, stable entry replay', () => {
+    withHarness(harness => {
+      const [texture] = makeTextures(1);
+      const { root, group } = buildGroupScene(texture!, target => {
+        for (let i = 0; i < 3; i++) {
+          const mesh = new Mesh({ vertices: quadVertices, indices: quadIndices, uvs: quadUvs, texture: texture! });
+
+          mesh.setPosition(i * 20, 0);
+          target.addChild(mesh);
+        }
+      });
+
+      const ladder = runLadder(harness, root);
+
+      expect(fragmentOf(group).isRecordable(harness.backend)).toBe(false);
+      expect(ladder.captures).toBe(0);
+      expect(ladder.poisons).toBe(0);
+      expect(ladder.replays).toBe(0);
+
+      // Entry replay stays correct and steady: one draw call per array mesh
+      // (they cannot batch) plus the live outside sprite, on every frame.
+      for (const frame of ladder.frames) {
+        expect(frame.drawCalls).toBe(4);
+        expect(frame.visibleNodes).toBe(4);
+      }
+
+      root.destroy();
+    });
+  });
+
+  it('does not admit a `dynamic`-usage geometry mesh', () => {
+    withHarness(harness => {
+      const [texture] = makeTextures(1);
+      const geometry = createQuadGeometry('dynamic');
+      const { root, group } = buildGroupScene(texture!, target => {
+        for (let i = 0; i < 2; i++) {
+          const mesh = new Mesh({ geometry, texture: texture! });
+
+          mesh.setPosition(i * 20, 0);
+          target.addChild(mesh);
+        }
+      });
+
+      const ladder = runLadder(harness, root);
+
+      expect(fragmentOf(group).isRecordable(harness.backend)).toBe(false);
+      expect(ladder.captures).toBe(0);
+      expect(ladder.poisons).toBe(0);
+
+      root.destroy();
+      geometry.destroy();
+    });
+  });
+
+  it('still admits a shared `static`-geometry mesh, which records and replays', () => {
+    withHarness(harness => {
+      const [texture] = makeTextures(1);
+      const geometry = createQuadGeometry('static');
+      const { root, group } = buildGroupScene(texture!, target => {
+        for (let i = 0; i < 2; i++) {
+          const mesh = new Mesh({ geometry, texture: texture! });
+
+          mesh.setPosition(i * 20, 0);
+          target.addChild(mesh);
+        }
+      });
+
+      const ladder = runLadder(harness, root);
+
+      expect(fragmentOf(group).isRecordable(harness.backend)).toBe(true);
+      expect(ladder.captures).toBe(1);
+      expect(ladder.poisons).toBe(0);
+      expect(ladder.replays).toBeGreaterThan(0);
+
+      root.destroy();
+      geometry.destroy();
+    });
+  });
+
+  it('does not admit a shader-path repeating sprite, but does admit a geometry-path one', () => {
+    withHarness(harness => {
+      const [texture] = makeTextures(1);
+      const shaderScene = buildGroupScene(texture!, target => {
+        // A bare Texture source resolves to the shader strategy.
+        target.addChild(new RepeatingSprite(texture!, { width: 64, height: 64 }));
+      });
+      const shaderLadder = runLadder(harness, shaderScene.root);
+
+      expect(fragmentOf(shaderScene.group).isRecordable(harness.backend)).toBe(false);
+      expect(shaderLadder.captures).toBe(0);
+      expect(shaderLadder.poisons).toBe(0);
+
+      shaderScene.root.destroy();
+
+      const region = makeRegion(texture!);
+      const geometryScene = buildGroupScene(texture!, target => {
+        target.addChild(new RepeatingSprite(region, { width: 64, height: 64 }));
+      });
+      const geometryLadder = runLadder(harness, geometryScene.root);
+
+      expect(fragmentOf(geometryScene.group).isRecordable(harness.backend)).toBe(true);
+      expect(geometryLadder.captures).toBe(1);
+      expect(geometryLadder.poisons).toBe(0);
+
+      geometryScene.root.destroy();
+    });
+  });
+
+  it('vetoes the whole fragment when a single non-admitted draw sits among admitted ones', () => {
+    withHarness(harness => {
+      const [texture] = makeTextures(1);
+      const geometry = createQuadGeometry('static');
+      const { root, group } = buildGroupScene(texture!, target => {
+        target.addChild(new Sprite(texture!));
+        target.addChild(new Mesh({ geometry, texture: texture! }));
+        // The one array-vertex mesh takes the whole group off the recorded tier.
+        target.addChild(new Mesh({ vertices: quadVertices, indices: quadIndices, uvs: quadUvs, texture: texture! }));
+      });
+
+      const ladder = runLadder(harness, root);
+
+      expect(fragmentOf(group).isRecordable(harness.backend)).toBe(false);
+      expect(ladder.captures).toBe(0);
+      expect(ladder.poisons).toBe(0);
+
+      root.destroy();
+      geometry.destroy();
+    });
+  });
+
+  it('keeps rendering an unrecorded array-mesh group correctly across mutation', () => {
+    withHarness(harness => {
+      const [texture] = makeTextures(1);
+      let moved: Mesh | null = null;
+      const { root } = buildGroupScene(texture!, target => {
+        for (let i = 0; i < 3; i++) {
+          const mesh = new Mesh({ vertices: quadVertices, indices: quadIndices, uvs: quadUvs, texture: texture! });
+
+          mesh.setPosition(i * 20, 0);
+          target.addChild(mesh);
+          moved ??= mesh;
+        }
+      });
+
+      measureFrame(harness, root);
+      measureFrame(harness, root);
+
+      const poisonSpy = vi.spyOn(harness.backend, '_poisonRetainedCaptures');
+
+      moved!.setPosition(200, 200);
+
+      const afterMove = measureFrame(harness, root);
+
+      expect(afterMove.drawCalls).toBe(4);
+      expect(afterMove.visibleNodes).toBe(4);
+      expect(poisonSpy).not.toHaveBeenCalled();
+
+      root.destroy();
+    });
+  });
+});

--- a/test/rendering/browser/webgl2-mesh-retained-instruction-replay.test.ts
+++ b/test/rendering/browser/webgl2-mesh-retained-instruction-replay.test.ts
@@ -201,6 +201,50 @@ const buildScene = () => {
   return { root, group, redA, redB, greenA, greenB, destroy };
 };
 
+/**
+ * Same shape as {@link buildScene}, but the group's meshes are built from raw
+ * vertex ARRAYS instead of a shared {@link Geometry}. Those can only ever take
+ * the mesh renderer's dynamic single-draw path, which is not recordable — the
+ * collect-time admission predicate must keep the group off the recorded tier
+ * entirely rather than letting it record and poison every frame.
+ */
+const buildArrayMeshScene = () => {
+  const blue = createSolidTexture('#0000ff');
+  const red = createSolidTexture('#ff0000');
+  const root = new Container();
+  const outside = new Sprite(blue);
+  const group = new RetainedContainer();
+  const vertices = new Float32Array([0, 0, 16, 0, 16, 16, 0, 16]);
+  const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);
+  const uvs = new Float32Array([0, 0, 1, 0, 1, 1, 0, 1]);
+  const meshA = new Mesh({ vertices, indices, uvs, texture: red });
+  const meshB = new Mesh({ vertices, indices, uvs, texture: red });
+
+  outside.setPosition(48, 0);
+  root.addChild(outside);
+
+  meshB.setPosition(16, 0);
+  group.addChild(meshA);
+  group.addChild(meshB);
+  group.setPosition(8, 24);
+  root.addChild(group);
+
+  const destroy = (): void => {
+    root.destroy();
+    blue.destroy();
+    red.destroy();
+  };
+
+  return { root, group, meshA, meshB, destroy };
+};
+
+const expectArrayScenePixels = (backend: WebGl2Backend): void => {
+  expectPixelNear(readWebGl2Pixel(backend, 52, 8), [0, 0, 255, 255]); // live outside sprite
+  expectPixelNear(readWebGl2Pixel(backend, 16, 32), [255, 0, 0, 255]); // meshA (8,24)-(24,40)
+  expectPixelNear(readWebGl2Pixel(backend, 32, 32), [255, 0, 0, 255]); // meshB (24,24)-(40,40)
+  expectPixelNear(readWebGl2Pixel(backend, 58, 58), [0, 0, 0, 255]); // background
+};
+
 const expectBaseScenePixels = (backend: WebGl2Backend): void => {
   expectPixelNear(readWebGl2Pixel(backend, 52, 8), [0, 0, 255, 255]); // live outside sprite
   expectPixelNear(readWebGl2Pixel(backend, 16, 32), [255, 0, 0, 255]); // redA (8,24)-(24,40)
@@ -401,6 +445,47 @@ describe('WebGL2 renderer matrix: Mesh retained instruction-set replay cells', (
       WebGl2MeshRenderer.prototype._rebaseRetainedNodeIndices = original;
       brokenScene.destroy();
       brokenBackend.destroy();
+    }
+  });
+
+  test('cell 6 — array-vertex meshes are never recorded: no capture, no poison, pixel-stable entry replay across mutation', async () => {
+    const backend = await createBackend();
+    const scene = buildArrayMeshScene();
+    const beginSpy = vi.spyOn(backend, '_beginRetainedCapture');
+    const poisonSpy = vi.spyOn(backend, '_poisonRetainedCaptures');
+
+    try {
+      // An array-vertex mesh re-packs its vertices into the renderer's own
+      // scratch buffers every frame, so it can only ever take the dynamic
+      // single draw — the path that poisons an open capture. The collect-time
+      // admission predicate keeps the capture from opening in the first place,
+      // which must not change a single pixel of what the group renders.
+      render(backend, scene.root); // F1 collect
+
+      const collectFrame = readCanvas(backend);
+
+      expectArrayScenePixels(backend);
+
+      render(backend, scene.root); // F2 — would have recorded, now does not
+      render(backend, scene.root); // F3 — would have poisoned + re-armed
+
+      expect(beginSpy).not.toHaveBeenCalled();
+      expect(poisonSpy).not.toHaveBeenCalled();
+      expect(readCanvas(backend)).toEqual(collectFrame);
+
+      // A cached replay that had gone stale would freeze the moved mesh at its
+      // old spot; the entry-replay tier must track it live.
+      scene.meshB.setPosition(0, 16);
+      render(backend, scene.root);
+
+      expect(poisonSpy).not.toHaveBeenCalled();
+      expectPixelNear(readWebGl2Pixel(backend, 16, 48), [255, 0, 0, 255]); // meshB now at group-local (0,16)
+      expectPixelNear(readWebGl2Pixel(backend, 32, 32), [0, 0, 0, 255]); // its old spot cleared
+      expectPixelNear(readWebGl2Pixel(backend, 16, 32), [255, 0, 0, 255]); // meshA unmoved
+      expectPixelNear(readWebGl2Pixel(backend, 52, 8), [0, 0, 255, 255]); // live sprite unaffected
+    } finally {
+      scene.destroy();
+      backend.destroy();
     }
   });
 });


### PR DESCRIPTION
The collect-time recordability predicate looked only at the renderer's capability flag, so it admitted draws whose renderer then had to poison the open capture from inside its draw path. Such a group opened a capture, recorded into it, poisoned it, failed validation, and re-armed on the next clean frame — every frame, forever, for a recording it can never replay. A 1000-mesh group ran the whole cycle 1000 times per frame.

## Admission veto

`_admitsRetainedRecording` joins the capable-renderer interface, consulted per draw entry before the own-material hook. Meshes require shared static geometry; repeating sprites require the geometry path. Both are properties of the drawable, so the capture is never opened instead of being poisoned.

Two poison call sites are NOT defensive and do fire on healthy frames: Text (a multi-batch flush, or a second Text flush in the same window) and WebGPU's single-mesh default path (the recordable draw needs a run of two or more same-geometry meshes). Neither is decidable per drawable. The "never expected on a healthy path" contracts on both backends claimed otherwise and are corrected to name which callers are which.

## Transition invariant

The predicate's answer is cached per capture and only re-taken when the capture is re-keyed, so the hook's contract requires inputs that are either immutable or content-revision-bumping — otherwise a `recordable -> non-recordable` flip would leave a group replaying a capture its renderer can no longer honour. Both inputs are immutable, so the flip is unreachable through the public API and needs no test:

| Input | Why it cannot flip |
| --- | --- |
| `Geometry.usage` | `readonly`, assigned once in the constructor |
| `Mesh._geometry` | written once in the constructor. The one subclass that rewrites it, the pooled `ImmediateMesh`, goes straight to the backend via `RenderingContext.drawGeometry` / `drawBatch` and never enters the scene graph, so it is never a captured fragment entry |
| `RepeatingSprite.resolvedStrategy` | derives from a private readonly source |

For contrast, the pre-existing own-material input IS mutable — `Sprite.material` — and its setter calls `invalidateCache()`, which bumps the content revision and re-keys the capture. The comments that described the poison calls as covering a live flip are corrected to say what they are: dead on the public API, kept as a structural safety net.

## Upload views

Separately, `WebGl2RenderBuffer.upload` takes an element count so a renderer can upload the filled prefix of a persistent scratch array without allocating a `subarray()` view per upload. Two shared helpers route it through WebGL2's `(srcData, srcOffset, length)` overloads; every runtime goes through them so a partial range can never silently upload the whole array. Only the mesh renderer's call sites take partial ranges so far — they were the per-DRAW ones. The remaining per-flush views in other renderers, and rectangular partial texture upload, stay open.

## Measured

Allocation gate median, 5 windows, Node v24.14.1 win32/x64: `mesh/1000` 574.61 -> 171.59 KB/frame, `filtered/100` unchanged. CPU over the same harness (median of 5x600 frames): `mesh/1000` 3.176 -> 3.077 ms/frame, `mesh/5000` 17.686 -> 16.430. Gate budgets deliberately untouched.

## Verification

Run against this branch's tree rebased onto the WebGPU device-lifecycle fix (#561): full node suite 531 files / 9827 tests; WebGL2 browser 53/53; WebGPU browser 59/59 clean, no `E_OUTOFMEMORY`; parity 110; `verify:quick` 12/12 gates; size within limits.

https://claude.ai/code/session_01KQKgUaCnC2acS9TUQ1suGv
