### PR TITLE
fix(rendering): refuse a persistent slot store the device cannot bind

### DIFF
--- a/src/rendering/plan/PersistentSlotDraw.ts
+++ b/src/rendering/plan/PersistentSlotDraw.ts
@@ -18,6 +18,23 @@ export interface PersistentSlotBundle {
   readonly generation: number;
   /** Release the GPU resources (root destroy, source invalidation, backend switch). */
   destroy?(): void;
+  /**
+   * Whether the backend can hold a selection this size at all, asked before the
+   * slots are written and answered against the device's real limits.
+   *
+   * The question exists because the bound is a property of the SELECTION, not of
+   * the source: a store's buffers grow with the slots the camera hands out, and
+   * a root of ten million items whose view admits a few thousand needs a few
+   * thousand. Refusing such a root at acquisition — the only other place the
+   * decision could live — would withdraw the indexed path from exactly the
+   * scenes it exists for.
+   *
+   * A `false` is a REFUSAL, not an error: the plan drops the store and puts the
+   * root back on the ordinary path, which has no per-root allocation to
+   * overflow. A backend whose representation has no such ceiling omits the
+   * method.
+   */
+  canRepresent?(slots: number, orderEntries: number): boolean;
 }
 
 /**

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -1100,6 +1100,19 @@ export class RenderPlanBuilder {
     const slots = product.slots;
     const backend = this.backend as RenderBackend & PersistentSlotBackend;
 
+    // The store's buffers are sized by the slot space, and a device puts a hard
+    // ceiling on how large one of them may be. Asked here rather than at
+    // acquisition because only a finished selection knows the slot count, and
+    // before the write because past the ceiling the backend's allocation is
+    // rejected by the driver rather than by us. The refusal is remembered, so
+    // the root spends one selection finding out and then stays on the ordinary
+    // path — which has no per-root buffer to overflow.
+    if (bundle.canRepresent?.(slots.slotCount, slots.orderCount) === false) {
+      representation.refusePersistentSlots(this.backend);
+
+      return false;
+    }
+
     if (slots.enteredCount > 0) {
       backend._writePersistentSlots!(bundle, source, slots.entered, slots.enteredCount);
     }

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -343,6 +343,21 @@ export class RetainedRootRepresentation {
     return bundle;
   }
 
+  /**
+   * Drop the slot store and refuse the indexed path for as long as this source
+   * lives — the backend has answered that it cannot represent the root.
+   *
+   * Sticky for the same reason an acquisition refusal is: the answer is a
+   * property of the source and the device, so asking again next frame would
+   * re-run the backend's walk over every item to be told the same thing. A
+   * rebuilt source releases the representation and with it the refusal.
+   */
+  public refusePersistentSlots(backend: RenderBackend): void {
+    this.releasePersistentSlots();
+    this._slotBackend = backend;
+    this._slotsRefused = true;
+  }
+
   /** Drop the slot store (source invalidation, backend switch, root destroy). */
   public releasePersistentSlots(): void {
     this._slotBundle?.destroy?.();

--- a/src/rendering/webgpu/WebGpuPersistentSlotStore.ts
+++ b/src/rendering/webgpu/WebGpuPersistentSlotStore.ts
@@ -34,6 +34,56 @@ const initialSlotCapacity = 1024;
 const slotsPerBlock = 256;
 
 /**
+ * WebGPU's spec-guaranteed defaults for the two limits that bound a persistent
+ * store's buffers.
+ *
+ * These are the values actually in force: a device requested without a
+ * `requiredLimits` entry is granted exactly the default, however much the
+ * adapter could have offered, and `WebGpuBackend` raises only the texture and
+ * sampler limits the batch layout needs. They double as the stand-in for a
+ * device that exposes no limits object at all — a conformant device is never
+ * granted less, so assuming them is the safe direction.
+ */
+const defaultMaxBufferSize = 2 ** 28; // 256 MiB
+const defaultMaxStorageBufferBindingSize = 2 ** 27; // 128 MiB
+
+/**
+ * Bytes the largest buffer of `capacity` slots may occupy on `device`.
+ *
+ * Both limits apply to every one of the four slot buffers: `createBuffer`
+ * rejects a size over `maxBufferSize`, and `createBindGroup` rejects a storage
+ * binding over `maxStorageBufferBindingSize` — which is the SMALLER of the two
+ * defaults, so on a device that asked for neither it is the one that bites.
+ */
+const storageBufferLimit = (device: GPUDevice): number => {
+  // Defensive optional access, as in `resolveSpriteBatchTextureSlots`: mocked
+  // devices in unit tests may not expose a limits object.
+  const limits = (device as { limits?: GPUSupportedLimits }).limits;
+
+  return Math.min(limits?.maxBufferSize ?? defaultMaxBufferSize, limits?.maxStorageBufferBindingSize ?? defaultMaxStorageBufferBindingSize);
+};
+
+/**
+ * The capacity {@link WebGpuPersistentSlotStore.ensureCapacity} settles on for
+ * `slots`, whatever the store currently holds.
+ *
+ * Independent of the current capacity because every capacity is a power of two
+ * at or above {@link initialSlotCapacity}: doubling from one of those reaches
+ * the same value as doubling from the initial one. That is what lets the limit
+ * be checked against a selection's slot count before the store has grown to it.
+ * @internal
+ */
+export const persistentSlotGrowthCapacity = (slots: number): number => {
+  let next = initialSlotCapacity;
+
+  while (next < slots) {
+    next *= 2;
+  }
+
+  return next;
+};
+
+/**
  * Bytes of the persistent pipeline's uniform block: mat4x4 projection + mat4x4
  * group + vec4 snap viewport + the premultiply mask, padded to the 16-byte
  * struct alignment WGSL requires.
@@ -222,6 +272,49 @@ export class WebGpuPersistentSlotStore implements PersistentSlotBundle {
       size: persistentUniformBytes,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
+  }
+
+  /**
+   * Whether a selection of `slots` slots and `orderEntries` order entries is
+   * representable on the device this store is connected to.
+   *
+   * All four slot buffers are `storage` bindings, so each is bounded by
+   * `min(maxBufferSize, maxStorageBufferBindingSize)` of the GRANTED device
+   * limits. Nothing raises either today, which puts the ceiling at the spec
+   * default of 128 MiB per binding — 4 194 304 slots at 32 bytes of transform
+   * row — on every device, however much the adapter would have offered.
+   *
+   * Answered against the SELECTION rather than against the source, because the
+   * source is not the bound: a root of ten million items whose camera admits a
+   * few thousand needs a few thousand slots, and refusing it at acquisition
+   * would cost the indexed path exactly the scenes it exists for. Answered
+   * BEFORE the growth allocates, because past the ceiling `createBuffer` still
+   * succeeds and `createBindGroup` does not — the root would keep selecting,
+   * keep uploading, and silently draw nothing behind an uncaptured validation
+   * error.
+   *
+   * A refusal is not a failure: the plan drops back to the streamed sprite
+   * path, which has no per-root buffer to overflow because it flushes.
+   */
+  public canRepresent(slots: number, orderEntries: number): boolean {
+    const device = this._device;
+
+    if (device === null) {
+      return false;
+    }
+
+    const limit = storageBufferLimit(device);
+    const capacity = persistentSlotGrowthCapacity(slots);
+
+    // Transform and quad rows are the widest and equal, so they are what breaks
+    // first; the tint and order streams are measured anyway, because a layout
+    // change must not leave one of them silently unbounded.
+    return (
+      capacity * transformBytesPerSlot <= limit &&
+      capacity * quadBytesPerSlot <= limit &&
+      capacity * tintBytesPerSlot <= limit &&
+      persistentSlotGrowthCapacity(orderEntries) * orderBytesPerEntry <= limit
+    );
   }
 
   /**

--- a/test/rendering/persistent-slot-capacity-refusal.test.ts
+++ b/test/rendering/persistent-slot-capacity-refusal.test.ts
@@ -1,0 +1,264 @@
+import { Container } from '#rendering/Container';
+import { Drawable } from '#rendering/Drawable';
+import type { PersistentSlotBundle } from '#rendering/plan/PersistentSlotDraw';
+import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
+import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
+import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import { RenderBackendType } from '#rendering/RenderBackendType';
+import type { RenderNode } from '#rendering/RenderNode';
+import { createRenderStats } from '#rendering/RenderStats';
+import { RenderTarget } from '#rendering/RenderTarget';
+import { View } from '#rendering/View';
+
+/**
+ * What the plan does when a backend's persistent slot store cannot represent the
+ * selection it was just handed.
+ *
+ * The store's buffers are bounded by the GRANTED device limits, and the bound is
+ * only knowable once the selection's slot count exists — a root of ten million
+ * items whose camera never admits more than a few thousand is perfectly
+ * representable, so refusing at acquisition on the item count would cost the
+ * fast path exactly the scenes it exists for. The answer is therefore asked per
+ * selection, and a refusal has to put the root back on the ordinary path rather
+ * than let the backend allocate something the device will reject.
+ */
+
+class Leaf extends Drawable {
+  public constructor(public readonly id: string) {
+    super();
+    this._setLocalBounds(0, 0, 16, 16);
+  }
+}
+
+const flaggedRenderer = { _supportsRetainedBatches: true, _supportsPersistentSlots: true };
+
+interface PersistentHarness {
+  backend: RenderBackend;
+  /** Ids passed to `backend.draw`, i.e. what the ORDINARY path drew. */
+  draws: string[];
+  /** One entry per `_drawPersistentOrder`, holding the order stream's length. */
+  persistentDraws: number[];
+  acquisitions: number;
+  writes: number;
+  /** Selections the store admits; a higher slot count is refused. */
+  representableSlots: number;
+}
+
+const createHarness = (): PersistentHarness => {
+  const renderTarget = new RenderTarget(800, 600, true);
+  const harness = {
+    draws: [] as string[],
+    persistentDraws: [] as number[],
+    acquisitions: 0,
+    writes: 0,
+    representableSlots: Number.POSITIVE_INFINITY,
+  };
+
+  const bundle: PersistentSlotBundle = {
+    generation: 1,
+    destroy() {},
+    canRepresent(slots: number): boolean {
+      return slots <= harness.representableSlots;
+    },
+  };
+
+  const backend = {
+    backendType: RenderBackendType.WebGl2,
+    stats: createRenderStats(),
+    renderTarget,
+    rendererRegistry: {
+      resolve(): unknown {
+        return flaggedRenderer;
+      },
+    },
+    get view() {
+      return renderTarget.view;
+    },
+    async initialize() {
+      return backend;
+    },
+    resetStats() {
+      return backend;
+    },
+    clear() {
+      return backend;
+    },
+    resize() {
+      return backend;
+    },
+    setView(view: View) {
+      renderTarget.setView(view);
+
+      return backend;
+    },
+    setRenderTarget() {
+      return backend;
+    },
+    pushScissorRect() {
+      return backend;
+    },
+    popScissorRect() {
+      return backend;
+    },
+    composeWithAlphaMask() {
+      return backend;
+    },
+    acquireRenderTexture() {
+      throw new Error('not used in this test');
+    },
+    releaseRenderTexture() {
+      return backend;
+    },
+    draw(drawable: unknown) {
+      harness.draws.push((drawable as Leaf).id);
+
+      return backend;
+    },
+    execute() {
+      return backend;
+    },
+    flush() {
+      return backend;
+    },
+    destroy() {
+      renderTarget.destroy();
+    },
+    _endDrawPlan(): void {},
+    _setRenderGroupTransform(): void {},
+    _acquirePersistentSlots(): PersistentSlotBundle | null {
+      harness.acquisitions++;
+
+      return bundle;
+    },
+    _writePersistentSlots(): void {
+      harness.writes++;
+    },
+    _drawPersistentOrder(_bundle: PersistentSlotBundle, _order: Uint32Array, count: number): void {
+      harness.persistentDraws.push(count);
+    },
+  } as unknown as RenderBackend;
+
+  return Object.assign(harness, { backend });
+};
+
+const playFrame = (root: RenderNode, backend: RenderBackend): void => {
+  const builder = RenderPlanBuilder.acquire();
+
+  try {
+    const plan = builder.build(root, backend);
+
+    RenderPlanOptimizer.optimize(plan);
+    RenderPlanPlayer.play(plan, backend);
+  } finally {
+    RenderPlanBuilder.release(builder);
+  }
+};
+
+const viewAt = (centerX: number, centerY = 300): View => new View(centerX, centerY, 800, 600);
+
+const addRow = (parent: Container, count: number, startX: number, spacing: number): void => {
+  for (let i = 0; i < count; i++) {
+    const leaf = new Leaf(`n${i}`);
+
+    leaf.setPosition(startX + i * spacing, 300);
+    parent.addChild(leaf);
+  }
+};
+
+/**
+ * Drive `root` to the tier where it selects from a persistent source and leave
+ * the camera at `centerX`. The build gate wants two consecutive rebuild frames
+ * over unchanged content, so the camera has to force a second rebuild first.
+ */
+const driveToSourceTier = (root: RenderNode, backend: RenderBackend, centerX = 400): void => {
+  backend.setView(viewAt(400));
+  playFrame(root, backend);
+
+  backend.setView(viewAt(100000));
+  playFrame(root, backend);
+
+  backend.setView(viewAt(centerX));
+  playFrame(root, backend);
+};
+
+const createScene = (): Container => {
+  const root = new Container();
+
+  root.cullable = false;
+  addRow(root, 200, -1000, 24);
+
+  return root;
+};
+
+describe('persistent slots: a store that cannot represent the selection', () => {
+  test('draws through the store while the selection fits', () => {
+    const harness = createHarness();
+    const root = createScene();
+
+    driveToSourceTier(root, harness.backend);
+    harness.draws.length = 0;
+    harness.persistentDraws.length = 0;
+
+    harness.backend.setView(viewAt(600));
+    playFrame(root, harness.backend);
+
+    expect(harness.persistentDraws.length).toBe(1);
+    expect(harness.draws).toEqual([]);
+
+    root.destroy();
+    harness.backend.destroy();
+  });
+
+  test('falls back to the ordinary path instead of letting the backend allocate', () => {
+    const harness = createHarness();
+    const root = createScene();
+
+    driveToSourceTier(root, harness.backend);
+
+    // Every slot this camera admits is now one too many. The refusal has to
+    // land BEFORE the write hook, which is where a real backend would size its
+    // buffers against the device.
+    harness.representableSlots = 0;
+    harness.draws.length = 0;
+    harness.persistentDraws.length = 0;
+    harness.writes = 0;
+
+    harness.backend.setView(viewAt(600));
+    playFrame(root, harness.backend);
+
+    expect(harness.persistentDraws).toEqual([]);
+    expect(harness.writes).toBe(0);
+    expect(harness.draws.length).toBeGreaterThan(0);
+
+    root.destroy();
+    harness.backend.destroy();
+  });
+
+  test('remembers the refusal rather than re-asking every frame', () => {
+    const harness = createHarness();
+    const root = createScene();
+
+    driveToSourceTier(root, harness.backend);
+    harness.representableSlots = 0;
+    harness.persistentDraws.length = 0;
+
+    harness.backend.setView(viewAt(600));
+    playFrame(root, harness.backend);
+
+    const afterRefusal = harness.acquisitions;
+
+    for (let i = 0; i < 3; i++) {
+      harness.backend.setView(viewAt(600 + i * 40));
+      playFrame(root, harness.backend);
+    }
+
+    // Re-acquiring would re-run the backend's whole eligibility walk over every
+    // item, once a frame, for a root that has already been answered.
+    expect(harness.acquisitions).toBe(afterRefusal);
+    expect(harness.persistentDraws).toEqual([]);
+
+    root.destroy();
+    harness.backend.destroy();
+  });
+});

--- a/test/rendering/webgpu-persistent-slot-limits.test.ts
+++ b/test/rendering/webgpu-persistent-slot-limits.test.ts
@@ -1,0 +1,189 @@
+/// <reference types="@webgpu/types" />
+
+/**
+ * Whether a persistent slot store admits that a selection is too big for the
+ * DEVICE it is connected to.
+ *
+ * The store's four per-slot buffers are `storage` bindings, so each one is
+ * bounded by `min(maxBufferSize, maxStorageBufferBindingSize)` of the GRANTED
+ * device limits — not the adapter's. A device requested without `requiredLimits`
+ * for either is granted exactly the spec defaults, which puts the ceiling at
+ * 4 194 304 slots (32 bytes of transform row) no matter what the hardware could
+ * offer. Past it `createBuffer` still succeeds and `createBindGroup` does not,
+ * so the failure is an uncaptured validation error and a root that silently
+ * stops drawing.
+ *
+ * The contract under test is therefore the REFUSAL: a store must answer that it
+ * cannot represent such a selection, before anything is allocated, so the plan
+ * can put the root back on the streamed path.
+ */
+
+import { persistentSlotGrowthCapacity, WebGpuPersistentSlotStore } from '#rendering/webgpu/WebGpuPersistentSlotStore';
+
+/** WebGPU's spec defaults — what a device gets when nothing higher is requested. */
+const DEFAULT_MAX_BUFFER_SIZE = 2 ** 28; // 256 MiB
+const DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE = 2 ** 27; // 128 MiB
+
+/** Mirrors the store's own row layout; a change to either must fail here loudly. */
+const TRANSFORM_BYTES_PER_SLOT = 8 * Float32Array.BYTES_PER_ELEMENT;
+const ORDER_BYTES_PER_ENTRY = Uint32Array.BYTES_PER_ELEMENT;
+const INITIAL_CAPACITY = 2 ** 10;
+
+/** Slots the default limits allow: the binding limit divided by the widest row. */
+const DEFAULT_SLOT_CEILING = DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE / TRANSFORM_BYTES_PER_SLOT;
+/** Order entries the default limits allow, which is a different, much later ceiling. */
+const DEFAULT_ORDER_CEILING = DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE / ORDER_BYTES_PER_ENTRY;
+
+const createMockDevice = (limits?: Partial<GPUSupportedLimits>): GPUDevice =>
+  ({
+    limits,
+    createBuffer: () => ({ destroy: () => undefined }) as unknown as GPUBuffer,
+    queue: { writeBuffer: () => undefined },
+  }) as unknown as GPUDevice;
+
+/**
+ * Run `body` with the `GPUBufferUsage` flags the store reads at buffer creation.
+ * They are a browser global the node lane does not have.
+ */
+const withGpuBufferUsage = (body: () => void): void => {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, 'GPUBufferUsage');
+
+  Object.defineProperty(globalThis, 'GPUBufferUsage', { configurable: true, value: { STORAGE: 128, COPY_DST: 8, UNIFORM: 64 } });
+
+  try {
+    body();
+  } finally {
+    if (previous) {
+      Object.defineProperty(globalThis, 'GPUBufferUsage', previous);
+    } else {
+      Object.defineProperty(globalThis, 'GPUBufferUsage', { configurable: true, value: undefined });
+    }
+  }
+};
+
+const createStore = (limits?: Partial<GPUSupportedLimits>): WebGpuPersistentSlotStore => {
+  const store = new WebGpuPersistentSlotStore();
+
+  store.connectDevice(createMockDevice(limits), undefined as never);
+
+  return store;
+};
+
+const defaultLimits = {
+  maxBufferSize: DEFAULT_MAX_BUFFER_SIZE,
+  maxStorageBufferBindingSize: DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE,
+} as Partial<GPUSupportedLimits>;
+
+describe('WebGpuPersistentSlotStore device limits', () => {
+  test('accepts an ordinary selection', () => {
+    withGpuBufferUsage(() => {
+      const store = createStore(defaultLimits);
+
+      expect(store.canRepresent(1, 1)).toBe(true);
+      expect(store.canRepresent(100000, 100000)).toBe(true);
+      expect(store.canRepresent(1000000, 1000000)).toBe(true);
+    });
+  });
+
+  test('accepts the last capacity that still fits, and refuses the first growth past it', () => {
+    withGpuBufferUsage(() => {
+      const store = createStore(defaultLimits);
+
+      // Capacity is a power of two, so the whole band below the ceiling settles
+      // on the ceiling itself: it is the last capacity the device can bind.
+      expect(store.canRepresent(DEFAULT_SLOT_CEILING / 2 + 1, 1)).toBe(true);
+      expect(store.canRepresent(DEFAULT_SLOT_CEILING - 1, 1)).toBe(true);
+
+      // Exactly on the boundary: the binding is `maxStorageBufferBindingSize`
+      // bytes, which the limit ADMITS — a refusal here would cost the fast path
+      // a capacity the device can serve.
+      expect(store.canRepresent(DEFAULT_SLOT_CEILING, 1)).toBe(true);
+
+      // One slot more doubles the capacity, which is what actually fails: the
+      // 256 MiB transform buffer is still creatable (it is exactly
+      // `maxBufferSize`) and cannot be bound as storage.
+      expect(store.canRepresent(DEFAULT_SLOT_CEILING + 1, 1)).toBe(false);
+    });
+  });
+
+  test('bounds the order stream on its own limit, not the slot one', () => {
+    withGpuBufferUsage(() => {
+      const store = createStore(defaultLimits);
+
+      // Four bytes an entry rather than 32, so the order buffer's own ceiling is
+      // eight times further out. It can never be the first buffer to break in a
+      // sprite store — order entries never outnumber slots — which is exactly
+      // why it needs its own assertion.
+      expect(store.canRepresent(INITIAL_CAPACITY, DEFAULT_ORDER_CEILING)).toBe(true);
+      expect(store.canRepresent(INITIAL_CAPACITY, DEFAULT_ORDER_CEILING + 1)).toBe(false);
+    });
+  });
+
+  test('takes whichever of the two limits binds first', () => {
+    withGpuBufferUsage(() => {
+      // A device that raised the binding limit but not the allocation one: the
+      // buffer size now decides, at twice the default slot ceiling.
+      const store = createStore({
+        maxBufferSize: DEFAULT_MAX_BUFFER_SIZE,
+        maxStorageBufferBindingSize: DEFAULT_MAX_BUFFER_SIZE * 8,
+      } as Partial<GPUSupportedLimits>);
+
+      const ceiling = DEFAULT_MAX_BUFFER_SIZE / TRANSFORM_BYTES_PER_SLOT;
+
+      expect(store.canRepresent(ceiling, 1)).toBe(true);
+      expect(store.canRepresent(ceiling + 1, 1)).toBe(false);
+    });
+  });
+
+  test('falls back to the spec defaults for a device that exposes no limits', () => {
+    withGpuBufferUsage(() => {
+      const store = createStore(undefined);
+
+      // A conformant device is never granted LESS than the defaults, so assuming
+      // them is safe; assuming no ceiling at all would be the unsafe direction.
+      expect(store.canRepresent(DEFAULT_SLOT_CEILING, 1)).toBe(true);
+      expect(store.canRepresent(DEFAULT_SLOT_CEILING + 1, 1)).toBe(false);
+    });
+  });
+
+  test('re-reads the ceiling from the device it is currently connected to', () => {
+    withGpuBufferUsage(() => {
+      const store = createStore({
+        maxBufferSize: DEFAULT_MAX_BUFFER_SIZE * 8,
+        maxStorageBufferBindingSize: DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE * 8,
+      } as Partial<GPUSupportedLimits>);
+
+      expect(store.canRepresent(DEFAULT_SLOT_CEILING * 4, 1)).toBe(true);
+
+      // Device loss, then recovery onto a device granting only the defaults. A
+      // ceiling cached from the lost device would still admit the selection.
+      store.invalidateDeviceResources();
+      store.connectDevice(createMockDevice(defaultLimits), undefined as never);
+
+      expect(store.canRepresent(DEFAULT_SLOT_CEILING * 4, 1)).toBe(false);
+      expect(store.canRepresent(DEFAULT_SLOT_CEILING, 1)).toBe(true);
+    });
+  });
+
+  test('refuses everything while no device is connected', () => {
+    const store = new WebGpuPersistentSlotStore();
+
+    // Nothing can be allocated without a device, so there is no capacity the
+    // store could honestly claim to represent.
+    expect(store.canRepresent(1, 1)).toBe(false);
+  });
+
+  test('predicts the capacity growth actually settles on', () => {
+    withGpuBufferUsage(() => {
+      // The ceiling is expressed in the growth policy's own terms, so the two
+      // must not drift: what `canRepresent` measures has to be the capacity
+      // `ensureCapacity` allocates.
+      for (const slots of [1, INITIAL_CAPACITY, INITIAL_CAPACITY + 1, 1500, 100000]) {
+        const probe = createStore(defaultLimits);
+
+        probe.ensureCapacity(slots);
+        expect(persistentSlotGrowthCapacity(slots)).toBe(probe.slotCapacity);
+      }
+    });
+  });
+});


