### PR TITLE
perf(rendering): finish the per-flush upload-view cleanup

### DIFF
--- a/packages/exojs-particles/src/renderers/WebGl2ParticleRenderer.ts
+++ b/packages/exojs-particles/src/renderers/WebGl2ParticleRenderer.ts
@@ -219,7 +219,7 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
       resources.meshBuffer.upload(meshGeometry.vertexData);
     }
 
-    resources.vertexBuffer.upload(this._resolveUpload(mode, resources));
+    resources.vertexBuffer.upload(this._resolveUploadSource(mode, resources), 0, this._drawCount * resources.stride);
 
     const sampler = mode.material.sampler;
 
@@ -268,11 +268,12 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
   }
 
   /**
-   * The slice of the mode's scratch buffer this draw uploads. The byte view is
-   * cached and only rebuilt when the mode swaps in a larger backing buffer, so
-   * a steady-state frame allocates nothing beyond the subarray itself.
+   * The mode's scratch buffer as bytes. The view is cached and only rebuilt
+   * when the mode swaps in a larger backing buffer; how much of it this draw
+   * uploads is expressed as an element count at the upload call, so a steady
+   * frame allocates nothing at all.
    */
-  private _resolveUpload(mode: ParticleRenderMode, resources: ParticleModeResources): Uint8Array {
+  private _resolveUploadSource(mode: ParticleRenderMode, resources: ParticleModeResources): Uint8Array {
     const data = mode.data;
 
     if (resources.source !== data) {
@@ -280,7 +281,7 @@ export class WebGl2ParticleRenderer extends AbstractWebGl2Renderer<ParticleSyste
       resources.bytes = new Uint8Array(data);
     }
 
-    return resources.bytes.subarray(0, this._drawCount * resources.stride);
+    return resources.bytes;
   }
 
   private _getOrCreateResources(mode: ParticleRenderMode): ParticleModeResources {

--- a/packages/exojs-tilemap/src/webgl2/WebGl2TileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgl2/WebGl2TileChunkRenderer.ts
@@ -341,7 +341,7 @@ export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNod
 
     this._shader.sync();
     backend.bindVertexArrayObject(vao);
-    instanceBuffer.upload(this._instanceFloat32.subarray(0, this._quadIndex * wordsPerInstance));
+    instanceBuffer.upload(this._instanceFloat32, 0, this._quadIndex * wordsPerInstance);
     vao.drawInstanced(4, 0, this._quadIndex, RenderingPrimitives.TriangleStrip);
     backend.stats.batches++;
     backend.stats.drawCalls++;

--- a/src/rendering/webgl2/AbstractWebGl2BatchedRenderer.ts
+++ b/src/rendering/webgl2/AbstractWebGl2BatchedRenderer.ts
@@ -80,7 +80,7 @@ export abstract class AbstractWebGl2BatchedRenderer extends AbstractWebGl2Render
 
     this.shader.sync();
     backend.bindVertexArrayObject(vao);
-    vertexBuffer.upload(this.float32View.subarray(0, this.batchIndex * this.attributeCount));
+    vertexBuffer.upload(this.float32View, 0, this.batchIndex * this.attributeCount);
     vao.draw(this.batchIndex * 6, 0);
     backend.stats.batches++;
     backend.stats.drawCalls++;

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -196,6 +196,20 @@ interface RetainedCaptureFrame {
 const renderTargetTextureSyncUnit = 17;
 
 /**
+ * Row length (in channels) from which packing a rectangular texture region
+ * switches from a plain element loop to `set(subarray(…))`.
+ *
+ * `set` copies natively but needs a view per row, and below roughly this length
+ * the call overhead outweighs the copy: measured per pack, 8x8 rows 74 ns
+ * (loop) vs 421 ns (set) and 32x32 rows 1.20 us vs 1.66 us, flipping at 48–64
+ * to 4.5 us vs 3.9 us at 64x64 and 10.5 us vs 6.0 us at 96x96. Glyph-atlas
+ * updates — the only rectangular region the engine itself produces — sit on the
+ * small side, where the loop is both faster AND allocation-free (a 32x32 pack
+ * allocated 3.3 KB of row views).
+ */
+const nativeRowCopyThreshold = 48;
+
+/**
  * WebGL 2.0 implementation of {@link RenderBackend}. Manages the GL
  * context, texture and framebuffer caches keyed by user-side
  * {@link Texture}/{@link RenderTexture} identity, the active VAO, shader
@@ -2062,54 +2076,66 @@ export class WebGl2Backend implements RenderBackend {
     this._materialSamplers.clear();
   }
 
+  /** Same hit/miss split as {@link _getTextureState}, and for the same reason. */
   private _getRenderTargetState(target: RenderTarget): ManagedRenderTargetState {
-    let state = this._renderTargetStates.get(target);
+    return this._renderTargetStates.get(target) ?? this._createRenderTargetState(target);
+  }
 
-    if (!state) {
-      this._subscribeToDestroy(target, this._renderTargetDestroyHandlers, () => {
-        this._evictRenderTarget(target, true);
-      });
+  private _createRenderTargetState(target: RenderTarget): ManagedRenderTargetState {
+    this._subscribeToDestroy(target, this._renderTargetDestroyHandlers, () => {
+      this._evictRenderTarget(target, true);
+    });
 
-      state = {
-        framebuffer: target.root ? null : this._createFramebuffer(),
-        version: -1,
-        attachedTexture: null,
-        stencilRenderbuffer: null,
-        stencilWidth: 0,
-        stencilHeight: 0,
-      };
+    const state: ManagedRenderTargetState = {
+      framebuffer: target.root ? null : this._createFramebuffer(),
+      version: -1,
+      attachedTexture: null,
+      stencilRenderbuffer: null,
+      stencilWidth: 0,
+      stencilHeight: 0,
+    };
 
-      this._renderTargetStates.set(target, state);
-    }
+    this._renderTargetStates.set(target, state);
 
     return state;
   }
 
+  /**
+   * The backend-side state for `texture`, created on first sight.
+   *
+   * The creation half lives in {@link _createTextureState} for one reason: its
+   * eviction handlers are closures over `texture`, and V8 allocates the scope
+   * that backs them when the function is ENTERED, not when the branch that
+   * builds them is taken. Keeping them here cost every cache hit ~45 bytes —
+   * and this runs once per bound texture per draw, so a 762-draw blend-churn
+   * scene paid 107 KB/frame (3.5 MB/frame at 25 000 draws) for closures it
+   * never created.
+   */
   private _getTextureState(texture: Texture | RenderTexture): ManagedTextureState {
-    let state = this._textureStates.get(texture);
+    return this._textureStates.get(texture) ?? this._createTextureState(texture);
+  }
 
-    if (!state) {
-      this._subscribeToDestroy(texture, this._textureDestroyHandlers, () => {
-        this._evictTexture(texture);
+  private _createTextureState(texture: Texture | RenderTexture): ManagedTextureState {
+    this._subscribeToDestroy(texture, this._textureDestroyHandlers, () => {
+      this._evictTexture(texture);
+    });
+
+    if (texture instanceof Texture) {
+      this._subscribeToRelease(texture, this._textureReleaseHandlers, () => {
+        this._evictTexture(texture, false);
       });
-
-      if (texture instanceof Texture) {
-        this._subscribeToRelease(texture, this._textureReleaseHandlers, () => {
-          this._evictTexture(texture, false);
-        });
-      }
-
-      state = {
-        handle: this._createTextureHandle(),
-        version: -1,
-        width: 0,
-        height: 0,
-        accountedBytes: 0,
-        partialUploadScratch: null,
-      };
-
-      this._textureStates.set(texture, state);
     }
+
+    const state: ManagedTextureState = {
+      handle: this._createTextureHandle(),
+      version: -1,
+      width: 0,
+      height: 0,
+      accountedBytes: 0,
+      partialUploadScratch: null,
+    };
+
+    this._textureStates.set(texture, state);
 
     return state;
   }
@@ -2382,9 +2408,13 @@ export class WebGl2Backend implements RenderBackend {
   }
 
   /**
-   * Return a packing scratch view sized exactly `length`, backed by
-   * `state.partialUploadScratch` (grown on demand, never shrunk, kind-matched
-   * to `source`). Reusing this buffer across every `DataTexture` upload that
+   * Return the packing scratch for `state`, at least `length` elements long
+   * (grown on demand, never shrunk, kind-matched to `source`). It is NOT
+   * narrowed to `length`: the caller passes it to the `(…, srcData, srcOffset)`
+   * overload, which reads exactly the rectangle's worth of elements from the
+   * offset — so a longer buffer uploads the same bytes as an exact-length view
+   * would, without allocating one per pack. Reusing this buffer across every
+   * `DataTexture` upload that
    * has to be packed at all — instead of allocating a fresh temporary array
    * per sync — is what keeps a barrier-heavy scene's per-frame CPU garbage
    * flat instead of scaling with flush count: each flush's transform (and now
@@ -2402,129 +2432,167 @@ export class WebGl2Backend implements RenderBackend {
       state.partialUploadScratch = scratch;
     }
 
-    return scratch.length === length ? scratch : scratch.subarray(0, length);
+    return scratch;
   }
 
+  /**
+   * Bind `texture` to the active unit, uploading first if its contents moved on
+   * since the last bind.
+   *
+   * Split into this binding-only fast path and {@link _syncTextureUpload}
+   * because a frame calls it once per bound texture per draw and almost never
+   * needs the upload: at a few thousand calls per frame, running them through
+   * the upload function's frame cost ~45 B each even when every branch in it
+   * was skipped (measured: 107 KB/frame on a 762-draw blend-churn scene, 3.5
+   * MB/frame at 25 000 draws, with a matching 19x difference in scavenge count
+   * — the bytes are real, not a profiler artefact). Keeping the hot path in a
+   * small function of its own removes that entirely.
+   */
   private _syncTexture(texture: Texture | RenderTexture): ManagedTextureState {
     assertLiveTexture(texture);
 
-    const gl = this._context;
     const state = this._getTextureState(texture);
     const version = texture instanceof RenderTexture ? texture.textureVersion : texture.version;
 
     this._bindTextureHandle(state.handle);
 
-    if (state.version !== version) {
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, texture.scaleMode);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, texture.scaleMode);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, texture.wrapMode);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, texture.wrapMode);
-      gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, texture.premultiplyAlpha);
+    if (state.version === version) {
+      return state;
+    }
 
-      if (texture instanceof DataTexture) {
-        // `instanceof DataTexture` narrows to `DataTexture<any>` (the generic is
-        // erased), so `texture.format` widens to `any`; the class invariant
-        // guarantees it is a `DataTextureFormat`, so restore that type here.
-        const format: DataTextureFormat = texture.format;
-        const formatInfo = webgl2DataTextureFormat(format);
-        const region = texture._consumeDirtyRegion();
-        const needsAlloc = state.version === -1 || state.width !== texture.width || state.height !== texture.height;
+    return this._syncTextureUpload(texture, state, version);
+  }
 
-        // Our DataTexture buffers are tightly packed (no per-row padding), but
-        // WebGL defaults UNPACK_ALIGNMENT to 4. For single-byte (r8) data a
-        // sub-region upload whose width isn't a multiple of 4 would be misread
-        // — or rejected with INVALID_OPERATION for height > 1 — leaving the
-        // region un-uploaded. That is exactly what corrupts a partial glyph-
-        // atlas upload when new glyphs first appear after the initial full
-        // upload (e.g. switching to a scene with new characters). Force tight
-        // packing for the upload, then restore the GL default.
-        gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
+  /**
+   * Upload `texture`'s current contents into its already-bound GL texture and
+   * re-stamp `state`. Split out of {@link _syncTexture}; never called for a
+   * texture whose version the state already carries.
+   */
+  private _syncTextureUpload(texture: Texture | RenderTexture, state: ManagedTextureState, version: number): ManagedTextureState {
+    const gl = this._context;
 
-        const bytesPerPixel = dataTextureBytesPerPixel(format);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, texture.scaleMode);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, texture.scaleMode);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, texture.wrapMode);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, texture.wrapMode);
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, texture.premultiplyAlpha);
 
