### PR TITLE
perf(rendering): stop rebuilding the effect path's control plane every frame

### DIFF
--- a/src/rendering/BackendTargetPass.ts
+++ b/src/rendering/BackendTargetPass.ts
@@ -1,5 +1,7 @@
 import type { Color } from '#core/Color';
+import type { Mutable } from '#core/types';
 import type { RenderPassCoordinatorHost } from '#rendering/pass/RenderPassCoordinator';
+import type { RenderPassDescriptor } from '#rendering/pass/RenderPassDescriptor';
 import { StencilAttachmentMode } from '#rendering/pass/RenderPassDescriptor';
 
 import type { BackendRenderPass } from './BackendRenderPass';
@@ -33,10 +35,41 @@ export interface BackendTargetPassOptions {
  * @internal
  */
 export class BackendTargetPass implements BackendRenderPass {
-  private readonly _callback: (backend: RenderBackend) => void;
-  private readonly _target: RenderTarget | null;
-  private readonly _view: View | null;
-  private readonly _clearColor: Color | null;
+  private _callback: (backend: RenderBackend) => void;
+  private _target: RenderTarget | null;
+  private _view: View | null;
+  private _clearColor: Color | null;
+
+  /**
+   * The descriptor handed to the coordinator, rewritten in place per execute.
+   *
+   * The coordinator reads it synchronously inside `withChildPass` and keeps no
+   * reference, so one instance per pass is enough. It matters because the
+   * effect path executes a pass per capture and per filter — a hundred filtered
+   * nodes is two hundred descriptors a frame, for a shape that never varies.
+   */
+  private readonly _descriptor: Mutable<RenderPassDescriptor> = {
+    target: null,
+    view: null,
+    load: 'load',
+    clearColor: null,
+    stencil: StencilAttachmentMode.None,
+  };
+
+  /**
+   * The pass body, allocated ONCE per pass rather than per execute.
+   *
+   * `withChildPass` takes a `() => void`, and the obvious inline arrow closes
+   * over `backend` — a fresh closure and its context on every execute, on the
+   * hottest effect path there is. Staging the backend on the instance instead
+   * lets one bound function serve every call. Not reentrant, which costs
+   * nothing: a pass cannot be executing inside itself.
+   */
+  private readonly _runCallback = (): void => {
+    this._callback(this._activeBackend!);
+  };
+
+  private _activeBackend: RenderBackend | null = null;
 
   public constructor(callback: (backend: RenderBackend) => void, options: BackendTargetPassOptions = {}) {
     this._callback = callback;
@@ -45,22 +78,51 @@ export class BackendTargetPass implements BackendRenderPass {
     this._clearColor = options.clearColor ?? null;
   }
 
+  /**
+   * Re-point this pass at a different body, target, view and clear colour.
+   *
+   * For callers that execute a target redirect every frame — the stock filters
+   * and `RenderNode`'s capture/composite — so they can hold ONE pass instead of
+   * constructing one per frame. A caller that configures a pass once still just
+   * uses the constructor.
+   */
+  public reconfigure(callback: (backend: RenderBackend) => void, target: RenderTarget | null, view: View | null, clearColor: Color | null): this {
+    this._callback = callback;
+
+    return this.retarget(target, view, clearColor);
+  }
+
+  /**
+   * Re-point this pass at a different target, view and clear colour, keeping
+   * its body. The stock filters draw the same sprite every time and only the
+   * output target moves, so they never need to touch the callback.
+   */
+  public retarget(target: RenderTarget | null, view: View | null, clearColor: Color | null): this {
+    this._target = target;
+    this._view = view;
+    this._clearColor = clearColor;
+
+    return this;
+  }
+
   public execute(backend: RenderBackend): void {
     const coordinator = (backend as RenderBackend & Partial<RenderPassCoordinatorHost>)._passCoordinator;
 
     if (coordinator) {
-      coordinator.withChildPass(
-        {
-          target: this._target,
-          view: this._view,
-          load: this._clearColor !== null ? 'clear' : 'load',
-          clearColor: this._clearColor,
-          stencil: StencilAttachmentMode.None,
-        },
-        () => {
-          this._callback(backend);
-        },
-      );
+      const descriptor = this._descriptor;
+      const previousBackend = this._activeBackend;
+
+      descriptor.target = this._target;
+      descriptor.view = this._view;
+      descriptor.load = this._clearColor !== null ? 'clear' : 'load';
+      descriptor.clearColor = this._clearColor;
+      this._activeBackend = backend;
+
+      try {
+        coordinator.withChildPass(descriptor, this._runCallback);
+      } finally {
+        this._activeBackend = previousBackend;
+      }
 
       return;
     }

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -354,6 +354,12 @@ export abstract class RenderNode extends SceneNode {
   private readonly _cacheBounds: Rectangle = new Rectangle();
   private _cacheSprite: RenderNodeSpriteLike | null = null;
   private _captureView: View | null = null;
+  /** Lazily built, then reused for every capture this node performs — see {@link _renderContentToTexture}. */
+  private _capturePass: BackendTargetPass | null = null;
+  private _captureContent: (() => void) | null = null;
+  private readonly _runCaptureContent = (): void => {
+    this._captureContent?.();
+  };
   private _mask: MaskSource = null;
   private _cacheAsBitmap = false;
   private _cacheDirty = true;
@@ -613,7 +619,16 @@ export abstract class RenderNode extends SceneNode {
 
   /** @internal */
   public _renderPlanCanReuseBitmapCache(left: number, top: number, width: number, height: number): boolean {
-    return this._cacheAsBitmap && !this._cacheDirty && this._cacheTexture !== null && this._cacheBounds.equals({ x: left, y: top, width, height });
+    if (!this._cacheAsBitmap || this._cacheDirty || this._cacheTexture === null) {
+      return false;
+    }
+
+    // Compared field by field rather than through `equals`, which takes a rect
+    // and so needed an object literal built here — once per cached barrier per
+    // frame, purely to be read and thrown away.
+    const bounds = this._cacheBounds;
+
+    return bounds.x === left && bounds.y === top && bounds.width === width && bounds.height === height;
   }
 
   /** @internal */
@@ -717,18 +732,22 @@ export abstract class RenderNode extends SceneNode {
       this._captureView.reset(left + width / 2, top + height / 2, width, height);
     }
 
-    backend.execute(
-      new BackendTargetPass(
-        () => {
-          renderContent();
-        },
-        {
-          target,
-          view: this._captureView,
-          clearColor: Color.transparentBlack,
-        },
-      ),
-    );
+    // The pass, its options object and the body closure were all built fresh
+    // here, once per barrier per frame. The pass is now owned by the node and
+    // re-pointed; the body is a bound method that reads the staged content
+    // callback, so it is allocated once instead of per capture.
+    //
+    // Staging is safe against nesting because the stack is per NODE: a filtered
+    // subtree inside another filtered node captures through the inner node's
+    // own pass. A node cannot be capturing inside itself.
+    this._capturePass ??= new BackendTargetPass(this._runCaptureContent);
+    this._captureContent = renderContent;
+
+    try {
+      backend.execute(this._capturePass.retarget(target, this._captureView, Color.transparentBlack));
+    } finally {
+      this._captureContent = null;
+    }
   }
 
   private _drawTexture(backend: RenderBackend, texture: RenderTexture, x: number, y: number, width: number, height: number, blendMode: BlendModes): void {

--- a/src/rendering/RenderTarget.ts
+++ b/src/rendering/RenderTarget.ts
@@ -160,10 +160,25 @@ export class RenderTarget {
   }
 
   public mapCoordsToPixel(point: Vector, view: View = this._view): Vector {
-    const viewport = this.getViewport(view);
-    const normalized = point.clone().transform(view.getTransform());
+    return this._mapCoordsToPixelInPlace(point.clone(), view);
+  }
 
-    return normalized.set((((normalized.x + 1) / 2) * viewport.width + viewport.left) | 0, (((-normalized.y + 1) / 2) * viewport.height + viewport.top) | 0);
+  /**
+   * {@link mapCoordsToPixel} without the defensive copy: transforms `point` in
+   * place and returns it.
+   *
+   * The public method must not touch its argument, so it clones — and the clip
+   * path calls it twice per scissor push, i.e. twice per clipped or masked
+   * barrier per frame, always on a scratch vector the caller already owns and
+   * is about to overwrite. Callers that own their point use this instead.
+   * @internal
+   */
+  public _mapCoordsToPixelInPlace(point: Vector, view: View = this._view): Vector {
+    const viewport = this.getViewport(view);
+
+    point.transform(view.getTransform());
+
+    return point.set((((point.x + 1) / 2) * viewport.width + viewport.left) | 0, (((-point.y + 1) / 2) * viewport.height + viewport.top) | 0);
   }
 
   public destroy(): void {

--- a/src/rendering/filters/BlurFilter.ts
+++ b/src/rendering/filters/BlurFilter.ts
@@ -25,6 +25,8 @@ export interface BlurFilterOptions {
 export class BlurFilter extends Filter {
   private readonly _sprite: Sprite = new Sprite(null);
   private readonly _sampleTint: Color = Color.white.clone();
+  /** One redirect pass, re-pointed per application — see {@link BackendTargetPass.retarget}. */
+  private readonly _pass: BackendTargetPass = new BackendTargetPass(backend => this._drawSamples(backend));
   private _radius = 2;
   private _quality = 1;
 
@@ -52,10 +54,8 @@ export class BlurFilter extends Filter {
   }
 
   public apply(backend: RenderBackend, input: RenderTexture, output: RenderTexture): void {
-    const radius = this._radius;
-    const quality = this._quality;
-    const steps = Math.max(1, quality * 2 + 1);
-    const sampleCount = radius <= 0 ? 1 : steps * 2;
+    const steps = Math.max(1, this._quality * 2 + 1);
+    const sampleCount = this._radius <= 0 ? 1 : steps * 2;
     const alpha = 1 / sampleCount;
 
     this._sampleTint.set(255, 255, 255, alpha);
@@ -63,30 +63,32 @@ export class BlurFilter extends Filter {
     this._sprite.width = output.width;
     this._sprite.height = output.height;
 
-    backend.execute(
-      new BackendTargetPass(
-        () => {
-          if (radius <= 0) {
-            drawDrawableDirect(this._sprite.setPosition(0, 0), backend);
+    backend.execute(this._pass.retarget(output, output.view, Color.transparentBlack));
+  }
 
-            return;
-          }
+  /**
+   * The pass body. A method rather than an inline closure so the sample loop
+   * reads its parameters off the instance instead of capturing them — the
+   * closure would otherwise be rebuilt for every filtered node, every frame.
+   */
+  private _drawSamples(backend: RenderBackend): void {
+    const radius = this._radius;
 
-          for (let step = 0; step < steps; step++) {
-            const t = steps === 1 ? 0 : step / (steps - 1);
-            const offset = (t * 2 - 1) * radius;
+    if (radius <= 0) {
+      drawDrawableDirect(this._sprite.setPosition(0, 0), backend);
 
-            drawDrawableDirect(this._sprite.setPosition(offset, 0), backend);
-            drawDrawableDirect(this._sprite.setPosition(0, offset), backend);
-          }
-        },
-        {
-          target: output,
-          view: output.view,
-          clearColor: Color.transparentBlack,
-        },
-      ),
-    );
+      return;
+    }
+
+    const steps = Math.max(1, this._quality * 2 + 1);
+
+    for (let step = 0; step < steps; step++) {
+      const t = steps === 1 ? 0 : step / (steps - 1);
+      const offset = (t * 2 - 1) * radius;
+
+      drawDrawableDirect(this._sprite.setPosition(offset, 0), backend);
+      drawDrawableDirect(this._sprite.setPosition(0, offset), backend);
+    }
   }
 
   public override destroy(): void {

--- a/src/rendering/filters/ColorFilter.ts
+++ b/src/rendering/filters/ColorFilter.ts
@@ -18,6 +18,8 @@ import { Filter } from './Filter';
 export class ColorFilter extends Filter {
   private readonly _color: Color;
   private readonly _sprite: Sprite = new Sprite(null);
+  /** One redirect pass, re-pointed per application — see {@link BackendTargetPass.reconfigure}. */
+  private readonly _pass: BackendTargetPass = new BackendTargetPass(backend => drawDrawableDirect(this._sprite, backend));
 
   public constructor(color: Color = Color.white) {
     super();
@@ -35,18 +37,7 @@ export class ColorFilter extends Filter {
     this._sprite.width = output.width;
     this._sprite.height = output.height;
 
-    backend.execute(
-      new BackendTargetPass(
-        () => {
-          drawDrawableDirect(this._sprite, backend);
-        },
-        {
-          target: output,
-          view: output.view,
-          clearColor: Color.transparentBlack,
-        },
-      ),
-    );
+    backend.execute(this._pass.retarget(output, output.view, Color.transparentBlack));
   }
 
   public override destroy(): void {

--- a/src/rendering/plan/RenderEffectExecutor.ts
+++ b/src/rendering/plan/RenderEffectExecutor.ts
@@ -7,20 +7,130 @@ import { Texture } from '#rendering/texture/Texture';
 
 import { type BarrierScope, ClipKind, type GroupScope } from './RenderScope';
 
+/**
+ * One barrier's in-flight state, held on a depth-indexed stack.
+ *
+ * The clip / rect-clip / mask chain is continuation-passing — each layer wraps
+ * the next and the innermost body does the actual work — and written the
+ * obvious way that means a fresh closure per layer per barrier per frame, plus
+ * the enclosing function's context. On a hundred filtered nodes that was the
+ * single largest steady-state allocation left in the effect path.
+ *
+ * Staging the state here instead lets every body be a static function allocated
+ * once. Barriers nest (a filtered node inside a filtered container), hence a
+ * stack rather than a single slot; the frames are reused across frames and
+ * across barriers, so the stack only ever grows to the deepest nesting the
+ * scene reaches.
+ */
+interface EffectFrame {
+  barrier: BarrierScope | null;
+  backend: RenderBackend | null;
+  playScope: ((scope: GroupScope) => void) | null;
+  /** Set on the `cacheAsBitmap` replay path — the baked texture to composite. */
+  cachedTexture: RenderTexture | null;
+  /** Set on the full path — the filter chain's output, or the capture when there are no filters. */
+  finalTexture: RenderTexture | null;
+  /**
+   * Set while resolving a NODE mask into its own target. Narrower than
+   * {@link MaskSource}: the texture-backed sources need no render pass, so only
+   * a node ever reaches the body that reads this.
+   */
+  maskSource: RenderNode | null;
+}
+
+const createFrame = (): EffectFrame => ({
+  barrier: null,
+  backend: null,
+  playScope: null,
+  cachedTexture: null,
+  finalTexture: null,
+  maskSource: null,
+});
+
 /** @internal */
 export class RenderEffectExecutor {
+  private static readonly _frames: EffectFrame[] = [];
+  private static _depth = 0;
+
+  /** The frame the currently executing body belongs to. */
+  private static _current(): EffectFrame {
+    // In range: bodies only run between a push and its matching pop.
+    return RenderEffectExecutor._frames[RenderEffectExecutor._depth - 1]!;
+  }
+
+  /** Body: play the barrier's child plan. Used by the effect-less and capture paths. */
+  private static readonly _playChildPlan = (): void => {
+    const frame = RenderEffectExecutor._current();
+
+    if (frame.barrier!.childPlan !== null) {
+      frame.playScope!(frame.barrier!.childPlan);
+    }
+  };
+
+  /** Body: draw the `cacheAsBitmap` texture straight back into the enclosing target. */
+  private static readonly _drawCachedTexture = (): void => {
+    const frame = RenderEffectExecutor._current();
+    const { barrier, backend, cachedTexture } = frame;
+
+    barrier!.node._renderPlanDrawTexture(backend!, cachedTexture!, barrier!.left, barrier!.top, barrier!.width, barrier!.height, barrier!.effect.blendMode);
+  };
+
+  /** Body: composite the filter chain's output back into the enclosing target. */
+  private static readonly _compositeFinalTexture = (): void => {
+    const frame = RenderEffectExecutor._current();
+    const { barrier, backend, finalTexture } = frame;
+    const { left, top, width, height, effect } = barrier!;
+
+    if (effect.needsBackdropBlend) {
+      backend!.composeWithBackdropBlend(finalTexture!, left, top, width, height, effect.blendMode);
+    } else {
+      barrier!.node._renderPlanDrawTexture(backend!, finalTexture!, left, top, width, height, effect.blendMode);
+    }
+  };
+
+  /** Body: render a node mask's own subtree into the mask target. */
+  private static readonly _renderMaskSource = (): void => {
+    const frame = RenderEffectExecutor._current();
+
+    frame.maskSource!.render(frame.backend!);
+  };
+
   public static play(barrier: BarrierScope, backend: RenderBackend, playScope: (scope: GroupScope) => void): void {
+    const depth = RenderEffectExecutor._depth;
+    const frame = (RenderEffectExecutor._frames[depth] ??= createFrame());
+
+    frame.barrier = barrier;
+    frame.backend = backend;
+    frame.playScope = playScope;
+    frame.cachedTexture = null;
+    frame.finalTexture = null;
+    frame.maskSource = null;
+    RenderEffectExecutor._depth = depth + 1;
+
+    try {
+      this._playFramed(barrier, backend, frame);
+    } finally {
+      RenderEffectExecutor._depth = depth;
+      // Drop the references rather than only the depth: a frame outlives the
+      // barrier it served, and holding the scope would pin its drawables until
+      // the same nesting depth is reached again.
+      frame.barrier = null;
+      frame.backend = null;
+      frame.playScope = null;
+      frame.cachedTexture = null;
+      frame.finalTexture = null;
+      frame.maskSource = null;
+    }
+  }
+
+  private static _playFramed(barrier: BarrierScope, backend: RenderBackend, frame: EffectFrame): void {
     const { node, effect } = barrier;
     const hasFilters = effect.filters.length > 0;
     const needsBitmapCache = effect.cacheAsBitmap;
     const { left, top, width, height } = barrier;
 
     if (!hasFilters && !needsBitmapCache && !effect.needsBackdropBlend) {
-      this._withClip(node, backend, barrier, () => {
-        if (barrier.childPlan !== null) {
-          playScope(barrier.childPlan);
-        }
-      });
+      this._withClip(node, backend, barrier, this._playChildPlan);
 
       return;
     }
@@ -29,9 +139,8 @@ export class RenderEffectExecutor {
       const cachedTexture = node._renderPlanGetCacheTexture();
 
       if (cachedTexture !== null) {
-        this._withClip(node, backend, barrier, () => {
-          node._renderPlanDrawTexture(backend, cachedTexture, left, top, width, height, effect.blendMode);
-        });
+        frame.cachedTexture = cachedTexture;
+        this._withClip(node, backend, barrier, this._drawCachedTexture);
       }
 
       return;
@@ -47,11 +156,7 @@ export class RenderEffectExecutor {
         pooledTexture = sourceTexture;
       }
 
-      node._renderPlanRenderToTexture(backend, sourceTexture, left, top, width, height, () => {
-        if (barrier.childPlan !== null) {
-          playScope(barrier.childPlan);
-        }
-      });
+      node._renderPlanRenderToTexture(backend, sourceTexture, left, top, width, height, this._playChildPlan);
 
       let finalTexture = sourceTexture;
 
@@ -88,13 +193,8 @@ export class RenderEffectExecutor {
         node._renderPlanStoreCacheTexture(cacheTexture!, left, top, width, height);
       }
 
-      this._withClip(node, backend, barrier, () => {
-        if (effect.needsBackdropBlend) {
-          backend.composeWithBackdropBlend(finalTexture, left, top, width, height, effect.blendMode);
-        } else {
-          node._renderPlanDrawTexture(backend, finalTexture, left, top, width, height, effect.blendMode);
-        }
-      });
+      frame.finalTexture = finalTexture;
+      this._withClip(node, backend, barrier, this._compositeFinalTexture);
     } finally {
       if (pooledTexture !== null) {
         backend.releaseRenderTexture(pooledTexture);
@@ -179,8 +279,9 @@ export class RenderEffectExecutor {
 
       backend.composeWithAlphaMask(contentTexture, maskTexture, barrier.left, barrier.top, barrier.width, barrier.height, barrier.effect.blendMode);
     } finally {
-      for (const texture of releasePool) {
-        backend.releaseRenderTexture(texture);
+      for (let i = 0; i < releasePool.length; i++) {
+        // In-bounds: i < length.
+        backend.releaseRenderTexture(releasePool[i]!);
       }
     }
   }
@@ -194,12 +295,17 @@ export class RenderEffectExecutor {
   ): Texture | RenderTexture {
     if (!(mask instanceof Texture) && !(mask instanceof RenderTexture)) {
       const maskTexture = backend.acquireRenderTexture(barrier.width, barrier.height);
+      const frame = RenderEffectExecutor._current();
+      const previousMask = frame.maskSource;
 
       releasePool.push(maskTexture);
+      frame.maskSource = mask;
 
-      node._renderPlanRenderToTexture(backend, maskTexture, barrier.left, barrier.top, barrier.width, barrier.height, () => {
-        mask.render(backend);
-      });
+      try {
+        node._renderPlanRenderToTexture(backend, maskTexture, barrier.left, barrier.top, barrier.width, barrier.height, this._renderMaskSource);
+      } finally {
+        frame.maskSource = previousMask;
+      }
 
       return maskTexture;
     }

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -1,5 +1,7 @@
+import type { Mutable } from '#core/types';
 import { type ReadonlyRectangle, Rectangle } from '#math/Rectangle';
 import type { Drawable } from '#rendering/Drawable';
+import type { Filter } from '#rendering/filters/Filter';
 import type { Geometry } from '#rendering/geometry/Geometry';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { RenderNode } from '#rendering/RenderNode';
@@ -114,8 +116,11 @@ interface SourceSelection {
  * playback semantics — the group uniform is suspended (the branch collected
  * world-space transforms) and fragment capture records a live re-dispatch.
  */
+/** Placeholder for a pooled descriptor's `filters` before its first fill. */
+const emptyFilters: readonly Filter[] = Object.freeze([]);
+
 const groupEscapeEffect: EffectDescriptor = Object.freeze({
-  filters: [],
+  filters: emptyFilters,
   clip: ClipKind.None,
   clipShape: null,
   maskSource: null,
@@ -211,6 +216,15 @@ export class RenderPlanBuilder {
   private _groupEntryPoolCursor = 0;
   private readonly _barrierEntryPool: BarrierScopeEntry[] = [];
   private _barrierEntryPoolCursor = 0;
+  // The barrier ENTRY was pooled; the scope and effect descriptor it points at
+  // were not, so every barrier still built two fresh objects per frame — on a
+  // path a static scene re-walks unchanged, because a barrier node never
+  // reaches the retained tier. Same cursor discipline as the pools above: reset
+  // per build, reused across frames, so a settled scene allocates none of them.
+  private readonly _barrierScopePool: Array<Mutable<BarrierScope>> = [];
+  private _barrierScopePoolCursor = 0;
+  private readonly _effectDescriptorPool: Array<Mutable<EffectDescriptor>> = [];
+  private _effectDescriptorPoolCursor = 0;
 
   // Reserved placement (replaces the per-call `{ seq, zIndex }` literal).
   private _reservedSeq = 0;
@@ -294,6 +308,8 @@ export class RenderPlanBuilder {
     this._drawEntryPoolCursor = 0;
     this._groupEntryPoolCursor = 0;
     this._barrierEntryPoolCursor = 0;
+    this._barrierScopePoolCursor = 0;
+    this._effectDescriptorPoolCursor = 0;
     this._drainScopeStack();
     this._hasPending = false;
     this._viewCullSuppression = 0;
@@ -417,16 +433,7 @@ export class RenderPlanBuilder {
         effect.cacheAsBitmap && node._renderPlanCanReuseBitmapCache(left, top, width, height)
           ? null
           : this._acquireGroupScope(this._resolvePreserveDrawOrder(node));
-      const barrierScope: BarrierScope = {
-        kind: RenderEntryKind.Barrier,
-        node,
-        effect,
-        childPlan,
-        left,
-        top,
-        width,
-        height,
-      };
+      const barrierScope = this._acquireBarrierScope(node, effect, childPlan, left, top, width, height);
 
       this._pushBarrierEntry(reservedSeq, reservedZ, barrierScope);
 
@@ -455,16 +462,7 @@ export class RenderPlanBuilder {
     // normal path (a nested boundary still gets its own transformNode scope).
     if (node.parent !== null && this._currentScope().transformNode === node.parent && node.parent._childEscapesTransformGroup(node)) {
       const childPlan = this._acquireGroupScope(this._resolvePreserveDrawOrder(node));
-      const barrierScope: BarrierScope = {
-        kind: RenderEntryKind.Barrier,
-        node,
-        effect: groupEscapeEffect,
-        childPlan,
-        left: 0,
-        top: 0,
-        width: 0,
-        height: 0,
-      };
+      const barrierScope = this._acquireBarrierScope(node, groupEscapeEffect, childPlan, 0, 0, 0, 0);
 
       this._pushBarrierEntry(reservedSeq, reservedZ, barrierScope);
       this._pushScope(childPlan);
@@ -1540,6 +1538,8 @@ export class RenderPlanBuilder {
     this._drawEntryPoolCursor = 0;
     this._groupEntryPoolCursor = 0;
     this._barrierEntryPoolCursor = 0;
+    this._barrierScopePoolCursor = 0;
+    this._effectDescriptorPoolCursor = 0;
     this._view = null;
     this._nodeIndex = 0;
     this._viewCullSuppression = 0;
@@ -1800,15 +1800,64 @@ export class RenderPlanBuilder {
     }
 
     const blendMode = node._renderPlanGetBlendMode();
-
-    return {
-      filters: node._renderPlanGetFilters(),
-      clip,
-      clipShape,
-      maskSource: mask,
-      cacheAsBitmap: node.cacheAsBitmap,
+    const descriptor = (this._effectDescriptorPool[this._effectDescriptorPoolCursor] ??= {
+      filters: emptyFilters,
+      clip: ClipKind.None,
+      clipShape: null,
+      maskSource: null,
+      cacheAsBitmap: false,
       blendMode,
-      needsBackdropBlend: isAdvancedBlendMode(blendMode),
-    };
+      needsBackdropBlend: false,
+    });
+
+    this._effectDescriptorPoolCursor++;
+
+    descriptor.filters = node._renderPlanGetFilters();
+    descriptor.clip = clip;
+    descriptor.clipShape = clipShape;
+    descriptor.maskSource = mask;
+    descriptor.cacheAsBitmap = node.cacheAsBitmap;
+    descriptor.blendMode = blendMode;
+    descriptor.needsBackdropBlend = isAdvancedBlendMode(blendMode);
+
+    return descriptor;
+  }
+
+  /**
+   * A barrier scope from the pool, filled in. Held only for the duration of the
+   * plan that produced it — the executor reads it during playback and keeps no
+   * reference past the frame.
+   */
+  private _acquireBarrierScope(
+    node: RenderNode,
+    effect: EffectDescriptor,
+    childPlan: GroupScope | null,
+    left: number,
+    top: number,
+    width: number,
+    height: number,
+  ): BarrierScope {
+    const scope = (this._barrierScopePool[this._barrierScopePoolCursor] ??= {
+      kind: RenderEntryKind.Barrier,
+      node,
+      effect,
+      childPlan,
+      left,
+      top,
+      width,
+      height,
+    });
+
+    this._barrierScopePoolCursor++;
+
+    scope.node = node;
+    scope.effect = effect;
+    scope.childPlan = childPlan;
+    scope.left = left;
+    scope.top = top;
+    scope.width = width;
+    scope.height = height;
+
+    return scope;
   }
 }

--- a/src/rendering/plan/RenderPlanPlayer.ts
+++ b/src/rendering/plan/RenderPlanPlayer.ts
@@ -28,6 +28,22 @@ interface RenderGroupPlaybackContext {
 }
 
 interface RenderPlanPlaybackContext {
+  /**
+   * The barrier continuation, built ONCE per playback rather than per barrier.
+   *
+   * `RenderEffectExecutor.play` needs a `(scope) => void` to re-enter playback
+   * with, and the obvious inline arrow closes over `backend`, `hooks` and this
+   * context — a fresh closure for every barrier, every frame, which on a
+   * hundred filtered nodes is a hundred closures for one unchanging call.
+   * Everything it captures is constant for the whole `play()`, so it belongs on
+   * the context that is already created there.
+   *
+   * Built on FIRST use, not eagerly: a plan with no barrier never needs one,
+   * and nested plans are the common case for exactly that shape — a node mask
+   * renders its own subtree through its own `play()`, once per masked node per
+   * frame. Allocating it up front made those scenes worse, not better.
+   */
+  playChildScope: ((scope: GroupScope) => void) | null;
   passInstructionIndex: number;
   passGroupIndex: number;
   activeGroupTransform: Matrix | null;
@@ -148,6 +164,8 @@ export class RenderPlanPlayer {
     hooks._beginDrawPlan?.(plan.nodeCount);
 
     try {
+      const context = this._createPlaybackContext();
+
       for (const pass of plan.passes) {
         if (pass.target !== null && backend.renderTarget !== pass.target) {
           backend.setRenderTarget(pass.target);
@@ -161,7 +179,7 @@ export class RenderPlanPlayer {
           backend.clear(pass.clearColor);
         }
 
-        this._playScope(pass.root, backend, hooks, this._createPlaybackContext());
+        this._playScope(pass.root, backend, hooks, context);
       }
     } finally {
       hooks._endDrawPlan?.();
@@ -176,9 +194,7 @@ export class RenderPlanPlayer {
 
   private static _playScope(scope: RenderScope, backend: RenderBackend, hooks: RenderPlanPlaybackHooks, context: RenderPlanPlaybackContext): void {
     if (scope.kind === RenderEntryKind.Barrier) {
-      RenderEffectExecutor.play(scope, backend, childScope => {
-        this._playScope(childScope, backend, hooks, context);
-      });
+      RenderEffectExecutor.play(scope, backend, context.playChildScope ?? this._createChildScopeCallback(backend, hooks, context));
 
       return;
     }
@@ -392,9 +408,7 @@ export class RenderPlanPlayer {
         }
 
         try {
-          RenderEffectExecutor.play(entry.scope, backend, childScope => {
-            this._playScope(childScope, backend, hooks, context);
-          });
+          RenderEffectExecutor.play(entry.scope, backend, context.playChildScope ?? this._createChildScopeCallback(backend, hooks, context));
         } finally {
           if (suspended !== null) {
             context.activeGroupTransform = suspended;
@@ -482,8 +496,28 @@ export class RenderPlanPlayer {
   /** Shared marker-restore scratch for {@link _replayRetainedInstructions}. */
   private static readonly _replayOuterStack: Array<Matrix | null> = [];
 
+  /**
+   * Build and cache the context's barrier continuation — see
+   * {@link RenderPlanPlaybackContext.playChildScope}.
+   *
+   * Split from the null check at the call sites on purpose. V8 allocates a
+   * function's closure scope on ENTRY, so folding the check in here would pay
+   * for the arrow below on every barrier, cached or not, and the caching would
+   * buy nothing.
+   */
+  private static _createChildScopeCallback(
+    backend: RenderBackend,
+    hooks: RenderPlanPlaybackHooks,
+    context: RenderPlanPlaybackContext,
+  ): (scope: GroupScope) => void {
+    return (context.playChildScope = (childScope: GroupScope): void => {
+      this._playScope(childScope, backend, hooks, context);
+    });
+  }
+
   private static _createPlaybackContext(): RenderPlanPlaybackContext {
     return {
+      playChildScope: null,
       passInstructionIndex: 0,
       passGroupIndex: 0,
       activeGroupTransform: null,

--- a/src/rendering/webgl2/WebGl2Backend.ts
+++ b/src/rendering/webgl2/WebGl2Backend.ts
@@ -251,8 +251,20 @@ export class WebGl2Backend implements RenderBackend {
   private readonly _materialSamplers = new Map<string, WebGLSampler>();
   private readonly _renderTargetDestroyHandlers: Map<RenderTarget, () => void> = new Map<RenderTarget, () => void>();
   private readonly _renderTexturePool: RenderTexturePool = new RenderTexturePool();
-  private readonly _clipBoundsStack: Rectangle[] = [];
+  /**
+   * Resolved scissor rectangles in target pixels, innermost at
+   * `_clipDepth - 1`.
+   *
+   * Grow-only and reused: the entries are plain mutable records rewritten on
+   * push, and {@link _clipDepth} — not `length` — says how many are live. A
+   * clip push happens once per clipped or masked barrier per frame, so
+   * allocating the record (plus the intersection's) there put four objects per
+   * barrier on the steady-state path for a stack that never gets deep.
+   */
   private readonly _clipPixelStack: PixelClipBoundsState[] = [];
+  private _clipDepth = 0;
+  /** Scratch for the incoming rect before it is intersected into its slot. */
+  private readonly _clipPixelScratch: PixelClipBoundsState = { x: 0, y: 0, width: 0, height: 0 };
   private readonly _clipPointA: Vector = new Vector();
   private readonly _clipPointB: Vector = new Vector();
   private readonly _maskCompositor: WebGl2MaskCompositor = new WebGl2MaskCompositor();
@@ -814,32 +826,34 @@ export class WebGl2Backend implements RenderBackend {
   public pushScissorRect(bounds: Rectangle): this {
     this._flushActiveRenderer();
 
-    this._clipBoundsStack.push(bounds.clone());
+    const depth = this._clipDepth;
+    const slot = (this._clipPixelStack[depth] ??= { x: 0, y: 0, width: 0, height: 0 });
+    const scratch = this._toClipPixels(bounds, this._clipPixelScratch);
 
-    const nextClip = this._toClipPixels(bounds);
-    const previousClip = this._clipPixelStack.length > 0 ? this._clipPixelStack[this._clipPixelStack.length - 1] : null;
-    const resolvedClip = previousClip ? this._intersectClips(previousClip, nextClip) : nextClip;
+    if (depth > 0) {
+      // In range: depth > 0 means a resolved clip is already on the stack.
+      this._intersectClips(this._clipPixelStack[depth - 1]!, scratch, slot);
+    } else {
+      slot.x = scratch.x;
+      slot.y = scratch.y;
+      slot.width = scratch.width;
+      slot.height = scratch.height;
+    }
 
-    this._clipPixelStack.push(resolvedClip);
+    this._clipDepth = depth + 1;
     this._applyClipState();
 
     return this;
   }
 
   public popScissorRect(): this {
-    if (this._clipBoundsStack.length === 0) {
+    if (this._clipDepth === 0) {
       return this;
     }
 
     this._flushActiveRenderer();
 
-    const removedClip = this._clipBoundsStack.pop();
-
-    if (removedClip) {
-      removedClip.destroy();
-    }
-
-    this._clipPixelStack.pop();
+    this._clipDepth--;
     this._applyClipState();
 
     return this;
@@ -1791,12 +1805,8 @@ export class WebGl2Backend implements RenderBackend {
     this._destroyManagedResources();
     this._renderTexturePool.destroy();
 
-    for (const clipBounds of this._clipBoundsStack) {
-      clipBounds.destroy();
-    }
-
-    this._clipBoundsStack.length = 0;
     this._clipPixelStack.length = 0;
+    this._clipDepth = 0;
     this._clipPointA.destroy();
     this._clipPointB.destroy();
 
@@ -2289,7 +2299,7 @@ export class WebGl2Backend implements RenderBackend {
       state.version = target.version;
     }
 
-    if (this._clipPixelStack.length > 0) {
+    if (this._clipDepth > 0) {
       this._applyClipState();
     }
   }
@@ -2617,9 +2627,10 @@ export class WebGl2Backend implements RenderBackend {
     return state;
   }
 
-  private _toClipPixels(bounds: Rectangle): PixelClipBoundsState {
-    const topLeft = this._renderTarget.mapCoordsToPixel(this._clipPointA.set(bounds.left, bounds.top));
-    const bottomRight = this._renderTarget.mapCoordsToPixel(this._clipPointB.set(bounds.right, bounds.bottom));
+  /** Writes into `out` and returns it — see {@link _clipPixelStack} for why nothing here allocates. */
+  private _toClipPixels(bounds: Rectangle, out: PixelClipBoundsState): PixelClipBoundsState {
+    const topLeft = this._renderTarget._mapCoordsToPixelInPlace(this._clipPointA.set(bounds.left, bounds.top));
+    const bottomRight = this._renderTarget._mapCoordsToPixelInPlace(this._clipPointB.set(bounds.right, bounds.bottom));
     const minX = Math.min(topLeft.x, bottomRight.x);
     const maxX = Math.max(topLeft.x, bottomRight.x);
     const minY = Math.min(topLeft.y, bottomRight.y);
@@ -2634,39 +2645,38 @@ export class WebGl2Backend implements RenderBackend {
     const height = Math.max(0, bottom - yTop);
     const y = Math.max(0, targetHeight - bottom);
 
-    return {
-      x,
-      y,
-      width,
-      height,
-    };
+    out.x = x;
+    out.y = y;
+    out.width = width;
+    out.height = height;
+
+    return out;
   }
 
-  private _intersectClips(first: PixelClipBoundsState, second: PixelClipBoundsState): PixelClipBoundsState {
+  /** Writes the intersection into `out`, which may alias neither input. */
+  private _intersectClips(first: PixelClipBoundsState, second: PixelClipBoundsState, out: PixelClipBoundsState): void {
     const left = Math.max(first.x, second.x);
     const bottom = Math.max(first.y, second.y);
     const right = Math.min(first.x + first.width, second.x + second.width);
     const top = Math.min(first.y + first.height, second.y + second.height);
 
-    return {
-      x: left,
-      y: bottom,
-      width: Math.max(0, right - left),
-      height: Math.max(0, top - bottom),
-    };
+    out.x = left;
+    out.y = bottom;
+    out.width = Math.max(0, right - left);
+    out.height = Math.max(0, top - bottom);
   }
 
   private _applyClipState(): void {
     const gl = this._context;
 
-    if (this._clipPixelStack.length === 0) {
+    if (this._clipDepth === 0) {
       gl.disable(gl.SCISSOR_TEST);
 
       return;
     }
 
     // In-bounds: the empty-stack case returned above, so the top entry exists.
-    const clip = this._clipPixelStack[this._clipPixelStack.length - 1]!;
+    const clip = this._clipPixelStack[this._clipDepth - 1]!;
     const scaleX = this._renderTarget.root && this._renderTarget.width > 0 ? this._canvas.width / this._renderTarget.width : 1;
     const scaleY = this._renderTarget.root && this._renderTarget.height > 0 ? this._canvas.height / this._renderTarget.height : 1;
     const x = Math.floor(clip.x * scaleX);

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -207,8 +207,16 @@ export class WebGpuBackend implements RenderBackend {
   private readonly _materialSamplers = new Map<string, GPUSampler>();
   private readonly _renderTargetDestroyHandlers: Map<RenderTarget, () => void> = new Map<RenderTarget, () => void>();
   private readonly _renderTexturePool: RenderTexturePool = new RenderTexturePool();
-  private readonly _clipBoundsStack: Rectangle[] = [];
+  /**
+   * Resolved scissor rectangles in target pixels, innermost at
+   * `_clipDepth - 1`. Grow-only and reused; {@link _clipDepth}, not `length`,
+   * says how many are live. See the WebGL2 backend's copy of this comment for
+   * why: a clip push happens once per clipped or masked barrier per frame.
+   */
   private readonly _clipPixelStack: PixelClipBoundsState[] = [];
+  private _clipDepth = 0;
+  /** Scratch for the incoming rect before it is intersected into its slot. */
+  private readonly _clipPixelScratch: PixelClipBoundsState = { x: 0, y: 0, width: 0, height: 0 };
   private readonly _clipPointA: Vector = new Vector();
   private readonly _clipPointB: Vector = new Vector();
   private readonly _maskCompositor: WebGpuMaskCompositor = new WebGpuMaskCompositor();
@@ -716,13 +724,21 @@ export class WebGpuBackend implements RenderBackend {
   public pushScissorRect(bounds: Rectangle): this {
     this._flushActiveRendererAndEndPass();
 
-    this._clipBoundsStack.push(bounds.clone());
+    const depth = this._clipDepth;
+    const slot = (this._clipPixelStack[depth] ??= { x: 0, y: 0, width: 0, height: 0 });
+    const scratch = this._toClipPixels(bounds, this._clipPixelScratch);
 
-    const nextClip = this._toClipPixels(bounds);
-    const previousClip = this._clipPixelStack.length > 0 ? this._clipPixelStack[this._clipPixelStack.length - 1] : null;
-    const resolvedClip = previousClip ? this._intersectClips(previousClip, nextClip) : nextClip;
+    if (depth > 0) {
+      // In range: depth > 0 means a resolved clip is already on the stack.
+      this._intersectClips(this._clipPixelStack[depth - 1]!, scratch, slot);
+    } else {
+      slot.x = scratch.x;
+      slot.y = scratch.y;
+      slot.width = scratch.width;
+      slot.height = scratch.height;
+    }
 
-    this._clipPixelStack.push(resolvedClip);
+    this._clipDepth = depth + 1;
 
     return this;
   }
@@ -808,19 +824,13 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   public popScissorRect(): this {
-    if (this._clipBoundsStack.length === 0) {
+    if (this._clipDepth === 0) {
       return this;
     }
 
     this._flushActiveRendererAndEndPass();
 
-    const removedClip = this._clipBoundsStack.pop();
-
-    if (removedClip) {
-      removedClip.destroy();
-    }
-
-    this._clipPixelStack.pop();
+    this._clipDepth--;
 
     return this;
   }
@@ -854,12 +864,12 @@ export class WebGpuBackend implements RenderBackend {
   }
 
   public getScissorRect(): PixelClipBoundsState | null {
-    if (this._clipPixelStack.length === 0) {
+    if (this._clipDepth === 0) {
       return null;
     }
 
     // Non-empty checked above, so the top-of-stack element exists.
-    const clip = this._clipPixelStack[this._clipPixelStack.length - 1]!;
+    const clip = this._clipPixelStack[this._clipDepth - 1]!;
     const scaleX = this._renderTarget.root && this._renderTarget.width > 0 ? this._canvas.width / this._renderTarget.width : 1;
     const scaleY = this._renderTarget.root && this._renderTarget.height > 0 ? this._canvas.height / this._renderTarget.height : 1;
 
@@ -979,12 +989,8 @@ export class WebGpuBackend implements RenderBackend {
     this._materialSamplers.clear();
     this._renderTexturePool.destroy();
 
-    for (const clipBounds of this._clipBoundsStack) {
-      clipBounds.destroy();
-    }
-
-    this._clipBoundsStack.length = 0;
     this._clipPixelStack.length = 0;
+    this._clipDepth = 0;
     this._clipPointA.destroy();
     this._clipPointB.destroy();
 
@@ -2701,9 +2707,10 @@ export class WebGpuBackend implements RenderBackend {
     }
   }
 
-  private _toClipPixels(bounds: Rectangle): PixelClipBoundsState {
-    const topLeft = this._renderTarget.mapCoordsToPixel(this._clipPointA.set(bounds.left, bounds.top));
-    const bottomRight = this._renderTarget.mapCoordsToPixel(this._clipPointB.set(bounds.right, bounds.bottom));
+  /** Writes into `out` and returns it — see {@link _clipPixelStack} for why nothing here allocates. */
+  private _toClipPixels(bounds: Rectangle, out: PixelClipBoundsState): PixelClipBoundsState {
+    const topLeft = this._renderTarget._mapCoordsToPixelInPlace(this._clipPointA.set(bounds.left, bounds.top));
+    const bottomRight = this._renderTarget._mapCoordsToPixelInPlace(this._clipPointB.set(bounds.right, bounds.bottom));
     const minX = Math.min(topLeft.x, bottomRight.x);
     const maxX = Math.max(topLeft.x, bottomRight.x);
     const minY = Math.min(topLeft.y, bottomRight.y);
@@ -2717,21 +2724,25 @@ export class WebGpuBackend implements RenderBackend {
     const width = Math.max(0, right - x);
     const height = Math.max(0, bottom - y);
 
-    return { x, y, width, height };
+    out.x = x;
+    out.y = y;
+    out.width = width;
+    out.height = height;
+
+    return out;
   }
 
-  private _intersectClips(first: PixelClipBoundsState, second: PixelClipBoundsState): PixelClipBoundsState {
+  /** Writes the intersection into `out`, which may alias neither input. */
+  private _intersectClips(first: PixelClipBoundsState, second: PixelClipBoundsState, out: PixelClipBoundsState): void {
     const left = Math.max(first.x, second.x);
     const top = Math.max(first.y, second.y);
     const right = Math.min(first.x + first.width, second.x + second.width);
     const bottom = Math.min(first.y + first.height, second.y + second.height);
 
-    return {
-      x: left,
-      y: top,
-      width: Math.max(0, right - left),
-      height: Math.max(0, bottom - top),
-    };
+    out.x = left;
+    out.y = top;
+    out.width = Math.max(0, right - left);
+    out.height = Math.max(0, bottom - top);
   }
 
   private _createSampler(texture: Texture | RenderTexture): GPUSampler {

--- a/test/perf/rendering/allocation.test.ts
+++ b/test/perf/rendering/allocation.test.ts
@@ -139,13 +139,13 @@ const FIXED_HEADROOM_KB = 1.25;
  *   nested/1000 d4                    1.20      0.65       1.20
  *   deep-hierarchy/1000 d16 1%        1.01      0.50       1.01
  *   mesh/1000                         0.68      0.37       0.68
- *   filtered/100                    218.60    229.59     229.59
+ *   filtered/100                    101.95    102.98     102.98
  *   blend/1000 plateau64              0.93      0.57       0.93
  *   blend/1000 alternating            1.19      0.47       1.19
  *
  * Spread, i.e. what the budget has to absorb: ≤0.13 KB across the five fresh
  * processes and ≤0.21 KB across six in-suite passes on every scene but
- * `filtered/100`, which holds 0.24% (218.1–219.5 fresh, 229.0–229.6 across four
+ * `filtered/100`, which holds 0.9% (101.9–102.1 fresh, 102.1–103.0 across four
  * in-suite passes).
  *
  * `scrolling-world/10000` is measured the same way but stays out of the gate:
@@ -153,6 +153,12 @@ const FIXED_HEADROOM_KB = 1.25;
  * bimodal at 14.6 vs 19.8 KB/frame between passes. See `ALLOCATION_REPORT_ONLY`.
  *
  * ── Ratchet history ─────────────────────────────────────────────
+ * 2026-08-16c: `filtered/100` ONLY, 229.59 → 102.98, after the effect path's
+ * control plane stopped being rebuilt per frame — the redirect pass and its
+ * descriptor, the clip/mask continuation closures, the barrier scope and its
+ * effect descriptor, and the scissor stack's per-push rectangle and vectors.
+ * Same rule as the entry below it: one row, no global re-baseline.
+ *
  * 2026-08-16b: `filtered/100` ONLY, 306.55 → 229.59, after the effect path
  * stopped building a whole render plan per filter pass and per composite. No
  * other row is touched and no global re-baseline: the change reaches nothing
@@ -186,7 +192,7 @@ const BASELINE_KB: Readonly<Record<string, number>> = {
   'nested/1000 d4': 1.2,
   'deep-hierarchy/1000 d16 1%': 1.01,
   'mesh/1000': 0.68,
-  'filtered/100': 229.59,
+  'filtered/100': 102.98,
   'blend/1000 plateau64': 0.93,
   'blend/1000 alternating': 1.19,
 };


### PR DESCRIPTION
Q11-B, the second of two independent cuts into filter/effect allocation. #566
removed the render-plan cycle the effect path ran per filter pass and per
composite; this one removes the control plane it rebuilt every frame.

## Why there was anything left to remove

A barrier node never reaches the retained tier, so a filtered scene re-walks the
whole effect path every frame even when nothing changed — and that path built
its own machinery each time. Measured per barrier on `color/100` after #566:

| what | KB/frame |
| --- | ---: |
| clip/rect-clip/mask continuation closures | 39.9 |
| `RenderNode`'s capture pass, its options and its body closure | 31.2 |
| the coordinator descriptor and the closure handed to it | 16.5 |
| the filter's own pass | 15.5 |
| the barrier scope and its effect descriptor | 16.4 |

All structure, no frame data — the shapes never vary from frame to frame.

## The three cuts

**Control plane** (`209ad627`). `BackendTargetPass` keeps one descriptor and one
bound body and gains `retarget` / `reconfigure`, so the stock filters and
`RenderNode`'s capture each hold ONE pass instead of constructing one per
application. The descriptor is rewritten in place because the coordinator reads
it synchronously and keeps no reference; the body reads a staged backend rather
than closing over it.

`RenderEffectExecutor`'s clip → rect-clip → mask chain is continuation-passing,
so it cost a closure per layer per barrier. Its state moves to a depth-indexed
frame stack — barriers nest, so a stack rather than a slot — and every body
becomes a static function allocated once. Frames drop their references on exit
rather than only their depth, so a frame never pins the scope it served.

`RenderPlanPlayer` builds the barrier continuation once per playback instead of
once per barrier. `RenderPlanBuilder` pools the barrier scope and the effect
descriptor on the cursor discipline its entry pools already use.

**Scissor push** (`666a5a9c`). A clip push happens once per clipped or masked
barrier per frame and allocated four objects: a defensive `Rectangle` clone, two
`Vector` clones inside `mapCoordsToPixel`, and one or two pixel-clip records.

The cloned rectangle went onto a stack **nothing ever read** — pushed, popped,
destroyed, iterated at teardown, and that is all. Its only live role was
`length === 0` as a depth guard, which the new depth counter now serves. Removed
rather than pooled: this is phantom state, not a GC problem.

The pixel stack becomes grow-only with a depth counter, and `_toClipPixels` /
`_intersectClips` write into a caller-supplied record. `mapCoordsToPixel` keeps
its contract (it must not touch its argument, so it clones); the new
`_mapCoordsToPixelInPlace` serves callers that own their point. Both backends
carried identical code, so both get identical changes — the WebGPU half is not
an analogy fix, it is the same lines.

**Budget** (`d01d12a9`). `filtered/100` 229.59 → 102.98 KB/frame. This row only,
no global re-baseline, same rule as the previous ratchet.

## Allocation: pre-Q11 → #566 → here

Fresh-process, one scene per process, 3 windows x 200 frames.

| scene | pre-Q11 | after #566 | now | total |
| --- | ---: | ---: | ---: | ---: |
| `none 100` (floor) | 1.02 | — | 0.92 | — |
| `clip 100` | 119.41 | 119.89 | **37.64** | −68.5% |
| `mask 100` | 246.28 | — | **128.85** | −47.7% |
| `color 1` | 6.08 | — | 3.42 | −43.8% |
| `color 10` | 31.03 | — | 12.19 | −60.7% |
| `color 100` | 282.36 | 218.60 | **101.95** | −63.9% |
| `color 200` | 568.96 | — | 204.57 | −64.0% |
| `stack2 100` | 376.08 | 280.41 | 131.62 | −65.0% |
| `stack3 100` | 471.00 | 342.68 | 161.78 | −65.7% |
| `blur-q1 100` | 501.40 | 330.47 | 213.04 | −57.5% |
| `blur-q3 100` | 980.23 | 560.26 | **440.27** | −55.1% |
| `container 1000` | 4.97 | 3.81 | 2.32 | −53.3% |
| `container-cached 1000` | 3.20 | 2.21 | 1.72 | −46.3% |

Per unit of work — the numbers the probe catalog exists to produce:

| unit | pre-Q11 | now |
| --- | ---: | ---: |
| barrier alone (no target, no filter pass) | 1.18 KB | **0.37 KB** |
| filtered node above the floor | 2.81 | **1.01** |
| each additional filter pass | 0.94 / 0.95 | **0.30 / 0.30** |
| each additional draw inside a pass | 0.44 / 0.60 | 0.22 / 0.28 |

The last row is unchanged since #566, and that is the honest result rather than
an oversight: per-draw cost is the flush path, not the control plane, and this
PR does not touch it. See the follow-up below.

## CPU

Medians of three alternating repetitions against worktrees pinned at pre-Q11 and
at the #566 merge, µs/frame.

| scene | pre-Q11 | after #566 | now | total |
| --- | ---: | ---: | ---: | ---: |
| `color 100` | 3293.7 | 3150.1 | 3062.2 | −7.0% |
| `blur-q3 100` | 13191.1 | 11224.6 | 11032.8 | −16.4% |
| `clip 100` | 773.7 | 765.4 | 776.7 | flat |
| `mask 100` | 2867.9 | 2809.8 | 2858.9 | flat |

## Structural / GPU

Byte-identical to the pre-Q11 measurement on every probe scene: render passes,
draw calls, batches, render texture acquisitions (0 pool misses), texture binds,
buffer uploads, transform upload bytes.

## Two things only measurement found

Both would have been wrong if reasoned about:

1. **Building the barrier continuation eagerly made `mask/100` 28 KB/frame
   worse.** A node mask renders its own subtree through its own `play()`, once
   per masked node per frame, and those nested plans contain no barrier at all —
   so the eager closure was pure waste. 174.33 → 134.57 once it was built on
   first use.
2. **The null check has to stay at the call site, not inside the creator.** V8
   allocates a function's closure scope on entry, so folding the check into the
   creator would pay for the arrow on every barrier and the caching would buy
   nothing: 102.19 against 108.05.

## Follow-up, deliberately not here

The largest remaining posts are `WebGl2SpriteRenderer.flush` (~44 KB/frame
across three stacks), `_syncTextureUpload` (~19), `withChildPass` (~12) and
`View.updateTransform` (~6). These scale with FLUSHES, not with barriers — the
effect path simply produces many (300 in `color/100`, 1600 in `blur-q3`).

Verified not to be a harness artefact, since that is exactly the shape Q10 was
caught by: the `fakeWebGl2` staging fix is intact, and `blend/1000 plateau64`
with ~16 flushes does not show `flush` in its profile at all.

So the remaining question is no longer "the filter control plane makes garbage"
but "effect execution creates a great many real flush boundaries", and both
sides of that trade are already measured: today `blur-q3` is 1600 draw calls and
48000 transform bytes; naively dropping the plan-depth bracket makes it 300 and
116288. That is a batching and scratch-lifetime design problem, not a GC one,
and it gets its own spike.