### PR DESCRIPTION
The WebGPU persistent slot path keeps four storage buffers per render root and
grows them by doubling, but nothing measured them against the device.

All four are bounded by `min(maxBufferSize, maxStorageBufferBindingSize)` of the
GRANTED device limits, and the device request raises only the texture and
sampler limits the batch layout needs — so every device runs on the spec
defaults of 256 MiB and 128 MiB, however much the adapter would have offered.
At 32 bytes of transform row that is a ceiling of 4 194 304 slots.

The first growth past it allocates 8 388 608 slots. `createBuffer` still accepts
the 256 MiB buffer (exactly `maxBufferSize`); `createBindGroup` rejects the
binding. There is no exception: the root keeps selecting and uploading, draws
nothing, and raises one uncaptured `GPUValidationError` a frame.

## The fix

The store now answers whether it can represent a selection at all, and the plan
asks after the selection is committed and before the write hook.

Asked against the SELECTION rather than the source, because the source is not
the bound: a root of ten million items whose camera admits a few thousand needs
a few thousand slots, and refusing it at acquisition on `itemCount` would
withdraw the indexed path from exactly the scenes it exists for.

Asked before the write, because past the ceiling the rejection comes from the
driver rather than from us.

A refusal drops the store and returns `false` from the persistent tier, which is
the fallback that already existed — the root takes the ordinary path in the same
frame, and that path flushes, so it has no per-root buffer to overflow. The
refusal is sticky for the source's lifetime, so the answer costs one selection
rather than one per frame.