-        if (needsAlloc || region === null || region.full) {
-          gl.texImage2D(gl.TEXTURE_2D, 0, formatInfo.internalFormat, texture.width, texture.height, 0, formatInfo.format, formatInfo.type, texture.buffer);
-          this._bookTextureStorage(state, texture, bytesPerPixel);
-          this._accountant.recordTextureUpload(texture.width * texture.height * bytesPerPixel);
+    if (texture instanceof DataTexture) {
+      // `instanceof DataTexture` narrows to `DataTexture<any>` (the generic is
+      // erased), so `texture.format` widens to `any`; the class invariant
+      // guarantees it is a `DataTextureFormat`, so restore that type here.
+      const format: DataTextureFormat = texture.format;
+      const formatInfo = webgl2DataTextureFormat(format);
+      const region = texture._consumeDirtyRegion();
+      const needsAlloc = state.version === -1 || state.width !== texture.width || state.height !== texture.height;
+
+      // Our DataTexture buffers are tightly packed (no per-row padding), but
+      // WebGL defaults UNPACK_ALIGNMENT to 4. For single-byte (r8) data a
+      // sub-region upload whose width isn't a multiple of 4 would be misread
+      // — or rejected with INVALID_OPERATION for height > 1 — leaving the
+      // region un-uploaded. That is exactly what corrupts a partial glyph-
+      // atlas upload when new glyphs first appear after the initial full
+      // upload (e.g. switching to a scene with new characters). Force tight
+      // packing for the upload, then restore the GL default.
+      gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
+
+      const bytesPerPixel = dataTextureBytesPerPixel(format);
+
+      if (needsAlloc || region === null || region.full) {
+        gl.texImage2D(gl.TEXTURE_2D, 0, formatInfo.internalFormat, texture.width, texture.height, 0, formatInfo.format, formatInfo.type, texture.buffer);
+        this._bookTextureStorage(state, texture, bytesPerPixel);
+        this._accountant.recordTextureUpload(texture.width * texture.height * bytesPerPixel);
+      } else {
+        const channels = formatInfo.channels;
+        const rowChannels = texture.width * channels;
+
+        // A region is already contiguous and tightly packed in the row-major
+        // buffer when it spans full rows, and equally when it is a single row
+        // (however narrow — one row never straddles a gap). Both let the
+        // `(…, srcData, srcOffset)` overload read straight out of the texture
+        // buffer at an element offset, with nothing to pack. Between them they
+        // cover every shape the engine's own uploads take: full-width bands
+        // (ring-buffer style writes, a whole transform store) and single-row
+        // spans (a patched transform row, a dirty range inside one texture
+        // line), so the packing path below is left to genuinely rectangular
+        // sub-regions like a partial glyph-atlas update.
+        if ((region.x === 0 && region.width === texture.width) || region.height === 1) {
+          gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            region.x,
+            region.y,
+            region.width,
+            region.height,
+            formatInfo.format,
+            formatInfo.type,
+            texture.buffer,
+            region.y * rowChannels + region.x * channels,
+          );
         } else {
-          const channels = formatInfo.channels;
-          const rowChannels = texture.width * channels;
+          // The rows are no longer contiguous, so lift the sub-region out of
+          // the row-major buffer into a reusable scratch view (grown once,
+          // never reallocated per call — see `_acquirePartialUploadScratch`)
+          // that gl.texSubImage2D can read as one tightly packed block.
+          const subRowChannels = region.width * channels;
+          const subView = this._acquirePartialUploadScratch(state, texture.buffer, region.width * region.height * channels);
+          const source = texture.buffer;
 
-          // A region is already contiguous and tightly packed in the row-major
-          // buffer when it spans full rows, and equally when it is a single row
-          // (however narrow — one row never straddles a gap). Both let the
-          // `(…, srcData, srcOffset)` overload read straight out of the texture
-          // buffer at an element offset, with nothing to pack. Between them they
-          // cover every shape the engine's own uploads take: full-width bands
-          // (ring-buffer style writes, a whole transform store) and single-row
-          // spans (a patched transform row, a dirty range inside one texture
-          // line), so the packing path below is left to genuinely rectangular
-          // sub-regions like a partial glyph-atlas update.
-          if ((region.x === 0 && region.width === texture.width) || region.height === 1) {
-            gl.texSubImage2D(
-              gl.TEXTURE_2D,
-              0,
-              region.x,
-              region.y,
-              region.width,
-              region.height,
-              formatInfo.format,
-              formatInfo.type,
-              texture.buffer,
-              region.y * rowChannels + region.x * channels,
-            );
-          } else {
-            // The rows are no longer contiguous, so lift the sub-region out of
-            // the row-major buffer into a reusable scratch view (grown once,
-            // never reallocated per call — see `_acquirePartialUploadScratch`)
-            // that gl.texSubImage2D can read as one tightly packed block.
-            const subRowChannels = region.width * channels;
-            const subView = this._acquirePartialUploadScratch(state, texture.buffer, region.width * region.height * channels);
-
+          if (subRowChannels <= nativeRowCopyThreshold) {
             for (let row = 0; row < region.height; row++) {
               const sourceStart = (region.y + row) * rowChannels + region.x * channels;
               const targetStart = row * subRowChannels;
 
-              subView.set(texture.buffer.subarray(sourceStart, sourceStart + subRowChannels), targetStart);
+              for (let i = 0; i < subRowChannels; i++) {
+                // In-bounds: the scratch is sized `region.width * region.height
+                // * channels` and the region lies inside the texture buffer.
+                subView[targetStart + i] = source[sourceStart + i]!;
+              }
             }
+          } else {
+            for (let row = 0; row < region.height; row++) {
+              const sourceStart = (region.y + row) * rowChannels + region.x * channels;
 
-            gl.texSubImage2D(gl.TEXTURE_2D, 0, region.x, region.y, region.width, region.height, formatInfo.format, formatInfo.type, subView);
+              subView.set(source.subarray(sourceStart, sourceStart + subRowChannels), row * subRowChannels);
+            }
           }
 
-          this._accountant.recordTextureUpload(region.width * region.height * bytesPerPixel);
+          gl.texSubImage2D(gl.TEXTURE_2D, 0, region.x, region.y, region.width, region.height, formatInfo.format, formatInfo.type, subView, 0);
         }
 
-        gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
-      } else if (texture instanceof RenderTexture) {
-        const info = webgl2DataTextureFormat(texture.format);
-
-        if (state.version === -1 || state.width !== texture.width || state.height !== texture.height || texture.source === null) {
-          gl.texImage2D(gl.TEXTURE_2D, 0, info.internalFormat, texture.width, texture.height, 0, info.format, info.type, texture.source);
-          this._bookTextureStorage(state, texture, info.bytesPerPixel);
-          this._accountant.recordTextureUpload(texture.width * texture.height * info.bytesPerPixel);
-        } else {
-          gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, texture.width, texture.height, info.format, info.type, texture.source);
-          this._accountant.recordTextureUpload(texture.width * texture.height * info.bytesPerPixel);
-        }
-      } else if (texture.source) {
-        if (state.version === -1 || state.width !== texture.width || state.height !== texture.height) {
-          gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, texture.source);
-          this._bookTextureStorage(state, texture, RGBA8_BYTES_PER_PIXEL);
-        } else {
-          gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, texture.source);
-        }
-
-        this._accountant.recordTextureUpload(texture.width * texture.height * RGBA8_BYTES_PER_PIXEL);
+        this._accountant.recordTextureUpload(region.width * region.height * bytesPerPixel);
       }
 
