### PR TITLE
perf(rendering): upload only the carried rows when a slot store grows

### DIFF
--- a/src/rendering/webgpu/WebGpuPersistentSlotStore.ts
+++ b/src/rendering/webgpu/WebGpuPersistentSlotStore.ts
@@ -241,6 +241,7 @@ export class WebGpuPersistentSlotStore implements PersistentSlotBundle {
       next *= 2;
     }
 
+    const carried = this._capacity;
     const transforms = new Float32Array(next * floatsPerTransformRow);
     const quads = new Float32Array(next * floatsPerQuadRecord);
     const tints = new Uint8Array(next * tintBytesPerSlot);
@@ -254,13 +255,23 @@ export class WebGpuPersistentSlotStore implements PersistentSlotBundle {
     this._tints = tints;
     this._capacity = next;
 
-    // Every row moved into fresh GPU buffers, so the whole store is pending
-    // regardless of which rows the caller is about to write.
+    // The rows this growth CARRIED ACROSS are pending: they moved into fresh GPU
+    // buffers, so their contents have to be pushed again. The rows above the old
+    // capacity are not. An arrival that writes one marks its own block through
+    // `writeSlotFrom`, and a row nothing writes is never named by an order
+    // stream, so no draw can read it — marking the whole new capacity uploaded
+    // the entire store on the one frame it allocates, up to half of it rows that
+    // had never been written.
+    //
+    // Rounding up to the block boundary keeps the partially filled last carried
+    // block. It also subsumes every mark already pending, because a pending mark
+    // can only address a row below the old capacity.
     const blocks = Math.ceil(next / slotsPerBlock);
+    const carriedBlocks = Math.ceil(carried / slotsPerBlock);
 
     this._dirtyBlocks = new Uint8Array(blocks);
-    this._dirtyBlocks.fill(1);
-    this._dirtyBlockCount = blocks;
+    this._dirtyBlocks.fill(1, 0, carriedBlocks);
+    this._dirtyBlockCount = carriedBlocks;
     this._allocateSlotBuffers(next);
   }
 

