### PR TITLE
perf(rendering): remove recurring WebGPU allocation churn

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,8 @@
     "perf:profile:gc": "node --expose-gc --import tsx/esm test/perf/profile-benchmark.ts",
     "size": "size-limit",
     "prepare": "husky",
-    "perf:renderers:instance-cost": "node --expose-gc --max-old-space-size=8192 --conditions=@codexo/source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-instance-cost.ts"
+    "perf:renderers:instance-cost": "node --expose-gc --max-old-space-size=8192 --conditions=@codexo/source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-instance-cost.ts",
+    "perf:webgpu:alloc": "tsx test/perf/webgpu/run-webgpu-allocation.ts"
   },
   "license": "MIT",
   "publishConfig": {

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -250,6 +250,18 @@ export class WebGpuBackend implements RenderBackend {
   private _renderTarget: RenderTarget;
   // Reused scratch for the device-pixel snap viewport rect (see _snapViewport).
   private readonly _snapViewportRect = { x: 0, y: 0, width: 0, height: 0 };
+  /** Reused record handed out by `_getAttachmentPixelSize` — see the contract there. */
+  private readonly _attachmentPixelSize = { width: 0, height: 0 };
+  /** Reused colour attachment + its clear value — see `createColorAttachment`. */
+  private readonly _clearValue = { r: 0, g: 0, b: 0, a: 0 };
+  private readonly _colorAttachment: GPURenderPassColorAttachment = {
+    view: undefined as unknown as GPUTextureView,
+    clearValue: this._clearValue,
+    loadOp: 'load',
+    storeOp: 'store',
+  };
+  /** Reused one-element command-buffer list for `submit`. */
+  private readonly _submitBatch: GPUCommandBuffer[] = [undefined as unknown as GPUCommandBuffer];
   private _renderer: Renderer | null = null;
   private _renderGroupTransform: Matrix | null = null;
   private _renderGroupTransformId = 0;
@@ -1069,6 +1081,14 @@ export class WebGpuBackend implements RenderBackend {
     }
   }
 
+  /**
+   * **The returned record is reused**, including its nested `clearValue`. The
+   * one caller (`WebGpuPassCoordinator.acquirePass`) hands it straight to
+   * `beginRenderPass`, which reads the descriptor synchronously — so nothing
+   * ever needs it to survive the call. An effect-heavy frame opens hundreds of
+   * passes (501 on `filter/color 100`), and two fresh records per pass was one
+   * of the larger remaining per-pass costs.
+   */
   public createColorAttachment(): GPURenderPassColorAttachment {
     const renderTarget = this._renderTarget;
     let view: GPUTextureView;
@@ -1087,21 +1107,25 @@ export class WebGpuBackend implements RenderBackend {
 
     this._clearRequested = false;
 
-    return {
-      view,
-      clearValue: {
-        r: this._clearColor.r / 255,
-        g: this._clearColor.g / 255,
-        b: this._clearColor.b / 255,
-        a: this._clearColor.a,
-      },
-      loadOp,
-      storeOp: 'store',
-    };
+    const attachment = this._colorAttachment;
+    const clearValue = this._clearValue;
+
+    clearValue.r = this._clearColor.r / 255;
+    clearValue.g = this._clearColor.g / 255;
+    clearValue.b = this._clearColor.b / 255;
+    clearValue.a = this._clearColor.a;
+
+    attachment.view = view;
+    attachment.loadOp = loadOp;
+
+    return attachment;
   }
 
   public submit(commandBuffer: GPUCommandBuffer): void {
-    this.device.queue.submit([commandBuffer]);
+    // Reused one-slot batch: `submit` copies the list synchronously, and an
+    // effect frame submits hundreds of times.
+    this._submitBatch[0] = commandBuffer;
+    this.device.queue.submit(this._submitBatch);
 
     if (this._renderTarget === this._rootRenderTarget) {
       this._hasPresentedFrame = true;
@@ -1140,14 +1164,29 @@ export class WebGpuBackend implements RenderBackend {
    * store (logical × pixelRatio), so a geometric stencil attachment for the root
    * must match these dimensions. RenderTexture targets back their colour and
    * stencil attachments with the same (logical) size.
+   *
+   * **The returned record is reused.** Read it (or destructure it) before the
+   * next call; it is never safe to keep. The reason is the call frequency:
+   * `_snapViewport` reaches it once per flush and once per replayed retained
+   * batch, so a fresh two-field literal per call was the single largest
+   * per-draw allocation in the WebGPU backend — 106 KB/frame on a 1000-flush
+   * frame, against a whole-frame total of 127 KB.
    * @internal
    */
   public _getAttachmentPixelSize(target: RenderTarget): { readonly width: number; readonly height: number } {
+    const size = this._attachmentPixelSize;
+
     if (target === this._rootRenderTarget) {
-      return { width: this._canvas.width, height: this._canvas.height };
+      size.width = this._canvas.width;
+      size.height = this._canvas.height;
+
+      return size;
     }
 
-    return { width: target.width, height: target.height };
+    size.width = target.width;
+    size.height = target.height;
+
+    return size;
   }
 
   public getTextureBinding(

--- a/src/rendering/webgpu/WebGpuBackend.ts
+++ b/src/rendering/webgpu/WebGpuBackend.ts
@@ -97,6 +97,15 @@ interface ManagedWebGpuTextureState {
    * usual shape — allocation-free.
    */
   contiguousUploadView: Float32Array | Uint8Array | null;
+  /**
+   * The `(view, sampler)` pair `getTextureBinding` hands out for this texture
+   * when no material sampler override is in play. Owned by the state and
+   * refreshed in place rather than minted per call: the renderers resolve one
+   * binding per bound texture per draw, so a fresh two-field literal there was
+   * the last per-draw allocation left in the sprite path — ~20 KB/frame on a
+   * 1000-flush frame.
+   */
+  binding: { view: GPUTextureView; sampler: GPUSampler };
 }
 
 interface PixelClipBoundsState {
@@ -1150,10 +1159,22 @@ export class WebGpuBackend implements RenderBackend {
   } {
     const state = this._syncTexture(texture);
 
-    return {
-      view: state.view,
-      sampler: samplerOverride === null ? state.sampler : this._getMaterialSampler(texture, samplerOverride),
-    };
+    if (samplerOverride !== null) {
+      // Material overrides are a custom-material path and rare enough that a
+      // fresh record costs nothing measurable; giving them the state's own
+      // record would mean the default path and an override path could not be
+      // resolved in the same batch.
+      return { view: state.view, sampler: this._getMaterialSampler(texture, samplerOverride) };
+    }
+
+    // Refreshed in place: `_syncTexture` may have replaced the GPU texture (and
+    // therefore the view/sampler) on this very call.
+    const binding = state.binding;
+
+    binding.view = state.view;
+    binding.sampler = state.sampler;
+
+    return binding;
   }
 
   /**
@@ -2252,10 +2273,13 @@ export class WebGpuBackend implements RenderBackend {
 
       const mipLevelCount = this._getMipLevelCount(texture);
 
+      const view = gpuTexture.createView();
+      const sampler = this._createSampler(texture);
+
       state = {
         texture: gpuTexture,
-        view: gpuTexture.createView(),
-        sampler: this._createSampler(texture),
+        view,
+        sampler,
         version: -1,
         width: texture.width,
         height: texture.height,
@@ -2265,6 +2289,7 @@ export class WebGpuBackend implements RenderBackend {
         partialUploadScratch: null,
         partialUploadView: null,
         contiguousUploadView: null,
+        binding: { view, sampler },
       };
 
       state.accountedBytes = this._accountant.reallocate(0, this._estimateTextureBytes(texture, mipLevelCount));

--- a/src/rendering/webgpu/WebGpuMeshRenderer.ts
+++ b/src/rendering/webgpu/WebGpuMeshRenderer.ts
@@ -467,6 +467,12 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
   private _indexBufferCapacity = 0;
   private _uniformBufferCapacity = 0;
   private _vertexData: ArrayBuffer = new ArrayBuffer(0);
+  /** Reused per-flush staging for the default path's uniform slots — see `flush`. */
+  private _defaultUniformStaging: ArrayBuffer = new ArrayBuffer(0);
+  private _defaultUniformStagingF32: Float32Array = new Float32Array(0);
+  /** Reused per-flush cursors for the custom-material paths — see `flush`. */
+  private readonly _customVertexCursors = new Map<Material, number>();
+  private readonly _customIndexCursors = new Map<Material, number>();
   private _float32View: Float32Array = new Float32Array(this._vertexData);
   private _uint32View: Uint32Array = new Uint32Array(this._vertexData);
   private _packedIndexData: Uint16Array = new Uint16Array(0);
@@ -778,8 +784,16 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
     // whole pass.
     let defaultVertices = 0;
     let defaultIndices = 0;
-    const customVertexCursors = new Map<Material, number>(); // running vertex count per material
-    const customIndexCursors = new Map<Material, number>();
+    // Reused, and cleared rather than rebuilt: a frame with no custom-material
+    // mesh never touches them, and rebuilding two Maps per flush is pure churn
+    // in a scene that flushes often.
+    const customVertexCursors = this._customVertexCursors; // running vertex count per material
+    const customIndexCursors = this._customIndexCursors;
+
+    if (customVertexCursors.size > 0) {
+      customVertexCursors.clear();
+      customIndexCursors.clear();
+    }
 
     for (let i = 0; i < this._drawCallCount; i++) {
       const dc = this._drawCalls[i] as { -readonly [K in keyof MeshDrawCall]: MeshDrawCall[K] };
@@ -865,8 +879,15 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
 
     // Phase 3: pack default-path vertex/index/uniform data.
     const defaultUniformBytes = defaultDrawCalls * this._uniformAlignment;
-    const defaultUniformData = defaultUniformBytes > 0 ? new ArrayBuffer(defaultUniformBytes) : null;
-    const defaultUniformF32 = defaultUniformData !== null ? new Float32Array(defaultUniformData) : null;
+    // Grown on demand and reused, like `_vertexData` / `_packedIndexData`
+    // beside it. A fresh buffer per flush is 256 bytes PER DRAW CALL of malloc
+    // and zero-fill — 256 KB every frame at a thousand meshes — and the bytes
+    // are dead the moment `writeBuffer` has copied them. Only the first
+    // `defaultUniformBytes` are uploaded, and every uploaded slot is fully
+    // written by the loop below, so stale contents beyond a slot's 32 declared
+    // bytes are padding no shader reads.
+    const defaultUniformData = defaultUniformBytes > 0 ? this._acquireDefaultUniformStaging(defaultUniformBytes) : null;
+    const defaultUniformF32 = defaultUniformData !== null ? this._defaultUniformStagingF32 : null;
 
     let defaultUniformIndex = 0;
 
@@ -1401,14 +1422,31 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
         matrix.combine(groupTransform);
       }
 
-      matrix.combine(backend.view.getTransform());
+      // The view is post-multiplied straight into the six affine components the
+      // bake needs, instead of through `matrix.combine(view)`. Writing the
+      // product back into the scratch matrix costs ~47 bytes per call in a
+      // browser V8 — nine double field stores — and this runs once per mesh, so
+      // it was 47 KB/frame at a thousand meshes, a third of that frame's total
+      // allocation. The projective row (`e`/`f`/`z`) is not read by the loop
+      // below, so nothing else needs the product. Same formula as
+      // {@link Matrix.combine}; keep the two in step.
+      const view = backend.view.getTransform();
+      const ma = matrix.a;
+      const mb = matrix.b;
+      const mx = matrix.x;
+      const mc = matrix.c;
+      const md = matrix.d;
+      const my = matrix.y;
+      const me = matrix.e;
+      const mf = matrix.f;
+      const mz = matrix.z;
 
-      const a = matrix.a;
-      const b = matrix.b;
-      const c = matrix.c;
-      const d = matrix.d;
-      const tx = matrix.x;
-      const ty = matrix.y;
+      const a = ma * view.a + mc * view.b + me * view.x;
+      const b = mb * view.a + md * view.b + mf * view.x;
+      const tx = mx * view.a + my * view.b + mz * view.x;
+      const c = ma * view.c + mc * view.d + me * view.y;
+      const d = mb * view.c + md * view.d + mf * view.y;
+      const ty = mx * view.c + my * view.d + mz * view.y;
 
       // vertices/uvs/colors are sized to vertexCount (×2 for the vec2 attrs);
       // sourceIndex/i stay within bounds for the whole loop.
@@ -2357,6 +2395,16 @@ export class WebGpuMeshRenderer extends AbstractWebGpuRenderer<Mesh> implements 
   // ---------------------------------------------------------------------------
   // Custom-path helpers
   // ---------------------------------------------------------------------------
+
+  /** Grow-only staging for the default path's uniform block. Never shrinks. */
+  private _acquireDefaultUniformStaging(bytes: number): ArrayBuffer {
+    if (this._defaultUniformStaging.byteLength < bytes) {
+      this._defaultUniformStaging = new ArrayBuffer(bytes);
+      this._defaultUniformStagingF32 = new Float32Array(this._defaultUniformStaging);
+    }
+
+    return this._defaultUniformStaging;
+  }
 
   private _totalCustomDraws(): number {
     let total = 0;

--- a/src/rendering/webgpu/WebGpuPassCoordinator.ts
+++ b/src/rendering/webgpu/WebGpuPassCoordinator.ts
@@ -43,6 +43,18 @@ export interface WebGpuActiveRenderPass {
   readonly stencilRef: number;
 }
 
+/**
+ * The reused descriptor's `depthStencilAttachment` has to be assignable to
+ * `undefined` (a pass without a stencil clip clears it), which the generated
+ * WebGPU types do not allow under `exactOptionalPropertyTypes`.
+ */
+type ReusablePassDescriptor = Omit<GPURenderPassDescriptor, 'depthStencilAttachment'> & {
+  depthStencilAttachment?: GPURenderPassDepthStencilAttachment | undefined;
+};
+
+/** Hoisted: the encoder descriptor is a constant, and `acquirePass` runs per pass. */
+const commandEncoderDescriptor: GPUCommandEncoderDescriptor = { label: 'pass-coordinator:command-encoder' };
+
 interface StencilClipEntry {
   readonly shape: Geometry;
   readonly transform: Matrix;
@@ -97,6 +109,12 @@ export class WebGpuPassCoordinator implements RenderPassCoordinator {
   private _stencilRef = 0;
   private _active: WebGpuActiveRenderPass | null = null;
   private _passHasDraws = false;
+  /** Reused render-pass descriptor and its colour-attachment list — see {@link acquirePass}. */
+  private readonly _colorAttachments: Array<GPURenderPassColorAttachment | null> = [null];
+  private readonly _passDescriptor: ReusablePassDescriptor = {
+    label: 'pass-coordinator:render-pass',
+    colorAttachments: this._colorAttachments,
+  };
 
   public constructor(backend: WebGpuPassBackend) {
     this._backend = backend;
@@ -176,17 +194,24 @@ export class WebGpuPassCoordinator implements RenderPassCoordinator {
 
     const backend = this._backend;
     const stencilEnabled = this.stencilActive;
-    const descriptor: GPURenderPassDescriptor = {
-      label: 'pass-coordinator:render-pass',
-      colorAttachments: [backend.createColorAttachment()],
-    };
+    // Descriptor and attachment list are reused: `beginRenderPass` and
+    // `createCommandEncoder` read their descriptors synchronously, so neither
+    // has to survive the call. An effect-heavy frame opens hundreds of passes
+    // (501 on `filter/color 100`), where a fresh descriptor plus a fresh
+    // one-element array per pass is a measurable per-pass cost. The `_active`
+    // record below is deliberately NOT pooled — renderers compare it by
+    // identity to decide whether their draws are in the open pass.
+    const descriptor = this._passDescriptor;
 
-    if (stencilEnabled) {
-      descriptor.depthStencilAttachment = this._createStencilAttachment(backend.renderTarget);
-    }
+    this._colorAttachments[0] = backend.createColorAttachment();
+    descriptor.depthStencilAttachment = stencilEnabled ? this._createStencilAttachment(backend.renderTarget) : undefined;
 
-    const encoder = backend.device.createCommandEncoder({ label: 'pass-coordinator:command-encoder' });
-    const pass = encoder.beginRenderPass(descriptor);
+    const encoder = backend.device.createCommandEncoder(commandEncoderDescriptor);
+    // Cast, not `delete`: an absent optional dictionary member and one set to
+    // `undefined` are the same thing to WebIDL, while `delete` would push the
+    // reused descriptor into dictionary mode. `exactOptionalPropertyTypes` is
+    // what makes the two spellings differ to TypeScript, not to the browser.
+    const pass = encoder.beginRenderPass(descriptor as GPURenderPassDescriptor);
 
     this._passHasDraws = false;
     backend.stats.renderPasses++;

--- a/src/rendering/webgpu/WebGpuSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuSpriteRenderer.ts
@@ -34,6 +34,7 @@ import { getWebGpuBlendState } from './WebGpuBlendState';
 import { WebGpuPassArena } from './WebGpuPassArena';
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
 import { persistentPremultiplyMaskIndex, persistentUniformBytes, WebGpuPersistentSlotStore } from './WebGpuPersistentSlotStore';
+import { pipelineVariantKey, WebGpuPipelineVariantCache } from './webgpuPipelineCache';
 import {
   retainedGroupUniformBytes,
   type WebGpuRetainedBatchPayload,
@@ -344,7 +345,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
   private _instanceData: ArrayBuffer = new ArrayBuffer(0);
   private _instanceFloat32 = new Float32Array(this._instanceData);
   private _instanceUint32 = new Uint32Array(this._instanceData);
-  private readonly _pipelines: Map<string, GPURenderPipeline> = new Map<string, GPURenderPipeline>();
+  private readonly _pipelines = new WebGpuPipelineVariantCache<GPURenderPipeline>();
 
   // Persistent-indexed path. Built on the first source a backend accepts rather
   // than at connect: an application whose roots never reach the tier should not
@@ -370,6 +371,11 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
   // because the cached bind groups are built against a different layout.
   private _customTextureSetBindGroups = new WeakMap<Texture | RenderTexture, TextureSetBindGroupEntry[]>();
   private readonly _textureSlots = new Map<Texture | RenderTexture, number>();
+  // Per-call scratch for `_getOrCreateTextureBindGroup`. Grown to the widest
+  // slot capacity ever asked for (the default tier's and the custom path's
+  // differ) and never handed out: cache entries copy out of it.
+  private readonly _resolvedTextures: Array<Texture | RenderTexture> = [];
+  private readonly _resolvedBindings: Array<ReturnType<WebGpuBackend['getTextureBinding']>> = [];
   private _slotCount = 0;
   private _instanceCount = 0;
   // Highest transform-storage row referenced by the pending batch; drives the
@@ -1214,7 +1220,13 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     }
 
     this._uniformHazardPass = active;
-    this._uniformBuffersInPass.clear();
+
+    // Guarded: `Set.clear()` allocates a fresh backing table even when the set
+    // is already empty, and on the default (non-custom-material) path it always
+    // is — this runs once per flush.
+    if (this._uniformBuffersInPass.size > 0) {
+      this._uniformBuffersInPass.clear();
+    }
   }
 
   /**
@@ -1371,8 +1383,12 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     // survives a renderer switch, so any recorded draw is at risk, not just
     // one of ours.
     if (coordinator.passHasDraws) {
-      for (const texture of payload.textures) {
-        if (backend._textureUploadWouldMutate(texture)) {
+      // Indexed: this guard runs once per replayed batch, and the array
+      // iterator is not scalar-replaced here (measured).
+      const batchTextures = payload.textures;
+
+      for (let i = 0; i < batchTextures.length; i++) {
+        if (backend._textureUploadWouldMutate(batchTextures[i]!)) {
           coordinator.endPass();
           this._instanceArena.resetPass();
           break;
@@ -1544,14 +1560,14 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
         // (`:n`) variants are prewarmed; the stencil pipelines are created
         // lazily on the first clipped draw (a rare path not worth the upfront
         // compile cost), matching the mesh and text renderers.
-        const pipelineKey = `${blendMode}:${format}:n`;
+        const pipelineKey = pipelineVariantKey(blendMode, false);
 
-        if (this._pipelines.has(pipelineKey)) {
+        if (this._pipelines.has(format, pipelineKey)) {
           continue;
         }
 
         const promise = device.createRenderPipelineAsync(this._buildPipelineDescriptor(blendMode, format)).then(pipeline => {
-          this._pipelines.set(pipelineKey, pipeline);
+          this._pipelines.set(format, pipelineKey, pipeline);
         });
 
         promises.push(promise);
@@ -1641,11 +1657,21 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
 
   private _resetSlots(): void {
     if (this._slotCount > 0) {
+      // Deleted key by key rather than `Map.clear()`: V8's `clear` drops the
+      // backing table and allocates a fresh one, and this runs once per flush —
+      // 18 KB/frame on an effect scene that flushes 300 times. The table holds
+      // at most `_maxBatchTextures` entries, so the delete loop is the cheaper
+      // side on both counts.
       for (let i = 0; i < this._slotCount; i++) {
+        const texture = this._activeTextures[i];
+
+        if (texture !== null && texture !== undefined) {
+          this._textureSlots.delete(texture);
+        }
+
         this._activeTextures[i] = null;
       }
 
-      this._textureSlots.clear();
       this._slotCount = 0;
     }
   }
@@ -1675,8 +1701,17 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     const slotCapacity = custom ? spriteMaterialTextureSlots : this._maxBatchTextures;
     const fallbackTexture = textures[0] ?? Texture.empty;
     const fallbackBinding = backend.getTextureBinding(fallbackTexture, samplerOverride);
-    const resolvedTextures = new Array<Texture | RenderTexture>(slotCapacity);
-    const resolvedBindings = new Array<ReturnType<WebGpuBackend['getTextureBinding']>>(slotCapacity);
+    // Reused scratch, not two fresh arrays: this runs once per bound texture
+    // set per draw, and a cache HIT — the steady state — used to allocate both
+    // arrays anyway. They never outlive the call; the cache-miss path below
+    // copies out of them before storing anything.
+    const resolvedTextures = this._resolvedTextures;
+    const resolvedBindings = this._resolvedBindings;
+
+    if (resolvedTextures.length < slotCapacity) {
+      resolvedTextures.length = slotCapacity;
+      resolvedBindings.length = slotCapacity;
+    }
 
     for (let i = 0; i < slotCapacity; i++) {
       const texture = textures[i] ?? fallbackTexture;
@@ -1697,7 +1732,11 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       cache.set(fallbackTexture, entries);
     }
 
-    for (const entry of entries) {
+    // Indexed rather than `for…of`: this loop runs once per draw, and V8 does
+    // not scalar-replace the array iterator here (measured — see the WebGPU
+    // allocation audit).
+    for (let entryIndex = 0; entryIndex < entries.length; entryIndex++) {
+      const entry = entries[entryIndex]!;
       let texturesMatch = true;
 
       for (let i = 0; i < slotCapacity; i++) {
@@ -1724,8 +1763,8 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
       }
 
       if (!bindingsMatch) {
-        entry.views = resolvedBindings.map(binding => binding.view);
-        entry.samplers = resolvedBindings.map(binding => binding.sampler);
+        entry.views = this._copyViews(resolvedBindings, slotCapacity);
+        entry.samplers = this._copySamplers(resolvedBindings, slotCapacity);
         entry.group = this._buildTextureBindGroup(device, resolvedBindings, custom);
       }
 
@@ -1734,10 +1773,13 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
 
     const group = this._buildTextureBindGroup(device, resolvedBindings, custom);
 
+    // Copied, not stored by reference: `resolvedTextures` is reused scratch and
+    // the entry has to survive the next call. `slice` rather than the whole
+    // array — the scratch may be longer than this flavour's slot capacity.
     entries.push({
-      textures: resolvedTextures,
-      views: resolvedBindings.map(binding => binding.view),
-      samplers: resolvedBindings.map(binding => binding.sampler),
+      textures: resolvedTextures.slice(0, slotCapacity),
+      views: this._copyViews(resolvedBindings, slotCapacity),
+      samplers: this._copySamplers(resolvedBindings, slotCapacity),
       group,
     });
 
@@ -1746,6 +1788,28 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
     }
 
     return group;
+  }
+
+  /** Slot-capacity-bounded copy of the resolved views — the scratch may be longer. */
+  private _copyViews(resolvedBindings: ReadonlyArray<ReturnType<WebGpuBackend['getTextureBinding']>>, slotCapacity: number): GPUTextureView[] {
+    const views = new Array<GPUTextureView>(slotCapacity);
+
+    for (let i = 0; i < slotCapacity; i++) {
+      views[i] = resolvedBindings[i]!.view;
+    }
+
+    return views;
+  }
+
+  /** Counterpart of {@link _copyViews} for the samplers. */
+  private _copySamplers(resolvedBindings: ReadonlyArray<ReturnType<WebGpuBackend['getTextureBinding']>>, slotCapacity: number): GPUSampler[] {
+    const samplers = new Array<GPUSampler>(slotCapacity);
+
+    for (let i = 0; i < slotCapacity; i++) {
+      samplers[i] = resolvedBindings[i]!.sampler;
+    }
+
+    return samplers;
   }
 
   private _buildTextureBindGroup(
@@ -1779,8 +1843,8 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
   }
 
   private _getPipeline(blendMode: BlendModes, format: GPUTextureFormat, stencil: boolean): GPURenderPipeline {
-    const pipelineKey = `${blendMode}:${format}:${stencil ? 's' : 'n'}`;
-    const existingPipeline = this._pipelines.get(pipelineKey);
+    const pipelineKey = pipelineVariantKey(blendMode, stencil);
+    const existingPipeline = this._pipelines.get(format, pipelineKey);
 
     if (existingPipeline) {
       return existingPipeline;
@@ -1792,7 +1856,7 @@ export class WebGpuSpriteRenderer extends AbstractWebGpuRenderer<Sprite> impleme
 
     const pipeline = this._device.createRenderPipeline(this._buildPipelineDescriptor(blendMode, format, stencil));
 
-    this._pipelines.set(pipelineKey, pipeline);
+    this._pipelines.set(format, pipelineKey, pipeline);
 
     return pipeline;
   }

--- a/src/rendering/webgpu/WebGpuTransformStorage.ts
+++ b/src/rendering/webgpu/WebGpuTransformStorage.ts
@@ -25,6 +25,17 @@ export class WebGpuTransformStorage {
   // per instance.
   private _tintStorageBuffer: GPUBuffer | null = null;
   private _tintAccountedBytes = 0;
+  /**
+   * Reused result record for {@link getBuffer}. Every caller reads it inside
+   * the statement that asks for it — it binds two buffers and a count and is
+   * done — and `getBuffer` runs once per flush, so a fresh record per call was
+   * ~16 KB/frame on a 300-flush effect frame.
+   */
+  private readonly _result = {
+    buffer: undefined as unknown as GPUBuffer,
+    tintBuffer: undefined as unknown as GPUBuffer,
+    count: 0,
+  };
 
   /**
    * Underlying shared transform buffer. Exposed for internal stats / tests
@@ -171,11 +182,13 @@ export class WebGpuTransformStorage {
       this._storageCount = snapshot.count;
     }
 
-    return {
-      buffer: this._storageBuffer!,
-      tintBuffer: this._tintStorageBuffer!,
-      count: snapshot.count,
-    };
+    const result = this._result;
+
+    result.buffer = this._storageBuffer!;
+    result.tintBuffer = this._tintStorageBuffer!;
+    result.count = snapshot.count;
+
+    return result;
   }
 
   public destroy(): void {

--- a/src/rendering/webgpu/webgpuPipelineCache.ts
+++ b/src/rendering/webgpu/webgpuPipelineCache.ts
@@ -1,0 +1,55 @@
+/// <reference types="@webgpu/types" />
+
+/**
+ * A render-pipeline cache keyed without building a key.
+ *
+ * Every WebGPU renderer selects its pipeline from the same three inputs — blend
+ * mode, target format, and whether a stencil clip is active — and the obvious
+ * encoding is a template literal (`` `${blendMode}:${format}:${stencil}` ``).
+ * That string is built on every draw and thrown away on every draw: measured on
+ * the WebGPU allocation harness, the sprite renderer's key alone accounted for
+ * **98 KB of the 127 KB a 1000-flush frame allocated** (`blend/1000
+ * alternating`), because a template literal of three parts costs the result
+ * string plus V8's intermediate cons strings.
+ *
+ * Two levels instead: the format is already an interned string constant, so it
+ * can be a `Map` key as-is, and the remaining two inputs pack into one small
+ * integer. Two map lookups, no allocation, same eviction story as before
+ * (`clear()` on disconnect / device loss).
+ *
+ * @internal
+ */
+export class WebGpuPipelineVariantCache<T> {
+  private readonly _byFormat = new Map<GPUTextureFormat, Map<number, T>>();
+
+  public get(format: GPUTextureFormat, variant: number): T | undefined {
+    return this._byFormat.get(format)?.get(variant);
+  }
+
+  public has(format: GPUTextureFormat, variant: number): boolean {
+    return this._byFormat.get(format)?.has(variant) ?? false;
+  }
+
+  public set(format: GPUTextureFormat, variant: number, value: T): void {
+    let variants = this._byFormat.get(format);
+
+    if (variants === undefined) {
+      variants = new Map<number, T>();
+      this._byFormat.set(format, variants);
+    }
+
+    variants.set(variant, value);
+  }
+
+  public clear(): void {
+    this._byFormat.clear();
+  }
+}
+
+/**
+ * Pack a blend mode and the stencil flag into one variant key. Blend modes are
+ * a small dense enum, so a shift keeps the key a Smi for any conceivable
+ * number of them.
+ * @internal
+ */
+export const pipelineVariantKey = (blendMode: number, stencil: boolean): number => (blendMode << 1) | (stencil ? 1 : 0);

--- a/test/perf/webgpu/heapSamplingCommands.ts
+++ b/test/perf/webgpu/heapSamplingCommands.ts
@@ -1,0 +1,93 @@
+/**
+ * Node-side CDP bridge for the WebGPU allocation harness.
+ *
+ * The Node allocation gate (`test/perf/rendering/allocation.ts`) drives V8's
+ * allocation sampling profiler through `node:inspector`. That session belongs
+ * to the Node process, and the WebGPU backend does not run there at all — it
+ * needs a real browser with a real adapter. The same profiler is reachable in
+ * Chromium over CDP (`HeapProfiler.startSampling` / `stopSampling`), and the
+ * playwright browser provider hands every vitest browser command a live
+ * `BrowserContext`, so these three commands bracket a measurement window from
+ * inside the page while the profiler itself runs where the JS heap is.
+ *
+ * The two `includeObjectsCollectedBy*GC` flags are as load-bearing here as they
+ * are in the Node sampler: without them the profile reports only what is still
+ * live at `stopSampling`, which is the opposite of a per-frame throwaway rate.
+ *
+ * Registered in `vitest.config.ts` under the `browser-webgpu-alloc` project.
+ *
+ * @internal Test/perf-only.
+ */
+import type { BrowserCommandContext } from 'vitest/node';
+
+/** One node of V8's sampling heap profile, as CDP serialises it. */
+export interface SamplingProfileNode {
+  readonly callFrame: {
+    readonly functionName: string;
+    readonly url: string;
+    readonly lineNumber: number;
+    readonly columnNumber: number;
+  };
+  readonly selfSize: number;
+  readonly id: number;
+  readonly children: readonly SamplingProfileNode[];
+}
+
+/**
+ * The playwright provider augments `BrowserCommandContext` with `page` and
+ * `context`; the augmentation is only visible where the provider's types are
+ * imported, so the two fields are narrowed locally instead.
+ */
+interface PlaywrightCommandContext extends BrowserCommandContext {
+  readonly page: object;
+  readonly context: { newCDPSession(page: object): Promise<CdpSession> };
+}
+
+interface CdpSession {
+  send(method: string, params?: Record<string, unknown>): Promise<unknown>;
+  detach(): Promise<void>;
+}
+
+/**
+ * One CDP session per measured window, torn down with it. A session held open
+ * across scenes would be a second reason for numbers to depend on what ran
+ * before, and this harness exists to have none.
+ */
+let session: CdpSession | null = null;
+
+export const startHeapSampling = async (ctx: BrowserCommandContext, samplingInterval = 512): Promise<number> => {
+  const { context, page } = ctx as PlaywrightCommandContext;
+
+  session = await context.newCDPSession(page);
+
+  await session.send('HeapProfiler.enable');
+  await session.send('HeapProfiler.startSampling', {
+    samplingInterval,
+    includeObjectsCollectedByMajorGC: true,
+    includeObjectsCollectedByMinorGC: true,
+  });
+
+  return 0;
+};
+
+export const stopHeapSampling = async (): Promise<SamplingProfileNode> => {
+  if (session === null) throw new Error('stopHeapSampling called without a matching startHeapSampling.');
+
+  const result = (await session.send('HeapProfiler.stopSampling')) as { profile: { head: SamplingProfileNode } };
+
+  await session.send('HeapProfiler.disable');
+  await session.detach();
+  session = null;
+
+  return result.profile.head;
+};
+
+/**
+ * The page cannot write files and cannot print to the runner's stdout in a way
+ * a driver can parse, so the cell hands its finished record here.
+ */
+export const emitAllocationRecord = (_ctx: BrowserCommandContext, record: unknown): number => {
+  process.stdout.write(`\n__EXOJS_WEBGPU_ALLOC__${JSON.stringify(record)}\n`);
+
+  return 0;
+};

--- a/test/perf/webgpu/run-webgpu-allocation.ts
+++ b/test/perf/webgpu/run-webgpu-allocation.ts
@@ -1,0 +1,141 @@
+/**
+ * Driver for the WebGPU allocation cell.
+ *
+ * Spawns one vitest run — and therefore one browser process — per (scene,
+ * repetition) pair, and reports the median across repetitions. Sequential on
+ * purpose: two browsers sharing one GPU contend for it, and a wall-clock or
+ * allocation number taken under contention describes the contention.
+ *
+ *   pnpm perf:webgpu:alloc                        every scene, 3 fresh processes each
+ *   pnpm perf:webgpu:alloc -- --id "mesh/1000"    one scene
+ *   pnpm perf:webgpu:alloc -- --id "…" --profile  plus the callsite table
+ *   pnpm perf:webgpu:alloc -- --mode cpu          wall-clock instead of bytes
+ *   pnpm perf:webgpu:alloc -- --mode structural   work units instead of bytes
+ *   pnpm perf:webgpu:alloc -- --json out.json     also write the raw records
+ *
+ * @internal Test/perf-only.
+ */
+import { spawnSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+import { WEBGPU_ALLOC_ARCHETYPES } from './webgpuAllocScenes';
+
+const args = process.argv.slice(2);
+
+const flag = (name: string): string | undefined => {
+  const index = args.indexOf(`--${name}`);
+
+  return index === -1 ? undefined : args[index + 1];
+};
+
+const id = flag('id');
+const mode = flag('mode') ?? 'alloc';
+const repeats = Number(flag('repeats') ?? (mode === 'alloc' ? 3 : 1));
+/** 0 = let the archetype decide; an explicit `--frames` overrides it. */
+const frames = Number(flag('frames') ?? 0);
+const warmup = Number(flag('warmup') ?? 0);
+const top = args.includes('--profile') ? Number(flag('top') ?? 20) : 0;
+const jsonOut = flag('json');
+
+const MARKER = '__EXOJS_WEBGPU_ALLOC__';
+
+interface CellRecord {
+  readonly id: string;
+  readonly mode?: string;
+  readonly skipped?: string;
+  readonly kbPerFrame?: number;
+  readonly medianUs?: number;
+  readonly p95Us?: number;
+  readonly callsites?: ReadonlyArray<{ site: string; selfKbPerFrame: number; totalKbPerFrame: number; stack: string }>;
+  readonly [key: string]: unknown;
+}
+
+const runCell = (sceneId: string): CellRecord => {
+  const result = spawnSync('npx', ['vitest', 'run', '--project=browser-webgpu-alloc'], {
+    encoding: 'utf8',
+    shell: true,
+    env: {
+      ...process.env,
+      EXOJS_ALLOC_ID: sceneId,
+      EXOJS_ALLOC_MODE: mode,
+      EXOJS_ALLOC_FRAMES: String(frames),
+      EXOJS_ALLOC_WARMUP: String(warmup),
+      EXOJS_ALLOC_TOP: String(top),
+      EXOJS_ALLOC_REPEATS: '1',
+    },
+  });
+
+  const line = `${result.stdout ?? ''}\n${result.stderr ?? ''}`.split('\n').find(candidate => candidate.includes(MARKER));
+
+  if (line === undefined) {
+    throw new Error(`no record from '${sceneId}' (exit ${result.status}):\n${result.stdout}\n${result.stderr}`);
+  }
+
+  return JSON.parse(line.slice(line.indexOf(MARKER) + MARKER.length)) as CellRecord;
+};
+
+const median = (values: readonly number[]): number => {
+  const sorted = [...values].sort((a, b) => a - b);
+
+  return sorted[Math.floor(sorted.length / 2)]!;
+};
+
+const scenes = id === undefined ? WEBGPU_ALLOC_ARCHETYPES.map(archetype => archetype.id) : [id];
+const records: CellRecord[] = [];
+
+for (const sceneId of scenes) {
+  const runs: CellRecord[] = [];
+
+  for (let repeat = 0; repeat < repeats; repeat++) {
+    runs.push(runCell(sceneId));
+  }
+
+  records.push(...runs);
+
+  const first = runs[0]!;
+
+  if (first.skipped !== undefined) {
+    console.log(`${sceneId.padEnd(32)} skipped — ${first.skipped}`);
+    continue;
+  }
+
+  if (mode === 'cpu') {
+    const medians = runs.map(run => run.medianUs!);
+    const p95s = runs.map(run => run.p95Us!);
+
+    console.log(
+      `${sceneId.padEnd(32)} ${median(medians).toFixed(1).padStart(9)} us/frame median   p95 ${median(p95s).toFixed(1).padStart(9)}   runs [${medians.join(', ')}]`,
+    );
+    continue;
+  }
+
+  if (mode === 'structural') {
+    const { id: _unused, mode: _unusedMode, ...counters } = first;
+
+    console.log(`${sceneId}`);
+
+    for (const [key, value] of Object.entries(counters)) {
+      console.log(`  ${key.padEnd(24)} ${String(value)}`);
+    }
+
+    continue;
+  }
+
+  const kbs = runs.map(run => run.kbPerFrame!);
+  const spread = Math.max(...kbs) / Math.max(1e-9, Math.min(...kbs));
+
+  console.log(
+    `${sceneId.padEnd(32)} ${median(kbs).toFixed(3).padStart(10)} KB/frame median   spread ${spread.toFixed(2)}x   runs [${kbs.map(value => value.toFixed(3)).join(', ')}]`,
+  );
+
+  if (top > 0) {
+    for (const row of first.callsites ?? []) {
+      console.log(`    ${row.selfKbPerFrame.toFixed(3).padStart(9)} KB/f self  ${row.totalKbPerFrame.toFixed(3).padStart(9)} KB/f total  ${row.site}`);
+    }
+  }
+}
+
+if (jsonOut !== undefined) {
+  writeFileSync(jsonOut, JSON.stringify(records, null, 2));
+  console.log(`\nwrote ${records.length} records to ${jsonOut}`);
+}

--- a/test/perf/webgpu/webgpu-allocation-cell.test.ts
+++ b/test/perf/webgpu/webgpu-allocation-cell.test.ts
@@ -1,0 +1,281 @@
+/**
+ * One WebGPU scene, one browser process, one measurement.
+ *
+ * The counterpart to `test/perf/rendering/run-allocation-cell.ts`, and it exists
+ * for the same reason: V8's optimisation state carries across scenes inside a
+ * process, so a source-of-truth number — and every callsite attribution — has to
+ * come from a process that rendered nothing else. Here "process" means a browser
+ * launched for this scene alone, which is why the scene id arrives through a
+ * build-time define and the driver (`run-webgpu-allocation.ts`) spawns one
+ * vitest run per scene rather than looping in-page.
+ *
+ * Four modes, selected by `__EXOJS_ALLOC_MODE__`:
+ *   alloc       bytes per frame, sampled through CDP (default)
+ *   cpu         wall-clock per frame, profiler off
+ *   cpu-ab      two spike variants interleaved in one process (see below)
+ *   structural  the frame's work units: passes, draws, submits, uploads, binds
+ *
+ * @internal Test/perf-only.
+ */
+import { expect, test } from 'vitest';
+import { commands } from 'vitest/browser';
+
+import type { SamplingProfileNode } from './heapSamplingCommands';
+import type { WebGpuHarness } from './webgpuAllocHarness';
+import { createWebGpuHarness, renderOnce } from './webgpuAllocHarness';
+import type { WebGpuAllocScene } from './webgpuAllocScenes';
+import { findWebGpuArchetype } from './webgpuAllocScenes';
+
+declare const __EXOJS_ALLOC_ID__: string;
+declare const __EXOJS_ALLOC_MODE__: string;
+declare const __EXOJS_ALLOC_FRAMES__: number;
+declare const __EXOJS_ALLOC_WARMUP__: number;
+declare const __EXOJS_ALLOC_TOP__: number;
+declare const __EXOJS_ALLOC_REPEATS__: number;
+
+interface AllocCommands {
+  startHeapSampling: (samplingInterval?: number) => Promise<number>;
+  stopHeapSampling: () => Promise<SamplingProfileNode>;
+  emitAllocationRecord: (record: unknown) => Promise<number>;
+}
+
+const sink = commands as unknown as AllocCommands;
+
+const sumSelfSize = (node: SamplingProfileNode): number => node.selfSize + node.children.reduce((total, child) => total + sumSelfSize(child), 0);
+
+interface CallsiteRow {
+  readonly site: string;
+  readonly selfBytes: number;
+  readonly totalBytes: number;
+  readonly stack: string;
+}
+
+const frameLabel = (node: SamplingProfileNode): string => {
+  const { functionName, url, lineNumber } = node.callFrame;
+  // Vite serves every module from a URL with a query string; the file name plus
+  // line is what identifies a callsite, and the query only makes rows differ
+  // that are the same site.
+  const file = url.replace(/\?.*$/u, '').replace(/^.*[/\\]/u, '') || '(native)';
+
+  return `${functionName || '(anonymous)'} @ ${file}:${lineNumber + 1}`;
+};
+
+/**
+ * Flatten the sampling tree into per-callsite rows keyed by the function AND its
+ * two nearest callers — aggregating by function identity alone merges every
+ * `(anonymous) @ (native)` in the page into one row and then reports whichever
+ * caller was visited first.
+ */
+const collectCallsites = (head: SamplingProfileNode): CallsiteRow[] => {
+  const bySite = new Map<string, { selfBytes: number; totalBytes: number; stack: string }>();
+
+  const walk = (node: SamplingProfileNode, ancestry: readonly string[]): void => {
+    const chain = [...ancestry, frameLabel(node)];
+    const site = chain.slice(-3).join(' < ');
+
+    if (node.selfSize > 0) {
+      const entry = bySite.get(site) ?? { selfBytes: 0, totalBytes: 0, stack: chain.slice(-7).join(' < ') };
+
+      entry.selfBytes += node.selfSize;
+      entry.totalBytes += sumSelfSize(node);
+      bySite.set(site, entry);
+    }
+
+    for (const child of node.children) {
+      walk(child, chain);
+    }
+  };
+
+  walk(head, []);
+
+  return [...bySite.entries()].map(([site, entry]) => ({ site, ...entry })).sort((a, b) => b.selfBytes - a.selfBytes);
+};
+
+const kb = (bytes: number): number => Number((bytes / 1024).toFixed(3));
+
+test(`webgpu allocation cell — ${__EXOJS_ALLOC_ID__}`, async () => {
+  const archetype = findWebGpuArchetype(__EXOJS_ALLOC_ID__);
+
+  expect(archetype, `unknown archetype '${__EXOJS_ALLOC_ID__}'`).toBeDefined();
+
+  const wantStructural = __EXOJS_ALLOC_MODE__ === 'structural';
+  const harness: WebGpuHarness | null = await createWebGpuHarness({ instrument: wantStructural });
+
+  if (harness === null) {
+    await sink.emitAllocationRecord({ id: __EXOJS_ALLOC_ID__, skipped: 'no WebGPU adapter in this browser' });
+
+    return;
+  }
+
+  // An explicit `--frames` / `--warmup` wins; otherwise the archetype decides,
+  // because a 33 ms effect frame and a 0.3 ms sprite frame cannot afford the
+  // same window.
+  const frames = __EXOJS_ALLOC_FRAMES__ > 0 ? __EXOJS_ALLOC_FRAMES__ : (archetype!.frames ?? 200);
+  const warmup = __EXOJS_ALLOC_WARMUP__ > 0 ? __EXOJS_ALLOC_WARMUP__ : (archetype!.warmup ?? 30);
+
+  // ── cpu-ab: two variants of the SAME build, interleaved in one process ──
+  // For A/B-ing a spike. Process-to-process variance is the dominant noise term
+  // in a browser CPU reading — ±13% measured on `mesh/1000`, which swamps the
+  // few percent an allocation fix is worth — and it cancels when both variants
+  // run as alternating blocks inside one process.
+  //
+  // The mode sets `globalThis.__EXOJS_WEBGPU_SPIKE__` to 0 or 1 before each
+  // block. NOTHING in shipped code reads it: a spike patch introduces the
+  // branch, this mode drives it, and the branch is removed before the fix
+  // lands. (It is how the mesh uniform-staging reuse was justified — the JS
+  // heap sampler cannot see an `ArrayBuffer` backing store at all, so the only
+  // available second indicator was wall clock.)
+  if (__EXOJS_ALLOC_MODE__ === 'cpu-ab') {
+    const scene: WebGpuAllocScene = archetype!.build(harness);
+    const flags = globalThis as unknown as Record<string, unknown>;
+
+    for (let i = 0; i < warmup; i++) renderOnce(harness, scene.root, scene.beforeFrame);
+
+    const blockSize = 50;
+    const a: number[] = [];
+    const b: number[] = [];
+
+    for (let block = 0; block < Math.max(2, Math.round(frames / blockSize)); block++) {
+      const variant = block % 2;
+
+      flags['__EXOJS_WEBGPU_SPIKE__'] = variant;
+
+      // Re-warm a few frames after the switch so the block measures the variant, not the switch.
+      for (let f = 0; f < 10; f++) renderOnce(harness, scene.root, scene.beforeFrame);
+
+      const started = performance.now();
+
+      for (let f = 0; f < blockSize; f++) renderOnce(harness, scene.root, scene.beforeFrame);
+
+      (variant === 0 ? a : b).push(((performance.now() - started) * 1000) / blockSize);
+    }
+
+    scene.teardown?.();
+    harness.destroy();
+
+    const median = (values: number[]): number => {
+      const sorted = [...values].sort((x, y) => x - y);
+
+      return Number(sorted[Math.floor(sorted.length / 2)]!.toFixed(1));
+    };
+
+    await sink.emitAllocationRecord({ id: __EXOJS_ALLOC_ID__, mode: 'cpu-ab', blockSize, variant0Us: median(a), variant1Us: median(b), a, b });
+
+    return;
+  }
+
+  if (__EXOJS_ALLOC_MODE__ === 'cpu') {
+    const scene: WebGpuAllocScene = archetype!.build(harness);
+
+    for (let i = 0; i < warmup; i++) renderOnce(harness, scene.root, scene.beforeFrame);
+
+    // `performance.now()` is clamped to ~100 us in a browser, so a per-frame
+    // reading quantises a 300 us frame to 0 or 100 and a percentile over those
+    // is noise. Blocks of frames are timed instead: each block is far above the
+    // clamp, and the spread across blocks is what a p95 would have been for.
+    const blockSize = Math.max(1, Math.round(frames / 20));
+    const blocks: number[] = [];
+
+    for (let i = 0; i < frames; i += blockSize) {
+      const count = Math.min(blockSize, frames - i);
+      const started = performance.now();
+
+      for (let f = 0; f < count; f++) renderOnce(harness, scene.root, scene.beforeFrame);
+
+      blocks.push(((performance.now() - started) * 1000) / count);
+    }
+
+    scene.teardown?.();
+    harness.destroy();
+    blocks.sort((a, b) => a - b);
+
+    const at = (quantile: number): number => Number(blocks[Math.min(blocks.length - 1, Math.floor(blocks.length * quantile))]!.toFixed(1));
+
+    await sink.emitAllocationRecord({
+      id: __EXOJS_ALLOC_ID__,
+      mode: 'cpu',
+      frames,
+      warmup,
+      blockSize,
+      medianUs: at(0.5),
+      p95Us: at(0.95),
+      minUs: at(0),
+    });
+
+    return;
+  }
+
+  if (wantStructural) {
+    const scene: WebGpuAllocScene = archetype!.build(harness);
+
+    for (let i = 0; i < warmup; i++) renderOnce(harness, scene.root, scene.beforeFrame);
+
+    harness.resetCounters();
+    renderOnce(harness, scene.root, scene.beforeFrame);
+
+    const { stats } = harness.backend;
+    const counters = { ...harness.counters };
+
+    scene.teardown?.();
+    harness.destroy();
+
+    await sink.emitAllocationRecord({
+      id: __EXOJS_ALLOC_ID__,
+      mode: 'structural',
+      warmup,
+      renderPasses: stats.renderPasses,
+      drawCalls: stats.drawCalls,
+      batches: stats.batches,
+      submittedNodes: stats.submittedNodes,
+      culledNodes: stats.culledNodes,
+      renderTargetChanges: stats.renderTargetChanges,
+      textureUploadBytes: stats.textureUploadBytes,
+      bufferUploadBytes: stats.bufferUploadBytes,
+      ...counters,
+    });
+
+    return;
+  }
+
+  // ── alloc: one scene, N sampled windows, each on its own scene instance ──
+  const windows: number[] = [];
+  let callsites: CallsiteRow[] = [];
+
+  for (let repeat = 0; repeat < Math.max(1, __EXOJS_ALLOC_REPEATS__); repeat++) {
+    const scene: WebGpuAllocScene = archetype!.build(harness);
+
+    for (let i = 0; i < warmup; i++) renderOnce(harness, scene.root, scene.beforeFrame);
+
+    await sink.startHeapSampling(512);
+
+    for (let i = 0; i < frames; i++) renderOnce(harness, scene.root, scene.beforeFrame);
+
+    const head = await sink.stopHeapSampling();
+
+    windows.push(sumSelfSize(head) / frames);
+
+    if (repeat === 0 && __EXOJS_ALLOC_TOP__ > 0) {
+      callsites = collectCallsites(head).slice(0, __EXOJS_ALLOC_TOP__);
+    }
+
+    scene.teardown?.();
+  }
+
+  harness.destroy();
+
+  await sink.emitAllocationRecord({
+    id: __EXOJS_ALLOC_ID__,
+    mode: 'alloc',
+    userAgent: navigator.userAgent,
+    frames,
+    warmup,
+    windowsKb: windows.map(kb),
+    kbPerFrame: kb(windows.reduce((total, value) => total + value, 0) / windows.length),
+    callsites: callsites.map(row => ({
+      site: row.site,
+      selfKbPerFrame: kb(row.selfBytes / frames),
+      totalKbPerFrame: kb(row.totalBytes / frames),
+      stack: row.stack,
+    })),
+  });
+});

--- a/test/perf/webgpu/webgpuAllocHarness.ts
+++ b/test/perf/webgpu/webgpuAllocHarness.ts
@@ -1,0 +1,242 @@
+/**
+ * Browser-side WebGPU harness for the allocation audit.
+ *
+ * Deliberately NOT a port of `test/perf/rendering/harness.ts`: that one wires
+ * the WebGL2 backend to a recording fake context in Node, and a fake context is
+ * exactly what this measurement must not have — the question is what the real
+ * `WebGpuBackend` allocates against a real `GPUDevice`, and a stub would either
+ * invent allocations of its own or skip the paths under audit.
+ *
+ * What it shares with the Node harness is the frame shape (`resetStats` →
+ * mutate → `clear` → `render` → `flush`) and the scene fixtures, so a WebGPU
+ * number and a WebGL2 number describe the same work even though they are not
+ * comparable in absolute terms.
+ *
+ * @internal Test/perf-only.
+ */
+import type { Application } from '#core/Application';
+import { Color } from '#core/Color';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Texture } from '#rendering/texture/Texture';
+import type { View } from '#rendering/View';
+import { WebGpuBackend } from '#rendering/webgpu/WebGpuBackend';
+
+import { wireCoreRenderers } from '../../rendering/browser/_coreRenderers';
+
+export const VIEW_WIDTH = 1280;
+export const VIEW_HEIGHT = 720;
+
+/**
+ * WebGPU-side work units per frame, counted by wrapping the device queue rather
+ * than read from `RenderStats`.
+ *
+ * `RenderStats` is backend-neutral by design and therefore says nothing about
+ * the objects this audit is about: how many command buffers were submitted, how
+ * many bind groups were built, how many `writeBuffer`/`writeTexture` calls the
+ * frame issued. Without those denominators a KB/frame figure cannot be turned
+ * into a per-work-unit cost, and an "allocation win" that quietly doubled the
+ * submit count would read as a win.
+ */
+export interface WebGpuWorkCounters {
+  writeBufferCalls: number;
+  writeBufferBytes: number;
+  writeTextureCalls: number;
+  writeTextureBytes: number;
+  submitCalls: number;
+  commandBuffers: number;
+  createBindGroupCalls: number;
+  createBufferCalls: number;
+  createTextureCalls: number;
+  createRenderPipelineCalls: number;
+}
+
+export interface WebGpuHarness {
+  readonly backend: WebGpuBackend;
+  readonly device: GPUDevice;
+  readonly view: View;
+  readonly counters: WebGpuWorkCounters;
+  resetCounters(): void;
+  destroy(): void;
+}
+
+const makeApp = (canvas: HTMLCanvasElement): Application =>
+  ({
+    canvas,
+    options: {
+      canvas: { width: VIEW_WIDTH, height: VIEW_HEIGHT },
+      clearColor: Color.black,
+      rendering: {
+        debug: false,
+        spriteRendererBatchSize: 1024,
+        particleRendererBatchSize: 1024,
+      },
+    },
+  }) as unknown as Application;
+
+/**
+ * Instrument the device in place. Wrapping is the only option that sees every
+ * caller: the renderers reach `device.queue` directly, and several of them hold
+ * the queue for the lifetime of the connection, so the queue object itself is
+ * patched rather than the getter.
+ */
+const instrument = (device: GPUDevice): { counters: WebGpuWorkCounters; reset: () => void } => {
+  const counters: WebGpuWorkCounters = {
+    writeBufferCalls: 0,
+    writeBufferBytes: 0,
+    writeTextureCalls: 0,
+    writeTextureBytes: 0,
+    submitCalls: 0,
+    commandBuffers: 0,
+    createBindGroupCalls: 0,
+    createBufferCalls: 0,
+    createTextureCalls: 0,
+    createRenderPipelineCalls: 0,
+  };
+
+  const { queue } = device;
+  const writeBuffer = queue.writeBuffer.bind(queue) as GPUQueue['writeBuffer'];
+  const writeTexture = queue.writeTexture.bind(queue) as GPUQueue['writeTexture'];
+  const submit = queue.submit.bind(queue) as GPUQueue['submit'];
+  const createBindGroup = device.createBindGroup.bind(device);
+  const createBuffer = device.createBuffer.bind(device);
+  const createTexture = device.createTexture.bind(device);
+  const createRenderPipeline = device.createRenderPipeline.bind(device);
+
+  queue.writeBuffer = ((buffer: GPUBuffer, offset: number, data: BufferSource, dataOffset?: number, size?: number): void => {
+    counters.writeBufferCalls++;
+    counters.writeBufferBytes += size ?? data.byteLength;
+    writeBuffer(buffer, offset, data, dataOffset, size);
+  }) as GPUQueue['writeBuffer'];
+
+  queue.writeTexture = ((destination: GPUTexelCopyTextureInfo, data: BufferSource, layout: GPUTexelCopyBufferLayout, size: GPUExtent3D): void => {
+    counters.writeTextureCalls++;
+    counters.writeTextureBytes += data.byteLength;
+    writeTexture(destination, data, layout, size);
+  }) as GPUQueue['writeTexture'];
+
+  queue.submit = ((buffers: readonly GPUCommandBuffer[]): void => {
+    counters.submitCalls++;
+    counters.commandBuffers += buffers.length;
+    submit(buffers);
+  }) as GPUQueue['submit'];
+
+  device.createBindGroup = (descriptor: GPUBindGroupDescriptor): GPUBindGroup => {
+    counters.createBindGroupCalls++;
+
+    return createBindGroup(descriptor);
+  };
+
+  device.createBuffer = (descriptor: GPUBufferDescriptor): GPUBuffer => {
+    counters.createBufferCalls++;
+
+    return createBuffer(descriptor);
+  };
+
+  device.createTexture = (descriptor: GPUTextureDescriptor): GPUTexture => {
+    counters.createTextureCalls++;
+
+    return createTexture(descriptor);
+  };
+
+  device.createRenderPipeline = (descriptor: GPURenderPipelineDescriptor): GPURenderPipeline => {
+    counters.createRenderPipelineCalls++;
+
+    return createRenderPipeline(descriptor);
+  };
+
+  const reset = (): void => {
+    counters.writeBufferCalls = 0;
+    counters.writeBufferBytes = 0;
+    counters.writeTextureCalls = 0;
+    counters.writeTextureBytes = 0;
+    counters.submitCalls = 0;
+    counters.commandBuffers = 0;
+    counters.createBindGroupCalls = 0;
+    counters.createBufferCalls = 0;
+    counters.createTextureCalls = 0;
+    counters.createRenderPipelineCalls = 0;
+  };
+
+  return { counters, reset };
+};
+
+/** `null` when this browser has no adapter at all — a measurement result, not a failure. */
+export const createWebGpuHarness = async (options: { instrument?: boolean } = {}): Promise<WebGpuHarness | null> => {
+  if (typeof navigator.gpu === 'undefined') return null;
+
+  const canvas = document.createElement('canvas');
+
+  canvas.width = VIEW_WIDTH;
+  canvas.height = VIEW_HEIGHT;
+
+  const backend = new WebGpuBackend(makeApp(canvas));
+
+  wireCoreRenderers(backend);
+
+  try {
+    await backend.initialize();
+  } catch {
+    return null;
+  }
+
+  const { device } = backend;
+  const wrapped = options.instrument === true ? instrument(device) : null;
+
+  return {
+    backend,
+    device,
+    view: backend.view,
+    counters: wrapped?.counters ?? {
+      writeBufferCalls: 0,
+      writeBufferBytes: 0,
+      writeTextureCalls: 0,
+      writeTextureBytes: 0,
+      submitCalls: 0,
+      commandBuffers: 0,
+      createBindGroupCalls: 0,
+      createBufferCalls: 0,
+      createTextureCalls: 0,
+      createRenderPipelineCalls: 0,
+    },
+    resetCounters: (): void => wrapped?.reset(),
+    destroy: (): void => backend.destroy(),
+  };
+};
+
+/**
+ * One frame, as lean as the Node sampler's: no `FrameMetrics` object, no
+ * per-frame closure, nothing between the mutation hook and the backend.
+ */
+export const renderOnce = (harness: WebGpuHarness, root: RenderNode, beforeFrame?: () => void): void => {
+  harness.backend.resetStats();
+  beforeFrame?.();
+  harness.backend.clear();
+  root.render(harness.backend);
+  harness.backend.flush();
+};
+
+/**
+ * A real, sampleable texture. The Node fixtures build source-less `Texture`s —
+ * enough for a fake context, rejected outright by the WebGPU backend, which
+ * requires a valid source before it will upload.
+ */
+export const makeCanvasTexture = (size = 64, seed = 0): Texture => {
+  const canvas = document.createElement('canvas');
+
+  canvas.width = size;
+  canvas.height = size;
+
+  const ctx = canvas.getContext('2d');
+
+  if (ctx === null) throw new Error('A 2D context is required to build the fixture texture.');
+
+  ctx.fillStyle = `rgb(${(seed * 53) % 256}, ${(seed * 97) % 256}, ${(seed * 151) % 256})`;
+  ctx.fillRect(0, 0, size, size);
+  ctx.fillStyle = 'rgba(255, 255, 255, 0.5)';
+  ctx.fillRect(0, 0, size / 2, size / 2);
+
+  return new Texture(canvas);
+};
+
+export const makeCanvasTextures = (count: number, size = 64): Texture[] =>
+  Array.from({ length: count }, (_unused, index) => makeCanvasTexture(size, index + 1));

--- a/test/perf/webgpu/webgpuAllocScenes.ts
+++ b/test/perf/webgpu/webgpuAllocScenes.ts
@@ -1,0 +1,251 @@
+/**
+ * Scene catalog for the WebGPU allocation audit.
+ *
+ * Mirrors the Node gate's archetypes (`test/perf/rendering/allocationScenes.ts`)
+ * scene for scene where the same work unit exists, so a WebGPU reading and a
+ * WebGL2 reading describe the same frame — they are NOT comparable as numbers
+ * (different upload machinery, different backend objects), only as shapes.
+ *
+ * Two deliberate differences from the Node catalog:
+ *
+ *  - every texture carries a real canvas source. The Node fixtures build
+ *    source-less `Texture`s, which the WebGPU backend rejects before it uploads.
+ *  - the effect scenes come along rather than living in a separate probe list.
+ *    Each scene here is measured in its own browser process anyway, so the
+ *    ordering constraint that keeps the Node gate's catalog frozen does not
+ *    apply.
+ *
+ * @internal Test/perf-only.
+ */
+import { Container } from '#rendering/Container';
+import { BlurFilter } from '#rendering/filters/BlurFilter';
+import { ColorFilter } from '#rendering/filters/ColorFilter';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Sprite } from '#rendering/sprite/Sprite';
+import type { Texture } from '#rendering/texture/Texture';
+import { BlendModes } from '#rendering/types';
+
+import { buildMeshScene, buildNestedScene, buildSpriteScene, scatterInView } from '../rendering/fixtures';
+import type { WebGpuHarness } from './webgpuAllocHarness';
+import { makeCanvasTexture, makeCanvasTextures, VIEW_HEIGHT, VIEW_WIDTH } from './webgpuAllocHarness';
+
+export interface WebGpuAllocScene {
+  readonly root: RenderNode;
+  readonly beforeFrame?: () => void;
+  readonly teardown?: () => void;
+}
+
+export interface WebGpuAllocArchetype {
+  readonly id: string;
+  /** The WebGPU path this scene reaches that the others do not. */
+  readonly rationale: string;
+  readonly warmup?: number;
+  readonly frames?: number;
+  build(harness: WebGpuHarness): WebGpuAllocScene;
+}
+
+/** Fixed-function blend modes only — `>= Darken` takes the backdrop-aware shader path. */
+const FIXED_FUNCTION_BLENDS = [BlendModes.Normal, BlendModes.Additive, BlendModes.Subtract, BlendModes.Multiply] as const;
+
+/**
+ * Where the light scenes' window series flattens HERE. The Node catalog needs
+ * 1500; a WebGPU frame costs orders more wall-clock, and the series is already
+ * stationary at 400 (verified by comparing successive windows in one process).
+ */
+const SETTLED_WARMUP = 400;
+
+/** Effect frames cost 30 ms and up on a real device, so the warm-up is sized to what is affordable AND settled. */
+const EFFECT_WARMUP = 150;
+
+/** Same reason for the window: 60 effect frames is already a minute of GPU work across three processes. */
+const EFFECT_FRAMES = 60;
+
+const nudgeEveryNth = (sprites: readonly Sprite[], stride: number): (() => void) => {
+  let frame = 0;
+
+  return (): void => {
+    frame++;
+
+    const dx = frame % 2 === 0 ? 1 : -1;
+
+    for (let i = 0; i < sprites.length; i += stride) {
+      const sprite = sprites[i]!;
+
+      sprite.setPosition(sprite.position.x + dx, sprite.position.y);
+    }
+  };
+};
+
+/** `count` scattered sprites under one root, each handed to `decorate`. */
+const decoratedSprites = (count: number, texture: Texture, decorate: (sprite: Sprite, index: number) => void): WebGpuAllocScene => {
+  const root = new Container();
+
+  for (let i = 0; i < count; i++) {
+    const sprite = new Sprite(texture);
+
+    scatterInView(sprite, i, VIEW_WIDTH, VIEW_HEIGHT);
+    decorate(sprite, i);
+    root.addChild(sprite);
+  }
+
+  return { root, teardown: () => root.destroy() };
+};
+
+export const WEBGPU_ALLOC_ARCHETYPES: readonly WebGpuAllocArchetype[] = [
+  {
+    id: 'empty',
+    rationale: 'Harness + sampler + browser floor. Everything else is read against this, not against zero.',
+    build: () => {
+      const { root } = buildSpriteScene({ count: 0, textures: [makeCanvasTexture()] });
+
+      return { root, teardown: () => root.destroy() };
+    },
+  },
+  {
+    id: 'sprite/1000 static',
+    rationale: 'Nothing dirty: retained replay plus the persistent slot path. Any per-frame allocation here is pure waste.',
+    build: () => {
+      const { root } = buildSpriteScene({ count: 1000, textures: [makeCanvasTexture()], viewW: VIEW_WIDTH, viewH: VIEW_HEIGHT });
+
+      return { root, teardown: () => root.destroy() };
+    },
+  },
+  {
+    id: 'sprite/1000 moving',
+    rationale: 'Every transform dirty every frame — the full transform storage re-upload path.',
+    build: () => {
+      const { root, sprites } = buildSpriteScene({ count: 1000, textures: [makeCanvasTexture()], viewW: VIEW_WIDTH, viewH: VIEW_HEIGHT });
+
+      return { root, beforeFrame: nudgeEveryNth(sprites, 1), teardown: () => root.destroy() };
+    },
+  },
+  {
+    id: 'sprite/10000 transform-only 1%',
+    rationale: 'Large static scene with a small moving subset — the sparse dirty-range path and the per-frame order upload.',
+    build: () => {
+      const { root, sprites } = buildSpriteScene({ count: 10000, textures: [makeCanvasTexture()], viewW: VIEW_WIDTH, viewH: VIEW_HEIGHT });
+
+      return { root, beforeFrame: nudgeEveryNth(sprites, 100), teardown: () => root.destroy() };
+    },
+  },
+  {
+    id: 'nested/1000 d4',
+    rationale: 'Many Group scopes, all clean: per-scope plan playback with retained group resources.',
+    build: () => {
+      const { root } = buildNestedScene({ count: 1000, perContainer: 8, depth: 4, textures: [makeCanvasTexture()], viewW: VIEW_WIDTH, viewH: VIEW_HEIGHT });
+
+      return { root, teardown: () => root.destroy() };
+    },
+  },
+  {
+    id: 'mesh/1000',
+    rationale: 'Per-drawable mesh draws — the WebGPU mesh renderer builds its own uniform/transform bind groups.',
+    build: () => {
+      const { root } = buildMeshScene({ count: 1000, textures: [makeCanvasTexture()], viewW: VIEW_WIDTH, viewH: VIEW_HEIGHT });
+
+      return { root, teardown: () => root.destroy() };
+    },
+  },
+  {
+    id: 'blend/1000 plateau64',
+    rationale: 'Four fixed-function blend modes in runs of 64 — ~16 flush boundaries per frame. Per-BATCH cost at a realistic rate.',
+    warmup: SETTLED_WARMUP,
+    build: () => {
+      const { root } = buildSpriteScene({
+        count: 1000,
+        textures: [makeCanvasTexture()],
+        blendModes: FIXED_FUNCTION_BLENDS,
+        blendRunLength: 64,
+        viewW: VIEW_WIDTH,
+        viewH: VIEW_HEIGHT,
+      });
+
+      return { root, teardown: () => root.destroy() };
+    },
+  },
+  {
+    id: 'blend/1000 alternating',
+    rationale: 'The same modes alternating per sprite — ~1000 flushes per frame. Deliberately pathological: it makes a per-flush cost legible.',
+    build: () => {
+      const { root } = buildSpriteScene({
+        count: 1000,
+        textures: [makeCanvasTexture()],
+        blendModes: FIXED_FUNCTION_BLENDS,
+        viewW: VIEW_WIDTH,
+        viewH: VIEW_HEIGHT,
+      });
+
+      return { root, teardown: () => root.destroy() };
+    },
+  },
+  {
+    id: 'texture/8 distinct',
+    rationale: 'Eight textures cycled across 1000 sprites — texture state lookup and material bind groups once per bound texture per draw.',
+    build: () => {
+      const { root } = buildSpriteScene({ count: 1000, textures: makeCanvasTextures(8), assign: 'distinct', viewW: VIEW_WIDTH, viewH: VIEW_HEIGHT });
+
+      return { root, teardown: () => root.destroy() };
+    },
+  },
+  {
+    id: 'filter/color 100',
+    rationale: 'One barrier + one offscreen target + one Filter.apply per sprite — the WebGPU effect path at its most repetitive.',
+    warmup: EFFECT_WARMUP,
+    frames: EFFECT_FRAMES,
+    build: () => decoratedSprites(100, makeCanvasTexture(), sprite => sprite.addFilter(new ColorFilter())),
+  },
+  {
+    id: 'filter/blur-q3 100',
+    rationale: 'Three blur draws per filter pass while the pass count stays at one — varies draws per pass, not passes.',
+    warmup: EFFECT_WARMUP,
+    frames: EFFECT_FRAMES,
+    build: () => decoratedSprites(100, makeCanvasTexture(), sprite => sprite.addFilter(new BlurFilter({ radius: 4, quality: 3 }))),
+  },
+  {
+    id: 'filter/container 1000',
+    rationale: 'A single filter over a large subtree — the opposite extreme from one filter per sprite.',
+    warmup: EFFECT_WARMUP,
+    frames: EFFECT_FRAMES,
+    build: () => {
+      const texture = makeCanvasTexture();
+      const root = new Container();
+      const group = new Container();
+
+      for (let i = 0; i < 1000; i++) {
+        const sprite = new Sprite(texture);
+
+        scatterInView(sprite, i, VIEW_WIDTH, VIEW_HEIGHT);
+        group.addChild(sprite);
+      }
+
+      group.addFilter(new ColorFilter());
+      root.addChild(group);
+
+      return { root, teardown: () => root.destroy() };
+    },
+  },
+  {
+    id: 'mesh/1000 moving',
+    rationale: 'Mesh draws with every transform dirty — mesh transforms take the same storage path as sprites but through the mesh renderer.',
+    build: () => {
+      const { root, meshes } = buildMeshScene({ count: 1000, textures: [makeCanvasTexture()], viewW: VIEW_WIDTH, viewH: VIEW_HEIGHT });
+      let frame = 0;
+
+      return {
+        root,
+        beforeFrame: (): void => {
+          frame++;
+
+          const dx = frame % 2 === 0 ? 1 : -1;
+
+          for (const mesh of meshes) {
+            mesh.setPosition(mesh.position.x + dx, mesh.position.y);
+          }
+        },
+        teardown: () => root.destroy(),
+      };
+    },
+  },
+];
+
+export const findWebGpuArchetype = (id: string): WebGpuAllocArchetype | undefined => WEBGPU_ALLOC_ARCHETYPES.find(archetype => archetype.id === id);

--- a/test/rendering/webgpu-pipeline-prewarm.test.ts
+++ b/test/rendering/webgpu-pipeline-prewarm.test.ts
@@ -12,8 +12,10 @@
  *
  * These tests run the real prewarm against a stub device, then perform the
  * real lookup for every prewarmed combination and require ZERO synchronous
- * pipeline creations. A second sweep asserts no unreachable (suffix-less)
- * keys remain in any cache.
+ * pipeline creations. A second sweep asserts no unreachable (suffix-less) keys
+ * remain in the caches that are still keyed by a built string. The sprite
+ * renderer's cache no longer is — it keys on `(format, packed variant)` — so
+ * its second test asserts the same property behaviourally instead.
  */
 
 import { BlendModes } from '#rendering/types';
@@ -76,7 +78,7 @@ afterAll(() => {
 });
 
 describe('WebGpuSpriteRenderer pipeline prewarm', () => {
-  const setup = (): { renderer: WebGpuSpriteRenderer; stub: StubDevice; pipelines: Map<string, GPURenderPipeline> } => {
+  const setup = (): { renderer: WebGpuSpriteRenderer; stub: StubDevice } => {
     const renderer = new WebGpuSpriteRenderer();
     const stub = createStubDevice();
     const internals = renderer as unknown as {
@@ -84,7 +86,6 @@ describe('WebGpuSpriteRenderer pipeline prewarm', () => {
       _shaderModule: unknown;
       _pipelineLayout: unknown;
       _backend: unknown;
-      _pipelines: Map<string, GPURenderPipeline>;
     };
 
     internals._device = stub.device;
@@ -92,7 +93,7 @@ describe('WebGpuSpriteRenderer pipeline prewarm', () => {
     internals._pipelineLayout = {};
     internals._backend = {};
 
-    return { renderer, stub, pipelines: internals._pipelines };
+    return { renderer, stub };
   };
 
   test('prewarmed pipelines are found by the hot-path lookup (no synchronous compiles)', async () => {
@@ -111,16 +112,30 @@ describe('WebGpuSpriteRenderer pipeline prewarm', () => {
     expect(stub.syncCreates()).toBe(0);
   });
 
-  test('the pipeline cache holds no unreachable (suffix-less) keys after prewarm', async () => {
-    const { renderer, pipelines } = setup();
+  // The sprite cache is keyed structurally (format, then a packed
+  // blend-mode/stencil variant) rather than by a built string, so there is no
+  // key spelling left to assert. The property the string check stood for is
+  // asserted behaviourally instead, and more strictly: the prewarmed set is hit
+  // without a synchronous compile, and the set outside it still compiles — so a
+  // prewarm that filled the wrong variants would fail on one side or the other.
+  test('prewarm fills exactly the non-stencil variants, and the stencil ones stay lazy', async () => {
+    const { renderer, stub } = setup();
 
     await renderer.prewarmPipelines(formats);
 
-    expect(pipelines.size).toBe(prewarmedBlendModes.length * formats.length);
+    const lookup = renderer as unknown as { _getPipeline(blendMode: BlendModes, format: GPUTextureFormat, stencil: boolean): GPURenderPipeline };
 
-    for (const key of pipelines.keys()) {
-      expect(key).toMatch(lookupKeyPattern);
+    for (const blendMode of prewarmedBlendModes) {
+      for (const format of formats) {
+        lookup._getPipeline(blendMode, format, false);
+      }
     }
+
+    expect(stub.syncCreates()).toBe(0);
+
+    lookup._getPipeline(BlendModes.Normal, formats[0]!, true);
+
+    expect(stub.syncCreates()).toBe(1);
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ import { playwright } from '@vitest/browser-playwright';
 import { webdriverio } from '@vitest/browser-webdriverio';
 import { defineConfig } from 'vitest/config';
 
+import { emitAllocationRecord, startHeapSampling, stopHeapSampling } from './test/perf/webgpu/heapSamplingCommands';
 import { resetParityEvidence, writeParityEvidence } from './test/rendering/parity/evidenceSink';
 
 // Note: Vite alias matching uses longest-first order. Subpath aliases must come
@@ -99,6 +100,10 @@ const renderingBrowserSetupFiles = [...browserSetupFiles, './test/rendering/brow
 // its evidence rows to these node-side commands.
 const parityCommands = { writeParityEvidence, resetParityEvidence };
 
+// The WebGPU allocation cell runs in the page; V8's allocation sampler is
+// reachable only over CDP, which lives on the node side. See the command module.
+const allocationCommands = { startHeapSampling, stopHeapSampling, emitAllocationRecord };
+
 export default defineConfig({
   test: {
     coverage: {
@@ -148,8 +153,15 @@ export default defineConfig({
         alias: aliasConfig,
         include: ['test/**/*.test.ts'],
         // The parity matrix runs in `browser-webgpu`: its runner imports the
-        // browser context module, which throws on import under jsdom.
-        exclude: ['test/rendering/browser/**/*.test.ts', 'test/rendering/parity/**/*.test.ts', 'test/perf/rendering/**/*.test.ts'],
+        // browser context module, which throws on import under jsdom. The
+        // WebGPU allocation cell is the same story one project further down
+        // (`browser-webgpu-alloc`) — it needs a real adapter and a CDP session.
+        exclude: [
+          'test/rendering/browser/**/*.test.ts',
+          'test/rendering/parity/**/*.test.ts',
+          'test/perf/rendering/**/*.test.ts',
+          'test/perf/webgpu/**/*.test.ts',
+        ],
         // `_particleGlslMocks` un-stubs the particle package's GLSL: the WebGPU
         // backend suite drives the particle renderer against a mock device, and
         // its render mode's `Material` carries both languages, so the stub's
@@ -355,6 +367,59 @@ export default defineConfig({
           browser: {
             enabled: true,
             commands: parityCommands,
+            headless: !webgpuCiHeaded,
+            provider: playwright({
+              launchOptions: {
+                channel: 'chromium',
+                args: [
+                  '--enable-unsafe-webgpu',
+                  '--enable-features=Vulkan',
+                  '--disable-vulkan-surface',
+                  '--ignore-gpu-blocklist',
+                  '--no-sandbox',
+                  '--disable-gpu-watchdog',
+                  '--disable-gpu-driver-bug-workarounds',
+                ],
+              },
+            }),
+            instances: [{ browser: 'chromium' }],
+          },
+        },
+      },
+
+      // ── browser-webgpu-alloc — the WebGPU allocation audit harness ───────
+      // Never part of `pnpm test`: it is driven one scene per invocation by
+      // `test/perf/webgpu/run-webgpu-allocation.ts`, because a steady-state
+      // allocation number is only a source of truth when nothing else rendered
+      // in the same process first (the lesson `scrolling-world/10000` records in
+      // `allocationScenes.ts`). The scene and the window shape arrive as
+      // build-time defines rather than as test names so the run stays a single
+      // test with a single browser.
+      //
+      // Same launch recipe as `browser-webgpu` on purpose — a measurement lane
+      // that configured the adapter differently from the lane that proves
+      // correctness would be measuring a renderer nobody ships.
+      {
+        ...browserBase,
+        define: {
+          ...browserBase.define,
+          __EXOJS_ALLOC_ID__: JSON.stringify(process.env['EXOJS_ALLOC_ID'] ?? ''),
+          __EXOJS_ALLOC_MODE__: JSON.stringify(process.env['EXOJS_ALLOC_MODE'] ?? 'alloc'),
+          __EXOJS_ALLOC_FRAMES__: JSON.stringify(Number(process.env['EXOJS_ALLOC_FRAMES'] ?? 200)),
+          __EXOJS_ALLOC_WARMUP__: JSON.stringify(Number(process.env['EXOJS_ALLOC_WARMUP'] ?? 0)),
+          __EXOJS_ALLOC_TOP__: JSON.stringify(Number(process.env['EXOJS_ALLOC_TOP'] ?? 0)),
+          __EXOJS_ALLOC_REPEATS__: JSON.stringify(Number(process.env['EXOJS_ALLOC_REPEATS'] ?? 1)),
+        },
+        test: {
+          name: 'browser-webgpu-alloc',
+          globals: true,
+          setupFiles: renderingBrowserSetupFiles,
+          include: ['test/perf/webgpu/webgpu-allocation-cell.test.ts'],
+          testTimeout: 600_000,
+          hookTimeout: 600_000,
+          browser: {
+            enabled: true,
+            commands: allocationCommands,
             headless: !webgpuCiHeaded,
             provider: playwright({
               launchOptions: {


### PR DESCRIPTION
## What this is

Q15 started as an audit: the WebGL2 backend had a series of recurring-allocation
problems (Q11–Q14), and the question was which of them have a WebGPU
counterpart.

Most of the suspected counterparts turned out not to exist:

- the scratch and source views that cost the WebGL2 path are already cached on
  the WebGPU side, from earlier work;
- the Q14 closure-shape problem has no practical equivalent here;
- the one real `subarray()` path that remains is cold and glyph-atlas related,
  not part of a steady-state frame.

What the audit did find is a separate set of WebGPU-specific recurring
allocations, in three places: sprite pipeline/binding preparation, render-pass
orchestration, and mesh staging. Every item was attributed by bisecting the
callsite on a real adapter, not inferred from a profile row.

## Commits

1. `test(rendering)` — the real-WebGPU steady-state allocation harness
   (`pnpm perf:webgpu:alloc`). No production change.
2. `perf(rendering)` — the sprite path: two-level pipeline cache instead of a
   template-literal key, reused bind-group scratch, texture binding record owned
   by the texture state, guarded per-flush `Map`/`Set` clears.
3. `perf(rendering)` — pass and mesh staging: reused render-pass descriptor,
   colour attachment and clear value, encoder descriptor and submit list;
   reused attachment-size and transform-storage records; mesh view product in
   locals instead of a scratch matrix; grow-only uniform staging; cursor maps
   cleared only when a custom-material draw filled them.

## Results

Steady-state JS allocation per frame, KB:

| scene | before | after | Δ |
|---|---:|---:|---:|
| `empty` (harness floor) | 1.09 | 0.92 | — |
| `sprite/1000 static` | 2.03 | 1.35 | −34 % |
| `sprite/1000 moving` | 2.16 | 1.64 | −24 % |
| `sprite/10000 transform-only 1%` | 2.33 | 1.69 | −27 % |
| `nested/1000 d4` | 2.13 | 1.40 | −34 % |
| `texture/8 distinct` | 2.45 | 1.79 | −27 % |
| `blend/1000 plateau64` | 7.69 | 1.95 | −75 % |
| `blend/1000 alternating` | 272.65 | 1.37 | **−99.5 %** |
| `mesh/1000` | 134.75 | 87.62 | −35 % |
| `mesh/1000 moving` | 136.51 | 89.94 | −34 % |
| `filter/color 100` | 270.98 | 116.78 | −57 % |
| `filter/container 1000` | 5.62 | 3.50 | −38 % |
| `filter/blur-q3 100` | 1266.76 | 392.53 | **−69 %** |

The largest single attributions: the sprite `_getPipeline` string key ~98 KB/f,
`_getOrCreateTextureBindGroup` ~160 KB/f, `getTextureBinding`'s record
~19.7 KB/f, `_writeMeshVertices`' scratch matrix ~47.5 KB/f, and the pass
descriptor / attachment / submit list together ~42 KB/f on `filter/color`. The
marginal cost per flush goes from ~269 B to approximately 0 B.

CPU:

- `mesh/1000` ~820 → 650 µs per frame, −21 %.
- `filter/color 100` 33 933 → 33 433 µs, −1.5 %.
- `blend/1000 alternating` measures +3.5 % across fresh processes. No
  attributable CPU regression was demonstrated: the observed fresh-process
  difference is at the measurement-resolution boundary (the per-run ranges
  overlap, 1043–1203 before against 1160–1297 after, while the same after-build
  measures 1132–1154 in same-process A/B), and the only candidate with plausible
  extra work — the two-level pipeline lookup replacing the built string key —
  is neutral when measured in isolation in the same process.

**GPU/structural work remained unchanged across all 17 checked counters**
(`renderPasses`, `drawCalls`, `batches`, `submittedNodes`, `culledNodes`,
`renderTargetChanges`, `textureUploadBytes`, `bufferUploadBytes`,
`writeBufferCalls`, `writeBufferBytes`, `writeTextureCalls`, `submitCalls`,
`commandBuffers`, `createBindGroupCalls`, `createBufferCalls`,
`createTextureCalls`, `createRenderPipelineCalls`), cross-checked on
`blend/1000 alternating`, `mesh/1000`, `filter/color 100` and
`sprite/1000 static`. Nothing was traded from the GPU to the JS heap.

## Measurement contract

- Chromium headless with a real NVIDIA (Blackwell) WebGPU adapter — not
  SwiftShader; the harness fails rather than falling back.
- CDP V8 allocation sampling, 512 B sampling interval, both
  collected-by-GC flags set.
- One scene per browser process; three fresh processes per value; median
  reported. Observed spread across processes ≈ 1.00–1.13×.

Two limits are worth stating explicitly:

- The JS heap sampler does not see `ArrayBuffer` backing stores at all. The mesh
  uniform-staging item is therefore not visible in the numbers above and was
  justified separately, on wall clock, with an interleaved same-process A/B
  (11–20 % faster per frame across three runs).
- There is no CI allocation gate for this. The real adapter, its driver and the
  browser build are part of the measurement, and CI has no environment where
  those are stable enough for a threshold to mean anything. The harness is a
  local instrument (`pnpm perf:webgpu:alloc`), run deliberately.

## Out of scope

The remaining cost on the effect scenes is dominated by the pass count itself.
That is the known effect-batching / flush-cluster item, which needs its own
spike and its own decision about batching across opaque callouts; it is
deliberately not touched here.