-      if (texture.generateMipMap && (texture instanceof RenderTexture || texture.source !== null)) {
-        gl.generateMipmap(gl.TEXTURE_2D);
+      gl.pixelStorei(gl.UNPACK_ALIGNMENT, 4);
+    } else if (texture instanceof RenderTexture) {
+      const info = webgl2DataTextureFormat(texture.format);
+
+      if (state.version === -1 || state.width !== texture.width || state.height !== texture.height || texture.source === null) {
+        gl.texImage2D(gl.TEXTURE_2D, 0, info.internalFormat, texture.width, texture.height, 0, info.format, info.type, texture.source);
+        this._bookTextureStorage(state, texture, info.bytesPerPixel);
+        this._accountant.recordTextureUpload(texture.width * texture.height * info.bytesPerPixel);
+      } else {
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, texture.width, texture.height, info.format, info.type, texture.source);
+        this._accountant.recordTextureUpload(texture.width * texture.height * info.bytesPerPixel);
+      }
+    } else if (texture.source) {
+      if (state.version === -1 || state.width !== texture.width || state.height !== texture.height) {
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, texture.source);
+        this._bookTextureStorage(state, texture, RGBA8_BYTES_PER_PIXEL);
+      } else {
+        gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, texture.source);
       }
 
-      state.version = version;
-      state.width = texture.width;
-      state.height = texture.height;
+      this._accountant.recordTextureUpload(texture.width * texture.height * RGBA8_BYTES_PER_PIXEL);
     }
