### PR TITLE
fix(webgpu): fail closed before shared storage exceeds device limits

### DIFF
--- a/src/rendering/webgpu/WebGpuPersistentSlotStore.ts
+++ b/src/rendering/webgpu/WebGpuPersistentSlotStore.ts
@@ -11,6 +11,7 @@ import { BlendModes } from '#rendering/types';
 
 import type { WebGpuBackend } from './WebGpuBackend';
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
+import { storageBufferLimit } from './webgpuStorageLimits';
 
 const floatsPerTransformRow = TRANSFORM_FLOATS_PER_ROW;
 const floatsPerQuadRecord = SOURCE_QUAD_FLOATS;
@@ -32,36 +33,6 @@ const initialSlotCapacity = 1024;
  * scrolling view were admitted together, so their slots were too.
  */
 const slotsPerBlock = 256;
-
-/**
- * WebGPU's spec-guaranteed defaults for the two limits that bound a persistent
- * store's buffers.
- *
- * These are the values actually in force: a device requested without a
- * `requiredLimits` entry is granted exactly the default, however much the
- * adapter could have offered, and `WebGpuBackend` raises only the texture and
- * sampler limits the batch layout needs. They double as the stand-in for a
- * device that exposes no limits object at all — a conformant device is never
- * granted less, so assuming them is the safe direction.
- */
-const defaultMaxBufferSize = 2 ** 28; // 256 MiB
-const defaultMaxStorageBufferBindingSize = 2 ** 27; // 128 MiB
-
-/**
- * Bytes the largest buffer of `capacity` slots may occupy on `device`.
- *
- * Both limits apply to every one of the four slot buffers: `createBuffer`
- * rejects a size over `maxBufferSize`, and `createBindGroup` rejects a storage
- * binding over `maxStorageBufferBindingSize` — which is the SMALLER of the two
- * defaults, so on a device that asked for neither it is the one that bites.
- */
-const storageBufferLimit = (device: GPUDevice): number => {
-  // Defensive optional access, as in `resolveSpriteBatchTextureSlots`: mocked
-  // devices in unit tests may not expose a limits object.
-  const limits = (device as { limits?: GPUSupportedLimits }).limits;
-
-  return Math.min(limits?.maxBufferSize ?? defaultMaxBufferSize, limits?.maxStorageBufferBindingSize ?? defaultMaxStorageBufferBindingSize);
-};
 
 /**
  * The capacity {@link WebGpuPersistentSlotStore.ensureCapacity} settles on for

--- a/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
+++ b/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
@@ -9,6 +9,7 @@ import type { BlendModes } from '#rendering/types';
 import type { View } from '#rendering/View';
 
 import type { WebGpuActiveRenderPass } from './WebGpuPassCoordinator';
+import { requireRepresentableStorageGrowth } from './webgpuStorageLimits';
 
 /** Bytes of one transform slot (2 × vec4<f32>, matches the WGSL `TransformSlot`). */
 export const retainedTransformSlotBytes = 32;
