### PR TITLE
perf(rendering): lazily materialize optional per-node state

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,8 @@
     "perf:renderers:browser": "vitest run --project=browser-webgl-chromium webgl2-renderer-perf",
     "perf:renderers:alloc": "node --conditions=@codexo/source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-allocation.ts",
     "perf:renderers:alloc:cell": "node --conditions=@codexo/source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-allocation-cell.ts",
+    "perf:renderers:bootstrap": "node --conditions=@codexo/source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-bootstrap-allocation.ts",
+    "perf:renderers:bootstrap:cell": "node --expose-gc --max-old-space-size=8192 --conditions=@codexo/source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-bootstrap-cell.ts",
     "perf:bench:rendering": "tsx test/perf/rendering-benchmark.ts",
     "perf:bench:audio": "tsx test/perf/audio-benchmark.ts",
     "perf:bench:collision": "tsx test/perf/collision-benchmark.ts",
@@ -162,7 +164,8 @@
     "perf:profile": "tsx test/perf/profile-benchmark.ts",
     "perf:profile:gc": "node --expose-gc --import tsx/esm test/perf/profile-benchmark.ts",
     "size": "size-limit",
-    "prepare": "husky"
+    "prepare": "husky",
+    "perf:renderers:instance-cost": "node --expose-gc --max-old-space-size=8192 --conditions=@codexo/source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-instance-cost.ts"
   },
   "license": "MIT",
   "publishConfig": {

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -46,6 +46,9 @@ interface RenderNodeSpriteLike extends Drawable {
 const isDestroyableFilter = (filter: Filter): filter is Filter & DestroyableFilter =>
   'destroy' in filter && typeof (filter as Partial<DestroyableFilter>).destroy === 'function';
 
+/** Shared empty result for every node that has no filter list of its own. */
+const NO_FILTERS: readonly Filter[] = [];
+
 /**
  * Acceptable mask sources for {@link RenderNode.mask}.
  *
@@ -350,16 +353,25 @@ export abstract class RenderNode extends SceneNode {
     return this;
   }
 
-  private readonly _filters: Filter[] = [];
-  private readonly _cacheBounds: Rectangle = new Rectangle();
+  /**
+   * Built on the first filter this node is given. Nodes without filters are the
+   * overwhelming majority in any real scene, and an always-allocated empty array
+   * costs every one of them a heap object for a feature it never uses; reads go
+   * through {@link NO_FILTERS} instead.
+   */
+  private _filters: Filter[] | null = null;
+  /**
+   * The bounds the bitmap cache was captured at — built on the first capture.
+   * A `Rectangle` is four heap objects (itself, its observable position and
+   * size, and the bound change callback), and only `cacheAsBitmap` nodes ever
+   * need one.
+   */
+  private _cacheBounds: Rectangle | null = null;
   private _cacheSprite: RenderNodeSpriteLike | null = null;
   private _captureView: View | null = null;
   /** Lazily built, then reused for every capture this node performs — see {@link _renderContentToTexture}. */
   private _capturePass: BackendTargetPass | null = null;
   private _captureContent: (() => void) | null = null;
-  private readonly _runCaptureContent = (): void => {
-    this._captureContent?.();
-  };
   private _mask: MaskSource = null;
   private _cacheAsBitmap = false;
   private _cacheDirty = true;
@@ -367,12 +379,21 @@ export abstract class RenderNode extends SceneNode {
   private _retainedRoot: RetainedRootRepresentation | null = null;
 
   public get filters(): readonly Filter[] {
-    return this._filters;
+    return this._filters ?? NO_FILTERS;
   }
 
   public set filters(filters: readonly Filter[]) {
-    this._filters.length = 0;
-    this._filters.push(...filters);
+    if (filters.length === 0) {
+      if (this._filters !== null) {
+        this._filters.length = 0;
+      }
+    } else {
+      const own = (this._filters ??= []);
+
+      own.length = 0;
+      own.push(...filters);
+    }
+
     this.invalidateCache();
   }
 
@@ -538,16 +559,16 @@ export abstract class RenderNode extends SceneNode {
   }
 
   public addFilter(filter: Filter): this {
-    this._filters.push(filter);
+    (this._filters ??= []).push(filter);
 
     return this.invalidateCache();
   }
 
   public removeFilter(filter: Filter): this {
-    const index = this._filters.indexOf(filter);
+    const index = this._filters?.indexOf(filter) ?? -1;
 
     if (index !== -1) {
-      this._filters.splice(index, 1);
+      this._filters!.splice(index, 1);
       this.invalidateCache();
     }
 
@@ -559,7 +580,7 @@ export abstract class RenderNode extends SceneNode {
   }
 
   public clearFilters(): this {
-    if (this._filters.length > 0) {
+    if (this._filters !== null && this._filters.length > 0) {
       this._filters.length = 0;
       this.invalidateCache();
     }
@@ -590,7 +611,13 @@ export abstract class RenderNode extends SceneNode {
 
   /** @internal */
   public _renderPlanHasBarrierEffects(): boolean {
-    return this._filters.length > 0 || this._mask !== null || this._cacheAsBitmap || this.clip || isAdvancedBlendMode(this._renderPlanGetBlendMode());
+    return (
+      (this._filters !== null && this._filters.length > 0) ||
+      this._mask !== null ||
+      this._cacheAsBitmap ||
+      this.clip ||
+      isAdvancedBlendMode(this._renderPlanGetBlendMode())
+    );
   }
 
   protected override _escapesTransformGroup(): boolean {
@@ -609,7 +636,7 @@ export abstract class RenderNode extends SceneNode {
 
   /** @internal */
   public _renderPlanGetFilters(): readonly Filter[] {
-    return this._filters;
+    return this._filters ?? NO_FILTERS;
   }
 
   /** @internal */
@@ -619,7 +646,7 @@ export abstract class RenderNode extends SceneNode {
 
   /** @internal */
   public _renderPlanCanReuseBitmapCache(left: number, top: number, width: number, height: number): boolean {
-    if (!this._cacheAsBitmap || this._cacheDirty || this._cacheTexture === null) {
+    if (!this._cacheAsBitmap || this._cacheDirty || this._cacheTexture === null || this._cacheBounds === null) {
       return false;
     }
 
@@ -644,7 +671,7 @@ export abstract class RenderNode extends SceneNode {
   /** @internal */
   public _renderPlanStoreCacheTexture(texture: RenderTexture, left: number, top: number, width: number, height: number): void {
     this._cacheTexture = texture;
-    this._cacheBounds.set(left, top, width, height);
+    (this._cacheBounds ??= new Rectangle()).set(left, top, width, height);
     this._cacheDirty = false;
   }
 
@@ -686,19 +713,24 @@ export abstract class RenderNode extends SceneNode {
       this._retainedRoot = null;
       unregisterRetainedRenderRoot();
     }
-    this._cacheBounds.destroy();
+    this._cacheBounds?.destroy();
+    this._cacheBounds = null;
     this._cacheSprite?.destroy();
     this._cacheSprite = null;
     this._captureView?.destroy();
     this._captureView = null;
 
-    for (const filter of this._filters) {
-      if (isDestroyableFilter(filter)) {
-        filter.destroy();
+    if (this._filters !== null) {
+      for (const filter of this._filters) {
+        if (isDestroyableFilter(filter)) {
+          filter.destroy();
+        }
       }
+
+      this._filters.length = 0;
+      this._filters = null;
     }
 
-    this._filters.length = 0;
     this._mask = null;
 
     if (this._signals !== null) {
@@ -740,7 +772,9 @@ export abstract class RenderNode extends SceneNode {
     // Staging is safe against nesting because the stack is per NODE: a filtered
     // subtree inside another filtered node captures through the inner node's
     // own pass. A node cannot be capturing inside itself.
-    this._capturePass ??= new BackendTargetPass(this._runCaptureContent);
+    // The indirection closure is built with the pass rather than held as a
+    // per-node field: every node paid for it, only capturing nodes use it.
+    this._capturePass ??= new BackendTargetPass(() => this._captureContent?.());
     this._captureContent = renderContent;
 
     try {

--- a/src/rendering/sprite/Sprite.ts
+++ b/src/rendering/sprite/Sprite.ts
@@ -49,9 +49,22 @@ export class Sprite extends Drawable {
   private _texture: Texture | RenderTexture | null = null;
   private _textureFrame: Rectangle = new Rectangle();
   private _material: SpriteMaterial | null = null;
-  private _vertices: Float32Array = new Float32Array(8);
-  private _texCoords: Uint32Array = new Uint32Array(4);
-  private readonly _normals: [Vector, Vector, Vector, Vector] = [new Vector(), new Vector(), new Vector(), new Vector()];
+  /**
+   * Quad corner cache, built on the first {@link vertices} read. Nothing on the
+   * render path reads it — the renderers pack their own quad through
+   * {@link _packSourceQuad} — so only collision queries and direct API readers
+   * pay for it. An eight-element Float32Array costs ~248 retained bytes: the
+   * view, its buffer, and the backing store.
+   */
+  private _vertices: Float32Array | null = null;
+  /** Packed UV cache, built on the first {@link texCoords} read. Same reasoning as {@link _vertices}. */
+  private _texCoords: Uint32Array | null = null;
+  /**
+   * Built on the first {@link getNormals} call. Five heap objects (the tuple and
+   * its four vectors) that only the SAT collision path ever reads, so a sprite
+   * that is merely drawn never pays for them.
+   */
+  private _normals: [Vector, Vector, Vector, Vector] | null = null;
   // World-transform version the cached vertices/normals were last built at.
   // The Vertices/Normals flags cover local changes (texture frame, own
   // transform); this version compare additionally catches an ancestor moving
@@ -179,28 +192,29 @@ export class Sprite extends Drawable {
     // Settle the world transform first: its version reflects any ancestor move,
     // which the lazy cascade no longer eagerly flags on this sprite.
     const transform = this.getGlobalTransform();
+    const vertices = (this._vertices ??= new Float32Array(8));
 
     if (this.flags.hasMask(SpriteFlags.Vertices) || this._verticesBuiltAtVersion !== this._globalTransformVersion) {
       const { left, top, right, bottom } = this.getLocalBounds();
       const { a, b, x, c, d, y } = transform;
 
-      this._vertices[0] = left * a + top * b + x;
-      this._vertices[1] = left * c + top * d + y;
+      vertices[0] = left * a + top * b + x;
+      vertices[1] = left * c + top * d + y;
 
-      this._vertices[2] = right * a + top * b + x;
-      this._vertices[3] = right * c + top * d + y;
+      vertices[2] = right * a + top * b + x;
+      vertices[3] = right * c + top * d + y;
 
-      this._vertices[4] = right * a + bottom * b + x;
-      this._vertices[5] = right * c + bottom * d + y;
+      vertices[4] = right * a + bottom * b + x;
+      vertices[5] = right * c + bottom * d + y;
 
-      this._vertices[6] = left * a + bottom * b + x;
-      this._vertices[7] = left * c + bottom * d + y;
+      vertices[6] = left * a + bottom * b + x;
+      vertices[7] = left * c + bottom * d + y;
 
       this.flags.removeMask(SpriteFlags.Vertices);
       this._verticesBuiltAtVersion = this._globalTransformVersion;
     }
 
-    return this._vertices;
+    return vertices;
   }
 
   /**
@@ -214,6 +228,8 @@ export class Sprite extends Drawable {
       throw new Error('texCoords can only be calculated when the sprite has a texture');
     }
 
+    const coords = (this._texCoords ??= new Uint32Array(4));
+
     if (this.flags.popMask(SpriteFlags.TextureCoords)) {
       const { width, height } = this._texture;
       const { left, top, right, bottom } = this._textureFrame;
@@ -223,19 +239,19 @@ export class Sprite extends Drawable {
       const maxY = (((bottom / height) * 65535) & 65535) << 16;
 
       if (this._texture.flipY) {
-        this._texCoords[0] = maxY | minX;
-        this._texCoords[1] = maxY | maxX;
-        this._texCoords[2] = minY | maxX;
-        this._texCoords[3] = minY | minX;
+        coords[0] = maxY | minX;
+        coords[1] = maxY | maxX;
+        coords[2] = minY | maxX;
+        coords[3] = minY | minX;
       } else {
-        this._texCoords[0] = minY | minX;
-        this._texCoords[1] = minY | maxX;
-        this._texCoords[2] = maxY | maxX;
-        this._texCoords[3] = maxY | minX;
+        coords[0] = minY | minX;
+        coords[1] = minY | maxX;
+        coords[2] = maxY | maxX;
+        coords[3] = maxY | minX;
       }
     }
 
-    return this._texCoords;
+    return coords;
   }
 
   /**
@@ -378,6 +394,7 @@ export class Sprite extends Drawable {
     // sees the up-to-date value.
     // vertices is a fixed 8-element Float32Array (4 corners).
     const v = this.vertices;
+    const normals = (this._normals ??= [new Vector(), new Vector(), new Vector(), new Vector()]);
 
     if (this.flags.hasMask(SpriteFlags.Normals) || this._normalsBuiltAtVersion !== this._globalTransformVersion) {
       const x1 = v[0]!;
@@ -389,19 +406,19 @@ export class Sprite extends Drawable {
       const x4 = v[6]!;
       const y4 = v[7]!;
 
-      this._normals[0]
+      normals[0]
         .set(x2 - x1, y2 - y1)
         .rperp()
         .normalize();
-      this._normals[1]
+      normals[1]
         .set(x3 - x2, y3 - y2)
         .rperp()
         .normalize();
-      this._normals[2]
+      normals[2]
         .set(x4 - x3, y4 - y3)
         .rperp()
         .normalize();
-      this._normals[3]
+      normals[3]
         .set(x1 - x4, y1 - y4)
         .rperp()
         .normalize();
@@ -410,7 +427,7 @@ export class Sprite extends Drawable {
       this._normalsBuiltAtVersion = this._globalTransformVersion;
     }
 
-    return this._normals;
+    return normals;
   }
 
   /**
@@ -484,8 +501,12 @@ export class Sprite extends Drawable {
   public override destroy(): void {
     super.destroy();
 
-    for (const normal of this._normals) {
-      normal.destroy();
+    if (this._normals !== null) {
+      for (const normal of this._normals) {
+        normal.destroy();
+      }
+
+      this._normals = null;
     }
 
     this._textureFrame.destroy();

--- a/test/perf/rendering/run-bootstrap-allocation.ts
+++ b/test/perf/rendering/run-bootstrap-allocation.ts
@@ -1,0 +1,108 @@
+/**
+ * Cold/bootstrap allocation driver.
+ *
+ * Spawns ONE fresh `run-bootstrap-cell.ts` process per cardinality — the cell
+ * runner's block comment explains why same-process attribution is worthless for
+ * a first-ever-touch measurement — collects each cell's JSON line, prints a
+ * scaling table, and writes `.workspace/output/render-perf/bootstrap-allocation.json`.
+ *
+ *   pnpm perf:renderers:bootstrap                       # 1k / 10k / 100k
+ *   pnpm perf:renderers:bootstrap -- --counts 1000,1000000
+ *   pnpm perf:renderers:bootstrap -- --cpu              # wall-clock companion
+ *   pnpm perf:renderers:bootstrap -- --incremental 100  # streaming shape
+ *
+ * @internal Test/perf-only.
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const args = process.argv.slice(2);
+
+const flag = (name: string): string | undefined => {
+  const index = args.indexOf(`--${name}`);
+
+  return index === -1 ? undefined : args[index + 1];
+};
+
+/** 1M is opt-in: one cell at that size costs minutes and several GB of heap. */
+const counts = (flag('counts') ?? '1000,10000,100000').split(',').map(value => Number(value.trim()));
+const wantCpu = args.includes('--cpu');
+const incremental = flag('incremental');
+const rampFrames = flag('frames');
+const steadyFrames = flag('steady');
+const steadyWarmup = flag('warmup');
+const samplingInterval = flag('interval');
+
+const CELL = 'test/perf/rendering/run-bootstrap-cell.ts';
+
+const nodeArgs = (count: number): string[] => [
+  '--expose-gc',
+  '--max-old-space-size=8192',
+  '--conditions=@codexo/source',
+  '--import',
+  './scripts/glsl-register.mjs',
+  '--import',
+  'tsx/esm',
+  CELL,
+  '--count',
+  String(count),
+  ...(rampFrames === undefined ? [] : ['--frames', rampFrames]),
+  ...(steadyFrames === undefined ? [] : ['--steady', steadyFrames]),
+  ...(steadyWarmup === undefined ? [] : ['--warmup', steadyWarmup]),
+  ...(samplingInterval === undefined ? [] : ['--interval', samplingInterval]),
+  ...(incremental === undefined ? [] : ['--incremental', incremental]),
+  ...(wantCpu ? ['--cpu'] : []),
+];
+
+const mb = (bytes: number): string => (bytes / 1024 / 1024).toFixed(2);
+
+const cells: unknown[] = [];
+
+for (const count of counts) {
+  const started = performance.now();
+  const run = spawnSync(process.execPath, nodeArgs(count), { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 });
+
+  if (run.status !== 0) {
+    process.stderr.write(run.stderr ?? '');
+    throw new Error(`cell for count=${count} exited with ${String(run.status)}`);
+  }
+
+  const lines = run.stdout.trim().split('\n');
+  const cell = JSON.parse(lines[lines.length - 1]!) as {
+    count: number;
+    bootstrapBytes: number;
+    steadyBytesPerFrame: number | null;
+    phases: Array<{ phase: string; allocBytes: number; retainedBytes: number | null; peakHeapBytes: number; ms: number }>;
+    timings?: Record<string, number>;
+  };
+
+  cells.push({ ...cell, seconds: Number(((performance.now() - started) / 1000).toFixed(1)) });
+
+  if (wantCpu) {
+    console.log(`count=${String(count).padStart(8)}  ${JSON.stringify(cell.timings)}`);
+    continue;
+  }
+
+  console.log(
+    `\ncount=${String(count).padStart(8)}  bootstrap ${mb(cell.bootstrapBytes).padStart(10)} MB  steady ${((cell.steadyBytesPerFrame ?? 0) / 1024).toFixed(2)} KB/frame`,
+  );
+
+  for (const entry of cell.phases) {
+    const retained = entry.retainedBytes === null ? '     n/a' : `${mb(entry.retainedBytes).padStart(8)}`;
+    console.log(
+      `  ${entry.phase.padEnd(26)} alloc ${mb(entry.allocBytes).padStart(9)} MB  retained ${retained} MB  peakHeap ${mb(entry.peakHeapBytes).padStart(8)} MB`,
+    );
+  }
+}
+
+const outDir = resolve(process.cwd(), '.workspace/output/render-perf');
+mkdirSync(outDir, { recursive: true });
+
+const outPath = resolve(outDir, wantCpu ? 'bootstrap-cpu.json' : 'bootstrap-allocation.json');
+writeFileSync(
+  outPath,
+  `${JSON.stringify({ env: `Node ${process.version} ${process.platform}/${process.arch}`, mode: incremental === undefined ? 'bulk' : 'incremental', cells }, null, 2)}\n`,
+);
+
+console.log(`\nWrote ${outPath}`);

--- a/test/perf/rendering/run-bootstrap-cell.ts
+++ b/test/perf/rendering/run-bootstrap-cell.ts
@@ -1,0 +1,427 @@
+/**
+ * Fresh-process COLD/BOOTSTRAP allocation cell runner.
+ *
+ * The steady-state runners (`run-allocation.ts`, `run-allocation-cell.ts`) warm
+ * past scene establishment on purpose and report a per-frame rate. This runner
+ * measures exactly what they discard: everything a scene allocates on the way
+ * from "nothing exists" to "the frame rate is flat".
+ *
+ *   pnpm perf:renderers:bootstrap:cell -- --count 1000000 [--frames 100] [--profile] [--top 25]
+ *   pnpm perf:renderers:bootstrap:cell -- --count 1000000 --cpu
+ *   pnpm perf:renderers:bootstrap:cell -- --count 100000 --incremental 100
+ *
+ * ── Why one cardinality per process ─────────────────────────────────────────
+ * V8's optimisation state carries across scenes inside a process and moves the
+ * sampling profiler's attribution with it (documented on `scrolling-world/10000`
+ * in `allocationScenes.ts`: the same frame reads 1.9 MB or 15 KB depending only
+ * on whether an earlier window ran). A bootstrap reading is a FIRST-EVER-touch
+ * measurement by definition, so it is worth nothing if anything else ran first.
+ * The driver (`run-bootstrap-allocation.ts`) spawns one process per cell.
+ *
+ * ── The four quantities, never inferred from one another ────────────────────
+ *   allocBytes     cumulative allocation traffic through the phase (sampler)
+ *   heapAfterBytes live heap after two forced GCs at the phase end
+ *   retainedBytes  heapAfter delta vs. the previous phase = what the phase kept
+ *   peakHeapBytes  `heapTotal` high-water mark observed at the phase end
+ *
+ * `allocBytes` is traffic, not residency: a phase can allocate 400 MB and retain
+ * 40. Only `retainedBytes` is memory the scene still costs afterwards.
+ *
+ * Requires `--expose-gc` (the script wires it); without it the heap columns are
+ * reported as null rather than silently reporting un-collected garbage as live.
+ *
+ * @internal Test/perf-only.
+ */
+import { Session } from 'node:inspector';
+
+import { Container } from '#rendering/Container';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Sprite } from '#rendering/sprite/Sprite';
+import type { Texture } from '#rendering/texture/Texture';
+
+import { makeTextures, scatterInView } from './fixtures';
+import type { WebGl2Harness } from './harness';
+import { createWebGl2Harness } from './harness';
+
+type ProfileNode = import('node:inspector').HeapProfiler.SamplingHeapProfileNode;
+
+const args = process.argv.slice(2);
+
+const flag = (name: string): string | undefined => {
+  const index = args.indexOf(`--${name}`);
+
+  return index === -1 ? undefined : args[index + 1];
+};
+
+const count = Number(flag('count') ?? 1000);
+const rampFrames = Number(flag('frames') ?? 100);
+const steadyFrames = Number(flag('steady') ?? 100);
+const steadyWarmup = Number(flag('warmup') ?? 600);
+const samplingInterval = Number(flag('interval') ?? 512);
+const top = Number(flag('top') ?? 25);
+const wantProfile = args.includes('--profile');
+const wantCpu = args.includes('--cpu');
+/** Chunks the scene is built in when streaming instead of bulk-constructing. */
+const incrementalChunks = Number(flag('incremental') ?? 0);
+
+const VIEW = { w: 1280, h: 720 } as const;
+const WORLD = { w: VIEW.w * 2, h: VIEW.h * 2 } as const;
+
+const gc = globalThis.gc as (() => void) | undefined;
+
+/** Live heap after settling the collector, or null when `--expose-gc` is missing. */
+const liveHeap = (): number | null => {
+  if (gc === undefined) {
+    return null;
+  }
+
+  gc();
+  gc();
+
+  return process.memoryUsage().heapUsed;
+};
+
+const post = <T>(session: Session, method: string, params?: Record<string, unknown>): Promise<T> =>
+  new Promise((resolve, reject) => {
+    session.post(method, params, (error: Error | null, result?: unknown) => {
+      if (error) {
+        reject(error);
+
+        return;
+      }
+
+      resolve(result as T);
+    });
+  });
+
+const sample = async (body: () => void): Promise<ProfileNode> => {
+  const session = new Session();
+  session.connect();
+
+  await post(session, 'HeapProfiler.enable');
+  // Without the two GC flags the profiler reports only what is still live at
+  // stop, which for a bootstrap window discards most of the traffic it exists
+  // to measure. See the block comment in `allocation.ts`.
+  await post(session, 'HeapProfiler.startSampling', {
+    samplingInterval,
+    includeObjectsCollectedByMajorGC: true,
+    includeObjectsCollectedByMinorGC: true,
+  });
+
+  body();
+
+  const { profile } = await post<{ profile: import('node:inspector').HeapProfiler.SamplingHeapProfile }>(session, 'HeapProfiler.stopSampling');
+  await post(session, 'HeapProfiler.disable');
+  session.disconnect();
+
+  return profile.head;
+};
+
+const sumSelfSize = (node: ProfileNode): number => node.selfSize + node.children.reduce((total, child) => total + sumSelfSize(child), 0);
+
+const frameLabel = (node: ProfileNode): string => {
+  const { functionName, url, lineNumber } = node.callFrame;
+  const file = url.replace(/^.*[/\\]/u, '') || '(native)';
+
+  return `${functionName || '(anonymous)'} @ ${file}:${lineNumber + 1}`;
+};
+
+interface CallsiteRow {
+  readonly site: string;
+  readonly selfBytes: number;
+}
+
+/** Flatten the sampling tree into per-callsite rows keyed by the two nearest callers. */
+const collectCallsites = (head: ProfileNode): CallsiteRow[] => {
+  const bySite = new Map<string, number>();
+
+  const walk = (node: ProfileNode, ancestry: readonly string[]): void => {
+    const chain = [...ancestry, frameLabel(node)];
+
+    if (node.selfSize > 0) {
+      const site = chain.slice(-3).join(' < ');
+      bySite.set(site, (bySite.get(site) ?? 0) + node.selfSize);
+    }
+
+    for (const child of node.children) {
+      walk(child, chain);
+    }
+  };
+
+  walk(head, []);
+
+  return [...bySite.entries()].map(([site, selfBytes]) => ({ site, selfBytes })).sort((a, b) => b.selfBytes - a.selfBytes);
+};
+
+/** Same lean frame the allocation gate drives — no `FrameMetrics` object. */
+const renderOnce = (harness: WebGl2Harness, root: RenderNode, beforeFrame?: () => void): void => {
+  harness.backend.resetStats();
+  harness.recorder.reset();
+  beforeFrame?.();
+  harness.backend.clear();
+  root.render(harness.backend);
+  harness.backend.flush();
+};
+
+/**
+ * Ping-pong the camera exactly as `buildScrollingWorldReference` does, so a
+ * bootstrap reading here and a steady reading from the reference stage describe
+ * the same scene. Ping-pong rather than wrap: a modulo wrap teleports the camera
+ * once per cycle and invalidates every view-dependent cached product at once.
+ */
+const pingPongCamera = (harness: WebGl2Harness, speed: number): (() => void) => {
+  const spanX = Math.max(1, WORLD.w - VIEW.w);
+  const spanY = Math.max(1, WORLD.h - VIEW.h);
+  const period = spanX * 2;
+  let frame = 0;
+
+  return (): void => {
+    frame++;
+
+    const t = (frame * speed) % period;
+    const offset = t <= spanX ? t : period - t;
+
+    harness.view.setCenter(VIEW.w / 2 + offset, VIEW.h / 2 + (offset / spanX) * spanY);
+  };
+};
+
+/**
+ * Construct `n` sprites into `root`, from `first`. Split out of the fixture
+ * builder on purpose: `buildSpriteScene` also accumulates a `Sprite[]` for the
+ * caller, and at a million nodes that array's geometric growth is a measurement
+ * artefact of the fixture rather than a cost the engine imposes. The array is
+ * measured here as its own phase instead of being folded into construction.
+ */
+const buildInto = (root: Container, texture: Texture, first: number, n: number): void => {
+  for (let i = first; i < first + n; i++) {
+    const sprite = new Sprite(texture);
+
+    scatterInView(sprite, i, WORLD.w, WORLD.h);
+    root.addChild(sprite);
+  }
+};
+
+interface PhaseResult {
+  readonly phase: string;
+  readonly allocBytes: number;
+  readonly ms: number;
+  readonly heapAfterBytes: number | null;
+  readonly retainedBytes: number | null;
+  readonly peakHeapBytes: number;
+  readonly rssBytes: number;
+  readonly callsites?: readonly CallsiteRow[];
+}
+
+const phases: PhaseResult[] = [];
+let previousHeap = liveHeap();
+
+/**
+ * Run one phase under the sampler and record all four quantities.
+ *
+ * The wall-clock in `ms` is taken WITH the profiler running and is therefore an
+ * upper bound, not a CPU reading — `--cpu` re-runs the same phase sequence with
+ * the profiler off for that.
+ */
+const phase = async (name: string, body: () => void): Promise<void> => {
+  const started = performance.now();
+  const head = await sample(body);
+  const ms = performance.now() - started;
+  const memory = process.memoryUsage();
+  const heapAfterBytes = liveHeap();
+
+  phases.push({
+    phase: name,
+    allocBytes: sumSelfSize(head),
+    ms: Number(ms.toFixed(1)),
+    heapAfterBytes,
+    retainedBytes: heapAfterBytes === null || previousHeap === null ? null : heapAfterBytes - previousHeap,
+    peakHeapBytes: memory.heapTotal,
+    rssBytes: memory.rss,
+    ...(wantProfile ? { callsites: collectCallsites(head).slice(0, top) } : {}),
+  });
+
+  previousHeap = heapAfterBytes;
+};
+
+/**
+ * Wall-clock companion mode (`--cpu`): the identical phase sequence with the
+ * profiler off. An initialization fix that traded bytes for cycles would be
+ * invisible to the sampled numbers, and the sampler's overhead makes a timed run
+ * under it useless as a CPU reading.
+ */
+if (wantCpu) {
+  const timings: Record<string, number> = {};
+  const time = (name: string, body: () => void): void => {
+    const started = performance.now();
+    body();
+    timings[name] = Number((performance.now() - started).toFixed(1));
+  };
+
+  let harness!: WebGl2Harness;
+  let texture!: Texture;
+  let root!: Container;
+
+  time('harness', () => {
+    harness = createWebGl2Harness();
+  });
+  time('textures', () => {
+    texture = makeTextures(1)[0]!;
+  });
+  time('construct', () => {
+    root = new Container();
+    buildInto(root, texture, 0, count);
+  });
+
+  harness.view.reset(VIEW.w / 2, VIEW.h / 2, VIEW.w, VIEW.h);
+
+  const beforeFrame = pingPongCamera(harness, 8);
+
+  time('frame1', () => renderOnce(harness, root, beforeFrame));
+  time('ramp', () => {
+    for (let i = 1; i < rampFrames; i++) {
+      renderOnce(harness, root, beforeFrame);
+    }
+  });
+  time('steadyWarmup', () => {
+    for (let i = 0; i < steadyWarmup; i++) {
+      renderOnce(harness, root, beforeFrame);
+    }
+  });
+  time('steady', () => {
+    for (let i = 0; i < steadyFrames; i++) {
+      renderOnce(harness, root, beforeFrame);
+    }
+  });
+
+  root.destroy();
+  harness.destroy();
+
+  console.log(JSON.stringify({ mode: 'cpu', count, rampFrames, steadyFrames, timings }));
+  process.exit(0);
+}
+
+let harness!: WebGl2Harness;
+let texture!: Texture;
+let root!: Container;
+
+await phase('harness', () => {
+  harness = createWebGl2Harness();
+});
+
+await phase('textures', () => {
+  texture = makeTextures(1)[0]!;
+});
+
+if (incrementalChunks > 0) {
+  // Streaming shape: the scene grows across frames instead of being fully built
+  // before the first render. Answers whether a reserve/bulk-build path would
+  // help a real loading screen or only a synthetic one-shot construction.
+  const perChunk = Math.ceil(count / incrementalChunks);
+
+  root = new Container();
+  harness.view.reset(VIEW.w / 2, VIEW.h / 2, VIEW.w, VIEW.h);
+
+  const beforeFrame = pingPongCamera(harness, 8);
+  let built = 0;
+
+  await phase('incrementalBuildAndRender', () => {
+    for (let chunk = 0; chunk < incrementalChunks; chunk++) {
+      const n = Math.min(perChunk, count - built);
+
+      buildInto(root, texture, built, n);
+      built += n;
+      renderOnce(harness, root, beforeFrame);
+    }
+  });
+
+  await phase('ramp', () => {
+    for (let i = 0; i < rampFrames; i++) {
+      renderOnce(harness, root, beforeFrame);
+    }
+  });
+
+  await phase('steadyWarmup', () => {
+    for (let i = 0; i < steadyWarmup; i++) {
+      renderOnce(harness, root, beforeFrame);
+    }
+  });
+
+  await phase('steady', () => {
+    for (let i = 0; i < steadyFrames; i++) {
+      renderOnce(harness, root, beforeFrame);
+    }
+  });
+} else {
+  await phase('construct', () => {
+    root = new Container();
+    buildInto(root, texture, 0, count);
+  });
+
+  // The fixture's own `Sprite[]`, measured on its own so the construction phase
+  // reports engine cost rather than harness cost.
+  await phase('fixtureArray', () => {
+    const sprites: unknown[] = [];
+
+    for (const child of root.children) {
+      sprites.push(child);
+    }
+
+    if (sprites.length !== count) {
+      throw new Error(`fixture array length ${sprites.length} != ${count}`);
+    }
+  });
+
+  harness.view.reset(VIEW.w / 2, VIEW.h / 2, VIEW.w, VIEW.h);
+
+  const beforeFrame = pingPongCamera(harness, 8);
+
+  await phase('frame1', () => renderOnce(harness, root, beforeFrame));
+
+  await phase('ramp', () => {
+    for (let i = 1; i < rampFrames; i++) {
+      renderOnce(harness, root, beforeFrame);
+    }
+  });
+
+  await phase('steadyWarmup', () => {
+    for (let i = 0; i < steadyWarmup; i++) {
+      renderOnce(harness, root, beforeFrame);
+    }
+  });
+
+  await phase('steady', () => {
+    for (let i = 0; i < steadyFrames; i++) {
+      renderOnce(harness, root, beforeFrame);
+    }
+  });
+}
+
+const bootstrapBytes = phases.filter(p => p.phase !== 'steady' && p.phase !== 'steadyWarmup').reduce((total, p) => total + p.allocBytes, 0);
+const steadyPhase = phases.find(p => p.phase === 'steady');
+
+if (wantProfile) {
+  for (const entry of phases) {
+    process.stderr.write(`\n── ${entry.phase} — ${(entry.allocBytes / 1024 / 1024).toFixed(2)} MB ──\n`);
+
+    for (const row of entry.callsites ?? []) {
+      process.stderr.write(`${(row.selfBytes / 1024 / 1024).toFixed(2).padStart(9)} MB  ${row.site}\n`);
+    }
+  }
+}
+
+root.destroy();
+harness.destroy();
+
+console.log(
+  JSON.stringify({
+    mode: incrementalChunks > 0 ? 'incremental' : 'bulk',
+    count,
+    rampFrames,
+    steadyFrames,
+    samplingInterval,
+    gcAvailable: gc !== undefined,
+    bootstrapBytes,
+    steadyBytesPerFrame: steadyPhase === undefined ? null : steadyPhase.allocBytes / steadyFrames,
+    phases: phases.map(({ callsites: _callsites, ...rest }) => rest),
+  }),
+);

--- a/test/perf/rendering/run-bootstrap-cell.ts
+++ b/test/perf/rendering/run-bootstrap-cell.ts
@@ -304,6 +304,56 @@ let harness!: WebGl2Harness;
 let texture!: Texture;
 let root!: Container;
 
+/**
+ * Window-series mode (`--series <windows> [--window <frames>]`): build the scene,
+ * render frame 1, then sample every following window separately and print the
+ * per-frame rate for each.
+ *
+ * This is the discriminator between one-time ramp-up work and the V8
+ * optimisation-state artefact already documented on this scene family (a frame
+ * that reads megabytes attributed to a function containing no allocation, and
+ * reads kilobytes later with nothing changed). One-time work ends at a frame and
+ * the series steps down; the artefact decays as V8 tiers up. Neither is legible
+ * from a single averaged window, which is why the ramp total on its own cannot
+ * be classified.
+ */
+const seriesWindows = Number(flag('series') ?? 0);
+const seriesWindowFrames = Number(flag('window') ?? 25);
+
+if (seriesWindows > 0) {
+  harness = createWebGl2Harness();
+  texture = makeTextures(1)[0]!;
+  root = new Container();
+  buildInto(root, texture, 0, count);
+  harness.view.reset(VIEW.w / 2, VIEW.h / 2, VIEW.w, VIEW.h);
+
+  const beforeFrame = pingPongCamera(harness, 8);
+  const series: Array<{ firstFrame: number; bytesPerFrame: number; drawCalls: number; submittedNodes: number }> = [];
+
+  await phase('frame1', () => renderOnce(harness, root, beforeFrame));
+
+  for (let window = 0; window < seriesWindows; window++) {
+    const head = await sample(() => {
+      for (let i = 0; i < seriesWindowFrames; i++) {
+        renderOnce(harness, root, beforeFrame);
+      }
+    });
+
+    series.push({
+      firstFrame: 2 + window * seriesWindowFrames,
+      bytesPerFrame: sumSelfSize(head) / seriesWindowFrames,
+      drawCalls: harness.backend.stats.drawCalls,
+      submittedNodes: harness.backend.stats.submittedNodes,
+    });
+  }
+
+  root.destroy();
+  harness.destroy();
+
+  console.log(JSON.stringify({ mode: 'series', count, windowFrames: seriesWindowFrames, frame1Bytes: phases[0]!.allocBytes, series }));
+  process.exit(0);
+}
+
 await phase('harness', () => {
   harness = createWebGl2Harness();
 });

--- a/test/perf/rendering/run-instance-cost.ts
+++ b/test/perf/rendering/run-instance-cost.ts
@@ -1,0 +1,147 @@
+/**
+ * Per-instance RETAINED cost probe.
+ *
+ * The bootstrap runner says a phase retained N megabytes; this says what one
+ * instance of a given class costs, so a construction bucket can be decomposed
+ * into the objects that actually make it up rather than attributed to whichever
+ * constructor frame the sampler happened to label.
+ *
+ *   pnpm perf:renderers:instance-cost                # every type, fresh process each
+ *   pnpm perf:renderers:instance-cost -- --type Sprite --n 200000
+ *
+ * ── Method ──────────────────────────────────────────────────────────────────
+ * Pre-size the holder array, settle the collector, read `heapUsed`, fill the
+ * holder, settle again, read again. The delta divided by `n` is retained bytes
+ * per instance INCLUDING everything the instance keeps alive (a `Rectangle`
+ * reports its `ObservableVector`, its `ObservableSize` and its bound callback,
+ * because those are what it costs).
+ *
+ * This is a residency measurement, not an allocation-traffic one, and it is the
+ * second indicator the bootstrap runner's sampler numbers are checked against:
+ * the two answer different questions and neither is inferred from the other.
+ *
+ * Requires `--expose-gc` (the script wires it).
+ *
+ * @internal Test/perf-only.
+ */
+import { spawnSync } from 'node:child_process';
+
+import { Bounds } from '#core/Bounds';
+import { Color } from '#core/Color';
+import { Flags } from '#math/Flags';
+import { Matrix } from '#math/Matrix';
+import { ObservableVector } from '#math/ObservableVector';
+import { Rectangle } from '#math/Rectangle';
+import { Vector } from '#math/Vector';
+import { Container } from '#rendering/Container';
+import { Sprite } from '#rendering/sprite/Sprite';
+
+import { makeTextures } from './fixtures';
+
+const args = process.argv.slice(2);
+
+const flag = (name: string): string | undefined => {
+  const index = args.indexOf(`--${name}`);
+
+  return index === -1 ? undefined : args[index + 1];
+};
+
+const n = Number(flag('n') ?? 200000);
+const type = flag('type');
+
+const gc = globalThis.gc as (() => void) | undefined;
+
+const settle = (): number => {
+  gc?.();
+  gc?.();
+
+  return process.memoryUsage().heapUsed;
+};
+
+const texture = makeTextures(1)[0]!;
+
+/**
+ * Each factory must allocate one fresh instance and nothing shared, so the
+ * holder slot is the only thing keeping it alive.
+ */
+const FACTORIES: Record<string, () => unknown> = {
+  'Object{}': () => ({}),
+  'Array[]': () => [],
+  Closure: () => () => texture,
+  'Float32Array(8)': () => new Float32Array(8),
+  'Uint32Array(4)': () => new Uint32Array(4),
+  Vector: () => new Vector(0, 0),
+  ObservableVector: () => new ObservableVector(null, 0, 0, 0),
+  Matrix: () => new Matrix(),
+  Flags: () => new Flags(),
+  Color: () => Color.white.clone(),
+  Rectangle: () => new Rectangle(),
+  Bounds: () => new Bounds(),
+  Container: () => new Container(),
+  Sprite: () => new Sprite(texture),
+};
+
+if (type === undefined) {
+  // Driver mode: one fresh process per type, so no type pays for another's
+  // fragmentation or for a holder array that already grew.
+  const rows: Array<{ type: string; bytesPerInstance: number }> = [];
+
+  for (const name of Object.keys(FACTORIES)) {
+    const run = spawnSync(
+      process.execPath,
+      [
+        '--expose-gc',
+        '--max-old-space-size=8192',
+        '--conditions=@codexo/source',
+        '--import',
+        './scripts/glsl-register.mjs',
+        '--import',
+        'tsx/esm',
+        'test/perf/rendering/run-instance-cost.ts',
+        '--type',
+        name,
+        '--n',
+        String(n),
+      ],
+      { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+    );
+
+    if (run.status !== 0) {
+      process.stderr.write(run.stderr ?? '');
+      throw new Error(`instance-cost cell for '${name}' exited with ${String(run.status)}`);
+    }
+
+    const lines = run.stdout.trim().split('\n');
+    const cell = JSON.parse(lines[lines.length - 1]!) as { type: string; bytesPerInstance: number };
+
+    rows.push(cell);
+    console.log(`${cell.type.padEnd(18)} ${cell.bytesPerInstance.toFixed(1).padStart(9)} bytes/instance retained`);
+  }
+
+  console.log(`\n${JSON.stringify({ n, rows })}`);
+  process.exit(0);
+}
+
+const factory = FACTORIES[type];
+
+if (factory === undefined) {
+  throw new Error(`unknown type '${type}' (known: ${Object.keys(FACTORIES).join(', ')})`);
+}
+
+// Pre-sized so the holder's own growth is paid before the baseline is read.
+const holder: unknown[] = new Array<unknown>(n).fill(null);
+const before = settle();
+
+for (let i = 0; i < n; i++) {
+  holder[i] = factory();
+}
+
+const after = settle();
+
+// Touch the holder after the second reading so nothing above can be optimised
+// away as dead.
+if (holder[n - 1] === undefined) {
+  throw new Error('holder was not filled');
+}
+
+console.log(JSON.stringify({ type, n, gcAvailable: gc !== undefined, bytesPerInstance: (after - before) / n }));


### PR DESCRIPTION
Q12 (cold/bootstrap allocation), slice 1. Base: `4e971c74`.

## What this changes

Six per-instance fields on `RenderNode` / `Sprite` are now built on first use instead of on
construction:

| Field | Was | Now |
| --- | --- | --- |
| `RenderNode._filters` | `Filter[] = []` | `null`, reads return a shared `NO_FILTERS` |
| `RenderNode._cacheBounds` | `new Rectangle()` | `null`, built in `_renderPlanStoreCacheTexture` |
| `RenderNode._runCaptureContent` | per-instance arrow field | closure built with the capture pass |
| `Sprite._vertices` | `new Float32Array(8)` | `null`, built in the `vertices` getter |
| `Sprite._texCoords` | `new Uint32Array(4)` | `null`, built in the `texCoords` getter |
| `Sprite._normals` | `[Vector x4]` | `null`, built in `getNormals()` |

None of these are read on the render path — the renderers pack their own quad through
`_packSourceQuad`, and `vertices` / `texCoords` / `getNormals()` are reached only from collision
queries and direct API reads. A scene that just draws its sprites was paying for six features it
never used, on every node.

Public contracts are unchanged: `filters` still returns `readonly Filter[]`, `texCoords` still
returns the same instance across reads (asserted by `test/rendering/sprite/sprite.test.ts`),
`getNormals()` still returns a `Vector[]`. No backend code is touched, so the change is
backend-neutral by construction.

## Measurements

Retained bytes per instance (200k instances, forced GC, one fresh process per step, reproducible to
+/-0.03 B):

| Step | bytes/Sprite | delta |
| --- | ---: | ---: |
| baseline | 3393.4 | — |
| + lazy `_filters` | 3361.4 | -32.0 |
| + lazy `_cacheBounds` | 3137.4 | -224.0 |
| + lazy `_runCaptureContent` | 2777.4 | **-360.0** |
| + lazy `_normals` | 2505.4 | -272.0 |
| + lazy `_vertices` / `_texCoords` | **2025.3** | -480.0 |

`Sprite` -40.3%, `Container` 2248.6 -> 1632.5 B (-27.4%).

Removing the one instance-field arrow function saved 360 bytes, not 56: the `JSFunction` plus its
per-instance context and feedback cell.

End-to-end on the 1M scrolling-world reference stage, fresh process:

| | baseline | this branch |
| --- | ---: | ---: |
| bootstrap traffic | 4377.6 MB | 2966.6 MB (-32.2%) |
| construction traffic | 3503.6 MB | 2093.7 MB (-40.2%) |
| construction retained | 3401.7 MB | 2033.6 MB (-40.2%) |
| peak heap | 4116 MB | 2484 MB (-39.7%) |
| RSS | 4470 MB | 2717 MB |
| first frame | 321.0 MB | 319.3 MB (unchanged) |
| frames 2-100 | 472.7 MB | 473.2 MB (unchanged) |

Scaling is linear across four decades; the saving is a constant per node.

| count | bootstrap base | bootstrap here | construct base | construct here | peak base | peak here |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1k | 8.57 MB | 7.18 MB | 3.94 MB | 2.49 MB | 37.1 MB | 35.3 MB |
| 10k | 48.90 MB | 35.38 MB | 35.25 MB | 21.68 MB | 117.0 MB | 103.9 MB |
| 100k | 428.02 MB | 293.29 MB | 335.48 MB | 201.02 MB | 505.3 MB | 374.5 MB |
| 1M | 4377.6 MB | 2966.6 MB | 3503.6 MB | 2093.7 MB | 4116 MB | 2484 MB |

Streaming construction (100 chunks of 1k, rendering between chunks, 100k) benefits by the same
proportion: bootstrap -34.4%, retained -37.9%, peak heap -27.7%. This is not a one-shot-synthetic
win.

Initialization CPU (profiler off, fresh process): construction 318.5 -> 187.5 ms at 100k (-41%),
ramp 339.6 -> 257.8 ms, first frame 158.5 -> 147.3 ms. Nothing regresses.

## Measurement infrastructure

Three source-accurate fresh-process runners under `test/perf/rendering/`, with scripts
`perf:renderers:bootstrap`, `perf:renderers:bootstrap:cell`, `perf:renderers:instance-cost`:

- `run-bootstrap-cell.ts` — one cardinality per process, phase by phase, keeping cumulative
  allocation traffic, live heap after forced GC, per-phase retained delta and peak heap as four
  separate quantities. `--cpu` (profiler off), `--incremental` (streaming shape) and `--series`
  (per-window rate series) companion modes.
- `run-bootstrap-allocation.ts` — spawns one cell per cardinality, writes the scaling table.
- `run-instance-cost.ts` — retained bytes per instance for the scene-graph primitives, as the second
  indicator the sampler numbers are checked against. The two agreed to within 0.01% at 1M.

These are test/perf-only, outside every shipped bundle, and not part of any CI lane.

## Verification

- `pnpm test` — 532 files, 9832 tests passed, 1 skipped. Includes the `rendering-alloc` steady-state
  gate (budgets unchanged) and the `rendering-perf` structural counters.
- `pnpm verify:quick` — all 12 gates pass.
- Structural counters identical between trees across the whole 600-frame series at 1M:
  `drawCalls` = 1, `submittedNodes` ~380k.