+
+    if (texture.generateMipMap && (texture instanceof RenderTexture || texture.source !== null)) {
+      gl.generateMipmap(gl.TEXTURE_2D);
+    }
+
+    state.version = version;
+    state.width = texture.width;
+    state.height = texture.height;
 
     return state;
   }

--- a/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
@@ -318,7 +318,7 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
 
     this._shader.sync();
     backend.bindVertexArrayObject(vao);
-    instanceBuffer.upload(this._instanceFloat32.subarray(0, this._quadIndex * wordsPerInstance));
+    instanceBuffer.upload(this._instanceFloat32, 0, this._quadIndex * wordsPerInstance);
     vao.drawInstanced(4, 0, this._quadIndex, RenderingPrimitives.TriangleStrip);
     backend.stats.batches++;
     backend.stats.drawCalls++;

--- a/src/rendering/webgl2/WebGl2PersistentSlotStore.ts
+++ b/src/rendering/webgl2/WebGl2PersistentSlotStore.ts
@@ -339,15 +339,18 @@ export class WebGl2PersistentSlotStore implements PersistentSlotBundle {
 
     this._order.set(order.subarray(0, count));
 
-    const view = this._order.subarray(0, Math.max(1, count));
+    // At least one element: a zero-length store is not a valid buffer.
+    const uploadCount = Math.max(1, count);
 
     if (this._orderBuffer === null) {
-      this._orderBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, view, BufferUsage.DynamicDraw).connect(
+      // Only the constructor still needs a narrowed view — it sizes the initial
+      // store from what it is handed and takes no element count.
+      this._orderBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, this._order.subarray(0, uploadCount), BufferUsage.DynamicDraw).connect(
         createRuntime(gl),
         this._accountant ?? undefined,
       );
     } else {
-      this._orderBuffer.upload(view);
+      this._orderBuffer.upload(this._order, 0, uploadCount);
     }
 
     return this._orderBuffer;

