### PR TITLE
perf(rendering): draw effect quads without building a plan for each

### DIFF
--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -6,6 +6,7 @@ import type { KeyEvent } from '#input/KeyEvent';
 import { Rectangle } from '#math/Rectangle';
 import type { Filter } from '#rendering/filters/Filter';
 import type { Geometry } from '#rendering/geometry/Geometry';
+import { drawDrawableDirect } from '#rendering/plan/drawDrawableDirect';
 import { playRenderTree } from '#rendering/plan/playRenderTree';
 import { type RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { RetainedRootRepresentation } from '#rendering/plan/RetainedRootRepresentation';
@@ -13,6 +14,7 @@ import { RenderTexture } from '#rendering/texture/RenderTexture';
 import type { Texture } from '#rendering/texture/Texture';
 
 import { BackendTargetPass } from './BackendTargetPass';
+import type { Drawable } from './Drawable';
 import type { RenderBackend } from './RenderBackend';
 import { BlendModes, isAdvancedBlendMode } from './types';
 import { View } from './View';
@@ -21,7 +23,14 @@ interface DestroyableFilter {
   destroy(): void;
 }
 
-interface RenderNodeSpriteLike {
+/**
+ * The cache sprite, described structurally so this module never imports the
+ * `Sprite` class (that edge would close a runtime cycle). `Drawable` is folded
+ * in as a TYPE-only extension because the composite path now hands the sprite
+ * straight to `backend.draw` — the factory returns a real `Sprite`, so this
+ * only writes down what was already true.
+ */
+interface RenderNodeSpriteLike extends Drawable {
   width: number;
   height: number;
   setTexture(texture: RenderTexture | null): this;
@@ -729,7 +738,7 @@ export abstract class RenderNode extends SceneNode {
 
     sprite.width = width;
     sprite.height = height;
-    sprite.render(backend);
+    drawDrawableDirect(sprite, backend);
   }
 
   private _ensureCacheTexture(width: number, height: number): RenderTexture {

--- a/src/rendering/filters/BlurFilter.ts
+++ b/src/rendering/filters/BlurFilter.ts
@@ -1,5 +1,6 @@
 import { Color } from '#core/Color';
 import { BackendTargetPass } from '#rendering/BackendTargetPass';
+import { drawDrawableDirect } from '#rendering/plan/drawDrawableDirect';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { Sprite } from '#rendering/sprite/Sprite';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
@@ -66,7 +67,7 @@ export class BlurFilter extends Filter {
       new BackendTargetPass(
         () => {
           if (radius <= 0) {
-            this._sprite.setPosition(0, 0).render(backend);
+            drawDrawableDirect(this._sprite.setPosition(0, 0), backend);
 
             return;
           }
@@ -75,8 +76,8 @@ export class BlurFilter extends Filter {
             const t = steps === 1 ? 0 : step / (steps - 1);
             const offset = (t * 2 - 1) * radius;
 
-            this._sprite.setPosition(offset, 0).render(backend);
-            this._sprite.setPosition(0, offset).render(backend);
+            drawDrawableDirect(this._sprite.setPosition(offset, 0), backend);
+            drawDrawableDirect(this._sprite.setPosition(0, offset), backend);
           }
         },
         {

--- a/src/rendering/filters/ColorFilter.ts
+++ b/src/rendering/filters/ColorFilter.ts
@@ -1,5 +1,6 @@
 import { Color } from '#core/Color';
 import { BackendTargetPass } from '#rendering/BackendTargetPass';
+import { drawDrawableDirect } from '#rendering/plan/drawDrawableDirect';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { Sprite } from '#rendering/sprite/Sprite';
 import type { RenderTexture } from '#rendering/texture/RenderTexture';
@@ -37,7 +38,7 @@ export class ColorFilter extends Filter {
     backend.execute(
       new BackendTargetPass(
         () => {
-          this._sprite.render(backend);
+          drawDrawableDirect(this._sprite, backend);
         },
         {
           target: output,

--- a/src/rendering/plan/drawDrawableDirect.ts
+++ b/src/rendering/plan/drawDrawableDirect.ts
@@ -1,0 +1,54 @@
+import type { Drawable } from '#rendering/Drawable';
+import type { RenderBackend } from '#rendering/RenderBackend';
+
+/** The two plan-depth hooks a backend may implement; both are optional (test stubs implement neither). */
+interface DrawPlanDepthHooks {
+  _beginDrawPlan?(nodeCount: number): void;
+  _endDrawPlan?(): void;
+}
+
+/**
+ * Draw ONE already-resolved drawable that engine-internal effect code owns,
+ * without building a render plan for it.
+ *
+ * `RenderNode.render()` is `playRenderTree` — build, optimize, play — and the
+ * filter and composite paths call it once per sprite they draw. That is a whole
+ * plan cycle to issue a single quad the caller already holds, positioned by the
+ * caller, into a target the caller already bound. A blur at quality 3 pays it
+ * fifteen times per filtered node per frame.
+ *
+ * Everything the plan would have contributed for this one node is either
+ * already true or already provided:
+ *
+ * - TARGET / VIEW / CLEAR — the enclosing `BackendTargetPass` bound them. A
+ *   single-sprite plan's pass carries `target: null` and the backend's own
+ *   view, so playing it changes neither.
+ * - TRANSFORM SLOT — the renderers already fall back to `_pushTransform` when
+ *   no plan draw command is active (`WebGl2SpriteRenderer`), which is the same
+ *   row the plan would have written at its group upload boundary.
+ * - FLUSH ORDER — the plan-depth bracket below keeps it. Ending a NESTED plan
+ *   flushes the active renderer and rewinds the transform rows it pushed, so
+ *   the drawable's batch lands in the target that is bound now and the
+ *   frame-scoped buffer does not grow per effect pass.
+ * - CULLING — deliberately dropped. The plan would have tested this drawable
+ *   against the cull rect, but effect code only reaches here for output it has
+ *   already decided to produce, and the quad fills the target it draws into.
+ *   The test can only remove a draw the caller asked for.
+ *
+ * NOT a general fast path and not a public one: it takes a drawable whose
+ * transform and texture the caller has just set, with no children, no filters
+ * and no effects of its own. Anything with a subtree still goes through
+ * `playRenderTree`.
+ * @internal
+ */
+export function drawDrawableDirect(drawable: Drawable, backend: RenderBackend): void {
+  const hooks = backend as RenderBackend & DrawPlanDepthHooks;
+
+  hooks._beginDrawPlan?.(1);
+
+  try {
+    backend.draw(drawable);
+  } finally {
+    hooks._endDrawPlan?.();
+  }
+}

--- a/test/perf/rendering/allocation.test.ts
+++ b/test/perf/rendering/allocation.test.ts
@@ -77,9 +77,12 @@ const NOISE_FLOOR_KB = 50;
  * Budget band for scenes above {@link NOISE_FLOOR_KB}. Measured pass-to-pass
  * median spread on those scenes is ≤0.4% (see the table on {@link BASELINE_KB}),
  * so nearly the whole 15% is headroom for cross-machine drift. `filtered/100` is
- * the only scene left above the floor, and it reads 329.89 KB/frame on the CI
- * runner (Node v24.19.0 linux/x64) against 306.55 in-suite here — +7.6%, half
- * the band — while a real ≥15% allocation regression still fails the gate.
+ * the only scene left above the floor, and the CI runner (Node v24.19.0
+ * linux/x64) reads it about 7.6% above this dev box — measured as 329.89 against
+ * 306.55 before the effect path stopped nesting a plan per pass. The band is
+ * stated as a RATIO for that reason: the absolute pair moves with every ratchet,
+ * the cross-machine factor does not, and half the band is still free at it while
+ * a real ≥15% allocation regression fails.
  */
 const TOLERANCE_LARGE = 1.15;
 
@@ -136,19 +139,29 @@ const FIXED_HEADROOM_KB = 1.25;
  *   nested/1000 d4                    1.20      0.65       1.20
  *   deep-hierarchy/1000 d16 1%        1.01      0.50       1.01
  *   mesh/1000                         0.68      0.37       0.68
- *   filtered/100                    295.18    306.55     306.55
+ *   filtered/100                    218.60    229.59     229.59
  *   blend/1000 plateau64              0.93      0.57       0.93
  *   blend/1000 alternating            1.19      0.47       1.19
  *
  * Spread, i.e. what the budget has to absorb: ≤0.13 KB across the five fresh
  * processes and ≤0.21 KB across six in-suite passes on every scene but
- * `filtered/100`, which holds 0.3% (295.5 fresh / 306.6 in-suite pass spread).
+ * `filtered/100`, which holds 0.24% (218.1–219.5 fresh, 229.0–229.6 across four
+ * in-suite passes).
  *
  * `scrolling-world/10000` is measured the same way but stays out of the gate:
  * fresh it is the steadiest scene here (1.65 KB/frame, 4.5%), in-suite it is
  * bimodal at 14.6 vs 19.8 KB/frame between passes. See `ALLOCATION_REPORT_ONLY`.
  *
  * ── Ratchet history ─────────────────────────────────────────────
+ * 2026-08-16b: `filtered/100` ONLY, 306.55 → 229.59, after the effect path
+ * stopped building a whole render plan per filter pass and per composite. No
+ * other row is touched and no global re-baseline: the change reaches nothing
+ * outside the barrier path, every other scene re-measured identical, and a
+ * ratchet that moves rows a slice did not affect is how a table drifts away
+ * from what it is supposed to prove. The filter work continues, so this row is
+ * expected to ratchet again — each landed slice protects its own gain rather
+ * than leaving the next one to collect them all.
+ *
  * 2026-08-16: whole table re-measured after the steady-state allocation track
  * closed, and every budget moved down again — by two to three ORDERS of
  * magnitude on the scenes the track actually hit (`mesh/1000` 574.69 → 0.68,
@@ -173,7 +186,7 @@ const BASELINE_KB: Readonly<Record<string, number>> = {
   'nested/1000 d4': 1.2,
   'deep-hierarchy/1000 d16 1%': 1.01,
   'mesh/1000': 0.68,
-  'filtered/100': 306.55,
+  'filtered/100': 229.59,
   'blend/1000 plateau64': 0.93,
   'blend/1000 alternating': 1.19,
 };

--- a/test/perf/rendering/effect-pass-shape.test.ts
+++ b/test/perf/rendering/effect-pass-shape.test.ts
@@ -1,0 +1,99 @@
+/**
+ * SHAPE gate for the effect path's nested draws.
+ *
+ * `ColorFilter.apply`, `BlurFilter.apply` and `RenderNode._drawTexture` issue
+ * their quads through `drawDrawableDirect`, which wraps each draw in the
+ * backend's plan-depth bracket. That bracket is not decoration: ending a NESTED
+ * plan flushes the active renderer and REWINDS the transform rows the draw
+ * pushed, so a frame with a hundred effect passes does not stack a hundred
+ * passes' worth of rows into the frame-scoped buffer.
+ *
+ * Nothing else catches its removal. The pixel suite
+ * (`browser/webgl2-effect-direct-draw.test.ts`) passes with the bracket gone —
+ * the picture is identical, only the buffer traffic and the flush granularity
+ * change — and the allocation gate reads a filtered scene as CHEAPER without
+ * it. Measured on `blur-q3`, dropping the bracket moves draw calls 1600 -> 300
+ * and transform bytes 48000 -> 116288: batching improves, upload traffic
+ * nearly triples.
+ *
+ * ── INTEGRATOR NOTE ─────────────────────────────────────────────────────────
+ * These are exact per-frame counts on a fixed scene, machine-independent for
+ * the same reason `counter-gates.test.ts` pins its table. Hoisting the bracket
+ * out of a filter's sample loop — batching a blur's samples into one draw — is
+ * a DELIBERATE follow-up that will move every number here. When that lands,
+ * re-measure and update the table, and confirm the transform-byte column moved
+ * the way you intended: fewer draw calls at the cost of more upload bytes is a
+ * trade to make on purpose, not to discover afterwards.
+ *
+ * @internal Test/perf-only.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { Container } from '#rendering/Container';
+import { BlurFilter } from '#rendering/filters/BlurFilter';
+import { ColorFilter } from '#rendering/filters/ColorFilter';
+import { Sprite } from '#rendering/sprite/Sprite';
+
+import { makeTextures, scatterInView } from './fixtures';
+import { createWebGl2Harness, measureSteadyFrame } from './harness';
+
+const VIEW = { w: 1280, h: 720 } as const;
+const NODES = 100;
+
+/** `NODES` scattered sprites, each carrying whatever `decorate` adds. */
+const buildScene = (decorate: (sprite: Sprite) => void): Container => {
+  const [texture] = makeTextures(1);
+  const root = new Container();
+
+  for (let i = 0; i < NODES; i++) {
+    const sprite = new Sprite(texture!);
+
+    scatterInView(sprite, i, VIEW.w, VIEW.h);
+    decorate(sprite);
+    root.addChild(sprite);
+  }
+
+  return root;
+};
+
+describe('effect pass shape', () => {
+  it('a single-pass filter costs one capture pass and one filter pass per node', () => {
+    const harness = createWebGl2Harness();
+    const root = buildScene(sprite => sprite.addFilter(new ColorFilter()));
+
+    try {
+      const frame = measureSteadyFrame(harness, root);
+
+      // Two passes and two acquired targets per filtered node; three draws —
+      // the subject into the capture, the filter quad, the composite.
+      expect(frame.renderPasses).toBe(2 * NODES);
+      expect(frame.drawCalls).toBe(3 * NODES);
+      expect(frame.transformUploadBytes).toBe(9568);
+    } finally {
+      root.destroy();
+      harness.destroy();
+    }
+  });
+
+  it('a blur flushes each offset sample and rewinds its transform rows', () => {
+    const harness = createWebGl2Harness();
+    const root = buildScene(sprite => sprite.addFilter(new BlurFilter({ radius: 4, quality: 3 })));
+
+    try {
+      const frame = measureSteadyFrame(harness, root);
+
+      // Pass count is unchanged from the single-pass filter — a blur is ONE
+      // filter pass with many draws inside it, which is exactly why the draw
+      // and byte columns are the ones that say whether the bracket is intact.
+      expect(frame.renderPasses).toBe(2 * NODES);
+      // 14 offset samples + the subject + the composite, per node.
+      expect(frame.drawCalls).toBe(16 * NODES);
+      // Without the per-draw rewind this reads 116288: every sample's row
+      // survives to the end of the frame instead of being handed back.
+      expect(frame.transformUploadBytes).toBe(48000);
+    } finally {
+      root.destroy();
+      harness.destroy();
+    }
+  });
+});

--- a/test/perf/rendering/filterScenes.ts
+++ b/test/perf/rendering/filterScenes.ts
@@ -202,6 +202,44 @@ export const FILTER_ARCHETYPES: readonly AllocationArchetype[] = [
       }),
   },
 
+  // ── The retained capture's cull margin ───────────────────────────────────
+  // Filtered sprites parked OUTSIDE the view but inside the inflated capture
+  // rect (`RETAINED_CULL_MARGIN_RATIO` = 1/16, so 80 px horizontally on a
+  // 1280-wide view). A capturing collect admits them, so their barriers run and
+  // their composites are issued — while the enclosing frame never shows them.
+  // This is the one place where "the effect path only draws what it already
+  // decided to draw" is not obviously true, so it is measured rather than
+  // argued: the structural counters here must not move.
+  {
+    id: 'filter/color 100 margin',
+    rationale: 'Filtered nodes inside the capture cull margin but outside the view — the case where a composite draw is collected but not visible.',
+    warmup: WARMUP,
+    build: () => {
+      const [texture] = makeTextures(1);
+      const root = new Container();
+
+      // Half in view, half in the margin. A root whose whole subtree sits
+      // outside is culled at the root and never reaches the barrier path at
+      // all, so the visible half is what keeps the root — and the capture —
+      // alive for the other half to be admitted by the inflated rect.
+      for (let i = 0; i < 100; i++) {
+        const sprite = new Sprite(texture!);
+
+        if (i % 2 === 0) {
+          scatterInView(sprite, i, VIEW.w, VIEW.h);
+        } else {
+          // x beyond the view's right edge, still well inside the +80 px margin.
+          sprite.setPosition(VIEW.w + 1 + (i % 15), (i * 251) % (VIEW.h - 64));
+        }
+
+        sprite.addFilter(new ColorFilter());
+        root.addChild(sprite);
+      }
+
+      return { root, teardown: () => root.destroy() };
+    },
+  },
+
   // ── ONE filter over a large subtree ──────────────────────────────────────
   {
     id: 'filter/container 1000',
@@ -246,6 +284,7 @@ export const FILTERED_NODE_COUNT: Readonly<Record<string, number>> = {
   'filter/color 10': 10,
   'filter/color 100': 100,
   'filter/color 200': 200,
+  'filter/color 100 margin': 100,
   'filter/stack2 100': 100,
   'filter/stack3 100': 100,
   'filter/blur-q1 100': 100,

--- a/test/perf/rendering/filterScenes.ts
+++ b/test/perf/rendering/filterScenes.ts
@@ -1,0 +1,258 @@
+/**
+ * Filter / effect allocation probe catalog.
+ *
+ * Deliberately NOT part of `ALLOCATION_ARCHETYPES`: that list's documented
+ * baselines are the medians ITS order produces, so appending to it would
+ * invalidate every number in the gate. These scenes answer a different
+ * question — how filter allocation SCALES — and are driven one-per-process by
+ * `run-allocation-cell.ts`.
+ *
+ * ── Why a matrix and not a coverage list ──────────────────────────────────
+ * `filtered/100` reads ~295 KB/frame against a ~1 KB floor for every other
+ * gated scene, and "≈3 KB per filtered sprite" does not say WHICH unit of work
+ * costs it. Three units are stacked inside a filtered node and each one is a
+ * different fix if it turns out to dominate:
+ *
+ *   BARRIER      the plan-side entry: an effect descriptor, a barrier scope, a
+ *                child plan, and a collect walk that cannot use the retained
+ *                tier. `clip/N` isolates it — a rect clip is a barrier with NO
+ *                offscreen target and NO filter pass.
+ *   TARGET       the offscreen capture: acquire, a `BackendTargetPass`, a
+ *                render-to-texture round trip, release. `mask/N` isolates it —
+ *                an alpha mask takes two targets and composites, with no
+ *                `Filter.apply` anywhere.
+ *   FILTER PASS  `Filter.apply` itself, once per filter in the chain.
+ *                `color/N` is one, `stack2` / `stack3` are two and three over
+ *                the same barrier and the same first target.
+ *
+ * Read down the family and the per-unit cost falls out by subtraction; read
+ * across `color/{1,10,100,200}` and the fixed-vs-per-node split does.
+ *
+ * The remaining families cover the shapes a fix must not regress rather than
+ * the scaling law: `blur-q{1,3}` varies DRAWS per filter pass while holding the
+ * pass count at one, `container/1000` puts a single filter over a large subtree
+ * (the opposite extreme from `color/100`), and `container-cached/1000` is that
+ * same subtree with `cacheAsBitmap`, where the filter passes are supposed to
+ * stop running after the bake.
+ *
+ * Every scene here is STATIC — no `beforeFrame`. That is the point: a static
+ * filtered scene should be the cheapest frame there is, and measuring one that
+ * is not is what this catalog exists for.
+ *
+ * @internal Test/perf-only.
+ */
+import { Container } from '#rendering/Container';
+import { BlurFilter } from '#rendering/filters/BlurFilter';
+import { ColorFilter } from '#rendering/filters/ColorFilter';
+import type { Filter } from '#rendering/filters/Filter';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Sprite } from '#rendering/sprite/Sprite';
+
+import type { AllocationArchetype, AllocationScene } from './allocationScenes';
+import { makeTextures, scatterInView } from './fixtures';
+
+/** Viewport the probes render through — matches the harness default. */
+const VIEW = { w: 1280, h: 720 } as const;
+
+/**
+ * Warm-up frames. Higher than the catalog default (30) for the same reason the
+ * light gate scenes need it: the per-frame rate is still falling while V8 tiers
+ * up the barrier walk, and a per-unit cost read off the transient is not the
+ * per-unit cost of a steady frame. These scenes are heavy enough that 400 is
+ * both settled and affordable.
+ */
+const WARMUP = 400;
+
+/** `count` scattered sprites under one root, each given whatever `decorate` does to it. */
+const buildDecoratedSprites = (count: number, decorate: (sprite: Sprite, index: number) => void): AllocationScene => {
+  const [texture] = makeTextures(1);
+  const root = new Container();
+
+  for (let i = 0; i < count; i++) {
+    const sprite = new Sprite(texture!);
+
+    scatterInView(sprite, i, VIEW.w, VIEW.h);
+    decorate(sprite, i);
+    root.addChild(sprite);
+  }
+
+  return { root, teardown: () => root.destroy() };
+};
+
+/** One filtered container over `count` plain sprites — the opposite extreme from one filter per sprite. */
+const buildFilteredContainer = (count: number, filters: readonly Filter[], cacheAsBitmap: boolean): AllocationScene => {
+  const [texture] = makeTextures(1);
+  const root = new Container();
+  const group = new Container();
+
+  for (let i = 0; i < count; i++) {
+    const sprite = new Sprite(texture!);
+
+    scatterInView(sprite, i, VIEW.w, VIEW.h);
+    group.addChild(sprite);
+  }
+
+  for (const filter of filters) {
+    group.addFilter(filter);
+  }
+
+  group.cacheAsBitmap = cacheAsBitmap;
+  root.addChild(group);
+
+  return { root, teardown: () => root.destroy() };
+};
+
+const colorFilterScene = (count: number, filtersPerNode: number): AllocationScene =>
+  buildDecoratedSprites(count, sprite => {
+    for (let i = 0; i < filtersPerNode; i++) {
+      sprite.addFilter(new ColorFilter());
+    }
+  });
+
+/**
+ * The probe catalog. Unlike `ALLOCATION_ARCHETYPES` the ORDER carries no
+ * meaning — every entry is measured in its own process.
+ */
+export const FILTER_ARCHETYPES: readonly AllocationArchetype[] = [
+  // ── BARRIER only: a rect clip takes the barrier path with no target ──────
+  {
+    id: 'filter/clip 100',
+    rationale: 'Rect-clip barrier: barrier entry + child plan + scissor, no offscreen target, no Filter.apply. The barrier floor.',
+    warmup: WARMUP,
+    build: () =>
+      buildDecoratedSprites(100, sprite => {
+        sprite.clip = true;
+      }),
+  },
+
+  // ── BARRIER + TARGET: an alpha mask composites, never calls a filter ─────
+  {
+    id: 'filter/mask 100',
+    rationale: 'Alpha-mask barrier: two acquired targets and a composite per node, with no Filter.apply. Isolates target cost from filter cost.',
+    warmup: WARMUP,
+    build: () => {
+      const [texture] = makeTextures(1);
+
+      return buildDecoratedSprites(100, sprite => {
+        const maskNode = new Sprite(texture!);
+
+        maskNode.setPosition(sprite.position.x, sprite.position.y);
+        sprite.mask = maskNode;
+      });
+    },
+  },
+
+  // ── FILTERED NODE COUNT: fixed cost vs per-node cost ─────────────────────
+  {
+    id: 'filter/color 1',
+    rationale: 'One filtered sprite. With the 10/100/200 rows this separates the per-frame fixed cost from the per-node cost.',
+    warmup: WARMUP,
+    build: () => colorFilterScene(1, 1),
+  },
+  {
+    id: 'filter/color 10',
+    rationale: 'Ten filtered sprites — the low end of the scaling series.',
+    warmup: WARMUP,
+    build: () => colorFilterScene(10, 1),
+  },
+  {
+    id: 'filter/color 100',
+    rationale: "The gate's `filtered/100`, rebuilt here so the whole series is measured by one runner under one warm-up.",
+    warmup: WARMUP,
+    build: () => colorFilterScene(100, 1),
+  },
+  {
+    id: 'filter/color 200',
+    rationale: 'Doubles the node count. Confirms (or breaks) linearity in filtered nodes before anything is attributed per node.',
+    warmup: WARMUP,
+    build: () => colorFilterScene(200, 1),
+  },
+
+  // ── FILTER PASSES per node: same barrier, same first target ──────────────
+  {
+    id: 'filter/stack2 100',
+    rationale: 'Two filters per node: one more Filter.apply and one more intermediate target, same barrier and same capture.',
+    warmup: WARMUP,
+    build: () => colorFilterScene(100, 2),
+  },
+  {
+    id: 'filter/stack3 100',
+    rationale: 'Three filters per node. With stack2 and color/100 this gives the marginal cost of a filter pass directly.',
+    warmup: WARMUP,
+    build: () => colorFilterScene(100, 3),
+  },
+
+  // ── DRAWS per filter pass: pass count held at one ────────────────────────
+  {
+    id: 'filter/blur-q1 100',
+    rationale: 'BlurFilter quality 1 — one pass, six draws. Varies draws per pass while the pass and target counts match color/100.',
+    warmup: WARMUP,
+    build: () =>
+      buildDecoratedSprites(100, sprite => {
+        sprite.addFilter(new BlurFilter({ radius: 2, quality: 1 }));
+      }),
+  },
+  {
+    id: 'filter/blur-q3 100',
+    rationale: 'BlurFilter quality 3 — one pass, fourteen draws. If cost tracks draws rather than passes, this row says so.',
+    warmup: WARMUP,
+    build: () =>
+      buildDecoratedSprites(100, sprite => {
+        sprite.addFilter(new BlurFilter({ radius: 4, quality: 3 }));
+      }),
+  },
+
+  // ── ONE filter over a large subtree ──────────────────────────────────────
+  {
+    id: 'filter/container 1000',
+    rationale: 'One filter over a 1000-sprite subtree: one barrier, one target, one filter pass, a thousand drawables.',
+    warmup: WARMUP,
+    build: () => buildFilteredContainer(1000, [new ColorFilter()], false),
+  },
+  {
+    id: 'filter/container-cached 1000',
+    rationale: 'The same subtree with cacheAsBitmap. After the bake the filter pass should not run per frame at all — verifies that it does not.',
+    warmup: WARMUP,
+    build: () => buildFilteredContainer(1000, [new ColorFilter()], true),
+  },
+];
+
+/** Baseline for the series: the same sprites with no effect of any kind. */
+export const FILTER_REFERENCE: readonly AllocationArchetype[] = [
+  {
+    id: 'filter/none 100',
+    rationale: 'The color/100 scene with the filters removed — the retained-tier floor the filtered rows are measured against.',
+    warmup: WARMUP,
+    build: () => colorFilterScene(100, 0),
+  },
+  {
+    id: 'filter/none 1000',
+    rationale: 'The container/1000 subtree with no filter — the floor for the container rows.',
+    warmup: WARMUP,
+    build: () => buildFilteredContainer(1000, [], false),
+  },
+];
+
+/** Every probe scene, by id. */
+export const ALL_FILTER_ARCHETYPES: readonly AllocationArchetype[] = [...FILTER_REFERENCE, ...FILTER_ARCHETYPES];
+
+/** Node count a scene's per-node numbers should be divided by (filtered/masked/clipped nodes, not drawables). */
+export const FILTERED_NODE_COUNT: Readonly<Record<string, number>> = {
+  'filter/none 100': 0,
+  'filter/none 1000': 0,
+  'filter/clip 100': 100,
+  'filter/mask 100': 100,
+  'filter/color 1': 1,
+  'filter/color 10': 10,
+  'filter/color 100': 100,
+  'filter/color 200': 200,
+  'filter/stack2 100': 100,
+  'filter/stack3 100': 100,
+  'filter/blur-q1 100': 100,
+  'filter/blur-q3 100': 100,
+  'filter/container 1000': 1,
+  'filter/container-cached 1000': 1,
+};
+
+/** Root node of a scene, for callers that need it without rebuilding. */
+export type FilterSceneRoot = RenderNode;

--- a/test/perf/rendering/run-allocation-cell.ts
+++ b/test/perf/rendering/run-allocation-cell.ts
@@ -11,10 +11,17 @@
  *
  *   pnpm perf:renderers:alloc:cell -- --id "mesh/1000" [--windows 1] [--frames 200] [--profile] [--top 25]
  *   pnpm perf:renderers:alloc:cell -- --id "mesh/1000" --cpu
+ *   pnpm perf:renderers:alloc:cell -- --id "filter/color 100" --structural
  *
  * Prints one JSON object on stdout (last line) so a driver can collect runs;
  * `--profile` writes the callsite table to stderr, so it never mixes into it.
  * `--cpu` swaps the sampler for wall-clock timing — see the block below it.
+ * `--structural` reports the frame's work units instead of its bytes — see the
+ * block below THAT, and read the two together: "3 KB per filter pass" and "3 KB
+ * per drawable" are the same KB/frame and different bugs.
+ *
+ * `--id` resolves against the gate catalog first, then the filter probe catalog
+ * in `filterScenes.ts`, then the `reference/<count>` stage.
  *
  * @internal Test/perf-only.
  */
@@ -24,6 +31,7 @@ import type { RenderNode } from '#rendering/RenderNode';
 
 import type { AllocationArchetype, AllocationScene } from './allocationScenes';
 import { ALLOCATION_ARCHETYPES, ALLOCATION_REPORT_ONLY, buildScrollingWorldReference } from './allocationScenes';
+import { ALL_FILTER_ARCHETYPES, FILTERED_NODE_COUNT } from './filterScenes';
 import type { WebGl2Harness } from './harness';
 import { createWebGl2Harness } from './harness';
 
@@ -66,7 +74,7 @@ const REFERENCE_WARMUP = 600;
 
 const archetype: AllocationArchetype | undefined =
   referenceCount === undefined
-    ? [...ALLOCATION_ARCHETYPES, ...ALLOCATION_REPORT_ONLY].find(candidate => candidate.id === id)
+    ? [...ALLOCATION_ARCHETYPES, ...ALLOCATION_REPORT_ONLY, ...ALL_FILTER_ARCHETYPES].find(candidate => candidate.id === id)
     : { id, rationale: 'reference stage', warmup: REFERENCE_WARMUP, build: harness => buildScrollingWorldReference(harness, Number(referenceCount)) };
 
 if (archetype === undefined) {
@@ -195,6 +203,99 @@ if (args.includes('--cpu')) {
   const at = (quantile: number): number => Number((timings[Math.min(timings.length - 1, Math.floor(timings.length * quantile))]! * 1000).toFixed(1));
 
   console.log(JSON.stringify({ id: archetype.id, frames, medianUs: at(0.5), p95Us: at(0.95) }));
+  process.exit(0);
+}
+
+/**
+ * Structural companion mode (`--structural`): the same scene and the same
+ * warm-up, counting the frame's WORK instead of its bytes.
+ *
+ * A KB/frame number alone cannot tell "3 KB per filter pass" from "3 KB per
+ * drawable" or "3 KB per acquired target" — they are the same rate and three
+ * different fixes. This prints the denominators: passes, draws, target
+ * acquisitions, binds, uploads. It is also the guard on any fix that follows,
+ * because trading JS allocation for an extra render pass or an extra texture
+ * copy is not a win.
+ *
+ * Reported for the LAST frame after warm-up, not a sum: every counter here is
+ * per-frame and the scenes are static, so the last frame IS the steady frame.
+ * Pool acquisitions are counted by wrapping the backend rather than by reading
+ * a stat, because the pool deliberately keeps none.
+ */
+if (args.includes('--structural')) {
+  const harness = createWebGl2Harness();
+  const scene: AllocationScene = archetype.build(harness);
+  const warmup = archetype.warmup ?? 30;
+  const backend = harness.backend;
+  const acquireRenderTexture = backend.acquireRenderTexture.bind(backend);
+  const releaseRenderTexture = backend.releaseRenderTexture.bind(backend);
+  const seenTextures = new WeakSet<object>();
+  let acquires = 0;
+  let releases = 0;
+  let poolMisses = 0;
+
+  backend.acquireRenderTexture = (width: number, height: number) => {
+    const texture = acquireRenderTexture(width, height);
+
+    acquires++;
+
+    // A texture this run has never seen before came from `new RenderTexture`,
+    // not from the pool. Counted rather than inferred from a pool size, which
+    // the backend does not expose — and after warm-up a miss means a per-frame
+    // GPU allocation, which is a different and worse problem than a per-frame
+    // JS one.
+    if (seenTextures.has(texture)) {
+      return texture;
+    }
+
+    seenTextures.add(texture);
+    poolMisses++;
+
+    return texture;
+  };
+
+  backend.releaseRenderTexture = (texture: Parameters<typeof releaseRenderTexture>[0]) => {
+    releases++;
+
+    return releaseRenderTexture(texture);
+  };
+
+  for (let i = 0; i < warmup; i++) {
+    renderOnce(harness, scene.root, scene.beforeFrame);
+  }
+
+  acquires = 0;
+  releases = 0;
+  poolMisses = 0;
+  renderOnce(harness, scene.root, scene.beforeFrame);
+
+  const stats = harness.backend.stats;
+  const { recorder } = harness;
+  const filteredNodes = FILTERED_NODE_COUNT[archetype.id];
+
+  scene.teardown?.();
+  harness.destroy();
+
+  console.log(
+    JSON.stringify({
+      id: archetype.id,
+      ...(filteredNodes === undefined ? {} : { filteredNodes }),
+      renderPasses: stats.renderPasses,
+      drawCalls: stats.drawCalls,
+      batches: stats.batches,
+      submittedNodes: stats.submittedNodes,
+      culledNodes: stats.culledNodes,
+      renderTextureAcquires: acquires,
+      renderTextureReleases: releases,
+      renderTexturePoolMisses: poolMisses,
+      textureBinds: recorder.textureBinds,
+      programChanges: recorder.programChanges,
+      bufferUploads: recorder.bufferUploads,
+      uploadedBufferBytes: recorder.bufferUploadBytes,
+      transformUploads: recorder.transformUploads,
+      transformUploadBytes: recorder.transformUploadBytes,
+    }),
+  );
   process.exit(0);
 }
 

--- a/test/rendering/browser/webgl2-effect-direct-draw.test.ts
+++ b/test/rendering/browser/webgl2-effect-direct-draw.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Pixel coverage for the effect path's direct-draw seam.
+ *
+ * `ColorFilter.apply`, `BlurFilter.apply` and `RenderNode._drawTexture` used to
+ * issue their quad through `sprite.render(backend)` — a full
+ * build/optimize/play plan cycle per quad. They now hand the drawable to
+ * `drawDrawableDirect`, which keeps the plan-depth bracket (flush order,
+ * transform-row rewind) and drops everything else, including the cull test.
+ *
+ * Structural counters do not move, so a structural test cannot see this change
+ * at all. What can go wrong is PIXELS: a quad drawn into the wrong target, in
+ * the wrong order, with a stale transform row, or not drawn. Every case below
+ * therefore reads the framebuffer.
+ *
+ * Runs against a real GPU (WebGL2 here; the composite path is backend-neutral,
+ * so `webgpu-effect-direct-draw.test.ts` covers the WebGPU half).
+ */
+import { describe, expect, test } from 'vitest';
+
+import { Color } from '#core/Color';
+import { Rectangle } from '#math/Rectangle';
+import { Container } from '#rendering/Container';
+import { BlurFilter } from '#rendering/filters/BlurFilter';
+import { ColorFilter } from '#rendering/filters/ColorFilter';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+
+import { createWebGl2TestBackend, readWebGl2Pixel, renderWebGl2Once } from './_backendSetup';
+import { expectPixelNear } from './_pixels';
+
+const SIZE = 64;
+
+const solidTexture = (color: string, width = 16, height = 16): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = width;
+  source.height = height;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, width, height);
+
+  return new Texture(source);
+};
+
+describe('effect direct-draw pixel behaviour (WebGL2)', () => {
+  test('a single ColorFilter tints its subject and leaves the rest of the frame alone', async () => {
+    const backend = await createWebGl2TestBackend(SIZE);
+    const texture = solidTexture('#ffffff');
+    const root = new Container();
+    const filtered = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(16, 16);
+      // Multiplying white by pure red must leave red — a filter that never ran
+      // would leave white, and one whose quad missed the target leaves black.
+      filtered.addFilter(new ColorFilter(new Color(255, 0, 0)));
+      filtered.addChild(sprite);
+      root.addChild(filtered);
+
+      renderWebGl2Once(backend, root);
+
+      expectPixelNear(readWebGl2Pixel(backend, 20, 20), [255, 0, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 4, 4), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('a two-filter stack composes both passes rather than keeping only the last', async () => {
+    const backend = await createWebGl2TestBackend(SIZE);
+    const texture = solidTexture('#ffffff');
+    const root = new Container();
+    const filtered = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(16, 16);
+      // White × yellow × magenta = red. Either pass alone leaves a channel the
+      // other kills, so this distinguishes "both ran" from "one ran".
+      filtered.addFilter(new ColorFilter(new Color(255, 255, 0)));
+      filtered.addFilter(new ColorFilter(new Color(255, 0, 255)));
+      filtered.addChild(sprite);
+      root.addChild(filtered);
+
+      renderWebGl2Once(backend, root);
+
+      expectPixelNear(readWebGl2Pixel(backend, 20, 20), [255, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('BlurFilter spreads colour past the subject bounds — its many offset draws all land', async () => {
+    const backend = await createWebGl2TestBackend(SIZE);
+    const texture = solidTexture('#ffffff');
+    const root = new Container();
+    const filtered = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(24, 24);
+      filtered.addFilter(new BlurFilter({ radius: 4, quality: 3 }));
+      filtered.addChild(sprite);
+      root.addChild(filtered);
+
+      renderWebGl2Once(backend, root);
+
+      const centre = readWebGl2Pixel(backend, 32, 32);
+
+      // The blur is additive over `quality * 2 + 1` offset samples per axis, so
+      // the centre stays lit. A run where only the last offset survived would
+      // read near-black here, and one where the samples never flushed reads
+      // exactly black.
+      expect(centre[0]).toBeGreaterThan(40);
+      expectPixelNear(readWebGl2Pixel(backend, 2, 2), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('a container filter covers every child of the subtree, not just the first', async () => {
+    const backend = await createWebGl2TestBackend(SIZE);
+    const texture = solidTexture('#ffffff', 8, 8);
+    const root = new Container();
+    const filtered = new Container();
+    const left = new Sprite(texture);
+    const right = new Sprite(texture);
+
+    try {
+      left.setPosition(8, 8);
+      right.setPosition(40, 40);
+      filtered.addFilter(new ColorFilter(new Color(0, 255, 0)));
+      filtered.addChild(left);
+      filtered.addChild(right);
+      root.addChild(filtered);
+
+      renderWebGl2Once(backend, root);
+
+      expectPixelNear(readWebGl2Pixel(backend, 10, 10), [0, 255, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 42, 42), [0, 255, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('a filtered subtree with cacheAsBitmap renders the same pixels on the baked frame as on the first', async () => {
+    const backend = await createWebGl2TestBackend(SIZE);
+    const texture = solidTexture('#ffffff');
+    const root = new Container();
+    const filtered = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(16, 16);
+      filtered.addFilter(new ColorFilter(new Color(0, 0, 255)));
+      filtered.cacheAsBitmap = true;
+      filtered.addChild(sprite);
+      root.addChild(filtered);
+
+      renderWebGl2Once(backend, root);
+
+      const first = readWebGl2Pixel(backend, 20, 20);
+
+      // The second frame replays the bake through `_drawTexture` — the direct
+      // draw — with no filter pass at all. Same pixels, different code path.
+      renderWebGl2Once(backend, root);
+
+      expectPixelNear(first, [0, 0, 255, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 20, 20), first);
+      expectPixelNear(readWebGl2Pixel(backend, 4, 4), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('resizing a filtered subject between frames re-sizes its targets and still composites correctly', async () => {
+    const backend = await createWebGl2TestBackend(SIZE);
+    const texture = solidTexture('#ffffff');
+    const root = new Container();
+    const filtered = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(8, 8);
+      filtered.addFilter(new ColorFilter(new Color(255, 0, 0)));
+      filtered.addChild(sprite);
+      root.addChild(filtered);
+
+      renderWebGl2Once(backend, root);
+      expectPixelNear(readWebGl2Pixel(backend, 12, 12), [255, 0, 0, 255]);
+      // Outside the 16x16 subject on frame one.
+      expectPixelNear(readWebGl2Pixel(backend, 36, 36), [0, 0, 0, 255]);
+
+      sprite.width = 40;
+      sprite.height = 40;
+
+      renderWebGl2Once(backend, root);
+
+      // The acquired targets follow the new bounds; a stale-size target would
+      // leave this pixel black or sample garbage.
+      expectPixelNear(readWebGl2Pixel(backend, 36, 36), [255, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('a rect mask still clips a filtered subject — the composite honours the enclosing scissor', async () => {
+    const backend = await createWebGl2TestBackend(SIZE);
+    const texture = solidTexture('#ffffff', 32, 32);
+    const root = new Container();
+    const effected = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(8, 8);
+      effected.addFilter(new ColorFilter(new Color(0, 255, 0)));
+      effected.mask = new Rectangle(16, 16, 16, 16);
+      effected.addChild(sprite);
+      root.addChild(effected);
+
+      renderWebGl2Once(backend, root);
+
+      expectPixelNear(readWebGl2Pixel(backend, 20, 20), [0, 255, 0, 255]);
+      // Inside the sprite, outside the mask.
+      expectPixelNear(readWebGl2Pixel(backend, 12, 20), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('mutating the filter colour between frames changes the output', async () => {
+    const backend = await createWebGl2TestBackend(SIZE);
+    const texture = solidTexture('#ffffff');
+    const root = new Container();
+    const filtered = new Container();
+    const sprite = new Sprite(texture);
+    const filter = new ColorFilter(new Color(255, 0, 0));
+
+    try {
+      sprite.setPosition(16, 16);
+      filtered.addFilter(filter);
+      filtered.addChild(sprite);
+      root.addChild(filtered);
+
+      renderWebGl2Once(backend, root);
+      expectPixelNear(readWebGl2Pixel(backend, 20, 20), [255, 0, 0, 255]);
+
+      filter.color.set(0, 0, 255);
+
+      renderWebGl2Once(backend, root);
+      expectPixelNear(readWebGl2Pixel(backend, 20, 20), [0, 0, 255, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('removing the last filter returns the subject to its unfiltered pixels', async () => {
+    const backend = await createWebGl2TestBackend(SIZE);
+    const texture = solidTexture('#ffffff');
+    const root = new Container();
+    const filtered = new Container();
+    const sprite = new Sprite(texture);
+    const filter = new ColorFilter(new Color(255, 0, 0));
+
+    try {
+      sprite.setPosition(16, 16);
+      filtered.addFilter(filter);
+      filtered.addChild(sprite);
+      root.addChild(filtered);
+
+      renderWebGl2Once(backend, root);
+      expectPixelNear(readWebGl2Pixel(backend, 20, 20), [255, 0, 0, 255]);
+
+      filtered.removeFilter(filter);
+
+      // No filters left means no barrier at all: the sprite draws straight into
+      // the frame, which is the other side of the seam this change touches.
+      renderWebGl2Once(backend, root);
+      expectPixelNear(readWebGl2Pixel(backend, 20, 20), [255, 255, 255, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('two filtered siblings composite independently — neither leaks the other’s target', async () => {
+    const backend = await createWebGl2TestBackend(SIZE);
+    const texture = solidTexture('#ffffff', 8, 8);
+    const root = new Container();
+    const first = new Sprite(texture);
+    const second = new Sprite(texture);
+
+    try {
+      first.setPosition(8, 8);
+      second.setPosition(40, 40);
+      first.addFilter(new ColorFilter(new Color(255, 0, 0)));
+      second.addFilter(new ColorFilter(new Color(0, 0, 255)));
+      root.addChild(first);
+      root.addChild(second);
+
+      renderWebGl2Once(backend, root);
+
+      // Pooled targets are reused between the two barriers; a composite that
+      // read the wrong one would paint both siblings the same colour.
+      expectPixelNear(readWebGl2Pixel(backend, 10, 10), [255, 0, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 42, 42), [0, 0, 255, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/browser/webgpu-effect-direct-draw.test.ts
+++ b/test/rendering/browser/webgpu-effect-direct-draw.test.ts
@@ -1,0 +1,168 @@
+/**
+ * WebGPU half of the effect direct-draw pixel coverage.
+ *
+ * `RenderNode._drawTexture` and the stock `ColorFilter` / `BlurFilter` are
+ * backend-neutral — they go through `backend.execute` and `backend.draw` — so
+ * the switch to `drawDrawableDirect` changes the WebGPU path as much as the
+ * WebGL2 one. WebGPU is also where it could plausibly break differently: a pass
+ * is an explicit encoder object here, not ambient state, so a quad issued
+ * outside the plan machinery is a real question about which encoder it lands
+ * in.
+ *
+ * Deliberately narrower than the WebGL2 suite: the cases below are the ones
+ * whose failure mode is backend-specific (pass/encoder routing, target
+ * restore), not the ones that re-test filter arithmetic.
+ *
+ * The lane guarantees a real adapter, so there is no availability guard here —
+ * a mid-test device loss is handled by `renderWebGpuOnce`, which skips.
+ *
+ * Run via:  pnpm test:browser:webgpu
+ */
+import { describe, expect, test } from 'vitest';
+
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { ColorFilter } from '#rendering/filters/ColorFilter';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { Texture } from '#rendering/texture/Texture';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { makeTestApp, makeTestCanvas, readWebGpuPixels, renderWebGpuOnce } from './_backendSetup';
+import { wireCoreRenderers } from './_coreRenderers';
+import { expectPixelNear } from './_pixels';
+
+const SIZE = 64;
+
+const solidTexture = (color: string, width = 16, height = 16): Texture => {
+  const source = document.createElement('canvas');
+
+  source.width = width;
+  source.height = height;
+
+  const context = source.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D context is required to create test textures.');
+  }
+
+  context.fillStyle = color;
+  context.fillRect(0, 0, width, height);
+
+  return new Texture(source);
+};
+
+const createBackend = async (): Promise<WebGpuBackend> => {
+  const app: Application = makeTestApp(makeTestCanvas(SIZE), SIZE);
+  const backend = new WebGpuBackend(app);
+
+  wireCoreRenderers(backend);
+  await backend.initialize();
+
+  return backend;
+};
+
+describe('effect direct-draw pixel behaviour (WebGPU)', () => {
+  test('a ColorFilter composites back into the frame, not into its own target', async ctx => {
+    const backend = await createBackend();
+    const texture = solidTexture('#ffffff');
+    const root = new Container();
+    const filtered = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(16, 16);
+      filtered.addFilter(new ColorFilter(new Color(255, 0, 0)));
+      filtered.addChild(sprite);
+      root.addChild(filtered);
+
+      if (!(await renderWebGpuOnce(ctx, backend, root))) {
+        return;
+      }
+
+      const pixel = readWebGpuPixels(backend, SIZE);
+
+      // A composite that stayed in the filter's own encoder leaves the frame
+      // black here; one that ran before the filter leaves white.
+      expectPixelNear(pixel(20, 20), [255, 0, 0, 255]);
+      expectPixelNear(pixel(4, 4), [0, 0, 0, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('two filtered siblings each composite into the frame in order', async ctx => {
+    const backend = await createBackend();
+    const texture = solidTexture('#ffffff', 8, 8);
+    const root = new Container();
+    const first = new Sprite(texture);
+    const second = new Sprite(texture);
+
+    try {
+      first.setPosition(8, 8);
+      second.setPosition(40, 40);
+      first.addFilter(new ColorFilter(new Color(255, 0, 0)));
+      second.addFilter(new ColorFilter(new Color(0, 0, 255)));
+      root.addChild(first);
+      root.addChild(second);
+
+      if (!(await renderWebGpuOnce(ctx, backend, root))) {
+        return;
+      }
+
+      const pixel = readWebGpuPixels(backend, SIZE);
+
+      expectPixelNear(pixel(10, 10), [255, 0, 0, 255]);
+      expectPixelNear(pixel(42, 42), [0, 0, 255, 255]);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+
+  test('a cacheAsBitmap replay draws the baked texture without re-running the filter', async ctx => {
+    const backend = await createBackend();
+    const texture = solidTexture('#ffffff');
+    const root = new Container();
+    const filtered = new Container();
+    const sprite = new Sprite(texture);
+
+    try {
+      sprite.setPosition(16, 16);
+      filtered.addFilter(new ColorFilter(new Color(0, 255, 0)));
+      filtered.cacheAsBitmap = true;
+      filtered.addChild(sprite);
+      root.addChild(filtered);
+
+      if (!(await renderWebGpuOnce(ctx, backend, root))) {
+        return;
+      }
+
+      expectPixelNear(readWebGpuPixels(backend, SIZE)(20, 20), [0, 255, 0, 255]);
+
+      const bakePasses = backend.stats.renderPasses;
+
+      // Frame two takes the bake branch: no capture pass and no filter pass,
+      // only the direct composite draw of the cached texture.
+      if (!(await renderWebGpuOnce(ctx, backend, root))) {
+        return;
+      }
+
+      const replayed = readWebGpuPixels(backend, SIZE);
+
+      expectPixelNear(replayed(20, 20), [0, 255, 0, 255]);
+      expectPixelNear(replayed(4, 4), [0, 0, 0, 255]);
+      // Compared against the bake frame rather than against zero: WebGPU counts
+      // the frame's own encoder as a pass (WebGL2 does not), so the absolute
+      // floor differs per backend while the drop does not.
+      expect(backend.stats.renderPasses).toBeLessThan(bakePasses);
+    } finally {
+      root.destroy();
+      texture.destroy();
+      backend.destroy();
+    }
+  });
+});

--- a/test/rendering/render-plan.test.ts
+++ b/test/rendering/render-plan.test.ts
@@ -445,14 +445,21 @@ describe('render plan', () => {
     expect(draw).toHaveBeenCalledTimes(1);
   });
 
+  // Driven by a RenderNode mask, not by `cacheAsBitmap`. The bitmap-cache
+  // composite used to render its cache sprite through `playRenderTree`, so it
+  // nested a builder; it now hands the sprite to `drawDrawableDirect` and does
+  // not. A node mask still renders its source subtree through a real nested
+  // plan (`RenderEffectExecutor._resolveMaskTexture`), which is what this test
+  // is actually about.
   test('builder pool is re-entrant and nested render() acquires distinct builders', () => {
     const { backend } = createRuntime();
     const root = new Container();
     const child = new BoxDrawable('child');
+    const maskSource = new BoxDrawable('mask');
     const acquiredBuilders: RenderPlanBuilder[] = [];
     const originalAcquire = RenderPlanBuilder.acquire;
 
-    root.cacheAsBitmap = true;
+    root.mask = maskSource;
     root.addChild(child);
 
     const acquireSpy = vi.spyOn(RenderPlanBuilder, 'acquire').mockImplementation(() => {


### PR DESCRIPTION
Q11-A. Removes the render-plan cycle the effect path was running per filter
pass and per composite.

## The finding

`filtered/100` reads ~295 KB/frame against a ~1 KB floor for every other gated
scene, and "≈3 KB per filtered sprite" does not say which unit of work costs
it. Three are stacked inside a filtered node, so they were isolated by
subtraction (`test/perf/rendering/filterScenes.ts`, driven one-scene-per-process
by the cell runner):

| unit | cost |
| --- | ---: |
| barrier alone (rect clip — no target, no filter pass) | 1.18 KB/node |
| first filter (capture pass + filter pass + composite + 2 acquires) | 1.63 KB/node |
| each additional filter in the chain | 0.94 / 0.95 KB |
| each additional **draw** inside a pass | 0.44 / 0.60 KB |

Linear in barrier nodes (`color 100` 2.81 vs `color 200` 2.84 KB/node), not in
drawables (`container/1000` is one barrier at 3.96 KB for a 1000-sprite
subtree).

The last row is the one that should not exist: an entire 1000-sprite frame
costs 1.02 KB. `ColorFilter.apply`, `BlurFilter.apply` and
`RenderNode._drawTexture` all drew their quad through `sprite.render(backend)`,
and `RenderNode.render` is `playRenderTree` — build, optimize, play. A filtered
node paid a full plan cycle twice per frame; a blur at quality 3 paid it
fifteen times, which is exactly why blur scaled with draws instead of passes.

## The change

`drawDrawableDirect(drawable, backend)` keeps the backend's plan-depth bracket
and drops everything else.

The bracket is the load-bearing half: ending a NESTED plan flushes the active
renderer and rewinds the transform rows the draw pushed, so flush order and
buffer traffic are unchanged. Everything else the plan would have contributed
was already true — the enclosing `BackendTargetPass` bound target, view and
clear; a single-sprite plan's pass carries `target: null` and the backend's own
view, so playing it changed neither; and the renderers already fall back to
`_pushTransform` when no plan draw command is active
(`WebGl2SpriteRenderer.ts`).

The cull test is deliberately dropped. Effect code only reaches these call
sites for output it has already decided to produce. The one configuration where
a collected node might not be visible — the retained capture's inflated cull
rect — is measured rather than argued (`filter/color 100 margin`, half the
nodes visible so the root survives): the counters are identical with and
without the change, because a filtered subtree never reaches the retained tier
in the first place.

Internal only. Not exported from `src/index.ts` or `renderer-sdk.ts`.

## Allocation (fresh-process, 3 windows x 200 frames)

| scene | before | after | Δ |
| --- | ---: | ---: | ---: |
| `color 100` | 282.36 | 218.60 | −22.6% |
| `stack2 100` | 376.08 | 280.41 | −25.4% |
| `stack3 100` | 471.00 | 342.68 | −27.2% |
| `blur-q1 100` | 501.40 | 330.47 | −34.1% |
| `blur-q3 100` | 980.23 | 560.26 | −42.8% |
| `container 1000` | 4.97 | 3.81 | −23.3% |
| `clip 100` (control — no filter, no composite) | 119.41 | 119.89 | unchanged |

Marginal cost per additional draw 0.44/0.60 → **0.22/0.29 KB**; per additional
filter pass 0.94/0.95 → **0.62 KB**.

## CPU (baseline worktree, alternating, three repetitions)

| scene | before | after | Δ | p95 |
| --- | ---: | ---: | ---: | --- |
| `color 100` | 3280.7 µs | 3083.4 | −6.0% | 3474.4 → 3294.5 |
| `stack3 100` | 5121.1 | 4793.5 | −6.4% | 5376.9 → 5127.8 |
| `blur-q3 100` | 12960.4 | 11230.0 | −13.4% | 13578.7 → 11868.7 |
| `container 1000` | 247.9 | 244.0 | −1.6% (noise) | 306.8 → 295.3 |

## Structural / GPU

Byte-identical on every probe scene: render passes, draw calls, batches, render
texture acquisitions (0 pool misses), texture binds, buffer uploads and
transform upload bytes. No GPU work traded for JS allocation.

## Tests

Framebuffer coverage on both backends, because a structural test cannot see
this change at all — what can break is pixels: single filter, two-filter stack,
blur's offset samples, container filter, `cacheAsBitmap` replay, subject
resize, filter + rect mask, uniform mutation between frames, filter removal,
two filtered siblings sharing pooled targets. Proven to have teeth rather than
assumed: with the draw suppressed inside `drawDrawableDirect`, all ten WebGL2
cases fail.

The WebGPU half is narrower on purpose — the cases whose failure mode is
backend-specific (which encoder a quad lands in, target restore). Its
`cacheAsBitmap` case compares the replay frame's pass count against the bake
frame's rather than against zero, because WebGPU counts the frame's own encoder
as a pass and WebGL2 does not.

A shape gate is added as well, because the pixel suite passes with the
plan-depth bracket removed — the picture is identical, and the allocation gate
then reads a filtered scene as *cheaper*. On `blur-q3`, dropping the bracket
moves draw calls 1600 → 300 and transform bytes 48000 → 116288. Pinning both
columns makes that a conscious trade rather than an accident.

One existing test moved: `render-plan.test.ts` drove builder re-entrancy
through `cacheAsBitmap`, whose composite no longer nests a builder. It now uses
a RenderNode mask, which still renders its source subtree through a real nested
plan.

## Budget

`filtered/100` ratchets 306.55 → 229.59 KB/frame (budget 264.0). **Only this
row moves — no global re-baseline.** The slice reaches nothing outside the
barrier path and every other scene re-measured identical. The filter work
continues, so this row is expected to ratchet again; each landed slice protects
its own gain rather than leaving the next one to collect them all.

## Follow-ups, not in this PR

- **Control-plane allocation.** The barrier floor of 1.18 KB/node is now 54% of
  what `color/100` costs above the harness floor: the per-frame
  `EffectDescriptor` and `BarrierScope`, the CPS closures through
  `BackendTargetPass` / `withChildPass`, and the clip path's `Rectangle` and
  `mapCoordsToPixel` temporaries.
- **Batching several internal effect draws inside one controlled transform
  lifetime.** The bracket is not overhead — it bounds transform-scratch
  lifetime — but its current per-draw granularity forces a flush between blur
  samples. That is a GPU-submission change with its own pixel, transform and
  batching evidence to produce, not an allocation question.
- Not a bug, recorded for later: a barrier breaks batching outright
  (`none/100` 1 draw call, `clip/100` 100). Whether those barriers genuinely
  need distinct GPU state is a separate question.
