### PR TITLE
perf(rendering): preserve pooled array capacity across frames

### DIFF
--- a/packages/exojs-tilemap/test/ImageLayerNode.test.ts
+++ b/packages/exojs-tilemap/test/ImageLayerNode.test.ts
@@ -35,7 +35,8 @@ function makeLayer(opts: Partial<ImageLayerOptions> = {}): ImageLayer {
  *  - `view.updateId`       — the retained-plan revision key,
  *  - `_isViewCullSuppressed: true` — makes the child `_collect` skip the
  *    `inView` frustum test and go straight to `emitNode` (no cull machinery),
- *  - `emitNode` / `_peekCurrentScopeEntries` — the no-slot capture bookkeeping,
+ *  - `emitNode` / `_peekCurrentScopeEntries` + `_peekCurrentScopeEntryCount` — the
+ *    no-slot capture bookkeeping,
  *  - `backend`             — stored verbatim by the retained-plan cache commit.
  */
 function mockBuilder(options: {
@@ -55,6 +56,7 @@ function mockBuilder(options: {
     },
     emitNode(): void {},
     _peekCurrentScopeEntries: (): readonly unknown[] => [],
+    _peekCurrentScopeEntryCount: (): number => 0,
   };
 }
 

--- a/src/rendering/Container.ts
+++ b/src/rendering/Container.ts
@@ -517,13 +517,14 @@ export class Container extends RenderNode {
    */
   private _replayRetainedChildren(builder: RenderPlanBuilder): void {
     // Non-null: only called from the isClean-guarded fast path above.
-    const slots = this._retainedPlan!.slots;
+    const cache = this._retainedPlan!;
+    const slotCount = cache.slotCount;
     let slotIndex = 0;
 
     for (let index = 0; index < this._childList.length; index++) {
-      const slot = slots[slotIndex];
+      const slot = slotIndex < slotCount ? cache.slotAt(slotIndex) : null;
 
-      if (slot?.childIndex === index) {
+      if (slot !== null && slot.childIndex === index) {
         builder._replayRetainedDraw(slot);
         slotIndex++;
       } else {
@@ -563,14 +564,16 @@ export class Container extends RenderNode {
 
       sawSlotCandidate = true;
 
-      const beforeCount = builder._peekCurrentScopeEntries().length;
+      // The scope is still open, so its entry COUNT is the collected length —
+      // the array itself may run past it (see `_peekCurrentScopeEntries`).
+      const beforeCount = builder._peekCurrentScopeEntryCount();
 
       child._collect(builder, index);
 
-      const entries = builder._peekCurrentScopeEntries();
+      const afterCount = builder._peekCurrentScopeEntryCount();
 
-      if (entries.length === beforeCount + 1) {
-        const entry = entries[entries.length - 1]!;
+      if (afterCount === beforeCount + 1) {
+        const entry = builder._peekCurrentScopeEntries()[afterCount - 1]!;
 
         if (entry.kind === RenderEntryKind.Draw && entry.command.drawable === child) {
           (this._retainedPlan ??= new RetainedPlanCache())._appendSlot(index, entry.command);

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -303,7 +303,7 @@ export class RetainedContainer extends Container {
       // keys. The key deliberately omits View.updateId (group-level culling
       // makes the fragment view-independent — the camera-pan win) and the
       // container's own transform (a move only changes the group matrix).
-      builder._replayRetainedFragment(this._fragment.entries);
+      builder._replayRetainedFragment(this._fragment.entries, this._fragment.entryCount);
       this._fragment.markReplayed();
       // Record-on-first-clean-frame: this clean playback
       // is the recording source; the player captures it if the backend
@@ -337,7 +337,13 @@ export class RetainedContainer extends Container {
     }
 
     if (!suppressCapture) {
-      this._fragment.capture(this._contentRevision, this._structureRevision, builder.backend, builder._peekCurrentScopeEntries());
+      this._fragment.capture(
+        this._contentRevision,
+        this._structureRevision,
+        builder.backend,
+        builder._peekCurrentScopeEntries(),
+        builder._peekCurrentScopeEntryCount(),
+      );
     }
   }
 

--- a/src/rendering/plan/RenderPlan.ts
+++ b/src/rendering/plan/RenderPlan.ts
@@ -24,8 +24,47 @@ export class MutableRenderPlan implements RenderPlan {
   public readonly passes: RenderPassScope[] = [];
   public nodeCount = 0;
 
+  /**
+   * Reset the counters a build starts from. The pass list is deliberately NOT
+   * emptied here: `RenderPlanBuilder.build` republishes it through
+   * {@link setSinglePass} once it knows whether the collect produced anything,
+   * and emptying it first would drop the pooled pass record — and the array's
+   * backing store with it — on every single frame.
+   */
   public reset(): void {
-    this.passes.length = 0;
     this.nodeCount = 0;
+  }
+
+  /**
+   * Publish this build's one pass, or no pass at all when `view` is `null`
+   * (a collect that produced no entries). The pass record is reused across
+   * frames; consumers read `passes` right after the build that filled it and
+   * never hold it across another one.
+   */
+  public setSinglePass(view: View | null, root: GroupScope): void {
+    if (view === null) {
+      if (this.passes.length !== 0) {
+        this.passes.length = 0;
+      }
+
+      return;
+    }
+
+    const pass = this.passes[0];
+
+    if (pass === undefined) {
+      this.passes.push({ target: null, view, clearColor: null, root });
+
+      return;
+    }
+
+    pass.target = null;
+    pass.view = view;
+    pass.clearColor = null;
+    pass.root = root;
+
+    if (this.passes.length !== 1) {
+      this.passes.length = 1;
+    }
   }
 }

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -75,6 +75,20 @@ const RETAINED_CULL_MARGIN_RATIO = 1 / 16;
 
 interface MutableGroupScope extends GroupScope, EntryPlacementState {
   /**
+   * How many of {@link GroupScope.entries} this collect has filled. Live only
+   * while the scope is on the stack: {@link RenderPlanBuilder._popScope} trims
+   * the array to it, so every consumer downstream of the collect still reads a
+   * scope whose physical length IS its entry count.
+   *
+   * The indirection exists because the alternative — emptying the array at
+   * acquire and pushing back into it — hands the backing store to the GC once
+   * per scope per frame and re-grows it through the whole doubling sequence on
+   * the refill, at ~27 bytes per entry per frame (28.6 KB/frame on a
+   * 1000-entry fragment replay). Overwriting the slots the scope already owns
+   * costs nothing in steady state.
+   */
+  entryCount: number;
+  /**
    * First-draw material of this scope, the `hasMixedPipeline` counterpart of
    * {@link MutableGroupScope.firstZ}. `firstPipelineKey === null` means "no draw
    * seen yet"; `firstBindKey`/`firstOwnMaterial` are only meaningful once it is
@@ -110,29 +124,63 @@ const groupEscapeEffect: EffectDescriptor = Object.freeze({
   needsBackdropBlend: false,
 });
 
+/**
+ * Append `entry` at the scope's logical end, reusing the slot the previous
+ * collect left there when the array is already that long. See
+ * {@link MutableGroupScope.entryCount} for why the array is not emptied and
+ * re-pushed instead.
+ */
+const appendScopeEntry = (scope: MutableGroupScope, entry: ScopeEntry): void => {
+  const index = scope.entryCount++;
+
+  if (index < scope.entries.length) {
+    scope.entries[index] = entry;
+  } else {
+    scope.entries.push(entry);
+  }
+};
+
 /** @internal */
 export class RenderPlanBuilder {
+  /**
+   * Free list of released builders, held with an explicit logical length: the
+   * acquire/release pair runs once per `render()` call, and draining the array
+   * physically would hand its backing store back and re-grow it on the very
+   * next release.
+   */
   private static readonly _available: RenderPlanBuilder[] = [];
-  private static readonly _active: RenderPlanBuilder[] = [];
+  private static _availableCount = 0;
+
+  /**
+   * Whether this builder is checked out. A flag rather than an `_active` list:
+   * the list was never read except to answer this one question, and answering it
+   * per builder costs nothing to maintain.
+   */
+  private _checkedOut = false;
 
   public static acquire(): RenderPlanBuilder {
-    const builder = RenderPlanBuilder._available.pop() ?? new RenderPlanBuilder();
+    const builder = RenderPlanBuilder._availableCount > 0 ? RenderPlanBuilder._available[--RenderPlanBuilder._availableCount]! : new RenderPlanBuilder();
 
-    RenderPlanBuilder._active.push(builder);
+    builder._checkedOut = true;
 
     return builder;
   }
 
   public static release(builder: RenderPlanBuilder): void {
-    const index = RenderPlanBuilder._active.lastIndexOf(builder);
-
-    if (index === -1) {
+    if (!builder._checkedOut) {
       return;
     }
 
-    RenderPlanBuilder._active.splice(index, 1);
+    builder._checkedOut = false;
     builder._resetRuntimeState();
-    RenderPlanBuilder._available.push(builder);
+
+    const index = RenderPlanBuilder._availableCount++;
+
+    if (index < RenderPlanBuilder._available.length) {
+      RenderPlanBuilder._available[index] = builder;
+    } else {
+      RenderPlanBuilder._available.push(builder);
+    }
   }
 
   public backend!: RenderBackend;
@@ -140,7 +188,14 @@ export class RenderPlanBuilder {
 
   private readonly _plan = new MutableRenderPlan();
   private readonly _groupPool: MutableGroupScope[] = [];
+  /**
+   * Open scopes, innermost last, with {@link _scopeDepth} as the cursor. Held
+   * that way rather than push/pop-drained for the same reason as every other
+   * per-frame store here: the array outlives the frame and its slots are
+   * overwritten, so no frame pays to re-grow it.
+   */
   private readonly _scopeStack: MutableGroupScope[] = [];
+  private _scopeDepth = 0;
   private _groupPoolCursor = 0;
 
   // Frame-persistent free-lists. Each lives on the builder INSTANCE
@@ -239,7 +294,7 @@ export class RenderPlanBuilder {
     this._drawEntryPoolCursor = 0;
     this._groupEntryPoolCursor = 0;
     this._barrierEntryPoolCursor = 0;
-    this._scopeStack.length = 0;
+    this._drainScopeStack();
     this._hasPending = false;
     this._viewCullSuppression = 0;
     this._retentionRoot = root._supportsRootRetention() ? root : null;
@@ -265,18 +320,11 @@ export class RenderPlanBuilder {
 
     const rootScope = this._acquireGroupScope(false);
 
-    this._scopeStack.push(rootScope);
+    this._pushScope(rootScope);
     root._collect(this);
-    this._scopeStack.pop();
+    this._popScope();
 
-    if (rootScope.entries.length > 0) {
-      this._plan.passes.push({
-        target: null,
-        view: this._viewUnobserved(),
-        clearColor: null,
-        root: rootScope,
-      });
-    }
+    this._plan.setSinglePass(rootScope.entries.length > 0 ? this._viewUnobserved() : null, rootScope);
 
     this._plan.nodeCount = this._nodeIndex - frameBase;
 
@@ -383,12 +431,12 @@ export class RenderPlanBuilder {
       this._pushBarrierEntry(reservedSeq, reservedZ, barrierScope);
 
       if (childPlan !== null) {
-        this._scopeStack.push(childPlan);
+        this._pushScope(childPlan);
 
         try {
           node._collectForRenderPlan(this);
         } finally {
-          this._scopeStack.pop();
+          this._popScope();
         }
       }
 
@@ -419,12 +467,12 @@ export class RenderPlanBuilder {
       };
 
       this._pushBarrierEntry(reservedSeq, reservedZ, barrierScope);
-      this._scopeStack.push(childPlan);
+      this._pushScope(childPlan);
 
       try {
         this.emitNode(node, seq);
       } finally {
-        this._scopeStack.pop();
+        this._popScope();
       }
 
       return;
@@ -450,7 +498,7 @@ export class RenderPlanBuilder {
 
     this._pushGroupEntry(reservedSeq, reservedZ, groupScope);
 
-    this._scopeStack.push(groupScope);
+    this._pushScope(groupScope);
 
     try {
       if (node === this._retentionRoot) {
@@ -459,7 +507,7 @@ export class RenderPlanBuilder {
         node._collectForRenderPlan(this);
       }
     } finally {
-      this._scopeStack.pop();
+      this._popScope();
     }
   }
 
@@ -832,12 +880,12 @@ export class RenderPlanBuilder {
     const groupScope = this._acquireGroupScope(group.preserveDrawOrder);
 
     this._pushGroupEntry(group.seq, group.zIndex, groupScope);
-    this._scopeStack.push(groupScope);
+    this._pushScope(groupScope);
 
     try {
       this._emitSourceSelection(group, selection, rect);
     } finally {
-      this._scopeStack.pop();
+      this._popScope();
     }
   }
 
@@ -915,7 +963,7 @@ export class RenderPlanBuilder {
         return;
       }
 
-      this._replayRetainedFragment(representation.fragment.entries);
+      this._replayRetainedFragment(representation.fragment.entries, representation.fragment.entryCount);
       representation.markReplayed();
       // Record-on-first-clean-frame: this clean playback is the recording
       // source, so the record cost never lands on a frame whose capture is
@@ -967,7 +1015,17 @@ export class RenderPlanBuilder {
       this._captureCullActive = false;
     }
 
-    representation.commitCapture(contentRevision, structureRevision, transformRevision, ancestryStamp, view, backend, target, this._peekCurrentScopeEntries());
+    representation.commitCapture(
+      contentRevision,
+      structureRevision,
+      transformRevision,
+      ancestryStamp,
+      view,
+      backend,
+      target,
+      this._peekCurrentScopeEntries(),
+      this._peekCurrentScopeEntryCount(),
+    );
   }
 
   /**
@@ -1251,13 +1309,23 @@ export class RenderPlanBuilder {
   }
 
   /**
-   * @internal — the entries pushed into the currently-active scope so far this
-   * collect. Read-only peek used by {@link RetainedPlanCache} to snapshot a
-   * container's direct-drawable fragment right after a full (non-skipped)
-   * collect of it.
+   * @internal — the entry array of the currently-active scope. Read-only peek
+   * used by {@link RetainedPlanCache} to snapshot a container's direct-drawable
+   * fragment right after a full (non-skipped) collect of it.
+   *
+   * Valid only up to {@link _peekCurrentScopeEntryCount}: while a scope is still
+   * open its array may run past the entries THIS collect filled, holding
+   * whatever the previous frame left in those slots (see
+   * {@link MutableGroupScope.entryCount}). Reading `entries.length` here instead
+   * of the count would snapshot a stale entry as if it had just been collected.
    */
   public _peekCurrentScopeEntries(): readonly ScopeEntry[] {
     return this._currentScope().entries;
+  }
+
+  /** @internal — how many entries the currently-active scope holds so far this collect. */
+  public _peekCurrentScopeEntryCount(): number {
+    return this._currentScope().entryCount;
   }
 
   /**
@@ -1403,8 +1471,10 @@ export class RenderPlanBuilder {
    * groups re-acquire pooled scopes, and barrier nodes re-dispatch through a
    * normal `_collect`.
    */
-  public _replayRetainedFragment(entries: readonly RetainedFragmentEntry[]): void {
-    for (const entry of entries) {
+  public _replayRetainedFragment(entries: readonly RetainedFragmentEntry[], entryCount = entries.length): void {
+    for (let index = 0; index < entryCount; index++) {
+      const entry = entries[index]!;
+
       if (entry.kind === RenderEntryKind.Draw) {
         this._replayRetainedDraw(entry);
       } else if (entry.kind === RenderEntryKind.Group) {
@@ -1453,17 +1523,17 @@ export class RenderPlanBuilder {
     }
 
     this._pushGroupEntry(fragment.seq, fragment.zIndex, groupScope);
-    this._scopeStack.push(groupScope);
+    this._pushScope(groupScope);
 
     try {
-      this._replayRetainedFragment(fragment.entries);
+      this._replayRetainedFragment(fragment.entries, fragment.entryCount);
     } finally {
-      this._scopeStack.pop();
+      this._popScope();
     }
   }
 
   private _resetRuntimeState(): void {
-    this._scopeStack.length = 0;
+    this._drainScopeStack();
     this._hasPending = false;
     this._groupPoolCursor = 0;
     this._commandPoolCursor = 0;
@@ -1480,13 +1550,36 @@ export class RenderPlanBuilder {
     // build and make it live forever.
     this._sourceStack.length = 0;
     this._sourceProducer = null;
-    this._sourceViewReaders.clear();
+
+    // `Set.clear()` installs a fresh backing table, so an unconditional clear
+    // allocates once per frame for a set that is empty on every frame that
+    // discovered no source.
+    if (this._sourceViewReaders.size > 0) {
+      this._sourceViewReaders.clear();
+    }
+  }
+
+  /**
+   * Empty the scope stack without discarding its backing store.
+   *
+   * `length = 0` is not the same thing: V8 trims an array's backing store to
+   * its new length, and it does so against the CAPACITY rather than the current
+   * length — so the assignment gives the store back even on a stack that is
+   * already empty, and the next push re-grows it. Popping leaves the store
+   * alone. The loop also runs the per-scope trim `_popScope` owes each scope an
+   * exception unwind may have left open.
+   */
+  private _drainScopeStack(): void {
+    while (this._scopeDepth > 0) {
+      this._popScope();
+    }
   }
 
   private _acquireGroupScope(preserveDrawOrder: boolean): MutableGroupScope {
     const scope = this._groupPool[this._groupPoolCursor] ?? {
       kind: RenderEntryKind.Group,
       entries: [],
+      entryCount: 0,
       hasMixedZ: false,
       hasMixedPipeline: false,
       preserveDrawOrder: false,
@@ -1504,7 +1597,7 @@ export class RenderPlanBuilder {
     this._groupPool[this._groupPoolCursor] = scope;
     this._groupPoolCursor++;
 
-    scope.entries.length = 0;
+    scope.entryCount = 0;
     scope.hasMixedZ = false;
     scope.hasMixedPipeline = false;
     scope.preserveDrawOrder = preserveDrawOrder;
@@ -1587,7 +1680,7 @@ export class RenderPlanBuilder {
     const scope = this._currentScope();
 
     this._foldMaterialIntoScope(scope, command);
-    scope.entries.push(entry);
+    appendScopeEntry(scope, entry);
   }
 
   private _pushGroupEntry(seq: number, zIndex: number, scope: GroupScope): void {
@@ -1603,7 +1696,7 @@ export class RenderPlanBuilder {
     }
 
     this._groupEntryPoolCursor++;
-    this._currentScope().entries.push(entry);
+    appendScopeEntry(this._currentScope(), entry);
   }
 
   private _pushBarrierEntry(seq: number, zIndex: number, scope: BarrierScope): void {
@@ -1619,7 +1712,7 @@ export class RenderPlanBuilder {
     }
 
     this._barrierEntryPoolCursor++;
-    this._currentScope().entries.push(entry);
+    appendScopeEntry(this._currentScope(), entry);
   }
 
   private _reserveEntryPlacement(seq: number | undefined, zIndex: number): void {
@@ -1642,8 +1735,41 @@ export class RenderPlanBuilder {
     return this._sourceStack[this._sourceStack.length - 1] ?? this._currentScope();
   }
 
+  /**
+   * Close the innermost scope: trim its entry array to what this collect
+   * actually filled, so everything downstream — the optimizer's z-sort, the
+   * player's walk, a fragment snapshot — reads a scope whose length is its
+   * entry count and never sees a slot left over from an earlier frame.
+   *
+   * The trim is the ONE place the array may shrink, and it only shrinks to the
+   * count this frame reached; the steady state where the count is unchanged
+   * does nothing at all.
+   */
+  private _popScope(): void {
+    if (this._scopeDepth === 0) {
+      return;
+    }
+
+    const scope = this._scopeStack[--this._scopeDepth]!;
+
+    if (scope.entries.length !== scope.entryCount) {
+      scope.entries.length = scope.entryCount;
+    }
+  }
+
+  /** Open `scope`, reusing the stack slot at this depth when one already exists. */
+  private _pushScope(scope: MutableGroupScope): void {
+    const depth = this._scopeDepth++;
+
+    if (depth < this._scopeStack.length) {
+      this._scopeStack[depth] = scope;
+    } else {
+      this._scopeStack.push(scope);
+    }
+  }
+
   private _currentScope(): MutableGroupScope {
-    const scope = this._scopeStack[this._scopeStack.length - 1];
+    const scope = this._scopeDepth > 0 ? this._scopeStack[this._scopeDepth - 1] : undefined;
 
     if (!scope) {
       throw new Error('RenderPlanBuilder scope stack is empty.');

--- a/src/rendering/plan/RetainedGroupFragment.ts
+++ b/src/rendering/plan/RetainedGroupFragment.ts
@@ -43,8 +43,14 @@ export interface RetainedFragmentGroup {
    * for scopes that collected entries normally.
    */
   retainedInstructions: RetainedInstructionSet | null;
-  /** Pooled entry list owned by this record, reset and refilled on recapture. */
+  /**
+   * Pooled entry list owned by this record, rewritten in place on recapture.
+   * Valid up to {@link RetainedFragmentGroup.entryCount} — the array itself may
+   * still hold records a longer earlier capture left behind, which is what keeps
+   * the recapture from re-growing it (see {@link RetainedGroupFragment}).
+   */
   readonly entries: RetainedFragmentEntry[];
+  entryCount: number;
 }
 
 /**
@@ -85,7 +91,16 @@ let nextDirtyRowEpoch = 1;
  * records in place and allocates zero objects.
  */
 export class RetainedGroupFragment {
+  /**
+   * Snapshotted entries, valid up to {@link _entryCount}. Like every other
+   * per-capture store here the array is rewritten rather than emptied: the
+   * records in it are pooled and immortal either way, and emptying would hand
+   * the backing store back and re-grow it on the next capture — ~33 bytes per
+   * entry per capture, which is the whole cost of recapturing a scene whose
+   * content changes every frame.
+   */
   private readonly _entries: RetainedFragmentEntry[] = [];
+  private _entryCount = 0;
   private _contentRevision = -1;
   private _structureRevision = -1;
   private _backend: RenderBackend | null = null;
@@ -128,12 +143,26 @@ export class RetainedGroupFragment {
   private _rowMinIndex = -1;
 
   // Nodes whose OWN transform moved since the last collect, pushed by
-  // the SceneNode seam through the enclosing group. A plain array (not a Set):
-  // `length = 0` on reset retains capacity, so the add-k/reset-per-frame churn
-  // cycle allocates nothing in steady state (unlike Set.clear). Dedup is O(1)
-  // via a per-node epoch stamp keyed on `_dirtyRowEpoch` — a globally unique
-  // value bumped on every reset, so a stale stamp never falsely dedups.
+  // the SceneNode seam through the enclosing group. A plain array (not a Set),
+  // held with an explicit LOGICAL length: the per-frame reset rewinds
+  // `_dirtyRowCount` and leaves the physical array alone, so the next frame
+  // overwrites the slots it already has.
+  //
+  // `length = 0` would be wrong here, not merely different. V8 hands the
+  // backing store back on a shrink to zero, so the refill re-grows from empty
+  // through the whole doubling sequence — measured at ~27 bytes per queued node
+  // per frame, which made this queue the single largest allocation in a scene
+  // where every node moves (28.6 KB/frame at 1000 nodes). Dedup is O(1) via a
+  // per-node epoch stamp keyed on `_dirtyRowEpoch` — a globally unique value
+  // bumped on every reset, so a stale stamp never falsely dedups.
+  //
+  // Slots at or beyond `_dirtyRowCount` keep whatever node they last held.
+  // That retains nothing a live subtree does not already retain, and it cannot
+  // outlive a node's removal: removing a child moves the subtree's structure
+  // revision, and the next build therefore recaptures or invalidates — both of
+  // which drop the references through {@link _dropDirtyTransformRows}.
   private readonly _dirtyTransformRows: RenderNode[] = [];
+  private _dirtyRowCount = 0;
   private _dirtyRowEpoch = nextDirtyRowEpoch++;
 
   /** Snapshot policy for nested transform groups — see {@link _snapshotInto}. */
@@ -200,15 +229,17 @@ export class RetainedGroupFragment {
 
     const map = new Map<Drawable, RetainedFragmentDraw>();
 
-    this._rowMinIndex = this._collectRowsInto(map, this._entries, -1);
+    this._rowMinIndex = this._collectRowsInto(map, this._entries, this._entryCount, -1);
     this._rowMap = map;
   }
 
   /** Fold every draw record (nested groups included) into `map`; returns the running minimum. */
-  private _collectRowsInto(map: Map<Drawable, RetainedFragmentDraw>, entries: readonly RetainedFragmentEntry[], min: number): number {
+  private _collectRowsInto(map: Map<Drawable, RetainedFragmentDraw>, entries: readonly RetainedFragmentEntry[], entryCount: number, min: number): number {
     let currentMin = min;
 
-    for (const entry of entries) {
+    for (let index = 0; index < entryCount; index++) {
+      const entry = entries[index]!;
+
       if (entry.kind === RenderEntryKind.Draw) {
         map.set(entry.drawable, entry);
 
@@ -216,7 +247,7 @@ export class RetainedGroupFragment {
           currentMin = entry.nodeIndex;
         }
       } else if (entry.kind === RenderEntryKind.Group) {
-        currentMin = this._collectRowsInto(map, entry.entries, currentMin);
+        currentMin = this._collectRowsInto(map, entry.entries, entry.entryCount, currentMin);
       }
     }
 
@@ -231,25 +262,49 @@ export class RetainedGroupFragment {
     }
 
     node._dirtyRowStamp = this._dirtyRowEpoch;
-    this._dirtyTransformRows.push(node);
+
+    const index = this._dirtyRowCount++;
+
+    if (index < this._dirtyTransformRows.length) {
+      this._dirtyTransformRows[index] = node;
+    } else {
+      this._dirtyTransformRows.push(node);
+    }
   }
 
   /** `true` when at least one transform-only move is queued for this frame. */
   public hasDirtyTransformRows(): boolean {
-    return this._dirtyTransformRows.length > 0;
+    return this._dirtyRowCount > 0;
   }
 
-  /** The queued moved nodes (insertion order, deduped). */
-  public get dirtyTransformRows(): readonly RenderNode[] {
-    return this._dirtyTransformRows;
+  /** How many moved nodes are queued for this frame. */
+  public get dirtyTransformRowCount(): number {
+    return this._dirtyRowCount;
+  }
+
+  /** Queued moved node `index` (insertion order, deduped); callers hold `index < dirtyTransformRowCount`. */
+  public dirtyTransformRowAt(index: number): RenderNode {
+    return this._dirtyTransformRows[index]!;
   }
 
   /** Drop the queue — after patching them, or after a full re-collect subsumed them. */
   public clearDirtyTransformRows(): void {
-    // length = 0 retains the backing store (no realloc next frame); a fresh
-    // epoch invalidates every prior dedup stamp in O(1).
-    this._dirtyTransformRows.length = 0;
+    // Rewinding the logical length keeps the backing store for the next frame
+    // (see the field comment); a fresh epoch invalidates every prior dedup
+    // stamp in O(1).
+    this._dirtyRowCount = 0;
     this._dirtyRowEpoch = nextDirtyRowEpoch++;
+  }
+
+  /**
+   * Drop the queue AND its references — the structural counterpart of
+   * {@link clearDirtyTransformRows}, for the two paths that follow a change in
+   * what the subtree contains. Keeping the backing store across those would let
+   * a removed node stay reachable through a slot nothing will overwrite again.
+   */
+  private _dropDirtyTransformRows(): void {
+    this._dirtyTransformRows.length = 0;
+    this.clearDirtyTransformRows();
   }
 
   /** The group's instruction set, or `null` if recording was never armed. */
@@ -274,7 +329,7 @@ export class RetainedGroupFragment {
     }
 
     if (this._recordableFor !== backend) {
-      this._recordable = isRetainedFragmentRecordable(this._entries, backend);
+      this._recordable = isRetainedFragmentRecordable(this._entries, this._entryCount, backend);
       this._recordableFor = backend;
     }
 
@@ -315,8 +370,17 @@ export class RetainedGroupFragment {
     return true;
   }
 
+  /**
+   * The captured entries. Valid up to {@link entryCount} — reading past it walks
+   * records an earlier, longer capture left in the array.
+   */
   public get entries(): readonly RetainedFragmentEntry[] {
     return this._entries;
+  }
+
+  /** How many of {@link entries} belong to the current capture. */
+  public get entryCount(): number {
+    return this._entryCount;
   }
 
   public isClean(contentRevision: number, structureRevision: number, backend: RenderBackend): boolean {
@@ -330,12 +394,19 @@ export class RetainedGroupFragment {
    * are recorded as re-dispatch references only (semantics-neutral by
    * construction). Called by {@link RetainedContainer}
    * right after a full collect of its scope.
+   *
+   * `entryCount` is how many of `entries` belong to this capture. It defaults to
+   * the array's own length, which is right for every exact array; a caller
+   * handing over a STILL-OPEN builder scope must pass the scope's entry count
+   * instead, because that array can run past what the collect filled (see
+   * `RenderPlanBuilder._peekCurrentScopeEntries`).
    */
   public capture(
     contentRevision: number,
     structureRevision: number,
     backend: RenderBackend,
     entries: readonly ScopeEntry[],
+    entryCount = entries.length,
     deferTransformGroups = false,
   ): void {
     this._deferTransformGroups = deferTransformGroups;
@@ -345,13 +416,12 @@ export class RetainedGroupFragment {
     this._drawPool.rewind();
     this._groupPool.rewind();
     this._barrierPool.rewind();
-    this._entries.length = 0;
     this._rowMap = null;
     // A full (re)capture reads every child's current transform: any queued
     // transform-only moves are subsumed and must not double-patch afterwards.
-    this.clearDirtyTransformRows();
+    this._dropDirtyTransformRows();
 
-    this._snapshotInto(this._entries, entries);
+    this._entryCount = this._snapshotInto(this._entries, entries, entryCount);
 
     this._contentRevision = contentRevision;
     this._structureRevision = structureRevision;
@@ -369,8 +439,9 @@ export class RetainedGroupFragment {
     releasePooledDrawables(this._drawPool);
     this._hasCapture = false;
     this._entries.length = 0;
+    this._entryCount = 0;
     this._rowMap = null;
-    this.clearDirtyTransformRows();
+    this._dropDirtyTransformRows();
     this._thrash.reset();
     this._recordableFor = null;
     this._instructions?.invalidate();
@@ -385,15 +456,20 @@ export class RetainedGroupFragment {
     this._instructions?.dispose();
   }
 
-  private _snapshotInto(target: RetainedFragmentEntry[], entries: readonly ScopeEntry[]): void {
-    for (const entry of entries) {
+  /** Copy `entryCount` scope entries into `target`, reusing its slots; returns how many it wrote. */
+  private _snapshotInto(target: RetainedFragmentEntry[], entries: readonly ScopeEntry[], entryCount: number): number {
+    let used = 0;
+
+    for (let index = 0; index < entryCount; index++) {
+      const entry = entries[index]!;
+
       if (entry.kind === RenderEntryKind.Draw) {
         const command = entry.command;
         const record = this._drawPool.acquire();
 
         copyRetainedDrawData(record, command);
         record.nodeIndex = command.nodeIndex;
-        target.push(record);
+        used = appendRecord(target, used, record);
       } else if (entry.kind === RenderEntryKind.Group) {
         // A snapshot that DEFERS transform groups (the automatic render-root
         // representation) records a nested boundary as a live re-dispatch
@@ -411,7 +487,7 @@ export class RetainedGroupFragment {
 
           deferred.seq = entry.seq;
           deferred.node = entry.scope.transformNode;
-          target.push(deferred);
+          used = appendRecord(target, used, deferred);
 
           continue;
         }
@@ -424,17 +500,18 @@ export class RetainedGroupFragment {
         record.transformNode = entry.scope.transformNode;
         // ?? null: hand-built test scopes may omit this field.
         record.retainedInstructions = entry.scope.retainedInstructions ?? null;
-        record.entries.length = 0;
-        this._snapshotInto(record.entries, entry.scope.entries);
-        target.push(record);
+        record.entryCount = this._snapshotInto(record.entries, entry.scope.entries, entry.scope.entries.length);
+        used = appendRecord(target, used, record);
       } else {
         const record = this._barrierPool.acquire();
 
         record.seq = entry.seq;
         record.node = entry.scope.node;
-        target.push(record);
+        used = appendRecord(target, used, record);
       }
     }
+
+    return used;
   }
 }
 
@@ -462,7 +539,19 @@ const createFragmentGroup = (): RetainedFragmentGroup => ({
   transformNode: null,
   retainedInstructions: null,
   entries: [],
+  entryCount: 0,
 });
+
+/** Write `record` at `used` in a snapshot array, reusing the slot when it exists. */
+const appendRecord = (target: RetainedFragmentEntry[], used: number, record: RetainedFragmentEntry): number => {
+  if (used < target.length) {
+    target[used] = record;
+  } else {
+    target.push(record);
+  }
+
+  return used + 1;
+};
 
 const createFragmentBarrier = (): RetainedFragmentBarrier => ({
   kind: RenderEntryKind.Barrier,

--- a/src/rendering/plan/RetainedInstructionSet.ts
+++ b/src/rendering/plan/RetainedInstructionSet.ts
@@ -300,24 +300,30 @@ interface BackendWithRendererRegistry {
  * uploaded rows/quads stay view-independent — a snapped draw is fully recordable.
  * @internal
  */
-export const isRetainedFragmentRecordable = (entries: readonly RetainedFragmentEntry[], backend: RenderBackend): boolean => {
+export const isRetainedFragmentRecordable = (entries: readonly RetainedFragmentEntry[], entryCount: number, backend: RenderBackend): boolean => {
   const registry = (backend as BackendWithRendererRegistry).rendererRegistry;
 
   if (!registry || typeof registry.resolve !== 'function') {
     return false;
   }
 
-  return entriesRecordable(entries, registry);
+  return entriesRecordable(entries, entryCount, registry);
 };
 
-const entriesRecordable = (entries: readonly RetainedFragmentEntry[], registry: NonNullable<BackendWithRendererRegistry['rendererRegistry']>): boolean => {
-  for (const entry of entries) {
+const entriesRecordable = (
+  entries: readonly RetainedFragmentEntry[],
+  entryCount: number,
+  registry: NonNullable<BackendWithRendererRegistry['rendererRegistry']>,
+): boolean => {
+  for (let index = 0; index < entryCount; index++) {
+    const entry = entries[index]!;
+
     if (entry.kind === RenderEntryKind.Barrier) {
       return false;
     }
 
     if (entry.kind === RenderEntryKind.Group) {
-      if (!entriesRecordable(entry.entries, registry)) {
+      if (!entriesRecordable(entry.entries, entry.entryCount, registry)) {
         return false;
       }
 

--- a/src/rendering/plan/RetainedPlanCache.ts
+++ b/src/rendering/plan/RetainedPlanCache.ts
@@ -62,9 +62,13 @@ const createSlot = (): MutableRetainedDrawSlot => ({
  * rewritten in place, so steady-state recapture allocates zero slot objects.
  */
 export class RetainedPlanCache {
-  /** Active slot list, reused across captures (pointer pushes only). */
-  private readonly _slots: MutableRetainedDrawSlot[] = [];
-  /** Grow-only record pool; `_slots` holds a cursor-ordered prefix of it. */
+  /**
+   * Grow-only record pool. It IS the slot list: `_appendSlot` acquires in
+   * capture order, so the pool's used prefix is exactly the capture, and a
+   * parallel array of the same records would only add a per-capture refill to
+   * maintain (`length = 0` plus one push per slot, ~34 bytes per slot per
+   * capture on a scene that recaptures every frame).
+   */
   private readonly _slotPool = new RetainedRecordPool(createSlot);
   private _contentRevision = -1;
   private _structureRevision = -1;
@@ -73,8 +77,14 @@ export class RetainedPlanCache {
   private _backend: RenderBackend | null = null;
   private _hasCapture = false;
 
-  public get slots(): readonly RetainedDrawSlot[] {
-    return this._slots;
+  /** How many slots the current capture holds. */
+  public get slotCount(): number {
+    return this._slotPool.used;
+  }
+
+  /** Slot `index` of the current capture; callers hold `index < slotCount`. */
+  public slotAt(index: number): RetainedDrawSlot {
+    return this._slotPool.at(index);
   }
 
   /**
@@ -103,7 +113,6 @@ export class RetainedPlanCache {
    */
   public _beginCapture(): void {
     this._hasCapture = false;
-    this._slots.length = 0;
     this._slotPool.rewind();
   }
 
@@ -117,7 +126,6 @@ export class RetainedPlanCache {
 
     slot.childIndex = childIndex;
     copyRetainedDrawData(slot, command);
-    this._slots.push(slot);
   }
 
   /** Key the capture; only after this does {@link isClean} consider it. */
@@ -133,7 +141,6 @@ export class RetainedPlanCache {
   public invalidate(): void {
     releasePooledDrawables(this._slotPool);
     this._hasCapture = false;
-    this._slots.length = 0;
     this._slotPool.rewind();
   }
 }

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -500,7 +500,9 @@ export class RetainedRootRepresentation {
     const viewRect = view.getBounds();
     const insideCaptureRect = this._viewFitsCaptureCullRect(view);
 
-    for (const node of this.fragment.dirtyTransformRows) {
+    for (let index = 0; index < this.fragment.dirtyTransformRowCount; index++) {
+      const node = this.fragment.dirtyTransformRowAt(index);
+
       if (this._culledDuringCapture && this.fragment.recordedDraw(node as unknown as Drawable) === undefined) {
         return false;
       }
@@ -627,11 +629,12 @@ export class RetainedRootRepresentation {
     backend: RenderBackend,
     target: RenderTargetIdentity | null,
     entries: readonly ScopeEntry[],
+    entryCount: number,
   ): void {
     // `true`: nested transform groups are recorded as live re-dispatches, so a
     // `RetainedContainer` under a render root keeps its own retention tier
     // untouched (see the snapshot policy in `RetainedGroupFragment`).
-    this.fragment.capture(contentRevision, structureRevision, backend, entries, true);
+    this.fragment.capture(contentRevision, structureRevision, backend, entries, entryCount, true);
 
     this._contentRevision = contentRevision;
     this._structureRevision = structureRevision;

--- a/src/rendering/plan/retainedTransformRowPatch.ts
+++ b/src/rendering/plan/retainedTransformRowPatch.ts
@@ -123,7 +123,8 @@ export const tryPatchRetainedTransformRow = (
  * stale extent can hide a real overlap.
  */
 const refreshRetainedDrawBounds = (fragment: RetainedGroupFragment): void => {
-  for (const node of fragment.dirtyTransformRows) {
+  for (let index = 0; index < fragment.dirtyTransformRowCount; index++) {
+    const node = fragment.dirtyTransformRowAt(index);
     const record = fragment.recordedDraw(node as unknown as Drawable);
 
     if (record === undefined) {
@@ -197,7 +198,9 @@ export const reconcileRetainedTransformRows = (fragment: RetainedGroupFragment, 
 
   refreshRetainedDrawBounds(fragment);
 
-  for (const node of fragment.dirtyTransformRows) {
+  for (let index = 0; index < fragment.dirtyTransformRowCount; index++) {
+    const node = fragment.dirtyTransformRowAt(index);
+
     if (!isEligible(node) || !tryPatchRetainedTransformRow(node, fragment, patchableBundle, backend, base)) {
       // Ineligible: drop the baked recording. Validation now fails, so the caller
       // falls back to entry replay (live transforms) and re-records this frame.

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -326,6 +326,9 @@ export class WebGl2Backend implements RenderBackend {
   private _tintTexture: DataTexture<TextureFormat.Rgba8> | null = null;
   private _activeDrawCommand: DrawCommand | null = null;
   private _drawPlanDepth = 0;
+  // Nested-plan stacks, indexed by `_drawPlanDepth` rather than push/pop-drained:
+  // the depth already IS the stack cursor, and a drained array gives its backing
+  // store back only to re-grow it on the next `render()` call.
   private readonly _planBaseStack: number[] = [];
   private readonly _planHashStack: number[] = [];
   private _renderPlanEpoch = 0;
@@ -468,8 +471,16 @@ export class WebGl2Backend implements RenderBackend {
     // current buffer count, so writes land in fresh frame-global slots and
     // batches survive across render() calls. Remember this plan's base so a
     // nested plan can free its rows on end.
-    this._planBaseStack.push(this._transformBuffer.count);
-    this._planHashStack.push(this._transformBuffer.frameHash);
+    const depth = this._drawPlanDepth;
+
+    if (depth < this._planBaseStack.length) {
+      this._planBaseStack[depth] = this._transformBuffer.count;
+      this._planHashStack[depth] = this._transformBuffer.frameHash;
+    } else {
+      this._planBaseStack.push(this._transformBuffer.count);
+      this._planHashStack.push(this._transformBuffer.frameHash);
+    }
+
     this._activeDrawCommand = null;
     this._drawPlanDepth++;
   }
@@ -666,8 +677,9 @@ export class WebGl2Backend implements RenderBackend {
   public _endDrawPlan(): void {
     this._activeDrawCommand = null;
 
-    const planBase = this._planBaseStack.pop() ?? 0;
-    const planHash = this._planHashStack.pop() ?? 0;
+    const depth = this._drawPlanDepth - 1;
+    const planBase = depth >= 0 ? (this._planBaseStack[depth] ?? 0) : 0;
+    const planHash = depth >= 0 ? (this._planHashStack[depth] ?? 0) : 0;
 
     if (this._drawPlanDepth > 0) {
       this._drawPlanDepth--;

--- a/test/rendering/retained-container.test.ts
+++ b/test/rendering/retained-container.test.ts
@@ -13,6 +13,7 @@ import type { GroupScope, GroupScopeEntry } from '#rendering/plan/RenderScope';
 import { type RetainedFragmentEntry, type RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderBackendType } from '#rendering/RenderBackendType';
+import type { RenderNode } from '#rendering/RenderNode';
 import { createRenderStats } from '#rendering/RenderStats';
 import { RenderTarget } from '#rendering/RenderTarget';
 import { RetainedContainer } from '#rendering/RetainedContainer';
@@ -25,6 +26,10 @@ class LeafDrawable extends Drawable {
 }
 
 const fragmentOf = (group: RetainedContainer): RetainedGroupFragment => (group as unknown as { _fragment: RetainedGroupFragment })._fragment;
+
+/** The fragment's queued transform-row nodes, materialized through its logical length. */
+const queuedRows = (fragment: RetainedGroupFragment): RenderNode[] =>
+  Array.from({ length: fragment.dirtyTransformRowCount }, (_unused, index) => fragment.dirtyTransformRowAt(index));
 
 // F4: the enqueue seam is gated on a live committed recording (only the
 // recorded-instruction tier ever consumes a queued row), so tests that
@@ -49,7 +54,7 @@ describe('RetainedContainer: transform-row patch seam', () => {
 
     child.setPosition(40, 40);
 
-    expect([...fragmentOf(group).dirtyTransformRows]).toEqual([child]);
+    expect(queuedRows(fragmentOf(group))).toEqual([child]);
 
     group.destroy();
     backend.destroy();
@@ -68,7 +73,7 @@ describe('RetainedContainer: transform-row patch seam', () => {
 
     child.setPosition(5, 5);
 
-    expect(fragmentOf(group).dirtyTransformRows.includes(child)).toBe(true);
+    expect(queuedRows(fragmentOf(group))).toContain(child);
 
     group.destroy();
     backend.destroy();
@@ -121,7 +126,7 @@ describe('RetainedContainer: transform-row patch seam', () => {
 
     child.setPosition(40, 40);
 
-    expect([...fragment.dirtyTransformRows]).toEqual([child]);
+    expect(queuedRows(fragment)).toEqual([child]);
 
     group.destroy();
     backend.destroy();
@@ -189,7 +194,7 @@ describe('RetainedContainer: transform-row patch seam', () => {
 
     child.setPosition(7, 7);
 
-    expect(fragmentOf(group).dirtyTransformRows.includes(child)).toBe(true);
+    expect(queuedRows(fragmentOf(group))).toContain(child);
 
     group.destroy();
     backend.destroy();
@@ -727,7 +732,7 @@ describe('RetainedContainer: pooled fragment snapshot', () => {
     collectDraws(root, backend); // capture with 2 draws (pool grows)
     collectDraws(root, backend); // splice
 
-    expect(fragment.entries).toHaveLength(2);
+    expect(fragment.entryCount).toBe(2);
     expect(fragment.entries[0]).toBe(firstRecord);
 
     const secondRecord = fragment.entries[1]!;
@@ -736,13 +741,16 @@ describe('RetainedContainer: pooled fragment snapshot', () => {
     collectDraws(root, backend); // capture with 1 draw (pool keeps record 2)
     collectDraws(root, backend); // splice
 
-    expect(fragment.entries).toHaveLength(1);
+    expect(fragment.entryCount).toBe(1);
     expect(fragment.entries[0]).toBe(firstRecord);
+    // The snapshot array keeps the slot the wider capture grew it to — that is
+    // what makes the re-grow below allocation-free.
+    expect(fragment.entries).toHaveLength(2);
 
     group.addChild(leafB);
     collectDraws(root, backend); // grow again: pooled record 2 is reused
 
-    expect(fragment.entries).toHaveLength(2);
+    expect(fragment.entryCount).toBe(2);
     expect(fragment.entries[1]).toBe(secondRecord);
 
     root.destroy();

--- a/test/rendering/retained-group-fragment.test.ts
+++ b/test/rendering/retained-group-fragment.test.ts
@@ -11,6 +11,18 @@ import { RenderBackendType } from '#rendering/RenderBackendType';
 import { createRenderStats } from '#rendering/RenderStats';
 import { RenderTarget } from '#rendering/RenderTarget';
 
+/** Real major GC + a macrotask hop so reclaimed WeakRefs settle (`--expose-gc` comes from the vitest project). */
+async function forceGc(): Promise<void> {
+  const gc = (globalThis as { gc?: () => void }).gc;
+
+  if (!gc) throw new Error('globalThis.gc is unavailable — the test project must pass --expose-gc to the fork pool');
+
+  for (let i = 0; i < 3; i++) {
+    gc();
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+}
+
 const material: MaterialKey = { rendererId: 1, blendMode: 0, textureId: -1, shaderId: -1, pipelineKey: 1, bindKey: 1, ownMaterial: false };
 const fakeBackendA = {} as RenderBackend;
 const fakeBackendB = {} as RenderBackend;
@@ -132,7 +144,9 @@ describe('RetainedGroupFragment', () => {
     fragment.enqueueDirtyTransformRow(b);
 
     expect(fragment.hasDirtyTransformRows()).toBe(true);
-    expect([...fragment.dirtyTransformRows]).toEqual([a, b]);
+    expect(fragment.dirtyTransformRowCount).toBe(2);
+    expect(fragment.dirtyTransformRowAt(0)).toBe(a);
+    expect(fragment.dirtyTransformRowAt(1)).toBe(b);
 
     fragment.clearDirtyTransformRows();
 
@@ -140,6 +154,52 @@ describe('RetainedGroupFragment', () => {
 
     a.destroy();
     b.destroy();
+  });
+
+  test('a cleared queue reports only what was queued after it, never the slots it kept', () => {
+    // The reset rewinds a logical length and keeps the backing array, so the
+    // records of the previous cycle are still physically in it. Nothing may see
+    // them: the count is the contract.
+    const fragment = new RetainedGroupFragment();
+    const a = new Drawable();
+    const b = new Drawable();
+    const c = new Drawable();
+
+    fragment.enqueueDirtyTransformRow(a);
+    fragment.enqueueDirtyTransformRow(b);
+    fragment.clearDirtyTransformRows();
+
+    fragment.enqueueDirtyTransformRow(c);
+
+    expect(fragment.dirtyTransformRowCount).toBe(1);
+    expect(fragment.dirtyTransformRowAt(0)).toBe(c);
+
+    a.destroy();
+    b.destroy();
+    c.destroy();
+  });
+
+  test('invalidate() releases the queue references so a dropped node can GC', async () => {
+    // The per-frame reset deliberately keeps its slots (that is what makes the
+    // refill allocation-free), so the structural paths — invalidate and capture —
+    // are what has to hand the references back.
+    const fragment = new RetainedGroupFragment();
+    // Queued, cleared and released inside a scope that ends here, so the only
+    // reference that could keep the node alive is the fragment's own slot.
+    const ref = ((): WeakRef<Drawable> => {
+      const node = new Drawable();
+
+      fragment.enqueueDirtyTransformRow(node);
+      fragment.clearDirtyTransformRows();
+      fragment.invalidate();
+      node.destroy();
+
+      return new WeakRef(node);
+    })();
+
+    await forceGc();
+
+    expect(ref.deref()).toBeUndefined();
   });
 
   test('invalidate() clears the capture', () => {
@@ -326,8 +386,8 @@ class SnapshotProbeContainer extends BoundaryContainer {
 
   protected override _collectContent(builder: RenderPlanBuilder): void {
     super._collectContent(builder);
-    this.probeFragment.capture(0, 0, builder.backend, builder._peekCurrentScopeEntries());
-    this.lastSnapshot = this.probeFragment.entries;
+    this.probeFragment.capture(0, 0, builder.backend, builder._peekCurrentScopeEntries(), builder._peekCurrentScopeEntryCount());
+    this.lastSnapshot = this.probeFragment.entries.slice(0, this.probeFragment.entryCount);
   }
 }
 

--- a/test/rendering/retained-plan-cache.test.ts
+++ b/test/rendering/retained-plan-cache.test.ts
@@ -58,7 +58,7 @@ describe('RetainedPlanCache', () => {
     const cache = new RetainedPlanCache();
 
     expect(cache.isClean(1, 1, 1, 1, fakeBackendA)).toBe(false);
-    expect(cache.slots).toEqual([]);
+    expect(cache.slotCount).toBe(0);
   });
 
   test('isClean is true only when content, structure, transform, view, and backend all match the last capture', () => {
@@ -68,8 +68,8 @@ describe('RetainedPlanCache', () => {
     captureOne(cache, drawable, 5, 3, 2, 7, fakeBackendA);
 
     expect(cache.isClean(5, 3, 2, 7, fakeBackendA)).toBe(true);
-    expect(cache.slots).toHaveLength(1);
-    expect(cache.slots[0]!.drawable).toBe(drawable);
+    expect(cache.slotCount).toBe(1);
+    expect(cache.slotAt(0).drawable).toBe(drawable);
 
     expect(cache.isClean(6, 3, 2, 7, fakeBackendA)).toBe(false); // content changed
     expect(cache.isClean(5, 4, 2, 7, fakeBackendA)).toBe(false); // structure changed
@@ -101,7 +101,7 @@ describe('RetainedPlanCache', () => {
     cache.invalidate();
 
     expect(cache.isClean(1, 1, 1, 1, fakeBackendA)).toBe(false);
-    expect(cache.slots).toEqual([]);
+    expect(cache.slotCount).toBe(0);
 
     drawable.destroy();
   });
@@ -112,7 +112,7 @@ describe('RetainedPlanCache', () => {
 
     captureOne(cache, drawable, 1, 1, 1, 1, fakeBackendA);
 
-    const slotBefore = cache.slots[0]!;
+    const slotBefore = cache.slotAt(0);
     const materialBefore = slotBefore.material;
 
     expect(materialBefore).not.toBe(material); // copied, not aliased
@@ -121,11 +121,11 @@ describe('RetainedPlanCache', () => {
     cache._appendSlot(3, makeCommand(drawable, 9));
     cache._commitCapture(2, 1, 1, 1, fakeBackendA);
 
-    expect(cache.slots[0]).toBe(slotBefore); // same pooled record...
-    expect(cache.slots[0]!.material).toBe(materialBefore); // ...same pooled key object
-    expect(cache.slots[0]!.childIndex).toBe(3); // ...refreshed data
-    expect(cache.slots[0]!.minX).toBe(9);
-    expect(cache.slots[0]!.material.pipelineKey).toBe(material.pipelineKey);
+    expect(cache.slotAt(0)).toBe(slotBefore); // same pooled record...
+    expect(cache.slotAt(0).material).toBe(materialBefore); // ...same pooled key object
+    expect(cache.slotAt(0).childIndex).toBe(3); // ...refreshed data
+    expect(cache.slotAt(0).minX).toBe(9);
+    expect(cache.slotAt(0).material.pipelineKey).toBe(material.pipelineKey);
 
     drawable.destroy();
   });
@@ -136,7 +136,7 @@ describe('RetainedPlanCache', () => {
 
     captureOne(cache, drawable, 1, 1, 1, 1, fakeBackendA);
 
-    const pooledSlot = cache.slots[0]!;
+    const pooledSlot = cache.slotAt(0);
 
     expect(pooledSlot.drawable).toBe(drawable);
 
@@ -152,8 +152,8 @@ describe('RetainedPlanCache', () => {
     cache._appendSlot(0, makeCommand(drawable));
     cache._commitCapture(2, 1, 1, 1, fakeBackendA);
 
-    expect(cache.slots[0]).toBe(pooledSlot);
-    expect(cache.slots[0]!.drawable).toBe(drawable);
+    expect(cache.slotAt(0)).toBe(pooledSlot);
+    expect(cache.slotAt(0).drawable).toBe(drawable);
 
     drawable.destroy();
   });
@@ -164,7 +164,7 @@ class ProbeContainer extends Container {
 
   protected override _collectContent(builder: RenderPlanBuilder): void {
     super._collectContent(builder);
-    this.probedEntryCount = builder._peekCurrentScopeEntries().length;
+    this.probedEntryCount = builder._peekCurrentScopeEntryCount();
   }
 }
 


### PR DESCRIPTION
`array.length = 0` does not preserve an array's backing store. V8 trims the store against the **capacity**, not the length, and the refill then re-grows through the whole doubling sequence. Measured on Node v24.14.1: 200 cycles of "push 100k, `length = 0`" allocate **523 MB** in 184 ms, against **2.6 MB** in 57 ms for the same work written through a cursor — so the cursor form is not only allocation-free but three times faster. Two controls bound the mechanism: `length = 0` without a refill costs nothing (the capacity is already gone after the first trim), and a balanced `push`/`pop` stack costs nothing either (1 B over 500k cycles). Only reset-plus-refill is expensive.

Eight per-frame stores in the render path were built on the opposite assumption. Two dominate:

- `RetainedGroupFragment._dirtyTransformRows` — 28.6 KB/frame on a 1000-sprite scene where everything moves, 86% of that scene.
- the pooled group scope's `entries` array — 28.6 KB/frame on `mesh/1000`, 93% of that scene. Attribution took an A/B: the bytes showed up as self-allocation of `_replayRetainedFragment`, and only swapping its `for…of` for an indexed loop ruled the iterator out (unchanged at 28,608 B/frame).

The rest: the fragment snapshot arrays, `RetainedPlanCache._slots`, `MutableRenderPlan.passes`, the builder's scope stack and free list, and the WebGL2 backend's nested-plan stacks. Plus one adjacent finding from the same profile — `Set.prototype.clear()` installs a fresh backing table, so `_sourceViewReaders.clear()` cost ~112 B/frame on a set that is empty in almost every frame.

## Two lifetime contracts, deliberately not commonized

Where consumers only iterate, the structure carries its own logical length and the capacity survives a shrink: the row queue (`dirtyTransformRowCount`/`dirtyTransformRowAt`), the fragment snapshot (`entryCount`, threaded through `isRetainedFragmentRecordable` and `_replayRetainedFragment`), the scope stack, the builder free list, the plan stacks. `RetainedPlanCache`'s parallel slot array is gone entirely — `_appendSlot` acquires in capture order, so the record pool's used prefix already was that list (`slotCount`/`slotAt`).

`GroupScope.entries` is the exception. `RenderPlanOptimizer` z-sorts it **in place** and there is no range sort, so the collect fills through a cursor and `_popScope` trims the array to this frame's count when the scope closes. Everything downstream keeps seeing an array whose length IS its entry count; the only window with a longer array is the still-open scope, and the exactly three call sites that read one go through `_peekCurrentScopeEntryCount()`.

## Retention

Slots past the logical length keep their references — that is the price of the capacity, and it is checked separately. For the pooled structures it is zero: what sits there is already held by the corresponding record pool. The row queue is the exception because its elements are **scene nodes**, so it hands them back on `capture()` and `invalidate()` — the two paths a removed node always reaches, since removing it moves the structure revision. Covered by a real GC test (`WeakRef` plus a forced major GC), and the test was checked for teeth: making `invalidate()` rewind only the length again turns it red.

## Numbers, and what kind of number each one is

**Fresh-process probes** — one scene per process, the load-bearing attribution:

| scene | before | after |
| --- | ---: | ---: |
| `mesh/1000` | 30.03 | **0.86** KB/frame |
| `sprite/1000 moving` | 32.39 | 9.76 KB/frame |

**Gate windows** (median of 5, before and after in one session) — a relative gate-stability reading, not a baseline:

| archetype | before | after |
| --- | ---: | ---: |
| `sprite/1000 moving` | 30.62 | 1.93 |
| `sprite/10000 transform-only 1%` | 6.29 | 3.24 |
| `mesh/1000` | 170.03 | 141.72 |
| `filtered/100` | 681.15 | 526.83 |
| `deep-hierarchy/1000 d16 1%` | 1.91 | 0.96 |
| `nested/1000 d4` | 2.00 | 1.16 |
| `sprite/1000 static` | 3.53 | 2.60 |
| `blend/1000 plateau64` | 5.30 | 4.42 |
| `blend/1000 alternating` | 236.28 | 234.26 |
| `empty` | 2.03 | 1.20 |

These are same-session gate windows and several of them read differently from the documented `BASELINE_KB` table, which was recorded in another session — so **none of them is a future baseline**. No budget was rebaselined here; the whole table is due for a fresh-process re-measurement as a unit, which is the next slice.

**CPU** — fresh process, 5 runs per side, 1000 frames each, alternating between a baseline worktree at `fd2e9ed6` and this branch. Median of medians 0.5068 → 0.4909 ms, median p95 0.5491 → 0.5266 ms; this branch's worst p95 (0.536) is below the baseline's median p95. An earlier single run had read 0.82 ms p95 — that was one outlier, not a tail shift. Elsewhere: `sprite/10000 transform-only 1%` 1.0585 → 0.6731 ms median, `mesh/1000` 3.0135 → 2.9862, everything else within noise.

**High-water stress** (5000 sprites, visibility driving the entry count, one process per case): constant-high 5.31 → 3.90 KB/frame, a 5-frame high/low plateau 88.97 → 21.27, one peak then permanently low 3.81 → 2.73 with retained heap unchanged at 33.1 MB, and a per-frame 50 ↔ 5000 flip 159.4 → 86.9. That last case is the honest residual: it runs entirely on the scope entries re-growing after the close-of-scope trim. Removing it means carrying the logical length through the optimizer and replacing the in-place sort with a range sort — a separate cut with its own CPU risk, left for the residual triage after the rebaseline.

## Not in scope

`PackedSourceItems` has no problem of this class — it already carries `_count`/`_capacity`, its `clear()` is teardown and its `truncate()` a deliberate shortening; its growth is bootstrap. `RetainedInstructionSet._instructions` has the same shape but never appears as a line item in any of the ten gate scenes, because recording is not a per-frame event in steady state. The WebGPU counterparts are untouched.

## Verification

`pnpm verify:quick` (12/12), `pnpm test` (9829 passed, 1 skipped), the allocation gate inside it with every budget still met and none rebaselined, `pnpm typecheck` + `typecheck:test`, the Chromium WebGL2 lane (307), the WebGPU lane (352), `pnpm size` within limits, `git diff --check` clean.

https://claude.ai/code/session_01KQKgUaCnC2acS9TUQ1suGv