--- a/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
@@ -327,8 +327,12 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
   private _geoVao: WebGl2VertexArrayObject | null = null;
   private _geoQuadCount = 0;
 
-  // Sampler cache keyed by "wrapS:wrapT:scaleMode"
-  private _samplers = new Map<string, WebGLSampler>();
+  /**
+   * Sampler cache keyed by wrapS/wrapT/scaleMode packed into one number. A
+   * template-string key would be rebuilt on every shader-path flush — measured
+   * at ~146 B per flush, which a blend-churn frame pays once per sprite.
+   */
+  private _samplers = new Map<number, WebGLSampler>();
 
   // Shared batch state
   private _maxNodeIndex = 0;
@@ -609,12 +613,12 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     gl.bindSampler(0, samplerHandle);
 
     backend.bindTransformBufferTexture(transformTextureUnit, this._maxNodeIndex + 1);
-    this._shaderPathShader.getUniform('u_texture').setValue(new Int32Array([0]));
+    this._shaderPathShader.getUniform('u_texture').setValue(this._textureUnitScratch);
     this._shaderPathShader.getUniform('u_transforms').setValue(this._transformUnitScratch);
     this._shaderPathShader.sync();
 
     backend.bindVertexArrayObject(vao);
-    buf.upload(this._shaderF32.subarray(0, this._shaderQuadCount * shaderWordsPerInstance));
+    buf.upload(this._shaderF32, 0, this._shaderQuadCount * shaderWordsPerInstance);
     vao.drawInstanced(4, 0, this._shaderQuadCount, RenderingPrimitives.TriangleStrip);
 
     backend.stats.batches++;
@@ -634,12 +638,12 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     if (!conn || !buf || !vao || this._geoQuadCount === 0) return;
 
     backend.bindTransformBufferTexture(transformTextureUnit, this._maxNodeIndex + 1);
-    this._geoPathShader.getUniform('u_texture').setValue(new Int32Array([0]));
+    this._geoPathShader.getUniform('u_texture').setValue(this._textureUnitScratch);
     this._geoPathShader.getUniform('u_transforms').setValue(this._transformUnitScratch);
     this._geoPathShader.sync();
 
     backend.bindVertexArrayObject(vao);