--- a/test/rendering/webgpu-persistent-slot-growth.test.ts
+++ b/test/rendering/webgpu-persistent-slot-growth.test.ts
@@ -1,0 +1,141 @@
+/// <reference types="@webgpu/types" />
+
+/**
+ * What a persistent slot store re-uploads when it GROWS.
+ *
+ * A growth moves every written row into fresh GPU buffers, so those rows are
+ * pending again and must be pushed. The rows ABOVE the old capacity are not:
+ * they are either written by the arrivals that triggered the growth — which mark
+ * their own blocks through `writeSlotFrom` — or never named by an order stream,
+ * so no draw can read them. Marking them anyway costs a full-store upload on the
+ * one frame a store allocates, of which up to half is rows nothing ever wrote.
+ *
+ * Every assertion here is on the slot count `commitDirtySlots()` reports, i.e.
+ * on what actually reached `queue.writeBuffer` — not on the dirty bookkeeping
+ * that produced it.
+ */
+
+import { SOURCE_QUAD_FLOATS } from '#rendering/sourceQuadRecord';
+import { TRANSFORM_FLOATS_PER_ROW, TRANSFORM_TINT_BYTES_PER_ROW } from '#rendering/TransformBuffer';
+import { WebGpuPersistentSlotStore } from '#rendering/webgpu/WebGpuPersistentSlotStore';
+
+/** Mirrors the store's own module constants; a change to either must fail here loudly. */
+const INITIAL_CAPACITY = 1024;
+const SLOTS_PER_BLOCK = 256;
+
+const createMockDevice = (): GPUDevice =>
+  ({
+    createBuffer: () => ({ destroy: () => undefined }) as unknown as GPUBuffer,
+    queue: { writeBuffer: () => undefined },
+  }) as unknown as GPUDevice;
+
+/**
+ * Run `body` with the `GPUBufferUsage` flags the store reads at buffer creation.
+ * They are a browser global the node lane does not have.
+ */
+const withGpuBufferUsage = (body: () => void): void => {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, 'GPUBufferUsage');
+
+  Object.defineProperty(globalThis, 'GPUBufferUsage', { configurable: true, value: { STORAGE: 128, COPY_DST: 8 } });
+
+  try {
+    body();
+  } finally {
+    if (previous) {
+      Object.defineProperty(globalThis, 'GPUBufferUsage', previous);
+    } else {
+      Object.defineProperty(globalThis, 'GPUBufferUsage', { configurable: true, value: undefined });
+    }
+  }
+};
+
+/** A connected store, ready to grow. */
+const createStore = (): WebGpuPersistentSlotStore => {
+  const store = new WebGpuPersistentSlotStore();
+
+  store.connectDevice(createMockDevice(), undefined as never);
+
+  return store;
+};
+
+/** Write one slot from zeroed source tables — the content is irrelevant, the dirty mark is not. */
+const writeSlot = (store: WebGpuPersistentSlotStore, slot: number): void => {
+  store.writeSlotFrom(
+    slot,
+    new Float32Array(TRANSFORM_FLOATS_PER_ROW),
+    0,
+    new Uint8Array(TRANSFORM_TINT_BYTES_PER_ROW),
+    0,
+    new Float32Array(SOURCE_QUAD_FLOATS),
+    0,
+    0,
+  );
+};
+
+describe('WebGpuPersistentSlotStore growth', () => {
+  test('re-uploads the rows it carried across, and only those', () => {
+    withGpuBufferUsage(() => {
+      const store = createStore();
+
+      store.ensureCapacity(1);
+      writeSlot(store, 0);
+      writeSlot(store, 300);
+
+      // Two blocks touched, block granularity: 512 slots.
+      expect(store.commitDirtySlots()).toBe(2 * SLOTS_PER_BLOCK);
+
+      store.ensureCapacity(INITIAL_CAPACITY + 1);
+
+      // The growth doubled capacity to 2048 and moved every written row into
+      // fresh buffers. Exactly the 1024 carried rows are pending — not the 2048
+      // the store can now hold, half of which no row has ever occupied.
+      expect(store.commitDirtySlots()).toBe(INITIAL_CAPACITY);
+    });
+  });
+
+  test('still uploads a slot written above the old capacity', () => {
+    withGpuBufferUsage(() => {
+      const store = createStore();
+
+      store.ensureCapacity(1);
+      store.commitDirtySlots();
+      store.ensureCapacity(INITIAL_CAPACITY + 1);
+      writeSlot(store, 1500);
+
+      // The carried rows plus the one block holding the new arrival. Narrowing
+      // the growth's dirty set must not lose a row the caller then writes.
+      expect(store.commitDirtySlots()).toBe(INITIAL_CAPACITY + SLOTS_PER_BLOCK);
+    });
+  });
+
+  test('uploads nothing for the first allocation until a row is written', () => {
+    withGpuBufferUsage(() => {
+      const store = createStore();
+
+      store.ensureCapacity(1);
+
+      // A store growing from zero carries no rows, so a commit before any write
+      // has nothing to push. This is the bootstrap saving: at a million items the
+      // first selection allocated 1 048 576 slots and uploaded all of them, 51%
+      // of which had never been written and no order stream would ever name.
+      expect(store.commitDirtySlots()).toBe(0);
+    });
+  });
+
+  test('keeps a partially filled carried block, rounding up to the block boundary', () => {
+    withGpuBufferUsage(() => {
+      const store = createStore();
+
+      // 1500 rounds up to 2048 capacity; write past a block boundary so the
+      // carried range ends mid-block.
+      store.ensureCapacity(1500);
+      writeSlot(store, 1400);
+      store.commitDirtySlots();
+      store.ensureCapacity(2049);
+
+      // 2048 carried rows is exactly 8 blocks — the boundary case where rounding
+      // up must not spill into the new half.
+      expect(store.commitDirtySlots()).toBe(2048);
+    });
+  });
+});


### PR DESCRIPTION
A persistent slot store that grows marks its whole new capacity dirty, so the
frame that allocates uploads every row the store can now hold — up to half of
them rows nothing has ever written and no order stream can ever name.

Only the rows a growth CARRIED ACROSS are genuinely pending: they moved into
fresh GPU buffers, so their contents have to be pushed again. Rows above the old
capacity are either written by the arrivals that triggered the growth, which
mark their own blocks, or unreachable.

The dirty set is therefore filled up to the carried capacity, rounded up to the
block boundary so the partially filled last carried block survives.

At a million items the first selection allocated 1 048 576 slots and uploaded
all of them; 51% of that was never-written rows.

## Tests

`test/rendering/webgpu-persistent-slot-growth.test.ts`, asserting on the slot
count `commitDirtySlots()` reports — i.e. what actually reached
`queue.writeBuffer`, not the dirty bookkeeping that produced it: the carried
rows and only those, a slot written above the old capacity still uploading, a
first allocation uploading nothing until a row is written, and the block-boundary
rounding case.

`pnpm test:core`, `pnpm verify:quick` and the WebGPU persistent-slots browser
lane are green.