@@ -301,6 +302,38 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
    */
   public ensureCapacity(device: GPUDevice, instanceBytes: number, transformBytes: number, tintBytes: number): void {
     let recreated = false;
+
+    // Both storage bindings are measured against the connected device BEFORE any
+    // buffer here is destroyed or created — including the instance buffer, which
+    // is a vertex binding and representable on its own. Past the ceiling
+    // `createBuffer` still succeeds and `createBindGroup` does not, so allocating
+    // first would leave the bundle holding a set the device cannot bind, with the
+    // failure surfacing as an uncaptured validation error a frame later. The two
+    // grow independently, so each is measured on its own row width rather than
+    // inferred from the wider one.
+    if (this._transformBuffer === null || this._transformCapacity < transformBytes) {
+      const capacity = growCapacity(this._transformCapacity, transformBytes);
+
+      requireRepresentableStorageGrowth(device, {
+        store: 'retained group transform storage',
+        resource: 'sprite:retained-transform-buffer',
+        requestedRows: Math.ceil(transformBytes / retainedTransformSlotBytes),
+        capacityRows: capacity / retainedTransformSlotBytes,
+        capacityBytes: capacity,
+      });
+    }
+
+    if (this._tintBuffer === null || this._tintCapacity < tintBytes) {
+      const capacity = growCapacity(this._tintCapacity, tintBytes);
+
+      requireRepresentableStorageGrowth(device, {
+        store: 'retained group tint storage',
+        resource: 'sprite:retained-tint-buffer',
+        requestedRows: Math.ceil(tintBytes / retainedTintSlotBytes),
+        capacityRows: capacity / retainedTintSlotBytes,
+        capacityBytes: capacity,
+      });
+    }
 
     if (this._instanceBuffer === null || this._instanceCapacity < instanceBytes) {
       const capacity = growCapacity(this._instanceCapacity, instanceBytes);

--- a/src/rendering/webgpu/WebGpuTransformStorage.ts
+++ b/src/rendering/webgpu/WebGpuTransformStorage.ts
@@ -6,6 +6,8 @@ import { PixelSnapMode } from '#rendering/pixelSnap';
 import type { DrawCommand } from '#rendering/plan/RenderCommand';
 import { TRANSFORM_FLOATS_PER_ROW, TRANSFORM_TINT_BYTES_PER_ROW, TransformBuffer } from '#rendering/TransformBuffer';
 
+import { requireRepresentableStorageGrowth } from './webgpuStorageLimits';
+
 const slotFloatCount = TRANSFORM_FLOATS_PER_ROW;
 const tintSlotBytes = TRANSFORM_TINT_BYTES_PER_ROW;
 
@@ -225,6 +227,27 @@ export class WebGpuTransformStorage {
     // how many rows they cover.
     const nextSlotCount = nextCapacity / (slotFloatCount * Float32Array.BYTES_PER_ELEMENT);
     const nextTintCapacity = nextSlotCount * tintSlotBytes;
+
+    // Both bindings are measured before EITHER buffer is touched: the storage is
+    // the path a persistent store's refusal falls back onto, and there is nothing
+    // below it to fall back to in turn, so an unrepresentable growth has to leave
+    // the current buffers intact and say why rather than allocate half of a set
+    // the device cannot bind. Measured on the capacity the doubling above settled
+    // on, which is the size that actually reaches `createBindGroup`.
+    requireRepresentableStorageGrowth(device, {
+      store: 'shared transform storage',
+      resource: 'transform:storage-buffer',
+      requestedRows: requiredCount,
+      capacityRows: nextSlotCount,
+      capacityBytes: nextCapacity,
+    });
+    requireRepresentableStorageGrowth(device, {
+      store: 'shared tint storage',
+      resource: 'transform:tint-storage-buffer',
+      requestedRows: requiredCount,
+      capacityRows: nextSlotCount,
+      capacityBytes: nextTintCapacity,
+    });
 
     this._storageBuffer?.destroy();
     this._storageBuffer = device.createBuffer({

--- a/src/rendering/webgpu/webgpuStorageLimits.ts
+++ b/src/rendering/webgpu/webgpuStorageLimits.ts
@@ -1,0 +1,109 @@
+/// <reference types="@webgpu/types" />
+
+import { RenderBackendType } from '#rendering/RenderBackendType';
+import { RenderError } from '#rendering/RenderError';
+
+/**
+ * WebGPU's spec-guaranteed defaults for the two limits that bound a storage
+ * buffer.
+ *
+ * These are the values actually in force: a device requested without a
+ * `requiredLimits` entry is granted exactly the default, however much the
+ * adapter could have offered, and `WebGpuBackend` raises only the texture and
+ * sampler limits the batch layout needs. They double as the stand-in for a
+ * device that exposes no limits object at all — a conformant device is never
+ * granted less, so assuming them is the safe direction.
+ */
+export const defaultMaxBufferSize = 2 ** 28; // 256 MiB
+export const defaultMaxStorageBufferBindingSize = 2 ** 27; // 128 MiB
+
+/** The granted limits of `device`, with the spec defaults standing in for a device that exposes none. */
+const grantedLimits = (device: GPUDevice): { readonly maxBufferSize: number; readonly maxStorageBufferBindingSize: number } => {
+  // Defensive optional access, as in `resolveSpriteBatchTextureSlots`: mocked
+  // devices in unit tests may not expose a limits object.
+  const limits = (device as { limits?: GPUSupportedLimits }).limits;
+
+  return {
+    maxBufferSize: limits?.maxBufferSize ?? defaultMaxBufferSize,
+    maxStorageBufferBindingSize: limits?.maxStorageBufferBindingSize ?? defaultMaxStorageBufferBindingSize,
+  };
+};
+
+/**
+ * Bytes the largest storage buffer bound in full may occupy on `device`.
+ *
+ * Both limits apply to every such buffer: `createBuffer` rejects a size over
+ * `maxBufferSize`, and `createBindGroup` rejects a storage binding over
+ * `maxStorageBufferBindingSize` — which is the SMALLER of the two defaults, so
+ * on a device that asked for neither it is the one that bites.
+ * @internal
+ */
+export const storageBufferLimit = (device: GPUDevice): number => {
+  const limits = grantedLimits(device);
+
+  return Math.min(limits.maxBufferSize, limits.maxStorageBufferBindingSize);
+};
+
+/** One store's growth target, as the caller's own growth policy computed it. @internal */
+export interface StorageGrowthRequest {
+  /** Human name of the store, as it should read in the failure message. */
+  readonly store: string;
+  /** `label` the buffer would have been created with. */
+  readonly resource: string;
+  /** Rows the caller asked for, BEFORE the growth policy rounded up. */
+  readonly requestedRows: number;
+  /** Rows the growth policy actually settles on — a power of two at or above `requestedRows`. */
+  readonly capacityRows: number;
+  /** Bytes `capacityRows` occupy, which is the size of the storage binding. */
+  readonly capacityBytes: number;
+}
+
+/**
+ * Refuse a storage growth the connected device could not bind, before anything
+ * is allocated.
+ *
+ * Measured against the capacity the caller's growth policy SETTLES on rather
+ * than the rows it was handed: every store here doubles, so one row over a
+ * ceiling asks for twice the bytes, and it is the doubled size that fails.
+ * Measured BEFORE the allocation because past the ceiling `createBuffer` still
+ * succeeds — the doubled size lands on `maxBufferSize` exactly — and
+ * `createBindGroup` does not, which turns the failure into an uncaptured
+ * validation error, a root that draws nothing, and a frame loop that keeps
+ * running.
+ *
+ * Unlike the persistent slot store, which answers `canRepresent` and falls back
+ * to the streamed path, these stores ARE the fallback: there is no further
+ * representation below them, so the honest contract is to fail loudly and
+ * typed — the same `RenderError('out-of-memory')` WebGL2 throws when its
+ * transform texture outgrows `MAX_TEXTURE_SIZE`.
+ * @internal
+ */
+export const requireRepresentableStorageGrowth = (device: GPUDevice, request: StorageGrowthRequest): void => {
+  const limits = grantedLimits(device);
+  const limit = Math.min(limits.maxBufferSize, limits.maxStorageBufferBindingSize);
+
+  if (request.capacityBytes <= limit) {
+    return;
+  }
+
+  // Ties go to the binding limit: it is the smaller of the two defaults and the
+  // one that fails later (at bind-group creation rather than allocation), so
+  // naming it is the more useful diagnosis when both are breached.
+  const binding = limits.maxStorageBufferBindingSize <= limits.maxBufferSize ? 'maxStorageBufferBindingSize' : 'maxBufferSize';
+  const rowBytes = request.capacityBytes / request.capacityRows;
+
+  throw new RenderError({
+    code: 'out-of-memory',
+    backendType: RenderBackendType.WebGpu,
+    resource: request.resource,
+    message:
+      `[ExoJS] ${request.store}: growing to ${request.capacityRows} rows needs a ${request.capacityBytes}-byte storage binding, ` +
+      `over this device's granted ${binding} of ${limit}.`,
+    detail:
+      `Requested ${request.requestedRows} rows; power-of-two growth settles on ${request.capacityRows} rows ` +
+      `(${rowBytes} bytes each, ${request.capacityBytes} bytes total). ` +
+      `Granted device limits: maxBufferSize ${limits.maxBufferSize}, maxStorageBufferBindingSize ${limits.maxStorageBufferBindingSize}; ` +
+      `${binding} binds and caps this store at ${Math.floor(limit / rowBytes)} rows. ` +
+      `ExoJS requests neither limit, so a device grants the WebGPU defaults no matter what the adapter could offer.`,
+  });
+};

--- a/test/rendering/webgpu-shared-storage-limits.test.ts
+++ b/test/rendering/webgpu-shared-storage-limits.test.ts
@@ -1,0 +1,391 @@
+/// <reference types="@webgpu/types" />
+
+/**
+ * Whether the ORDINARY WebGPU storage buffers admit that a frame is too big for
+ * the device they are about to allocate on.
+ *
+ * These are the buffers the persistent slot store's refusal falls back to: the
+ * frame-global shared transform + tint storage, and the per-group retained
+ * transform + tint storage. All four are `storage` bindings bound in full, with
+ * no `offset`/`size` sub-range, so each is bounded by
+ * `min(maxBufferSize, maxStorageBufferBindingSize)` of the GRANTED device limits.
+ * Past that ceiling `createBuffer` still succeeds — the doubled size is exactly
+ * `maxBufferSize` — and `createBindGroup` does not, which makes the failure an
+ * uncaptured validation error, a frame that draws nothing, and a loop that keeps
+ * running.
+ *
+ * There is no further representation to fall back to here, so the contract under
+ * test is fail-closed: a typed `RenderError` before the allocation, naming the
+ * store, the capacity the growth policy settles on, and which limit binds.
+ */
+
+import { GpuResourceAccountant } from '#rendering/GpuResourceAccountant';
+import { RenderBackendType } from '#rendering/RenderBackendType';
+import { RenderError } from '#rendering/RenderError';
+import { createRenderStats } from '#rendering/RenderStats';
+import { retainedTintSlotBytes, retainedTransformSlotBytes, WebGpuRetainedGroupBundle } from '#rendering/webgpu/WebGpuRetainedGroupResources';
+import { WebGpuTransformStorage } from '#rendering/webgpu/WebGpuTransformStorage';
+
+/** WebGPU's spec defaults — what a device gets when nothing higher is requested. */
+const DEFAULT_MAX_BUFFER_SIZE = 2 ** 28; // 256 MiB
+const DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE = 2 ** 27; // 128 MiB
+
+/** Mirrors both stores' row layout; a change to either must fail here loudly. */
+const TRANSFORM_BYTES_PER_ROW = 32;
+const TINT_BYTES_PER_ROW = 4;
+
+/** Rows the default limits allow: the binding limit divided by the widest row. */
+const DEFAULT_ROW_CEILING = DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE / TRANSFORM_BYTES_PER_ROW;
+
+const defaultLimits = {
+  maxBufferSize: DEFAULT_MAX_BUFFER_SIZE,
+  maxStorageBufferBindingSize: DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE,
+} as Partial<GPUSupportedLimits>;
+
+interface MockDevice {
+  readonly device: GPUDevice;
+  readonly sizes: number[];
+}
+
+const createMockDevice = (limits: Partial<GPUSupportedLimits> | undefined = defaultLimits): MockDevice => {
+  const sizes: number[] = [];
+
+  const device = {
+    limits,
+    createBuffer: (descriptor: GPUBufferDescriptor) => {
+      sizes.push(descriptor.size);
+
+      return { destroy: () => undefined } as unknown as GPUBuffer;
+    },
+    queue: { writeBuffer: () => undefined },
+  } as unknown as GPUDevice;
+
+  return { device, sizes };
+};
+
+/**
+ * Run `body` with the `GPUBufferUsage` flags the stores read at buffer creation.
+ * They are a browser global the node lane does not have.
+ */
+const withGpuBufferUsage = (body: () => void): void => {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, 'GPUBufferUsage');
+
+  Object.defineProperty(globalThis, 'GPUBufferUsage', {
+    configurable: true,
+    value: { STORAGE: 128, COPY_DST: 8, UNIFORM: 64, VERTEX: 32 },
+  });
+
+  try {
+    body();
+  } finally {
+    if (previous) {
+      Object.defineProperty(globalThis, 'GPUBufferUsage', previous);
+    } else {
+      Object.defineProperty(globalThis, 'GPUBufferUsage', { configurable: true, value: undefined });
+    }
+  }
+};
+
+const createBundle = (): WebGpuRetainedGroupBundle => new WebGpuRetainedGroupBundle(new GpuResourceAccountant(createRenderStats()), () => undefined);
+
+/** Assert `body` fails with this fix's contract and name the store it blames. */
+const expectRefusal = (body: () => void, store: string): RenderError => {
+  let caught: unknown = null;
+
+  try {
+    body();
+  } catch (error) {
+    caught = error;
+  }
+
+  expect(caught).toBeInstanceOf(RenderError);
+
+  const error = caught as RenderError;
+
+  expect(error.code).toBe('out-of-memory');
+  expect(error.backendType).toBe(RenderBackendType.WebGpu);
+  expect(error.message).toContain(store);
+
+  return error;
+};
+
+describe('WebGpuTransformStorage device limits', () => {
+  test('accepts the last capacity the device can bind, and refuses the first growth past it', () => {
+    withGpuBufferUsage(() => {
+      // The band below the ceiling settles on the ceiling itself — capacity is a
+      // power of two — so it is the last capacity the device can serve.
+      const below = createMockDevice();
+
+      new WebGpuTransformStorage().reserve(below.device, DEFAULT_ROW_CEILING / 2 + 1);
+      expect(below.sizes).toContain(DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE);
+
+      // Exactly on the boundary: the binding is `maxStorageBufferBindingSize`
+      // bytes, which the limit ADMITS. A refusal here would cost the frame a
+      // capacity the device can bind.
+      const exact = createMockDevice();
+
+      new WebGpuTransformStorage().reserve(exact.device, DEFAULT_ROW_CEILING);
+      expect(exact.sizes).toContain(DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE);
+
+      // One row more doubles the capacity, and that is what actually fails: the
+      // 256 MiB transform buffer is still creatable (it is exactly
+      // `maxBufferSize`) and cannot be bound as storage.
+      const over = createMockDevice();
+
+      const error = expectRefusal(() => new WebGpuTransformStorage().reserve(over.device, DEFAULT_ROW_CEILING + 1), 'shared transform storage');
+
+      // Diagnosis must carry the numbers a reader needs to act, not just the fact.
+      expect(error.message).toContain(String(DEFAULT_ROW_CEILING * 2));
+      expect(error.detail).toContain(String(DEFAULT_ROW_CEILING + 1));
+      expect(error.detail).toContain(String(DEFAULT_MAX_BUFFER_SIZE));
+      expect(error.detail).toContain(String(DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE));
+      expect(error.detail).toContain('maxStorageBufferBindingSize');
+
+      // Fail CLOSED: nothing was allocated on the way to the refusal.
+      expect(over.sizes).toEqual([]);
+    });
+  });
+
+  test('refuses through getBuffer as well, not only through reserve', () => {
+    withGpuBufferUsage(() => {
+      const mock = createMockDevice();
+
+      expectRefusal(() => new WebGpuTransformStorage().getBuffer(mock.device, DEFAULT_ROW_CEILING + 1), 'shared transform storage');
+      expect(mock.sizes).toEqual([]);
+    });
+  });
+
+  test('takes whichever of the two limits binds first', () => {
+    withGpuBufferUsage(() => {
+      // A device with a smaller allocation limit: the buffer size decides.
+      const bufferBound = createMockDevice({
+        maxBufferSize: 2 ** 26,
+        maxStorageBufferBindingSize: DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE,
+      } as Partial<GPUSupportedLimits>);
+      const bufferCeiling = 2 ** 26 / TRANSFORM_BYTES_PER_ROW;
+
+      new WebGpuTransformStorage().reserve(bufferBound.device, bufferCeiling);
+      expect(bufferBound.sizes).toContain(2 ** 26);
+
+      const overBuffer = createMockDevice({
+        maxBufferSize: 2 ** 26,
+        maxStorageBufferBindingSize: DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE,
+      } as Partial<GPUSupportedLimits>);
+
+      expect(expectRefusal(() => new WebGpuTransformStorage().reserve(overBuffer.device, bufferCeiling + 1), 'shared transform storage').detail).toContain(
+        'maxBufferSize',
+      );
+
+      // A device with a smaller binding limit: the binding size decides, at the
+      // same row count but for the other reason.
+      const bindingBound = createMockDevice({
+        maxBufferSize: DEFAULT_MAX_BUFFER_SIZE,
+        maxStorageBufferBindingSize: 2 ** 26,
+      } as Partial<GPUSupportedLimits>);
+
+      new WebGpuTransformStorage().reserve(bindingBound.device, bufferCeiling);
+      expect(bindingBound.sizes).toContain(2 ** 26);
+
+      const overBinding = createMockDevice({
+        maxBufferSize: DEFAULT_MAX_BUFFER_SIZE,
+        maxStorageBufferBindingSize: 2 ** 26,
+      } as Partial<GPUSupportedLimits>);
+
+      expect(expectRefusal(() => new WebGpuTransformStorage().reserve(overBinding.device, bufferCeiling + 1), 'shared transform storage').detail).toContain(
+        'maxStorageBufferBindingSize',
+      );
+    });
+  });
+
+  test('falls back to the spec defaults for a device that exposes no limits', () => {
+    withGpuBufferUsage(() => {
+      const accepted = createMockDevice(undefined);
+
+      // A conformant device is never granted LESS than the defaults, so assuming
+      // them is safe; assuming no ceiling at all would be the unsafe direction.
+      new WebGpuTransformStorage().reserve(accepted.device, DEFAULT_ROW_CEILING);
+      expect(accepted.sizes).toContain(DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE);
+
+      const refused = createMockDevice(undefined);
+
+      expectRefusal(() => new WebGpuTransformStorage().reserve(refused.device, DEFAULT_ROW_CEILING + 1), 'shared transform storage');
+    });
+  });
+
+  test('reads the limits of the device it is currently growing on', () => {
+    withGpuBufferUsage(() => {
+      const storage = new WebGpuTransformStorage();
+      const generous = createMockDevice({
+        maxBufferSize: DEFAULT_MAX_BUFFER_SIZE * 8,
+        maxStorageBufferBindingSize: DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE * 8,
+      } as Partial<GPUSupportedLimits>);
+
+      storage.reserve(generous.device, DEFAULT_ROW_CEILING * 4);
+      expect(generous.sizes).toContain(DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE * 4);
+
+      // Device loss, then recovery onto a device granting only the defaults. A
+      // ceiling cached from the lost device would still admit the growth.
+      storage.destroy();
+
+      const modest = createMockDevice(defaultLimits);
+
+      expectRefusal(() => storage.reserve(modest.device, DEFAULT_ROW_CEILING * 4), 'shared transform storage');
+      expect(modest.sizes).toEqual([]);
+    });
+  });
+
+  test('leaves an ordinary growth structurally unchanged', () => {
+    withGpuBufferUsage(() => {
+      const mock = createMockDevice();
+
+      new WebGpuTransformStorage().reserve(mock.device, 1000);
+
+      // Doubling from one row's worth of bytes: 32 → 32768, i.e. 1024 rows, and
+      // a tint buffer covering exactly the same rows. Both sizes are pinned so a
+      // guard cannot quietly change what gets allocated.
+      expect(mock.sizes).toEqual([1024 * TRANSFORM_BYTES_PER_ROW, 1024 * TINT_BYTES_PER_ROW]);
+    });
+  });
+});
+
+describe('WebGpuRetainedGroupBundle device limits', () => {
+  const instanceBytes = 1024;
+
+  test('grows on the row widths this file assumes', () => {
+    // Every ceiling below is derived from these two numbers; a layout change has
+    // to fail here rather than silently move the boundaries under the tests.
+    expect(retainedTransformSlotBytes).toBe(TRANSFORM_BYTES_PER_ROW);
+    expect(retainedTintSlotBytes).toBe(TINT_BYTES_PER_ROW);
+  });
+
+  test('accepts the last transform capacity the device can bind, and refuses the first growth past it', () => {
+    withGpuBufferUsage(() => {
+      const exact = createMockDevice();
+
+      createBundle().ensureCapacity(exact.device, instanceBytes, DEFAULT_ROW_CEILING * TRANSFORM_BYTES_PER_ROW, TINT_BYTES_PER_ROW);
+      expect(exact.sizes).toContain(DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE);
+
+      const over = createMockDevice();
+      const error = expectRefusal(
+        () => createBundle().ensureCapacity(over.device, instanceBytes, (DEFAULT_ROW_CEILING + 1) * TRANSFORM_BYTES_PER_ROW, TINT_BYTES_PER_ROW),
+        'retained group transform storage',
+      );
+
+      expect(error.message).toContain(String(DEFAULT_ROW_CEILING * 2));
+      expect(error.detail).toContain(String(DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE));
+
+      // Fail CLOSED across the whole call: not even the instance buffer, which
+      // is checked first today and would be representable on its own.
+      expect(over.sizes).toEqual([]);
+    });
+  });
+
+  test('bounds the tint storage on its own row width, not the transform one', () => {
+    withGpuBufferUsage(() => {
+      // Four bytes a row rather than 32, so the tint ceiling is eight times
+      // further out. It can never break first in lockstep growth — which is
+      // exactly why the two buffers grow independently here and need their own
+      // boundary.
+      const tintCeilingRows = DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE / TINT_BYTES_PER_ROW;
+      const exact = createMockDevice();
+
+      createBundle().ensureCapacity(exact.device, instanceBytes, TRANSFORM_BYTES_PER_ROW, tintCeilingRows * TINT_BYTES_PER_ROW);
+      expect(exact.sizes).toContain(DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE);
+
+      const over = createMockDevice();
+
+      expectRefusal(
+        () => createBundle().ensureCapacity(over.device, instanceBytes, TRANSFORM_BYTES_PER_ROW, (tintCeilingRows + 1) * TINT_BYTES_PER_ROW),
+        'retained group tint storage',
+      );
+      expect(over.sizes).toEqual([]);
+    });
+  });
+
+  test('takes whichever of the two limits binds first', () => {
+    withGpuBufferUsage(() => {
+      const ceilingRows = 2 ** 26 / TRANSFORM_BYTES_PER_ROW;
+      const bufferBound = {
+        maxBufferSize: 2 ** 26,
+        maxStorageBufferBindingSize: DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE,
+      } as Partial<GPUSupportedLimits>;
+      const bindingBound = {
+        maxBufferSize: DEFAULT_MAX_BUFFER_SIZE,
+        maxStorageBufferBindingSize: 2 ** 26,
+      } as Partial<GPUSupportedLimits>;
+
+      for (const limits of [bufferBound, bindingBound]) {
+        const accepted = createMockDevice(limits);
+
+        createBundle().ensureCapacity(accepted.device, instanceBytes, ceilingRows * TRANSFORM_BYTES_PER_ROW, TINT_BYTES_PER_ROW);
+        expect(accepted.sizes).toContain(2 ** 26);
+
+        const refused = createMockDevice(limits);
+
+        expectRefusal(
+          () => createBundle().ensureCapacity(refused.device, instanceBytes, (ceilingRows + 1) * TRANSFORM_BYTES_PER_ROW, TINT_BYTES_PER_ROW),
+          'retained group transform storage',
+        );
+        expect(refused.sizes).toEqual([]);
+      }
+    });
+  });
+
+  test('reads the limits of the device it is currently growing on', () => {
+    withGpuBufferUsage(() => {
+      const bundle = createBundle();
+      const generous = createMockDevice({
+        maxBufferSize: DEFAULT_MAX_BUFFER_SIZE * 8,
+        maxStorageBufferBindingSize: DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE * 8,
+      } as Partial<GPUSupportedLimits>);
+
+      bundle.ensureCapacity(generous.device, instanceBytes, DEFAULT_ROW_CEILING * 4 * TRANSFORM_BYTES_PER_ROW, TINT_BYTES_PER_ROW);
+      expect(generous.sizes).toContain(DEFAULT_MAX_STORAGE_BUFFER_BINDING_SIZE * 4);
+
+      // Device loss drops every buffer; the recovered device grants the defaults.
+      bundle.invalidateDeviceState(true);
+
+      const modest = createMockDevice(defaultLimits);
+
+      expectRefusal(
+        () => bundle.ensureCapacity(modest.device, instanceBytes, DEFAULT_ROW_CEILING * 4 * TRANSFORM_BYTES_PER_ROW, TINT_BYTES_PER_ROW),
+        'retained group transform storage',
+      );
+      expect(modest.sizes).toEqual([]);
+    });
+  });
+
+  test('leaves an ordinary growth structurally unchanged', () => {
+    withGpuBufferUsage(() => {
+      const mock = createMockDevice();
+
+      createBundle().ensureCapacity(mock.device, 1000, 100 * TRANSFORM_BYTES_PER_ROW, 100 * TINT_BYTES_PER_ROW);
+
+      // Power-of-two growth from 256 B: instance 1000 → 1024, transform
+      // 3200 → 4096, tint 400 → 512, plus the constant uniform block.
+      expect(mock.sizes).toEqual([1024, 4096, 512, 144]);
+    });
+  });
+});
+
+describe('persistent refusal falls onto a path that now fails loudly', () => {
+  test('a selection past the shared ceiling is refused by the store and thrown by the fallback', async () => {
+    const { WebGpuPersistentSlotStore } = await import('#rendering/webgpu/WebGpuPersistentSlotStore');
+
+    withGpuBufferUsage(() => {
+      const mock = createMockDevice();
+      const store = new WebGpuPersistentSlotStore();
+
+      store.connectDevice(mock.device, undefined as never);
+
+      // Step 1 (NEU-S1): the per-root store cannot represent the selection, so
+      // the plan puts the root back on the streamed path.
+      expect(store.canRepresent(DEFAULT_ROW_CEILING + 1, DEFAULT_ROW_CEILING + 1)).toBe(false);
+
+      // Step 2 (this fix): the streamed path needs the same rows in the
+      // frame-global shared storage, against the same ceiling — and says so
+      // instead of drawing nothing behind an uncaptured validation error.
+      expectRefusal(() => new WebGpuTransformStorage().reserve(mock.device, DEFAULT_ROW_CEILING + 1), 'shared transform storage');
+    });
+  });
+});


### PR DESCRIPTION
## Root cause

The persistent slot store answers `canRepresent` before it grows (#572), so a selection past the granted device limits falls back to the ordinary streamed path. That path carried the same unchecked ceiling.

Two classes allocate scene-sized `GPUBufferUsage.STORAGE` buffers and never consulted a device limit:

- `WebGpuTransformStorage._growBuffers` — the frame-global shared transform + tint storage.
- `WebGpuRetainedGroupBundle.ensureCapacity` (`WebGpuRetainedGroupResources.ts`) — the per-group retained transform + tint storage, which grow **independently** of each other, not in lockstep.

`storageBufferLimit` — the helper #572 introduced — existed only inside `WebGpuPersistentSlotStore`.

## Why it failed silently

All of these bindings bind the whole buffer, with no `offset`/`size` sub-range, so the binding size *is* the buffer size. Each is bounded by `min(maxBufferSize, maxStorageBufferBindingSize)` of the **granted** device limits. ExoJS requests neither, so every device runs on the WebGPU defaults: 256 MiB and 128 MiB.

At 32 bytes per transform row that puts the ceiling at **4 194 304 rows**. The next power-of-two growth asks for 8 388 608 rows = 268 435 456 bytes, and that size is *exactly* `maxBufferSize`:

```text
maxBufferSize               = 268435456
maxStorageBufferBindingSize = 134217728

2**27 bytes: createBuffer = ok    createBindGroup = ok
2**28 bytes: createBuffer = ok    createBindGroup = INVALID
  Binding size (268435456) is larger than the maximum
  storage buffer binding size (134217728).
```

So allocation succeeded, bind-group creation did not, and the failure surfaced as an uncaptured `GPUValidationError`: logged, deduplicated, dispatched to `onError` — while the frame drew nothing and the loop kept running. The consecutive-error counter deliberately does not apply to async render errors.

## Fix

Both classes now measure the capacity their **own** growth policy actually settles on — not the rows they were handed — against `min(maxBufferSize, maxStorageBufferBindingSize)` of the connected device, and throw before any `createBuffer`:

```
RenderError({ code: 'out-of-memory', backendType: WebGpu })
```

There is no further representation below these stores, so a fallback is not available and failing loudly is the honest contract — the same one WebGL2 has always had when its transform texture outgrows `MAX_TEXTURE_SIZE`. All four cells of the backend matrix are now fail-closed.

The diagnosis names the store, the rows requested, the capacity growth settles on, the bytes it needs, both granted limits and which one binds:

```text
[ExoJS] shared transform storage: growing to 8388608 rows needs a 268435456-byte
storage binding, over this device's granted maxStorageBufferBindingSize of 134217728.

Requested 4194305 rows; power-of-two growth settles on 8388608 rows (32 bytes each,
268435456 bytes total). Granted device limits: maxBufferSize 268435456,
maxStorageBufferBindingSize 134217728; maxStorageBufferBindingSize binds and caps
this store at 4194304 rows.
```

Fail-closed is literal: nothing is destroyed or created on the way to a refusal — not even the retained group's instance buffer, which is a vertex binding and representable on its own.

The limit lookup moves into a shared internal helper, `src/rendering/webgpu/webgpuStorageLimits.ts`, which the persistent store now imports. Three stores cannot drift apart on what the ceiling is.

## RED → GREEN

```text
RED    10 failed | 2 passed (12)
       every failure: "expected null to be an instance of RenderError"
       the 2 green ones are the "ordinary growth unchanged" tests — they pin
       the existing allocation sizes and had to stay green

GREEN  13 passed (13)
```

Pinned boundaries, per store and per row width:

| store | accepted | first refusal |
|---|---|---|
| shared transform | 4 194 304 rows (`2**27` B) | 4 194 305 → growth to **8 388 608** rows / `2**28` B |
| shared tint | same rows, own byte width | own check; never binds first today |
| retained transform | 4 194 304 rows | 4 194 305 |
| retained tint | 33 554 432 rows | 33 554 433 — its **own** ceiling |

Also pinned: exactly on the boundary is accepted; `createBuffer` is not called for an invalid growth; a smaller `maxBufferSize` binds and is named; a smaller `maxStorageBufferBindingSize` binds and is named; a device exposing no `limits` falls back to the spec defaults; a store re-reads the limits of the device it is currently growing on after device loss; and both ordinary growths are pinned to their exact size lists (`[32768, 4096]` and `[1024, 4096, 512, 144]`) so a guard cannot quietly change what gets allocated.

One test walks the whole chain: persistent store refuses the selection → the ordinary path needs the same rows against the same ceiling → it throws instead of drawing nothing.

## Not changed

`requiredLimits` / `requestDevice`, adapter maxima, power-of-two growth, persistent paging or sharding, frame chunking, WebGL2, `NEU-S4`, mobile policies, assets, renderer batching. The only touch outside the two finding sites is removing the now-duplicated `storageBufferLimit` copy from the persistent store, which is the shared contract this cut is about.

## Gates

| gate | result |
|---|---|
| targeted storage-limit test | 13 passed |
| `pnpm test:core` | 401 files / 6 803 tests passed |
| `pnpm test` (all node lanes) | 536 passed, 1 skipped / 9 860 tests |
| `pnpm verify:quick` | all 12 gates passed |
| `pnpm test:browser:webgpu` | 355 tests passed |

One re-run of the WebGPU lane hit `webgpu-video.test.ts` with `timed out waiting for video.play() (videoWidth=0, readyState=0)`. Classified in isolation before attributing it: the file passes on its own (2/2), and this diff touches neither the video nor the texture-upload path. Flake.