-    buf.upload(this._geoF32.subarray(0, this._geoQuadCount * geoWordsPerInstance));
+    buf.upload(this._geoF32, 0, this._geoQuadCount * geoWordsPerInstance);
     vao.drawInstanced(4, 0, this._geoQuadCount, RenderingPrimitives.TriangleStrip);
 
     backend.stats.batches++;
@@ -809,7 +813,9 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
   }
 
   private _getOrCreateSampler(gl: WebGL2RenderingContext, wrapS: WrapModes, wrapT: WrapModes, scaleMode: ScaleModes): WebGLSampler {
-    const key = `${wrapS}:${wrapT}:${scaleMode}`;
+    // Exact, allocation-free key: every wrap and scale mode is a GL enum well
+    // below 0x10000, so three of them pack into one integer below 2^53.
+    const key = (wrapS * 0x10000 + wrapT) * 0x10000 + scaleMode;
     const existing = this._samplers.get(key);
     if (existing !== undefined) return existing;
 

--- a/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
+++ b/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
@@ -416,16 +416,20 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
       throw new Error('WebGl2RetainedGroupResources: device not connected before instance upload.');
     }
 
-    const view = this._instanceFloats.subarray(0, this._usedWords);
-
     if (this._instanceBuffer === null) {
-      this._instanceBuffer = new WebGl2RenderBuffer(BufferTypes.ArrayBuffer, view, BufferUsage.DynamicDraw).connect(
-        this._createBufferRuntime(this._gl),
-        this._accountant ?? undefined,
-      );
-    } else {
-      this._instanceBuffer.upload(view);
+      // Only the constructor still needs a narrowed view: it sizes the initial
+      // GPU store from what it is handed and takes no element count. That runs
+      // once per group; every later upload states the range instead.
+      this._instanceBuffer = new WebGl2RenderBuffer(
+        BufferTypes.ArrayBuffer,
+        this._instanceFloats.subarray(0, this._usedWords),
+        BufferUsage.DynamicDraw,
+      ).connect(this._createBufferRuntime(this._gl), this._accountant ?? undefined);
+
+      return;
     }
+
+    this._instanceBuffer.upload(this._instanceFloats, 0, this._usedWords);
   }
 
   /**

--- a/src/rendering/webgl2/WebGl2SpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2SpriteRenderer.ts
@@ -388,7 +388,7 @@ export class WebGl2SpriteRenderer extends AbstractWebGl2Renderer<Sprite> impleme
 
     shader.sync();
     backend.bindVertexArrayObject(vao);
-    instanceBuffer.upload(this._instanceFloat32.subarray(0, this._instanceCount * wordsPerInstance));
+    instanceBuffer.upload(this._instanceFloat32, 0, this._instanceCount * wordsPerInstance);
     this._bindBaseTextureSamplers(backend, material, this._slotCount);
     vao.drawInstanced(4, 0, this._instanceCount, RenderingPrimitives.TriangleStrip);
     this._unbindBaseTextureSamplers(backend, material, this._slotCount);

--- a/src/rendering/webgl2/WebGl2StencilClipper.ts
+++ b/src/rendering/webgl2/WebGl2StencilClipper.ts
@@ -39,6 +39,8 @@ export class WebGl2StencilClipper {
   private readonly _shader: Shader = new Shader(vertexSource, fragmentSource);
   private readonly _matrix: Matrix = new Matrix();
   private _positions: Float32Array = new Float32Array(64);
+  private _view: DataView | null = null;
+  private _viewSource: Float32Array | ArrayBuffer | null = null;
   private _connection: StencilClipperConnection | null = null;
 
   public connect(backend: WebGl2Backend): void {
@@ -78,6 +80,10 @@ export class WebGl2StencilClipper {
     connection.vao.destroy();
     this._shader.disconnect();
     this._connection = null;
+    // Drop the memoised view so a disconnected clipper holds no clip shape's
+    // vertex data alive.
+    this._view = null;
+    this._viewSource = null;
   }
 
   /**
@@ -105,7 +111,7 @@ export class WebGl2StencilClipper {
     this._shader.sync();
 
     backend.bindVertexArrayObject(connection.vao);
-    connection.vertexBuffer.upload(this._positions.subarray(0, vertexCount * 2));
+    connection.vertexBuffer.upload(this._positions, 0, vertexCount * 2);
 
     const mode = shape.topology === 'triangle-strip' ? RenderingPrimitives.TriangleStrip : RenderingPrimitives.Triangles;
 
@@ -122,7 +128,7 @@ export class WebGl2StencilClipper {
     }
 
     const { stride, vertexData, indices } = shape;
-    const view = vertexData instanceof Float32Array ? new DataView(vertexData.buffer, vertexData.byteOffset, vertexData.byteLength) : new DataView(vertexData);
+    const view = this._viewOf(vertexData);
     const drawCount = indices !== null ? indices.length : shape.vertexCount;
 
     this._ensureCapacity(drawCount);
@@ -139,6 +145,22 @@ export class WebGl2StencilClipper {
     }
 
     return drawCount;
+  }
+
+  /**
+   * A `DataView` over `vertexData`, memoised on the source it was built from.
+   * A clip shape is drawn twice per clipped scope per frame (push and pop) and
+   * its vertex data is the same object every time, so building a fresh view per
+   * draw was ~30 B per clipper draw for nothing.
+   */
+  private _viewOf(vertexData: Float32Array | ArrayBuffer): DataView {
+    if (this._viewSource !== vertexData || this._view === null) {
+      this._viewSource = vertexData;
+      this._view =
+        vertexData instanceof Float32Array ? new DataView(vertexData.buffer, vertexData.byteOffset, vertexData.byteLength) : new DataView(vertexData);
+    }
+
+    return this._view;
   }
 
   private _resolvePositionAttribute(attributes: readonly GeometryAttribute[]): GeometryAttribute {

--- a/src/rendering/webgl2/WebGl2TextRenderer.ts
+++ b/src/rendering/webgl2/WebGl2TextRenderer.ts
@@ -462,7 +462,11 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
       nodeCount,
       gl.RGBA,
       gl.FLOAT,
-      this._nodeDataArray.subarray(0, nodeCount * nodeFloats),
+      // `(srcData, srcOffset)`: the rectangle above already fixes how much is
+      // read (`nodeTexels * nodeCount` texels from element 0), so narrowing the
+      // array with a `subarray()` view per flush would only allocate.
+      this._nodeDataArray,
+      0,
     );
   }
 