`canRepresent` is optional on `PersistentSlotBundle`; WebGL2 does not implement
it and its behaviour is unchanged.

## Measured, on this machine (Chromium)

```
maxBufferSize                    adapter 2147483648  device 268435456
maxStorageBufferBindingSize      adapter 2147483644  device 134217728
maxStorageBuffersPerShaderStage  adapter         16  device         8
maxStorageBuffersInVertexStage   adapter         16  device         8   (path uses 4)
```

Raising `requiredLimits` would move the ceiling — with the doubling policy
unchanged, to 2^25 slots, since 2^26 * 32 lands 4 bytes above the adapter's
binding limit. That is a device-request policy decision with a growth-policy
question attached, and deliberately not part of this cut.

## Tests

`test/rendering/webgpu-persistent-slot-limits.test.ts`: the last capacity that
fits, exactly on the boundary (which must be ACCEPTED — a safety guard must not
quietly become conservative), the first growth past it, the order stream's own
ceiling, which of the two limits binds, a device exposing no limits at all
(spec defaults as the safe assumption), no device connected, device recovery
onto a smaller device (no stale ceiling), and that the ceiling is expressed in
the same terms the real growth uses.

`test/rendering/persistent-slot-capacity-refusal.test.ts`: the plan draws
through the store while the selection fits, falls back to the ordinary path
without calling the write hook when it does not, and remembers the refusal
instead of re-acquiring every frame.

`pnpm test:core`, `pnpm verify:quick` and both persistent-slot browser lanes are
green on this branch, rebased onto #571.

## Side finding, not changed

WebGL2 has the same class of ceiling (`rowsPerLine * MAX_TEXTURE_SIZE`) and
already fails closed on it with a `RenderError` from
`createTransformTextureLayout` — 2 097 152 rows on a minimal context, i.e.
earlier than WebGPU, but loudly rather than silently. Unifying the two backends'
contract is a separate question.