### PR TITLE
fix(tooling): read guide code fences wherever CommonMark puts them

### DIFF
--- a/scripts/check-guide-no-check-reasons.ts
+++ b/scripts/check-guide-no-check-reasons.ts
@@ -29,13 +29,9 @@
  * This does not replace `extract-guide-snippets.ts`'s own `no-check` handling
  * (a plain `meta.includes('no-check')` check) - a reason sits right after
  * `no-check` on the same fence-meta line without breaking that check, so no
- * change there is needed or made. This script re-parses the same fences
- * independently (mirroring `extract-guide-snippets.ts`'s own `CHECKED_LANGS` +
- * `FENCE_RE`) rather than importing from the extractor, so the count matches
- * what that script actually processes - NOT a raw text grep, which also
- * matches fences the extractor cannot see at all (`FENCE_RE` anchors
- * `` ^``` `` at column 0, so a list-indented fence is invisible to both the
- * extractor and this gate) - and so this gate can run standalone, before the
+ * change there is needed or made. This script scans the fences itself, through
+ * the same `parseFences` the extractor uses, so the count matches what that
+ * script actually processes and this gate can still run standalone, before the
  * much heavier extraction + typecheck pass.
  */
 import { readdirSync, readFileSync } from 'node:fs';
@@ -49,6 +45,7 @@ import {
   writePartialBaseline,
   type BaselineDiff,
 } from './guide-partial-baseline.ts';
+import { parseFences } from './guide-fences.ts';
 
 const REPO_ROOT = join(import.meta.dirname, '..');
 const GUIDE_DIR = join(REPO_ROOT, 'site', 'src', 'content', 'guide');
@@ -66,10 +63,9 @@ const BASELINE_NOTE =
   `Run \`${UPDATE_COMMAND}\` to record a decrease (adding a reason, or removing the block, both shrink it). ` +
   'A guide with no such blocks is absent from this file.';
 
-// Mirrors extract-guide-snippets.ts's own fence scan (CHECKED_LANGS + FENCE_RE)
-// exactly, so the count here matches what that script actually processes.
+// Mirrors extract-guide-snippets.ts's own language filter, so the count here
+// matches what that script actually processes.
 const CHECKED_LANGS = new Set(['ts', 'tsx', 'typescript', 'js', 'javascript']);
-const FENCE_RE = /^```(?<lang>[a-zA-Z]+)?(?<meta>[^\n]*)?\n(?<body>[\s\S]*?)^```/gm;
 
 // A reason is anything non-whitespace after `no-check`, once an optional
 // `--` / `:` / em-dash separator is stripped: ```ts no-check -- pseudo-code```
@@ -111,10 +107,7 @@ function scanGuide(): NoCheckBlock[] {
     const content = readFileSync(file, 'utf8');
     const rel = relative(GUIDE_DIR, file).replaceAll('\\', '/');
 
-    for (const match of content.matchAll(FENCE_RE)) {
-      const lang = (match.groups?.lang ?? '').toLowerCase();
-      const meta = match.groups?.meta ?? '';
-
+    for (const { lang, meta } of parseFences(content)) {
       if (!CHECKED_LANGS.has(lang) || !meta.includes('no-check')) continue;
 
       const reason = (NO_CHECK_REASON_RE.exec(meta)?.[1] ?? '').trim();

--- a/scripts/extract-guide-snippets.ts
+++ b/scripts/extract-guide-snippets.ts
@@ -97,6 +97,7 @@ import {
   readPartialBaseline,
   writePartialBaseline,
 } from './guide-partial-baseline.ts';
+import { parseFences } from './guide-fences.ts';
 
 const REPO_ROOT = join(import.meta.dirname, '..');
 const GUIDE_DIR = join(REPO_ROOT, 'site', 'src', 'content', 'guide');
@@ -128,10 +129,6 @@ function isInScope(rel: string): boolean {
 }
 
 const CHECKED_LANGS = new Set(['ts', 'tsx', 'typescript', 'js', 'javascript']);
-
-// Matches a fenced code block. Group "lang" = language tag, "meta" = rest of
-// the opening fence line, "body" = the block content (without the fences).
-const FENCE_RE = /^```(?<lang>[a-zA-Z]+)?(?<meta>[^\n]*)?\n(?<body>[\s\S]*?)^```/gm;
 
 // Bare-method prefixes that indicate a snippet is a class method body shown
 // without its enclosing class — these snippets cannot be compiled standalone
@@ -771,11 +768,7 @@ for (const file of files) {
   const allCodeBodies: string[] = [];
   bareMemberCounter = 0;
 
-  for (const match of content.matchAll(FENCE_RE)) {
-    const lang = (match.groups?.lang ?? '').toLowerCase();
-    const meta = match.groups?.meta ?? '';
-    const body = match.groups?.body ?? '';
-
+  for (const { lang, meta, body } of parseFences(content)) {
     if (!CHECKED_LANGS.has(lang)) continue;
 
     allCodeBodies.push(body);

--- a/scripts/guide-fences.ts
+++ b/scripts/guide-fences.ts
@@ -1,0 +1,60 @@
+/**
+ * Fenced-code-block scanner shared by the guide snippet extractor and the
+ * `no-check` budget that counts through it.
+ *
+ * A fence is matched wherever CommonMark allows one, not only in column 0: a
+ * block written inside a list item carries the item's indentation, and a
+ * scanner anchored to column 0 skips it entirely. Such a block is unchecked by
+ * `typecheck:guides` and absent from the budget that bounds what is unchecked,
+ * so it is invisible in both directions.
+ *
+ * The closing fence must repeat the indentation of its opening fence. Without
+ * that, an indented fence pair sitting inside a wider block would close the
+ * outer block early and the remainder of its body would be read as prose.
+ */
+
+export interface GuideFence {
+  /** Language tag of the opening fence, lowercase-preserving, `''` when absent. */
+  readonly lang: string;
+  /** Rest of the opening fence line after the language tag, e.g. `' no-check'`. */
+  readonly meta: string;
+  /** Block content with the fence indentation removed from every line. */
+  readonly body: string;
+  /** Leading whitespace the fence pair is written at. */
+  readonly indent: string;
+}
+
+const FENCE_RE = /^(?<indent>[ \t]*)```(?<lang>[a-zA-Z]+)?(?<meta>[^\n]*)?\n(?<body>[\s\S]*?)^\k<indent>```/gm;
+
+/**
+ * Removes the fence indentation from each body line. A line shorter than the
+ * indentation (a blank line inside an indented block is usually written as a
+ * genuinely empty line) is left as it is rather than being reported as a
+ * malformed block.
+ */
+function dedent(body: string, indent: string): string {
+  if (indent === '') return body;
+
+  return body
+    .split('\n')
+    .map(line => (line.startsWith(indent) ? line.slice(indent.length) : line))
+    .join('\n');
+}
+
+/** Every fenced code block in `content`, in source order. */
+export function parseFences(content: string): GuideFence[] {
+  const fences: GuideFence[] = [];
+
+  for (const match of content.matchAll(FENCE_RE)) {
+    const indent = match.groups?.indent ?? '';
+
+    fences.push({
+      lang: (match.groups?.lang ?? '').toLowerCase(),
+      meta: match.groups?.meta ?? '',
+      body: dedent(match.groups?.body ?? '', indent),
+      indent,
+    });
+  }
+
+  return fences;
+}

--- a/scripts/guide-no-check-baseline.json
+++ b/scripts/guide-no-check-baseline.json
@@ -4,7 +4,7 @@
     "assets/aseprite.mdx": 6,
     "assets/ldtk.mdx": 9,
     "assets/loading-and-resources.mdx": 5,
-    "assets/tiled-maps.mdx": 11,
+    "assets/tiled-maps.mdx": 13,
     "audio/audio-basics.mdx": 1,
     "audio/audio-effects.mdx": 1,
     "audio/spatial-audio.mdx": 1,

--- a/test/site/guide-fences.test.ts
+++ b/test/site/guide-fences.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for scripts/guide-fences.ts - the fenced-code-block scanner the guide
+ * extractor and the `no-check` budget both count through.
+ *
+ * The property that matters here is that a fence is recognized wherever
+ * CommonMark puts one, not only in column 0: a block nested in a list item is
+ * indented, and a scanner anchored to column 0 reports such a guide as having
+ * fewer code blocks than it has. That undercount is invisible in both
+ * directions - the block never reaches `typecheck:guides`, and it never
+ * appears in the budget that claims to bound what is unchecked.
+ */
+
+import { parseFences } from '../../scripts/guide-fences';
+
+describe('parseFences', () => {
+  test('reads a fence in column 0', () => {
+    const fences = parseFences(['```ts', 'const a = 1;', '```'].join('\n'));
+
+    expect(fences).toEqual([{ lang: 'ts', meta: '', body: 'const a = 1;\n', indent: '' }]);
+  });
+
+  test('reads a fence indented inside a list item', () => {
+    const content = ['- a list item:', '', '  ```js no-check', '  const a = 1;', '  ```'].join('\n');
+
+    expect(parseFences(content)).toEqual([{ lang: 'js', meta: ' no-check', body: 'const a = 1;\n', indent: '  ' }]);
+  });
+
+  test('strips the fence indentation from every body line', () => {
+    const content = ['  ```ts', '  if (a) {', '    b();', '  }', '  ```'].join('\n');
+
+    expect(parseFences(content)[0]?.body).toBe('if (a) {\n  b();\n}\n');
+  });
+
+  test('leaves a body line that is shorter than the indentation alone', () => {
+    const content = ['  ```ts', '  const a = 1;', '', '  const b = 2;', '  ```'].join('\n');
+
+    expect(parseFences(content)[0]?.body).toBe('const a = 1;\n\nconst b = 2;\n');
+  });
+
+  test('a closing fence must carry the indentation of its opening fence', () => {
+    // An outer column-0 block whose body contains an indented fence pair: the
+    // inner fences must not terminate the outer block, or one block is read as
+    // two and the second one's body is prose.
+    const content = ['```md', 'prose', '  ```ts', '  const a = 1;', '  ```', 'more prose', '```'].join('\n');
+
+    const fences = parseFences(content);
+
+    expect(fences).toHaveLength(1);
+    expect(fences[0]?.lang).toBe('md');
+  });
+
+  test('reads consecutive blocks at different indentations', () => {
+    const content = ['```ts', 'const a = 1;', '```', '', '- item:', '', '  ```tsx', '  const b = 2;', '  ```'].join('\n');
+
+    expect(parseFences(content).map(fence => fence.lang)).toEqual(['ts', 'tsx']);
+  });
+
+  test('carries the meta of an indented fence, so `no-check` still counts', () => {
+    const content = ['  ```ts no-check', '  partial();', '  ```'].join('\n');
+
+    expect(parseFences(content)[0]?.meta).toContain('no-check');
+  });
+
+  test('reads a fence with no language tag', () => {
+    const fences = parseFences(['```', 'plain', '```'].join('\n'));
+
+    expect(fences).toEqual([{ lang: '', meta: '', body: 'plain\n', indent: '' }]);
+  });
+
+  test('ignores an unterminated fence', () => {
+    expect(parseFences(['```ts', 'const a = 1;'].join('\n'))).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes `NEU-T2` from the review master, the one item there whose batch entry carried "no decision needed".

## The defect

The guide extractor's fence scan anchored ` ``` ` to column 0, so a code block written inside a list item was invisible to it. Two such blocks sit in `assets/tiled-maps.mdx`, one of the integration guides with the highest foreign-format density.

They were unseen in both directions at once:

- never extracted, so `typecheck:guides` never compiled them;
- never counted, so the `no-check` budget claimed a coverage it did not have over exactly that file.

The gap between the raw grep count (76) and the extracted count (74) was precisely these two.

## The fix

The scan moves into `scripts/guide-fences.ts` and both callers use it. That also removes the deliberate duplication between the extractor and the `no-check` gate: the gate re-parsed the fences itself to stay runnable before the heavy extraction pass, and mirrored the defect while doing so.

Two properties the shared scanner has to hold:

- **A closing fence repeats the indentation of its opening fence.** Otherwise an indented pair nested inside a wider block closes the outer one early and the remainder of its body reads as prose.
- **Body lines lose the fence indentation**, so an indented block that becomes checkable later compiles as written.

## Budget

The `no-check` budget rises from 74 to 76, `assets/tiled-maps.mdx` from 11 to 13.

That is recovered coverage becoming visible, not new unchecked code: both blocks already carried `no-check` and neither was ever in scope before. The raw grep count and the extracted count now agree at 76.

## Verification

RED before the implementation - 9 cases in `test/site/guide-fences.test.ts` against a module that did not exist yet - and RED again at the gate itself once both callers shared the scanner (74 -> 76, `assets/tiled-maps.mdx` 11 -> 13) before the budget was raised.

`pnpm verify:quick` - all 13 gates pass. `pnpm typecheck:guides` green at 262 snippet files.