@@ -581,8 +585,8 @@ export class WebGl2TextRenderer extends AbstractWebGl2Renderer<Text | BitmapText
 
       batchCount++;
 
-      c.vertexBuffer.upload(this._float32View.subarray(0, totalVerts * vertexStrideWords));
-      c.indexBuffer.upload(this._indexData.subarray(0, totalIndices));
+      c.vertexBuffer.upload(this._float32View, 0, totalVerts * vertexStrideWords);
+      c.indexBuffer.upload(this._indexData, 0, totalIndices);
 
       backend.bindVertexArrayObject(c.vao);
       for (let slot = 0; slot < atlasTextures.length; slot++) {

--- a/test/rendering/browser/webgl2-data-texture-partial-upload.test.ts
+++ b/test/rendering/browser/webgl2-data-texture-partial-upload.test.ts
@@ -93,6 +93,41 @@ describe('WebGL2 uploads a partial DataTexture region', () => {
     }
   });
 
+  test('a wide inset region packs through the native row copy', async () => {
+    const backend = await createWebGl2TestBackend(CANVAS);
+    const root = new Container();
+    const texture = makeTexture();
+
+    root.addChild(new Sprite(texture));
+
+    try {
+      renderWebGl2Once(backend, root, Color.black);
+
+      // 20 rgba8 texels = 80 channels per row, past the width at which the
+      // packing loop switches from element-wise copying to `set(subarray(…))`.
+      // The narrow case above stays on the element-wise side, so the two tests
+      // together cover both branches of that switch.
+      paintRect(texture, 4, 6, 20, 5, BLUE);
+      texture.commitRect(4, 6, 20, 5);
+
+      renderWebGl2Once(backend, root, Color.black);
+
+      const frame = readWebGl2Frame(backend, CANVAS);
+
+      expect(pixelAt(frame, 4, 6)).toEqual([...BLUE]);
+      expect(pixelAt(frame, 23, 10)).toEqual([...BLUE]);
+      expect(pixelAt(frame, 14, 8)).toEqual([...BLUE]);
+      // One texel outside the region on every side stayed red.
+      expect(pixelAt(frame, 3, 8)).toEqual([...RED]);
+      expect(pixelAt(frame, 24, 8)).toEqual([...RED]);
+      expect(pixelAt(frame, 14, 5)).toEqual([...RED]);
+      expect(pixelAt(frame, 14, 11)).toEqual([...RED]);
+    } finally {
+      root.destroy();
+      backend.destroy();
+    }
+  });
+
   test('a full-width band of rows uploads the same bytes as an inset region would', async () => {
     const backend = await createWebGl2TestBackend(CANVAS);
     const root = new Container();

--- a/test/rendering/webgl2-partial-upload-contiguous.test.ts
+++ b/test/rendering/webgl2-partial-upload-contiguous.test.ts
@@ -131,9 +131,14 @@ describe('WebGL2 partial DataTexture upload: full-width fast path', () => {
     const [packed] = harness.calls;
 
     expect(packed).toBeDefined();
-    expect(packed).toHaveLength(9);
+    // Packed into the per-texture scratch, which is at least the region's size
+    // and handed to GL through the same `(srcData, srcOffset)` overload — the
+    // rectangle's dimensions fix how much is read, so the scratch never has to
+    // be narrowed to an exact-length view.
+    expect(packed).toHaveLength(10);
     expect(packed![8]).not.toBe(texture.buffer);
-    expect((packed![8] as Float32Array).length).toBe(7 * 8);
+    expect((packed![8] as Float32Array).length).toBeGreaterThanOrEqual(7 * 8);
+    expect(packed![9]).toBe(0);
 
     texture.destroy();
   });
@@ -153,7 +158,10 @@ describe('WebGL2 partial DataTexture upload: full-width fast path', () => {
 
     const [packed] = harness.calls;
 
-    expect(Array.from(packed![8] as Uint8Array)).toEqual([5, 6, 9, 10]);
+    // Only the region's own elements are read (2x2 from offset 0); whatever the
+    // scratch holds past them is never uploaded.
+    expect(Array.from((packed![8] as Uint8Array).subarray(0, 4))).toEqual([5, 6, 9, 10]);
+    expect(packed![9]).toBe(0);
 
     texture.destroy();
   });


### PR DESCRIPTION
Closes the per-flush half of the render-allocation audit's upload-view item, and
one allocation found while measuring it that turned out to dwarf it.

## Per-flush upload views

Every WebGL2 renderer that fills a prefix of a grown-once scratch array still
expressed the upload length by materializing `data.subarray(0, used)` — one
throwaway view per flush per buffer. Invisible on a scene that flushes once, the
largest single site on one that flushes per drawable: on a 1000-sprite filtered
scene (3000 flushes) the sprite renderer's single view cost 305 KB/frame.

They now use the range overload the buffer already carries
(`upload(data, offset, elementCount)`) — same GPU bytes, same store size, same
accounted traffic. Converted: sprite, nine-slice, repeating (both paths), text
(vertex, index, and the node-data texture upload via the `(srcData, srcOffset)`
texture overload), stencil clipper, the batched-renderer base, the retained
group's instance store, the persistent slot store, plus the tilemap and particle
package renderers.

Kept, with reasons: retained RECORDING views hand a snapshot to a capture and
only run while a capture window is open; two constructor calls size the initial
store from what they are handed and take no element count, once per buffer.

Three per-flush allocations next to those uploads go with them: a
`new Int32Array([0])` rebuilt per repeating flush although the field exists, the
sampler cache's `"wrapS:wrapT:scaleMode"` string key (~146 B per flush, now one
packed integer), and a fresh `DataView` per stencil-clipper draw.

## Closures the texture sync never creates

`_getTextureState` builds its eviction handlers as closures over `texture`, and
V8 allocates the scope backing them on ENTRY, not when the miss branch is taken.
Every cache hit paid ~45 bytes for closures it never created — once per bound
texture per draw. Splitting the creation half out removes it;
`_getRenderTargetState` had the same shape and gets the same split.

The bytes are real, not a profiler artefact: with a 1 MB semi-space the same
scene runs 52.0 scavenges/s against 2.7 with the miss branch moved out.

## Rectangular texture packing

The packing path a partial glyph-atlas update takes allocated a view per ROW
plus one to narrow the scratch. The scratch view is unnecessary outright — the
`(srcData, srcOffset)` overload reads exactly the rectangle's worth. The row
views are a trade, decided per row length by measurement: 8x8 rows cost 74 ns as
an element loop against 421 ns via `set`, 32x32 rows 1.20 vs 1.66 us, flipping
at 48–64 to 4.5 vs 3.9 us at 64x64 and 10.5 vs 6.0 us at 96x96. Rows up to the
threshold copy element-wise (faster AND allocation-free), wider rows keep the
native copy. The Chromium lane covers both sides.

## Measured

Per-frame allocation, one sampling window per process — several scenes in one
process contaminate the later ones, which is how an earlier pass came to
attribute ~700 KB/frame to a texture-sync path that uploads nothing at all.

| scene | before | after |
| --- | ---: | ---: |
| blend/1000 alternating | 109.8 | 2.4 KB/f |
| blend/25000 alternating | 3524 | 978 KB/f |
| blend/1000 plateau64 | 9.6 | 3.8 KB/f |
| filtered/100 | 686.3 | 458.1 KB/f |
| filtered/1000 | 6776 | 4479 KB/f |
| repeating shader churn/200 | 191.1 | 87.6 KB/f |
| nine-slice churn/200 | 22.1 | 3.2 KB/f |
| repeating geometry churn/200 | 22.1 | 3.3 KB/f |
| stencil clip/200 | 120.6 | 89.2 KB/f |
| mesh/5000 | 166.3 | 155.0 KB/f |

CPU submission time is unchanged or better everywhere: filtered/1000 45.8 ->
37.3 ms median, mesh/5000 18.4 -> 15.7 ms, stencil clip/200 0.96 -> 0.82 ms.

Allocation gate budgets are deliberately untouched; they are rebaselined as a
whole once the remaining audit items land.

## Verification

`pnpm verify:quick` (12/12), `pnpm test` (9827), `--project=rendering-perf`
(106), full WebGL2 Chromium lane (307), full WebGPU lane (351 + the known
`webgpu-video` decode timeout, identical signature, green in isolation; no
WebGPU code is touched here), parity (110), `pnpm size`, `git diff --check`.

https://claude.ai/code/session_01KQKgUaCnC2acS9TUQ1suGv
