### PR TITLE
test(rendering): pin and instrument the retained capture-margin contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,8 @@
     "perf:renderers:browser": "vitest run --project=browser-webgl-chromium webgl2-renderer-perf",
     "perf:renderers:alloc": "node --conditions=@codexo/exojs-source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-allocation.ts",
     "perf:renderers:alloc:cell": "node --conditions=@codexo/exojs-source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-allocation-cell.ts",
+    "perf:renderers:cull-margin": "node --conditions=@codexo/exojs-source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-cull-margin.ts",
+    "perf:renderers:cull-margin:cell": "node --expose-gc --max-old-space-size=8192 --conditions=@codexo/exojs-source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-cull-margin-cell.ts",
     "perf:renderers:bootstrap": "node --conditions=@codexo/exojs-source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-bootstrap-allocation.ts",
     "perf:renderers:bootstrap:cell": "node --expose-gc --max-old-space-size=8192 --conditions=@codexo/exojs-source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-bootstrap-cell.ts",
     "perf:bench:rendering": "tsx test/perf/rendering-benchmark.ts",

--- a/packages/exojs-bench/src/rendering/adapters/exojs.ts
+++ b/packages/exojs-bench/src/rendering/adapters/exojs.ts
@@ -211,8 +211,8 @@ const buildViewGrid = (count: number): View[] => {
  * The calibration arms exist because `RETAINED_CULL_MARGIN_RATIO` is a module
  * constant in the engine: sweeping it would otherwise mean one source edit and
  * one build per point, which is not a comparison. The arm patches the builder's
- * private inflation step instead — the harness page imports engine SOURCE
- * through the `#` alias, so the same object the engine uses is reachable — and
+ * private inflation step instead - the harness page imports engine SOURCE
+ * through the `#` alias, so the same object the engine uses is reachable - and
  * every other arm, the production default included, is left untouched.
  */
 export type ExoJsAdapterConfig = 'current' | 'retained' | `cull-margin-${string}`;

--- a/packages/exojs-bench/src/rendering/adapters/exojs.ts
+++ b/packages/exojs-bench/src/rendering/adapters/exojs.ts
@@ -6,6 +6,7 @@ import { Geometry } from '#rendering/geometry/Geometry';
 import { ShaderSource } from '#rendering/material/ShaderSource';
 import { SpriteMaterial } from '#rendering/material/SpriteMaterial';
 import { Mesh } from '#rendering/mesh/Mesh';
+import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import { RenderBatch } from '#rendering/RenderBatch';
 import { RetainedContainer } from '#rendering/RetainedContainer';
@@ -201,11 +202,70 @@ const buildViewGrid = (count: number): View[] => {
  * sequence (`resetStats(); clear(); rendering.render(root); flush()`) is
  * identical on both, so only {@link init} branches on the backend type.
  */
-/** Which ExoJS arm this adapter represents: today's default path, or the Slice-2 RetainedContainer spine. */
-export type ExoJsAdapterConfig = 'current' | 'retained';
+/**
+ * Which ExoJS arm this adapter represents: today's default path, the Slice-2
+ * RetainedContainer spine, or a calibration arm that overrides the retained
+ * capture margin (`cull-margin-<numerator>_<denominator>`, e.g.
+ * `cull-margin-1_8`).
+ *
+ * The calibration arms exist because `RETAINED_CULL_MARGIN_RATIO` is a module
+ * constant in the engine: sweeping it would otherwise mean one source edit and
+ * one build per point, which is not a comparison. The arm patches the builder's
+ * private inflation step instead — the harness page imports engine SOURCE
+ * through the `#` alias, so the same object the engine uses is reachable — and
+ * every other arm, the production default included, is left untouched.
+ */
+export type ExoJsAdapterConfig = 'current' | 'retained' | `cull-margin-${string}`;
+
+/** `cull-margin-1_8` -> `0.125`; anything else -> `null`. */
+const parseCullMarginConfig = (config: string): number | null => {
+  const match = /^cull-margin-(\d+)_(\d+)$/.exec(config);
+
+  if (match === null) {
+    return null;
+  }
+
+  const denominator = Number(match[2]);
+
+  return denominator === 0 ? null : Number(match[1]) / denominator;
+};
+
+/** Builder internals the calibration arm reaches into; `private` is compile-time only. */
+interface CullRectInternals {
+  _captureCullRect: { set(x: number, y: number, width: number, height: number): void };
+  _captureCullActive: boolean;
+  _inflateCaptureCullRect(view: View): void;
+}
+
+const defaultInflateCullRect = (RenderPlanBuilder.prototype as unknown as CullRectInternals)._inflateCaptureCullRect;
+
+/**
+ * Point every capture and every indexed selection at a cull rect grown by
+ * `ratio` per side, or back at the engine's own constant when `ratio` is `null`.
+ * Called on every `init` so an arm never inherits the previous arm's override.
+ */
+const applyCullMarginOverride = (ratio: number | null): void => {
+  const prototype = RenderPlanBuilder.prototype as unknown as CullRectInternals;
+
+  if (ratio === null) {
+    prototype._inflateCaptureCullRect = defaultInflateCullRect;
+
+    return;
+  }
+
+  prototype._inflateCaptureCullRect = function inflate(this: CullRectInternals, view: View): void {
+    const rect = view.getBounds();
+    const marginX = rect.width * ratio;
+    const marginY = rect.height * ratio;
+
+    this._captureCullRect.set(rect.x - marginX, rect.y - marginY, rect.width + 2 * marginX, rect.height + 2 * marginY);
+    this._captureCullActive = true;
+  };
+};
 
 export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: ExoJsAdapterConfig = 'current'): EngineAdapter => {
   const supported: readonly Backend[] = backendFilter ?? ['webgl2', 'webgpu'];
+  const cullMargin = parseCullMarginConfig(config);
 
   let app: Application | null = null;
   let root: Container | null = null;
@@ -304,6 +364,10 @@ export const createExoJsAdapter = (backendFilter?: readonly Backend[], config: E
       if (!supported.includes(backend)) {
         throw new Error(`The exojs adapter was not configured for the '${backend}' backend.`);
       }
+
+      // Per `init` rather than per module load: arms share the page, so an arm
+      // that does not override has to actively restore the engine's own margin.
+      applyCullMarginOverride(cullMargin);
 
       const instance = new Application({
         canvas: { element: canvas, width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT, pixelRatio: 1 },

--- a/packages/exojs-bench/src/rendering/driver.ts
+++ b/packages/exojs-bench/src/rendering/driver.ts
@@ -165,6 +165,26 @@ const ADAPTER_CAPABILITIES: readonly EngineAdapter[] = [
 ];
 
 /**
+ * Opt-in calibration arms for the retained capture margin: identical to
+ * `exojs current` except for the ratio the retention layer grows its cull rect
+ * by (see `ExoJsAdapterConfig`).
+ *
+ * Deliberately NOT in {@link ADAPTER_CAPABILITIES}: they answer an engine-tuning
+ * question, not a cross-library one, and folding them into the default matrix
+ * would silently redefine what a reportable run covers. They enter the matrix
+ * only when `--config` names them, and they cover only the archetypes with real
+ * off-screen content - on a fully-visible scene the margin cannot change the
+ * selected set, so an arm there would just duplicate `current`.
+ */
+const CALIBRATION_CAPABILITIES: readonly EngineAdapter[] = ['1_32', '1_16', '3_32', '1_8', '3_16', '1_4'].map(ratio =>
+  capabilityDescriptor('exojs', `cull-margin-${ratio}`, ['webgl2', 'webgpu'], spec => isScrolling(spec)),
+);
+
+/** The calibration arms this invocation explicitly asked for, if any. */
+const requestedCalibrationArms = (selection: MatrixSelection | undefined): readonly EngineAdapter[] =>
+  selection?.configs === undefined ? [] : CALIBRATION_CAPABILITIES.filter(adapter => selection.configs!.includes(adapter.config));
+
+/**
  * Starts a programmatic Vite dev server rooted at the matrix harness page.
  *
  * Thin wrapper over the shared factory in `shared/viteServer.ts` - the Vite
@@ -791,7 +811,7 @@ export const runMatrix = async (options: {
 }): Promise<MatrixOutcome> => {
   const engineVersion = readEngineVersion();
   const libraries = readLibraryProvenance(LIBRARY_ARMS);
-  const allCells = buildMatrix(ADAPTER_CAPABILITIES, options.backends);
+  const allCells = buildMatrix([...ADAPTER_CAPABILITIES, ...requestedCalibrationArms(options.selection)], options.backends);
   const filtered = options.filter ? applyFilter(allCells, options.filter) : allCells;
   const selected = options.selection ? applySelection(filtered, options.selection) : filtered;
   const cells = options.timedFramesOverride === undefined ? selected : selected.map(cell => ({ ...cell, timedFrames: options.timedFramesOverride! }));

--- a/packages/exojs-bench/src/rendering/page/harness.ts
+++ b/packages/exojs-bench/src/rendering/page/harness.ts
@@ -471,7 +471,10 @@ const resolveAdapter = async (engine: string, config: string): Promise<EngineAda
   let adapter: EngineAdapter;
 
   if (engine === 'exojs') {
-    adapter = createExoJsAdapter(undefined, config === 'retained' ? 'retained' : 'current');
+    // `cull-margin-*` arms are calibration arms and carry their ratio in the
+    // config label itself, so the label is passed through rather than folded to
+    // one of the two named arms (see `ExoJsAdapterConfig`).
+    adapter = createExoJsAdapter(undefined, config === 'retained' || config.startsWith('cull-margin-') ? (config as 'retained') : 'current');
   } else if (engine === 'pixi') {
     const { createPixiAdapter } = await import('../adapters/pixi');
 

--- a/test/perf/rendering/capture-kept-bounds.test.ts
+++ b/test/perf/rendering/capture-kept-bounds.test.ts
@@ -1,0 +1,155 @@
+/**
+ * The capture tier's SECOND view tolerance — the one the capture cull rect
+ * cannot express.
+ *
+ * `RetainedRootRepresentation.isCleanIgnoringTransform` accepts a moved view two
+ * ways. The first is the capture margin: the view still fits the rect the
+ * capture culled against. The second is `_keptBounds` — nothing was culled and
+ * the view still contains every kept node — and it exists for the case the first
+ * one structurally cannot cover: a view that GREW past the capture rect.
+ *
+ * That distinction decides what the two fields are. `_keptBounds` / `_keptEmpty`
+ * only ever ADMIT more views, so removing them would cost replays and never
+ * pixels: they are an optimisation. `_culledDuringCapture` is what gates them,
+ * and it is not: with it forced to `false`, a capture that dropped a node would
+ * replay under a view that admits that node again, and the node would be missing
+ * from the frame with nothing to notice it. The tests below assert both halves,
+ * so neither field can be removed on the strength of a summary of what they do.
+ *
+ * The indexed slot tier is refused here on purpose: it sits above the capture
+ * tier and answers a zoom-out with a re-selection, which would hide the very
+ * decision under test.
+ *
+ * @internal Test/perf-only.
+ */
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { Container } from '#rendering/Container';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import type { ServedBy } from './cullMarginProbe';
+import { beginProbeFrame, endProbeFrame, installTierProbe, refusePersistentSlots } from './cullMarginProbe';
+import { makeTextures } from './fixtures';
+import type { WebGl2Harness } from './harness';
+import { createWebGl2Harness } from './harness';
+
+refusePersistentSlots(WebGl2Backend.prototype);
+installTierProbe();
+
+const VIEW_WIDTH = 800;
+const VIEW_HEIGHT = 600;
+
+const live: Array<{ harness: WebGl2Harness; root: Container }> = [];
+
+/**
+ * A handful of sprites clustered in the middle of the view, plus — when asked —
+ * one far enough away that the capturing collect has to drop it.
+ */
+const openScene = (withOffscreen: boolean): { harness: WebGl2Harness; root: Container } => {
+  const harness = createWebGl2Harness({ width: VIEW_WIDTH, height: VIEW_HEIGHT });
+  const textures = makeTextures(1, 16);
+  const root = new Container();
+
+  root.cullable = true;
+
+  for (let index = 0; index < 8; index++) {
+    const sprite = new Sprite(textures[0]!);
+
+    sprite.cullable = true;
+    sprite.setPosition(300 + index * 20, 280);
+    root.addChild(sprite);
+  }
+
+  if (withOffscreen) {
+    const far = new Sprite(textures[0]!);
+
+    far.cullable = true;
+    far.setPosition(40_000, 40_000);
+    root.addChild(far);
+  }
+
+  harness.view.reset(VIEW_WIDTH / 2, VIEW_HEIGHT / 2, VIEW_WIDTH, VIEW_HEIGHT);
+  live.push({ harness, root });
+
+  return { harness, root };
+};
+
+const render = (harness: WebGl2Harness, root: Container): { submitted: number; servedBy: ServedBy } => {
+  const { backend } = harness;
+
+  beginProbeFrame();
+  backend.resetStats();
+  backend.clear();
+  root.render(backend);
+  backend.flush();
+
+  return { submitted: backend.stats.submittedNodes, servedBy: endProbeFrame(root) };
+};
+
+/** Whether the capture's own cull rect could still be carrying the frame. */
+const viewFitsCaptureRect = (root: Container): boolean => {
+  const representation = (root as unknown as { _retainedRootRepresentation(): unknown })._retainedRootRepresentation() as {
+    _captureCullRect: { containsRect(rect: unknown): boolean };
+    _hasCaptureCullRect: boolean;
+  };
+
+  return representation._hasCaptureCullRect;
+};
+
+afterEach(() => {
+  for (const { harness, root } of live.splice(0)) {
+    root.destroy();
+    harness.destroy();
+  }
+});
+
+describe('capture reuse when nothing was culled', () => {
+  test('a zoom-out past the capture rect still replays when the capture culled nothing', () => {
+    const { harness, root } = openScene(false);
+
+    render(harness, root);
+    render(harness, root);
+    render(harness, root);
+
+    expect(viewFitsCaptureRect(root)).toBe(true);
+
+    // Four times the view on each axis: far outside any margin the builder
+    // grows the capture rect by, so only the kept-bounds rule can accept it.
+    harness.view.setZoom(0.25);
+
+    const zoomed = render(harness, root);
+
+    expect(zoomed.servedBy).toBe('captureReplay');
+    expect(zoomed.submitted).toBe(8);
+  });
+
+  test('the same zoom-out does NOT replay when the capture dropped a node', () => {
+    const { harness, root } = openScene(true);
+
+    render(harness, root);
+    render(harness, root);
+    render(harness, root);
+
+    harness.view.setZoom(0.25);
+
+    const zoomed = render(harness, root);
+
+    expect(zoomed.servedBy).not.toBe('captureReplay');
+    expect(zoomed.submitted).toBe(8);
+  });
+
+  test('a zoom-out far enough to admit the dropped node draws it', () => {
+    const { harness, root } = openScene(true);
+
+    render(harness, root);
+    render(harness, root);
+    render(harness, root);
+
+    // The far sprite sits at (40000, 40000); a view wide enough to reach it must
+    // draw all nine, which is only possible because the capture was refused.
+    harness.view.reset(20_000, 20_000, 100_000, 100_000);
+
+    expect(render(harness, root).submitted).toBe(9);
+  });
+});

--- a/test/perf/rendering/capture-kept-bounds.test.ts
+++ b/test/perf/rendering/capture-kept-bounds.test.ts
@@ -1,11 +1,11 @@
 /**
- * The capture tier's SECOND view tolerance — the one the capture cull rect
+ * The capture tier's SECOND view tolerance - the one the capture cull rect
  * cannot express.
  *
  * `RetainedRootRepresentation.isCleanIgnoringTransform` accepts a moved view two
  * ways. The first is the capture margin: the view still fits the rect the
- * capture culled against. The second is `_keptBounds` — nothing was culled and
- * the view still contains every kept node — and it exists for the case the first
+ * capture culled against. The second is `_keptBounds` - nothing was culled and
+ * the view still contains every kept node - and it exists for the case the first
  * one structurally cannot cover: a view that GREW past the capture rect.
  *
  * That distinction decides what the two fields are. `_keptBounds` / `_keptEmpty`
@@ -43,7 +43,7 @@ const VIEW_HEIGHT = 600;
 const live: Array<{ harness: WebGl2Harness; root: Container }> = [];
 
 /**
- * A handful of sprites clustered in the middle of the view, plus — when asked —
+ * A handful of sprites clustered in the middle of the view, plus - when asked -
  * one far enough away that the capturing collect has to drop it.
  */
 const openScene = (withOffscreen: boolean): { harness: WebGl2Harness; root: Container } => {

--- a/test/perf/rendering/cull-margin-correctness.test.ts
+++ b/test/perf/rendering/cull-margin-correctness.test.ts
@@ -1,6 +1,6 @@
 /**
  * The retention tiers must answer every camera operation with the set of nodes
- * the view actually contains — not just the small continuous step the capture
+ * the view actually contains - not just the small continuous step the capture
  * margin is tuned for.
  *
  * The margin makes a capture (and an indexed selection) valid for a RANGE of
@@ -13,7 +13,7 @@
  *
  * - **The tier is right.** An operation that leaves the valid range must NOT be
  *   answered by a replay. This is the one a stale product fails, and it is
- *   exact — the probe reads which branch the builder took, not a symptom.
+ *   exact - the probe reads which branch the builder took, not a symptom.
  * - **The set is complete.** The frame must submit at least every leaf whose
  *   quad meets the view, computed analytically from the scene's own layout. The
  *   tiers may legitimately submit MORE (a node that has left the view since the
@@ -114,7 +114,7 @@ const cold = (ops: readonly CameraOp[]): FrameResult => {
   return render(fixture);
 };
 
-/** Every leaf whose quad meets `harness`'s current view — the floor no tier may fall below. */
+/** Every leaf whose quad meets `harness`'s current view - the floor no tier may fall below. */
 const analyticVisible = (harness: WebGl2Harness): number => {
   const columns = Math.max(1, Math.ceil(Math.sqrt(NODE_COUNT)));
   const rows = Math.max(1, Math.ceil(NODE_COUNT / columns));

--- a/test/perf/rendering/cull-margin-correctness.test.ts
+++ b/test/perf/rendering/cull-margin-correctness.test.ts
@@ -1,0 +1,289 @@
+/**
+ * The retention tiers must answer every camera operation with the set of nodes
+ * the view actually contains — not just the small continuous step the capture
+ * margin is tuned for.
+ *
+ * The margin makes a capture (and an indexed selection) valid for a RANGE of
+ * views rather than for one, and every tier reasons about that range
+ * geometrically. A camera cut, a zoom, a resize or a rotation leaves that range
+ * in ways a small pan does not, and the failure mode is silent: a stale product
+ * replays, a node that entered the view is never drawn, and nothing throws.
+ *
+ * Two properties per operation, and they are different claims:
+ *
+ * - **The tier is right.** An operation that leaves the valid range must NOT be
+ *   answered by a replay. This is the one a stale product fails, and it is
+ *   exact — the probe reads which branch the builder took, not a symptom.
+ * - **The set is complete.** The frame must submit at least every leaf whose
+ *   quad meets the view, computed analytically from the scene's own layout. The
+ *   tiers may legitimately submit MORE (a node that has left the view since the
+ *   capture is drawn and clipped), never fewer.
+ *
+ * Deliberately not a margin-VALUE test: nothing here encodes `1/16`. The
+ * boundary cases derive their distances from the ratio the builder actually
+ * culls with, so the file keeps its teeth through a recalibration.
+ *
+ * @internal Test/perf-only.
+ */
+import { afterEach, describe, expect, test } from 'vitest';
+
+import type { ServedBy } from './cullMarginProbe';
+import { beginProbeFrame, buildScrollingWorld, endProbeFrame, installTierProbe, SCROLLING_WORLD, VIEWPORT_HEIGHT, VIEWPORT_WIDTH } from './cullMarginProbe';
+import type { WebGl2Harness } from './harness';
+import { createWebGl2Harness } from './harness';
+
+const NODE_COUNT = 4000;
+const SPEED = SCROLLING_WORLD.cameraSpeed;
+const SPAN = SCROLLING_WORLD.worldSpan;
+const GRID_MARGIN = 32;
+const SPRITE_SIZE = 8;
+/** Frames of ordinary scrolling before the operation under test. */
+const WARMUP = 40;
+
+installTierProbe();
+
+interface Fixture {
+  readonly harness: WebGl2Harness;
+  readonly scene: ReturnType<typeof buildScrollingWorld>;
+}
+
+const live: Fixture[] = [];
+
+const openScene = (): Fixture => {
+  const harness = createWebGl2Harness({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT });
+  const fixture = { harness, scene: buildScrollingWorld(harness, NODE_COUNT, SPEED, SPAN) };
+
+  live.push(fixture);
+
+  return fixture;
+};
+
+interface FrameResult {
+  readonly submitted: number;
+  readonly servedBy: ServedBy;
+}
+
+const render = ({ harness, scene }: Fixture): FrameResult => {
+  const { backend } = harness;
+
+  beginProbeFrame();
+  backend.resetStats();
+  backend.clear();
+  scene.root.render(backend);
+  backend.flush();
+
+  return { submitted: backend.stats.submittedNodes, servedBy: endProbeFrame(scene.root) };
+};
+
+/** One camera mutation applied to a view. */
+type CameraOp = (harness: WebGl2Harness) => void;
+
+/**
+ * Run `ops` on a root that has been retaining for {@link WARMUP} frames of
+ * ordinary scrolling, rendering after each one, and report the last frame.
+ */
+const warm = (ops: readonly CameraOp[]): FrameResult => {
+  const fixture = openScene();
+
+  for (let frame = 0; frame < WARMUP; frame++) {
+    fixture.scene.step(frame);
+    render(fixture);
+  }
+
+  let result = render(fixture);
+
+  for (const op of ops) {
+    op(fixture.harness);
+    result = render(fixture);
+  }
+
+  return result;
+};
+
+/**
+ * The same view, reached by a root with no history: `ops` are applied without
+ * rendering between them, so only the final camera state is ever drawn.
+ */
+const cold = (ops: readonly CameraOp[]): FrameResult => {
+  const fixture = openScene();
+
+  for (const op of ops) {
+    op(fixture.harness);
+  }
+
+  return render(fixture);
+};
+
+/** Every leaf whose quad meets `harness`'s current view — the floor no tier may fall below. */
+const analyticVisible = (harness: WebGl2Harness): number => {
+  const columns = Math.max(1, Math.ceil(Math.sqrt(NODE_COUNT)));
+  const rows = Math.max(1, Math.ceil(NODE_COUNT / columns));
+  const cellWidth = (VIEWPORT_WIDTH * SPAN - 2 * GRID_MARGIN) / columns;
+  const cellHeight = (VIEWPORT_HEIGHT * SPAN - 2 * GRID_MARGIN) / rows;
+  const rect = harness.view.getBounds();
+  const right = rect.x + rect.width;
+  const bottom = rect.y + rect.height;
+
+  let visible = 0;
+
+  for (let index = 0; index < NODE_COUNT; index++) {
+    const x = GRID_MARGIN + (index % columns) * cellWidth + cellWidth / 2;
+    const y = GRID_MARGIN + Math.floor(index / columns) * cellHeight + cellHeight / 2;
+
+    if (x < right && x + SPRITE_SIZE > rect.x && y < bottom && y + SPRITE_SIZE > rect.y) {
+      visible++;
+    }
+  }
+
+  return visible;
+};
+
+/** The margin the builder is compiled with, recovered from the rect it culls against. */
+const marginRatio = (): number => {
+  const fixture = openScene();
+
+  render(fixture);
+
+  const view = fixture.harness.view.getBounds();
+  const representation = (fixture.scene.root as unknown as { _retainedRootRepresentation(): unknown })._retainedRootRepresentation() as {
+    _captureCullRect: { width: number };
+    _hasCaptureCullRect: boolean;
+  };
+
+  return representation._hasCaptureCullRect ? (representation._captureCullRect.width - view.width) / (2 * view.width) : 0;
+};
+
+const setCenter =
+  (x: number, y: number): CameraOp =>
+  (harness): void => {
+    harness.view.setCenter(x, y);
+  };
+
+/** Both claims at once: the tiers never drop a node the view contains. */
+const expectComplete = (ops: readonly CameraOp[]): FrameResult => {
+  const probe = openScene();
+
+  for (const op of ops) {
+    op(probe.harness);
+  }
+
+  const floor = analyticVisible(probe.harness);
+  const coldFrame = cold(ops);
+  const warmFrame = warm(ops);
+
+  expect(coldFrame.submitted).toBeGreaterThanOrEqual(floor);
+  expect(warmFrame.submitted).toBeGreaterThanOrEqual(floor);
+
+  return warmFrame;
+};
+
+afterEach(() => {
+  for (const { harness, scene } of live.splice(0)) {
+    scene.destroy();
+    harness.destroy();
+  }
+});
+
+describe('retained selection under camera operations', () => {
+  test('the archetype keeps real off-screen content, so the comparison has teeth', () => {
+    const fixture = openScene();
+
+    expect(analyticVisible(fixture.harness)).toBeLessThan(NODE_COUNT / 2);
+  });
+
+  test('the builder culls captures against a rect strictly larger than the view', () => {
+    expect(marginRatio()).toBeGreaterThan(0);
+  });
+
+  test('a step that stays inside the margin is answered by a replay', () => {
+    const ratio = marginRatio();
+    const start = { x: 1500, y: 800 };
+    const inside = setCenter(start.x + VIEWPORT_WIDTH * ratio * 0.25, start.y);
+    const result = expectComplete([setCenter(start.x, start.y), inside]);
+
+    expect(result.servedBy === 'slotReplay' || result.servedBy === 'captureReplay').toBe(true);
+  });
+
+  test('a step to exactly the margin boundary is still answered by a replay', () => {
+    const ratio = marginRatio();
+    const start = { x: 1500, y: 800 };
+    const boundary = setCenter(start.x + VIEWPORT_WIDTH * ratio, start.y);
+    const result = expectComplete([setCenter(start.x, start.y), boundary]);
+
+    expect(result.servedBy === 'slotReplay' || result.servedBy === 'captureReplay').toBe(true);
+  });
+
+  test('a step one unit past the margin boundary is NOT answered by a replay', () => {
+    const ratio = marginRatio();
+    const start = { x: 1500, y: 800 };
+    const past = setCenter(start.x + VIEWPORT_WIDTH * ratio + 1, start.y);
+    const result = expectComplete([setCenter(start.x, start.y), past]);
+
+    expect(result.servedBy === 'slotReplay' || result.servedBy === 'captureReplay').toBe(false);
+  });
+
+  test('a reversal of direction stays complete', () => {
+    expectComplete([setCenter(1500, 800), setCenter(1400, 750), setCenter(1300, 700), setCenter(1400, 750)]);
+  });
+
+  test('a teleport across the world is NOT answered by a replay and stays complete', () => {
+    const result = expectComplete([setCenter(1900, 1000)]);
+
+    expect(result.servedBy === 'slotReplay' || result.servedBy === 'captureReplay').toBe(false);
+  });
+
+  test('a teleport far outside the world draws nothing at all', () => {
+    const teleport = [setCenter(50_000, 20_000)];
+
+    expect(cold(teleport).submitted).toBe(0);
+    expect(warm(teleport).submitted).toBe(0);
+  });
+
+  test('a teleport out and straight back stays complete', () => {
+    expectComplete([setCenter(50_000, 20_000), setCenter(900, 600)]);
+  });
+
+  test('sub-pixel shake stays complete', () => {
+    expectComplete([setCenter(1000.37, 700.91), setCenter(1000.91, 700.37), setCenter(1000.02, 700.55)]);
+  });
+
+  test('a zoom-out past the capture rect stays complete', () => {
+    expectComplete([
+      setCenter(1280, 720),
+      (harness): void => {
+        harness.view.setZoom(0.25);
+      },
+    ]);
+  });
+
+  test('a zoom-in stays complete', () => {
+    expectComplete([
+      setCenter(1280, 720),
+      (harness): void => {
+        harness.view.setZoom(4);
+      },
+    ]);
+  });
+
+  test('a resize stays complete', () => {
+    expectComplete([
+      setCenter(1280, 720),
+      (harness): void => {
+        harness.view.resize(1920, 1080);
+      },
+    ]);
+  });
+
+  test('a rotation stays complete', () => {
+    expectComplete([
+      setCenter(1280, 720),
+      (harness): void => {
+        harness.view.setRotation(37);
+      },
+    ]);
+  });
+
+  test('a follow-shaped run of small steps stays complete', () => {
+    expectComplete([setCenter(1500, 800), setCenter(1520, 815), setCenter(1541, 831), setCenter(1563, 848)]);
+  });
+});

--- a/test/perf/rendering/cull-margin-probe-fidelity.test.ts
+++ b/test/perf/rendering/cull-margin-probe-fidelity.test.ts
@@ -19,13 +19,12 @@ import { describe, expect, test } from 'vitest';
 import { ARCHETYPES } from '../../../packages/exojs-bench/src/rendering/archetypes';
 import type { ArchetypeSpec } from '../../../packages/exojs-bench/src/rendering/EngineAdapter';
 import * as world from '../../../packages/exojs-bench/src/rendering/world';
-
 import * as probe from './cullMarginProbe';
 
 const SPEC = ARCHETYPES.find((archetype): archetype is ArchetypeSpec => archetype.id === 'scrolling-world')!;
 
 describe('cull-margin probe fidelity', () => {
-  test('the archetype parameters the probe hard-codes are the archetype\'s own', () => {
+  test("the archetype parameters the probe hard-codes are the archetype's own", () => {
     expect(SPEC.cameraSpeed).toBe(probe.SCROLLING_WORLD.cameraSpeed);
     expect(SPEC.worldSpan).toBe(probe.SCROLLING_WORLD.worldSpan);
     expect(SPEC.nestingDepth).toBe(probe.SCROLLING_WORLD.nestingDepth);
@@ -46,7 +45,12 @@ describe('cull-margin probe fidelity', () => {
 
     for (const nodeCount of [5_000, 25_000, 100_000, 1_000_000]) {
       const expected = world.gridLayout(nodeCount, extent.width, extent.height, world.GRID_MARGIN);
-      const actual = probe.gridLayout(nodeCount, probe.VIEWPORT_WIDTH * probe.SCROLLING_WORLD.worldSpan, probe.VIEWPORT_HEIGHT * probe.SCROLLING_WORLD.worldSpan, probe.GRID_MARGIN);
+      const actual = probe.gridLayout(
+        nodeCount,
+        probe.VIEWPORT_WIDTH * probe.SCROLLING_WORLD.worldSpan,
+        probe.VIEWPORT_HEIGHT * probe.SCROLLING_WORLD.worldSpan,
+        probe.GRID_MARGIN,
+      );
 
       expect(actual).toEqual(expected);
     }
@@ -70,7 +74,7 @@ describe('cull-margin probe fidelity', () => {
     }
   });
 
-  test('the on-screen leaf count matches the bench, so the off-screen fraction is the archetype\'s', () => {
+  test("the on-screen leaf count matches the bench, so the off-screen fraction is the archetype's", () => {
     for (const frame of [0, 7, 64, 199]) {
       expect(probe.visibleLeafCount(25_000, frame, SPEC.cameraSpeed!, SPEC.worldSpan!)).toBe(
         world.visibleLeafCount(SPEC, 25_000, frame, world.VIEWPORT_WIDTH, world.VIEWPORT_HEIGHT, world.GRID_MARGIN, world.SPRITE_SIZE),

--- a/test/perf/rendering/cull-margin-probe-fidelity.test.ts
+++ b/test/perf/rendering/cull-margin-probe-fidelity.test.ts
@@ -6,7 +6,7 @@
  * drifts silently: a changed grid inset or camera path would leave every margin
  * number in the calibration report describing a scene the benchmark no longer
  * runs, with nothing failing. So the copy is pinned here against the bench's own
- * `world.ts` — the single source both the harness page and every arm use.
+ * `world.ts` - the single source both the harness page and every arm use.
  *
  * Type-only import chain: `world.ts` pulls one `type` from `EngineAdapter`,
  * which pulls one `type` from `shared/result`, and neither reaches a competitor

--- a/test/perf/rendering/cull-margin-probe-fidelity.test.ts
+++ b/test/perf/rendering/cull-margin-probe-fidelity.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The margin probe's scene must BE `scrolling-world`, not merely resemble it.
+ *
+ * `cullMarginProbe` re-implements the archetype's geometry rather than importing
+ * it, because the bench package sits outside the workspace typecheck. A copy
+ * drifts silently: a changed grid inset or camera path would leave every margin
+ * number in the calibration report describing a scene the benchmark no longer
+ * runs, with nothing failing. So the copy is pinned here against the bench's own
+ * `world.ts` — the single source both the harness page and every arm use.
+ *
+ * Type-only import chain: `world.ts` pulls one `type` from `EngineAdapter`,
+ * which pulls one `type` from `shared/result`, and neither reaches a competitor
+ * library. Nothing here loads Playwright or the bench driver.
+ *
+ * @internal Test/perf-only.
+ */
+import { describe, expect, test } from 'vitest';
+
+import { ARCHETYPES } from '../../../packages/exojs-bench/src/rendering/archetypes';
+import type { ArchetypeSpec } from '../../../packages/exojs-bench/src/rendering/EngineAdapter';
+import * as world from '../../../packages/exojs-bench/src/rendering/world';
+
+import * as probe from './cullMarginProbe';
+
+const SPEC = ARCHETYPES.find((archetype): archetype is ArchetypeSpec => archetype.id === 'scrolling-world')!;
+
+describe('cull-margin probe fidelity', () => {
+  test('the archetype parameters the probe hard-codes are the archetype\'s own', () => {
+    expect(SPEC.cameraSpeed).toBe(probe.SCROLLING_WORLD.cameraSpeed);
+    expect(SPEC.worldSpan).toBe(probe.SCROLLING_WORLD.worldSpan);
+    expect(SPEC.nestingDepth).toBe(probe.SCROLLING_WORLD.nestingDepth);
+    expect(SPEC.cullingEnabled).toBe(true);
+    expect(SPEC.mutationFraction).toBe(0);
+    expect(SPEC.textureCount).toBe(1);
+  });
+
+  test('the viewport, grid inset and leaf size match the bench', () => {
+    expect(probe.VIEWPORT_WIDTH).toBe(world.VIEWPORT_WIDTH);
+    expect(probe.VIEWPORT_HEIGHT).toBe(world.VIEWPORT_HEIGHT);
+    expect(probe.GRID_MARGIN).toBe(world.GRID_MARGIN);
+    expect(probe.SPRITE_SIZE).toBe(world.SPRITE_SIZE);
+  });
+
+  test('the grid layout matches the bench at every measured node count', () => {
+    const extent = world.worldExtent(SPEC, world.VIEWPORT_WIDTH, world.VIEWPORT_HEIGHT);
+
+    for (const nodeCount of [5_000, 25_000, 100_000, 1_000_000]) {
+      const expected = world.gridLayout(nodeCount, extent.width, extent.height, world.GRID_MARGIN);
+      const actual = probe.gridLayout(nodeCount, probe.VIEWPORT_WIDTH * probe.SCROLLING_WORLD.worldSpan, probe.VIEWPORT_HEIGHT * probe.SCROLLING_WORLD.worldSpan, probe.GRID_MARGIN);
+
+      expect(actual).toEqual(expected);
+    }
+  });
+
+  test('leaf positions match the bench across the grid', () => {
+    const extent = world.worldExtent(SPEC, world.VIEWPORT_WIDTH, world.VIEWPORT_HEIGHT);
+    const benchLayout = world.gridLayout(25_000, extent.width, extent.height, world.GRID_MARGIN);
+    const probeLayout = probe.gridLayout(25_000, probe.VIEWPORT_WIDTH * 2, probe.VIEWPORT_HEIGHT * 2, probe.GRID_MARGIN);
+
+    for (const index of [0, 1, 158, 4_999, 12_500, 24_999]) {
+      expect(probe.gridPosition(index, probeLayout, probe.GRID_MARGIN)).toEqual(world.gridPosition(index, benchLayout, world.GRID_MARGIN));
+    }
+  });
+
+  test('the camera path matches the bench frame for frame, reflections included', () => {
+    for (let frame = 0; frame < 400; frame++) {
+      expect(probe.cameraCenterAt(frame, SPEC.cameraSpeed!, SPEC.worldSpan!)).toEqual(
+        world.cameraCenterAt(SPEC, frame, world.VIEWPORT_WIDTH, world.VIEWPORT_HEIGHT),
+      );
+    }
+  });
+
+  test('the on-screen leaf count matches the bench, so the off-screen fraction is the archetype\'s', () => {
+    for (const frame of [0, 7, 64, 199]) {
+      expect(probe.visibleLeafCount(25_000, frame, SPEC.cameraSpeed!, SPEC.worldSpan!)).toBe(
+        world.visibleLeafCount(SPEC, 25_000, frame, world.VIEWPORT_WIDTH, world.VIEWPORT_HEIGHT, world.GRID_MARGIN, world.SPRITE_SIZE),
+      );
+    }
+  });
+});

--- a/test/perf/rendering/cullMarginProbe.ts
+++ b/test/perf/rendering/cullMarginProbe.ts
@@ -182,9 +182,11 @@ interface BuilderInternals {
   _inflateCaptureCullRect(view: View): void;
 }
 
-type BuilderProto = RenderPlanBuilder & BuilderInternals;
-
-const originalInflate = (RenderPlanBuilder.prototype as unknown as BuilderProto)._inflateCaptureCullRect;
+// Cast to the internals shape ALONE, never to an intersection with the class:
+// `_captureCullRect` is `private` on `RenderPlanBuilder` and public here, and TypeScript
+// reduces such an intersection to `never` — after which every member access on it is an
+// error (TS2339). The `unknown` hop is what makes the reinterpretation legal.
+const originalInflate = (RenderPlanBuilder.prototype as unknown as BuilderInternals)._inflateCaptureCullRect;
 
 /**
  * Make every capture and every indexed selection cull against the view grown by
@@ -193,7 +195,7 @@ const originalInflate = (RenderPlanBuilder.prototype as unknown as BuilderProto)
  * {@link restoreCaptureMargin}.
  */
 export const installCaptureMargin = (ratio: number): void => {
-  (RenderPlanBuilder.prototype as unknown as BuilderProto)._inflateCaptureCullRect = function inflate(this: BuilderInternals, view: View): void {
+  (RenderPlanBuilder.prototype as unknown as BuilderInternals)._inflateCaptureCullRect = function inflate(this: BuilderInternals, view: View): void {
     const rect = view.getBounds();
     const marginX = rect.width * ratio;
     const marginY = rect.height * ratio;
@@ -205,7 +207,7 @@ export const installCaptureMargin = (ratio: number): void => {
 
 /** Put the engine's own margin back. */
 export const restoreCaptureMargin = (): void => {
-  (RenderPlanBuilder.prototype as unknown as BuilderProto)._inflateCaptureCullRect = originalInflate;
+  (RenderPlanBuilder.prototype as unknown as BuilderInternals)._inflateCaptureCullRect = originalInflate;
 };
 
 /**

--- a/test/perf/rendering/cullMarginProbe.ts
+++ b/test/perf/rendering/cullMarginProbe.ts
@@ -1,0 +1,465 @@
+/**
+ * Retained capture-margin probe: the `scrolling-world` scene, a configurable
+ * capture margin, and per-frame retention-tier accounting.
+ *
+ * Three pieces, none of which exist in the engine:
+ *
+ * - **The scene.** A faithful re-implementation of the `scrolling-world`
+ *   archetype from `@codexo/exojs-bench` (`src/rendering/archetypes.ts`,
+ *   `src/rendering/world.ts`, `src/rendering/adapters/exojs.ts`): a nesting-4
+ *   container spine, leaves on a near-square grid over `worldSpan` viewports per
+ *   axis, culling on, and a camera travelling the world diagonal at a fixed
+ *   speed and reflecting off the world edges. Re-implemented rather than
+ *   imported because the bench package sits outside the workspace typecheck and
+ *   its adapters reach competitor libraries; the geometry is pure arithmetic and
+ *   is pinned against the bench's own `world.ts` by
+ *   `cull-margin-probe-fidelity.test.ts`, so the copy cannot drift silently.
+ * - **The margin injection.** `RETAINED_CULL_MARGIN_RATIO` is a module constant
+ *   in `RenderPlanBuilder`, so a sweep over it would otherwise mean one source
+ *   edit and one rebuild per point. {@link installCaptureMargin} replaces the
+ *   builder's private inflation step instead, which keeps the production default
+ *   untouched and every sweep point inside one process.
+ * - **The tier accounting.** Which of the retention tiers served a frame is not
+ *   an engine statistic. The probe wraps the four decision points and classifies
+ *   each frame from what they answered, so a margin's cost can be read as
+ *   "frames per capture miss" rather than inferred from a wall clock.
+ *
+ * @internal Test/perf-only.
+ */
+import type { ReadonlyRectangle } from '#math/Rectangle';
+import { Container } from '#rendering/Container';
+import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
+import { RetainedRootRepresentation } from '#rendering/plan/RetainedRootRepresentation';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Sprite } from '#rendering/sprite/Sprite';
+import type { View } from '#rendering/View';
+
+import { makeTextures } from './fixtures';
+import type { WebGl2Harness } from './harness';
+
+/** Fixed design-space viewport every arm of the bench initialises at. */
+export const VIEWPORT_WIDTH = 1280;
+/** Fixed design-space viewport every arm of the bench initialises at. */
+export const VIEWPORT_HEIGHT = 720;
+/** Inset that keeps every gridded leaf off the world edge. */
+export const GRID_MARGIN = 32;
+/** Side length of the generated leaf quads, in pixels. */
+export const SPRITE_SIZE = 8;
+/** `scrolling-world`'s own archetype parameters. */
+export const SCROLLING_WORLD = { nestingDepth: 4, worldSpan: 2, cameraSpeed: 8 } as const;
+
+/** Row/column layout of the leaf grid, plus the cell size derived from it. */
+export interface GridLayout {
+  readonly columns: number;
+  readonly rows: number;
+  readonly cellWidth: number;
+  readonly cellHeight: number;
+}
+
+/** Near-square grid covering `width` x `height` inset by `margin` on every side. */
+export const gridLayout = (nodeCount: number, width: number, height: number, margin: number): GridLayout => {
+  const columns = Math.max(1, Math.ceil(Math.sqrt(nodeCount)));
+  const rows = Math.max(1, Math.ceil(nodeCount / columns));
+
+  return { columns, rows, cellWidth: (width - 2 * margin) / columns, cellHeight: (height - 2 * margin) / rows };
+};
+
+/** Resting position of leaf `index` on `layout`, in row-major order. */
+export const gridPosition = (index: number, layout: GridLayout, margin: number): { x: number; y: number } => ({
+  x: margin + (index % layout.columns) * layout.cellWidth + layout.cellWidth / 2,
+  y: margin + Math.floor(index / layout.columns) * layout.cellHeight + layout.cellHeight / 2,
+});
+
+/** Triangle wave: `value` folded back and forth inside `[0, span]`. */
+export const reflect = (value: number, span: number): number => {
+  if (span <= 0) {
+    return 0;
+  }
+
+  const period = 2 * span;
+  const wrapped = ((value % period) + period) % period;
+
+  return wrapped <= span ? wrapped : period - wrapped;
+};
+
+/**
+ * Camera centre for `frame`, as a closed form in the frame index. The camera
+ * travels the diagonal at `speed` world units per frame — equal per-axis
+ * components of a unit diagonal — and reflects off the world edges.
+ */
+export const cameraCenterAt = (frame: number, speed: number, worldSpan: number): { x: number; y: number } => {
+  const worldW = VIEWPORT_WIDTH * worldSpan;
+  const worldH = VIEWPORT_HEIGHT * worldSpan;
+  const travel = frame * speed * Math.SQRT1_2;
+
+  return {
+    x: VIEWPORT_WIDTH / 2 + reflect(travel, worldW - VIEWPORT_WIDTH),
+    y: VIEWPORT_HEIGHT / 2 + reflect(travel, worldH - VIEWPORT_HEIGHT),
+  };
+};
+
+/** Leaves whose quad intersects the view rect at `frame` — the on-screen count. */
+export const visibleLeafCount = (nodeCount: number, frame: number, speed: number, worldSpan: number): number => {
+  const layout = gridLayout(nodeCount, VIEWPORT_WIDTH * worldSpan, VIEWPORT_HEIGHT * worldSpan, GRID_MARGIN);
+  const centre = cameraCenterAt(frame, speed, worldSpan);
+  const left = centre.x - VIEWPORT_WIDTH / 2;
+  const top = centre.y - VIEWPORT_HEIGHT / 2;
+  const right = left + VIEWPORT_WIDTH;
+  const bottom = top + VIEWPORT_HEIGHT;
+
+  let visible = 0;
+
+  for (let index = 0; index < nodeCount; index++) {
+    const position = gridPosition(index, layout, GRID_MARGIN);
+
+    if (position.x < right && position.x + SPRITE_SIZE > left && position.y < bottom && position.y + SPRITE_SIZE > top) {
+      visible++;
+    }
+  }
+
+  return visible;
+};
+
+export interface ScrollingWorldScene {
+  readonly root: RenderNode;
+  /** Park the camera on the centre for `frame`. */
+  step(frame: number): void;
+  destroy(): void;
+}
+
+/** Build the `scrolling-world` scene against `harness` and park the camera on frame 0. */
+export const buildScrollingWorld = (harness: WebGl2Harness, nodeCount: number, speed: number, worldSpan: number): ScrollingWorldScene => {
+  const textures = makeTextures(1, SPRITE_SIZE);
+  const root = new Container();
+
+  root.cullable = true;
+
+  const spine: Container[] = [root];
+
+  for (let depth = 1; depth < SCROLLING_WORLD.nestingDepth; depth++) {
+    const container = new Container();
+
+    container.cullable = true;
+    spine[depth - 1]!.addChild(container);
+    spine.push(container);
+  }
+
+  const layout = gridLayout(nodeCount, VIEWPORT_WIDTH * worldSpan, VIEWPORT_HEIGHT * worldSpan, GRID_MARGIN);
+
+  for (let i = 0; i < nodeCount; i++) {
+    const leaf = new Sprite(textures[0]!);
+    const cell = gridPosition(i, layout, GRID_MARGIN);
+
+    leaf.cullable = true;
+    leaf.setPosition(cell.x, cell.y);
+    spine[i % spine.length]!.addChild(leaf);
+  }
+
+  const view = harness.view;
+  const start = cameraCenterAt(0, speed, worldSpan);
+
+  view.reset(start.x, start.y, VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+
+  return {
+    root,
+    step(frame: number): void {
+      const centre = cameraCenterAt(frame, speed, worldSpan);
+
+      view.setCenter(centre.x, centre.y);
+    },
+    destroy(): void {
+      root.destroy();
+    },
+  };
+};
+
+// ── Margin injection ────────────────────────────────────────────────────────
+
+/** Shape of the builder internals the injection reaches into. */
+interface BuilderInternals {
+  _captureCullRect: { set(x: number, y: number, width: number, height: number): void };
+  _captureCullActive: boolean;
+  _inflateCaptureCullRect(view: View): void;
+}
+
+type BuilderProto = RenderPlanBuilder & BuilderInternals;
+
+const originalInflate = (RenderPlanBuilder.prototype as unknown as BuilderProto)._inflateCaptureCullRect;
+
+/**
+ * Make every capture and every indexed selection cull against the view grown by
+ * `ratio` per side, for the rest of the process. `ratio = 0` reproduces a tight
+ * view-rect cull; restoring the production constant means calling
+ * {@link restoreCaptureMargin}.
+ */
+export const installCaptureMargin = (ratio: number): void => {
+  (RenderPlanBuilder.prototype as unknown as BuilderProto)._inflateCaptureCullRect = function inflate(this: BuilderInternals, view: View): void {
+    const rect = view.getBounds();
+    const marginX = rect.width * ratio;
+    const marginY = rect.height * ratio;
+
+    this._captureCullRect.set(rect.x - marginX, rect.y - marginY, rect.width + 2 * marginX, rect.height + 2 * marginY);
+    this._captureCullActive = true;
+  };
+};
+
+/** Put the engine's own margin back. */
+export const restoreCaptureMargin = (): void => {
+  (RenderPlanBuilder.prototype as unknown as BuilderProto)._inflateCaptureCullRect = originalInflate;
+};
+
+/**
+ * Make every backend refuse the indexed slot path for the rest of the process,
+ * so a root falls to the capture / source-selection tiers instead.
+ *
+ * `scrolling-world` qualifies for persistent slots, and a qualifying root never
+ * reaches the capture tier at all — which would leave the tier the capture
+ * margin is NAMED after unmeasured. Refusing here rather than deforming the
+ * scene (mixed z, a non-group sibling) keeps the two runs comparable: identical
+ * geometry, identical camera, one tier apart.
+ */
+export const refusePersistentSlots = (backendPrototype: object): void => {
+  (backendPrototype as { _acquirePersistentSlots?: unknown })._acquirePersistentSlots = (): null => null;
+};
+
+// ── Retention-tier accounting ───────────────────────────────────────────────
+
+/**
+ * Which tier served one frame. Ordered cheapest first, and named after the code
+ * path rather than after the old "replay vs recollect" dichotomy, which no
+ * longer describes what a margin miss costs.
+ */
+export interface TierCounts {
+  /** Indexed tier, cached: the last selection's order stream was re-issued. */
+  slotReplay: number;
+  /** Indexed tier, missed: membership re-queried from the spatial index. */
+  slotReselect: number;
+  /** Capture tier: the recorded product was replayed. */
+  captureReplay: number;
+  /** Capture missed, but the persistent source still answered the frame. */
+  sourceSelect: number;
+  /** Neither tier held: the frame walked the scene graph. */
+  fullCollect: number;
+  /** Source discovery walks (one O(N) pass plus one item per drawable). */
+  sourceBuild: number;
+  /** Captures committed. */
+  captureCommit: number;
+}
+
+/** Spatial-index query volume, summed over the measured window. */
+export interface QueryTotals {
+  cells: number;
+  candidates: number;
+  entered: number;
+  exited: number;
+  visible: number;
+}
+
+export interface ProbeTotals {
+  readonly tiers: TierCounts;
+  readonly query: QueryTotals;
+  /** Frames folded in. */
+  frames: number;
+}
+
+const zeroTiers = (): TierCounts => ({
+  slotReplay: 0,
+  slotReselect: 0,
+  captureReplay: 0,
+  sourceSelect: 0,
+  fullCollect: 0,
+  sourceBuild: 0,
+  captureCommit: 0,
+});
+
+const zeroQuery = (): QueryTotals => ({ cells: 0, candidates: 0, entered: 0, exited: 0, visible: 0 });
+
+/** Per-frame classification state, written by the wrappers below. */
+interface FrameState {
+  persistentServed: boolean;
+  persistentCovered: boolean;
+  captureClean: boolean;
+  sourceSelected: boolean;
+  sourceBuilt: boolean;
+  captured: boolean;
+}
+
+interface PlanBuilderPrivate {
+  _collectPersistentRoot(...args: never[]): boolean;
+  _resolveSourceSelection(...args: never[]): unknown;
+  _discoverSource(...args: never[]): unknown;
+}
+
+/**
+ * Wrap the four retention decision points for the rest of the process.
+ *
+ * Cheap by construction: each wrapper runs once per render root per frame and
+ * does one boolean write, so the accounting can stay installed while the same
+ * run is timed. The alternative — a second, uninstrumented run — would compare
+ * two different JIT histories, which is the exact hazard `run-allocation-cell`
+ * documents for this scene.
+ */
+export const installTierProbe = (): ProbeTotals => {
+  const totals: ProbeTotals = { tiers: zeroTiers(), query: zeroQuery(), frames: 0 };
+  const state: FrameState = {
+    persistentServed: false,
+    persistentCovered: false,
+    captureClean: false,
+    sourceSelected: false,
+    sourceBuilt: false,
+    captured: false,
+  };
+
+  probeState = state;
+  probeTotals = totals;
+
+  const builder = RenderPlanBuilder.prototype as unknown as PlanBuilderPrivate;
+  const representation = RetainedRootRepresentation.prototype;
+
+  const collectPersistentRoot = builder._collectPersistentRoot;
+  const resolveSourceSelection = builder._resolveSourceSelection;
+  const discoverSource = builder._discoverSource;
+  const isClean = representation.isCleanIgnoringTransform;
+  const covers = representation.persistentSelectionCovers;
+  const commitCapture = representation.commitCapture;
+
+  builder._collectPersistentRoot = function collect(this: PlanBuilderPrivate, ...args: never[]): boolean {
+    const served = collectPersistentRoot.apply(this, args);
+
+    state.persistentServed = served;
+
+    return served;
+  };
+
+  builder._resolveSourceSelection = function resolve(this: PlanBuilderPrivate, ...args: never[]): unknown {
+    const selection = resolveSourceSelection.apply(this, args);
+
+    state.sourceSelected = selection !== null;
+
+    return selection;
+  };
+
+  builder._discoverSource = function discover(this: PlanBuilderPrivate, ...args: never[]): unknown {
+    state.sourceBuilt = true;
+
+    return discoverSource.apply(this, args);
+  };
+
+  representation.isCleanIgnoringTransform = function clean(this: RetainedRootRepresentation, ...args): boolean {
+    const value = isClean.apply(this, args);
+
+    state.captureClean = value;
+
+    return value;
+  };
+
+  representation.persistentSelectionCovers = function covered(this: RetainedRootRepresentation, view: View): boolean {
+    const value = covers.call(this, view);
+
+    state.persistentCovered = value;
+
+    return value;
+  };
+
+  representation.commitCapture = function commit(this: RetainedRootRepresentation, ...args): void {
+    state.captured = true;
+
+    commitCapture.apply(this, args);
+  };
+
+  return totals;
+};
+
+let probeState: FrameState | null = null;
+let probeTotals: ProbeTotals | null = null;
+
+/** Clear the per-frame classification. Call immediately before a render. */
+export const beginProbeFrame = (): void => {
+  if (probeState === null) {
+    return;
+  }
+
+  probeState.persistentServed = false;
+  probeState.persistentCovered = false;
+  probeState.captureClean = false;
+  probeState.sourceSelected = false;
+  probeState.sourceBuilt = false;
+  probeState.captured = false;
+};
+
+/** Which tier answered one frame — the return of {@link endProbeFrame}. */
+export type ServedBy = 'slotReplay' | 'slotReselect' | 'captureReplay' | 'sourceSelect' | 'fullCollect';
+
+/**
+ * Fold the frame just rendered into the totals, reading the selection delta off
+ * `root`'s representation for the query volume the frame actually paid, and
+ * report which tier served it so a caller can bracket its timings by tier.
+ */
+export const endProbeFrame = (root: RenderNode): ServedBy => {
+  const state = probeState;
+  const totals = probeTotals;
+
+  if (state === null || totals === null) {
+    return 'fullCollect';
+  }
+
+  const tiers = totals.tiers;
+
+  totals.frames++;
+
+  let served: ServedBy;
+
+  if (state.persistentServed) {
+    served = state.persistentCovered ? 'slotReplay' : 'slotReselect';
+  } else if (state.captureClean) {
+    served = 'captureReplay';
+  } else if (state.sourceSelected) {
+    served = 'sourceSelect';
+  } else {
+    served = 'fullCollect';
+  }
+
+  tiers[served]++;
+
+  if (state.sourceBuilt) {
+    tiers.sourceBuild++;
+  }
+
+  if (state.captured) {
+    tiers.captureCommit++;
+  }
+
+  // Only a frame that actually queried has a delta worth folding. Both replay
+  // tiers leave the previous selection's numbers in place, so folding them
+  // would count the same query once per frame it stayed valid for — which is
+  // precisely the quantity the margin is supposed to reduce.
+  if (served === 'slotReplay' || served === 'captureReplay') {
+    return served;
+  }
+
+  const delta = (root as unknown as { _retainedRootRepresentation(): RetainedRootRepresentation })._retainedRootRepresentation().derivedProduct?.delta;
+
+  if (delta === undefined) {
+    return served;
+  }
+
+  totals.query.cells += delta.cells;
+  totals.query.candidates += delta.candidates;
+  totals.query.entered += delta.entered;
+  totals.query.exited += delta.exited;
+  totals.query.visible += delta.visible;
+
+  return served;
+};
+
+/** Item count of the root's persistent source, or 0 while it has none. */
+export const sourceItemCount = (root: RenderNode): number =>
+  (root as unknown as { _retainedRootRepresentation(): RetainedRootRepresentation })._retainedRootRepresentation().source?.itemCount ?? 0;
+
+/** The rect the last capture culled against, or `null` while there is none. */
+export const captureCullRectOf = (root: RenderNode): ReadonlyRectangle | null => {
+  const representation = (root as unknown as { _retainedRootRepresentation(): RetainedRootRepresentation })._retainedRootRepresentation();
+  const internals = representation as unknown as { _captureCullRect: ReadonlyRectangle; _hasCaptureCullRect: boolean };
+
+  return internals._hasCaptureCullRect ? internals._captureCullRect : null;
+};

--- a/test/perf/rendering/cullMarginProbe.ts
+++ b/test/perf/rendering/cullMarginProbe.ts
@@ -84,8 +84,8 @@ export const reflect = (value: number, span: number): number => {
 
 /**
  * Camera centre for `frame`, as a closed form in the frame index. The camera
- * travels the diagonal at `speed` world units per frame — equal per-axis
- * components of a unit diagonal — and reflects off the world edges.
+ * travels the diagonal at `speed` world units per frame - equal per-axis
+ * components of a unit diagonal - and reflects off the world edges.
  */
 export const cameraCenterAt = (frame: number, speed: number, worldSpan: number): { x: number; y: number } => {
   const worldW = VIEWPORT_WIDTH * worldSpan;
@@ -98,7 +98,7 @@ export const cameraCenterAt = (frame: number, speed: number, worldSpan: number):
   };
 };
 
-/** Leaves whose quad intersects the view rect at `frame` — the on-screen count. */
+/** Leaves whose quad intersects the view rect at `frame` - the on-screen count. */
 export const visibleLeafCount = (nodeCount: number, frame: number, speed: number, worldSpan: number): number => {
   const layout = gridLayout(nodeCount, VIEWPORT_WIDTH * worldSpan, VIEWPORT_HEIGHT * worldSpan, GRID_MARGIN);
   const centre = cameraCenterAt(frame, speed, worldSpan);
@@ -184,7 +184,7 @@ interface BuilderInternals {
 
 // Cast to the internals shape ALONE, never to an intersection with the class:
 // `_captureCullRect` is `private` on `RenderPlanBuilder` and public here, and TypeScript
-// reduces such an intersection to `never` — after which every member access on it is an
+// reduces such an intersection to `never` - after which every member access on it is an
 // error (TS2339). The `unknown` hop is what makes the reinterpretation legal.
 const originalInflate = (RenderPlanBuilder.prototype as unknown as BuilderInternals)._inflateCaptureCullRect;
 
@@ -215,7 +215,7 @@ export const restoreCaptureMargin = (): void => {
  * so a root falls to the capture / source-selection tiers instead.
  *
  * `scrolling-world` qualifies for persistent slots, and a qualifying root never
- * reaches the capture tier at all — which would leave the tier the capture
+ * reaches the capture tier at all - which would leave the tier the capture
  * margin is NAMED after unmeasured. Refusing here rather than deforming the
  * scene (mixed z, a non-group sibling) keeps the two runs comparable: identical
  * geometry, identical camera, one tier apart.
@@ -297,7 +297,7 @@ interface PlanBuilderPrivate {
  *
  * Cheap by construction: each wrapper runs once per render root per frame and
  * does one boolean write, so the accounting can stay installed while the same
- * run is timed. The alternative — a second, uninstrumented run — would compare
+ * run is timed. The alternative - a second, uninstrumented run - would compare
  * two different JIT histories, which is the exact hazard `run-allocation-cell`
  * documents for this scene.
  */
@@ -389,7 +389,7 @@ export const beginProbeFrame = (): void => {
   probeState.captured = false;
 };
 
-/** Which tier answered one frame — the return of {@link endProbeFrame}. */
+/** Which tier answered one frame - the return of {@link endProbeFrame}. */
 export type ServedBy = 'slotReplay' | 'slotReselect' | 'captureReplay' | 'sourceSelect' | 'fullCollect';
 
 /**
@@ -433,7 +433,7 @@ export const endProbeFrame = (root: RenderNode): ServedBy => {
 
   // Only a frame that actually queried has a delta worth folding. Both replay
   // tiers leave the previous selection's numbers in place, so folding them
-  // would count the same query once per frame it stayed valid for — which is
+  // would count the same query once per frame it stayed valid for - which is
   // precisely the quantity the margin is supposed to reduce.
   if (served === 'slotReplay' || served === 'captureReplay') {
     return served;

--- a/test/perf/rendering/run-cull-margin-cell.ts
+++ b/test/perf/rendering/run-cull-margin-cell.ts
@@ -78,7 +78,7 @@ gc?.();
 const heapBefore = process.memoryUsage().heapUsed;
 const totals = installTierProbe();
 const samples = new Float64Array(frames);
-/** Timings split by which tier served the frame — the replay/miss contrast O45 is about. */
+/** Timings split by which tier served the frame: the replay/miss contrast the sweep is about. */
 const replaySamples: number[] = [];
 const missSamples: number[] = [];
 
@@ -125,7 +125,7 @@ const heapAfter = process.memoryUsage().heapUsed;
 const sorted = Float64Array.from(samples).sort();
 const at = (percentile: number): number => sorted[Math.max(0, Math.ceil((percentile / 100) * sorted.length) - 1)]!;
 
-/** Count, median, mean and worst of one tier's frames — `null` when it served none. */
+/** Count, median, mean and worst of one tier's frames - `null` when it served none. */
 const summarize = (values: readonly number[]): { count: number; median: number; mean: number; max: number } | null => {
   if (values.length === 0) {
     return null;

--- a/test/perf/rendering/run-cull-margin-cell.ts
+++ b/test/perf/rendering/run-cull-margin-cell.ts
@@ -1,0 +1,187 @@
+/**
+ * One capture-margin sweep cell, in a process of its own.
+ *
+ * Renders the `scrolling-world` scene at one (margin, nodeCount, cameraSpeed)
+ * point and prints a single JSON object on stdout. One cell per process on
+ * purpose: this scene's cost is the documented case where V8's optimisation
+ * state carries across scenes inside a process and moves the reading by ~25%
+ * (see the `scrolling-world/10000` note in `allocationScenes.ts`), so a sweep
+ * that rendered every margin in one process would compare tier-up histories
+ * rather than margins.
+ *
+ *   pnpm perf:renderers:cull-margin:cell -- --margin 0.0625 --nodes 25000 [--speed 8] [--frames 300] [--warmup 60]
+ *
+ * @internal Test/perf-only.
+ */
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import {
+  beginProbeFrame,
+  buildScrollingWorld,
+  captureCullRectOf,
+  endProbeFrame,
+  installCaptureMargin,
+  installTierProbe,
+  refusePersistentSlots,
+  SCROLLING_WORLD,
+  sourceItemCount,
+  VIEWPORT_HEIGHT,
+  VIEWPORT_WIDTH,
+  visibleLeafCount,
+} from './cullMarginProbe';
+import { createWebGl2Harness } from './harness';
+
+const args = process.argv.slice(2);
+
+const flag = (name: string, fallback: number): number => {
+  const index = args.indexOf(`--${name}`);
+
+  return index === -1 ? fallback : Number(args[index + 1]);
+};
+
+const margin = flag('margin', 1 / 16);
+const nodes = flag('nodes', 25_000);
+const speed = flag('speed', SCROLLING_WORLD.cameraSpeed);
+const frames = flag('frames', 300);
+const warmup = flag('warmup', 60);
+const worldSpan = SCROLLING_WORLD.worldSpan;
+
+installCaptureMargin(margin);
+
+if (args.includes('--no-slots')) {
+  refusePersistentSlots(WebGl2Backend.prototype);
+}
+
+const harness = createWebGl2Harness({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT });
+const scene = buildScrollingWorld(harness, nodes, speed, worldSpan);
+const { backend, recorder } = harness;
+
+const renderFrame = (frame: number): void => {
+  scene.step(frame);
+  backend.resetStats();
+  recorder.reset();
+  backend.clear();
+  scene.root.render(backend);
+  backend.flush();
+};
+
+// Warmup is discarded: it settles the source build, the spatial index, the slot
+// stores and the JIT, none of which a margin comparison is about.
+for (let frame = 0; frame < warmup; frame++) {
+  renderFrame(frame);
+}
+
+const gc = (globalThis as { gc?: () => void }).gc;
+
+gc?.();
+
+const heapBefore = process.memoryUsage().heapUsed;
+const totals = installTierProbe();
+const samples = new Float64Array(frames);
+/** Timings split by which tier served the frame — the replay/miss contrast O45 is about. */
+const replaySamples: number[] = [];
+const missSamples: number[] = [];
+
+let submittedNodes = 0;
+let culledNodes = 0;
+let drawCalls = 0;
+let instances = 0;
+let bufferUploads = 0;
+let uploadedBufferBytes = 0;
+
+for (let i = 0; i < frames; i++) {
+  const frame = warmup + i;
+
+  beginProbeFrame();
+
+  const start = performance.now();
+
+  renderFrame(frame);
+
+  const elapsed = performance.now() - start;
+
+  samples[i] = elapsed;
+
+  const served = endProbeFrame(scene.root);
+
+  // Both tiers have a cheap "the margin still holds" answer and an expensive
+  // "it does not" one; the split is by that, not by which tier answered.
+  if (served === 'slotReplay' || served === 'captureReplay') {
+    replaySamples.push(elapsed);
+  } else {
+    missSamples.push(elapsed);
+  }
+
+  submittedNodes += backend.stats.submittedNodes;
+  culledNodes += backend.stats.culledNodes;
+  drawCalls += backend.stats.drawCalls;
+  instances += recorder.instances;
+  bufferUploads += recorder.bufferUploads;
+  uploadedBufferBytes += recorder.bufferUploadBytes;
+}
+
+const heapAfter = process.memoryUsage().heapUsed;
+
+const sorted = Float64Array.from(samples).sort();
+const at = (percentile: number): number => sorted[Math.max(0, Math.ceil((percentile / 100) * sorted.length) - 1)]!;
+
+/** Count, median, mean and worst of one tier's frames — `null` when it served none. */
+const summarize = (values: readonly number[]): { count: number; median: number; mean: number; max: number } | null => {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const ordered = [...values].sort((a, b) => a - b);
+
+  return {
+    count: ordered.length,
+    median: ordered[Math.floor(ordered.length / 2)]!,
+    mean: ordered.reduce((a, b) => a + b, 0) / ordered.length,
+    max: ordered[ordered.length - 1]!,
+  };
+};
+
+// The on-screen truth the capture is compared against, averaged over the same
+// window: the analytic count, so it is a property of the archetype rather than
+// of whichever tier answered the frame.
+let visibleTotal = 0;
+
+for (let i = 0; i < frames; i++) {
+  visibleTotal += visibleLeafCount(nodes, warmup + i, speed, worldSpan);
+}
+
+const cullRect = captureCullRectOf(scene.root);
+
+process.stdout.write(
+  `${JSON.stringify({
+    margin,
+    nodes,
+    speed,
+    frames,
+    warmup,
+    noSlots: args.includes('--no-slots'),
+    captureAreaFactor: (1 + 2 * margin) ** 2,
+    marginPixelsX: VIEWPORT_WIDTH * margin,
+    marginPixelsY: VIEWPORT_HEIGHT * margin,
+    tiers: totals.tiers,
+    query: totals.query,
+    sourceItems: sourceItemCount(scene.root),
+    cullRect: cullRect === null ? null : { width: cullRect.width, height: cullRect.height },
+    perFrame: {
+      submittedNodes: submittedNodes / frames,
+      culledNodes: culledNodes / frames,
+      drawCalls: drawCalls / frames,
+      visibleLeaves: visibleTotal / frames,
+      instances: instances / frames,
+      bufferUploads: bufferUploads / frames,
+      uploadedBufferBytes: uploadedBufferBytes / frames,
+    },
+    cpuMs: { median: at(50), p95: at(95), max: sorted[sorted.length - 1]!, mean: samples.reduce((a, b) => a + b, 0) / frames },
+    replayMs: summarize(replaySamples),
+    missMs: summarize(missSamples),
+    heapDeltaBytes: heapAfter - heapBefore,
+  })}\n`,
+);
+
+scene.destroy();
+harness.destroy();

--- a/test/perf/rendering/run-cull-margin.ts
+++ b/test/perf/rendering/run-cull-margin.ts
@@ -2,13 +2,12 @@
  * Capture-margin sweep driver.
  *
  * Spawns one {@link file://./run-cull-margin-cell.ts} process per
- * (margin, nodeCount, cameraSpeed) point — see that file for why a cell owns its
- * process — collects the JSON each prints, and writes a Markdown table plus the
+ * (margin, nodeCount, cameraSpeed) point - see that file for why a cell owns its
+ * process - collects the JSON each prints, and writes a Markdown table plus the
  * raw JSONL.
  *
  *   pnpm perf:renderers:cull-margin [--margins 0,0.0625,0.125] [--nodes 25000,100000]
- *                                   [--speeds 8] [--frames 300] [--warmup 60] [--repeats 3]
- *                                   [--out .workspace/output/cull-margin]
+ *                                   [--speeds 8] [--frames 300] [--warmup 60] [--repeats 3] [--out <dir>]
  *
  * @internal Test/perf-only.
  */
@@ -100,7 +99,7 @@ for (const nodes of nodeCounts) {
   }
 }
 
-/** Median of a numeric series — the repeats are combined, never averaged. */
+/** Median of a numeric series - the repeats are combined, never averaged. */
 const median = (values: number[]): number => {
   const sorted = [...values].sort((a, b) => a - b);
 

--- a/test/perf/rendering/run-cull-margin.ts
+++ b/test/perf/rendering/run-cull-margin.ts
@@ -1,0 +1,157 @@
+/**
+ * Capture-margin sweep driver.
+ *
+ * Spawns one {@link file://./run-cull-margin-cell.ts} process per
+ * (margin, nodeCount, cameraSpeed) point — see that file for why a cell owns its
+ * process — collects the JSON each prints, and writes a Markdown table plus the
+ * raw JSONL.
+ *
+ *   pnpm perf:renderers:cull-margin [--margins 0,0.0625,0.125] [--nodes 25000,100000]
+ *                                   [--speeds 8] [--frames 300] [--warmup 60] [--repeats 3]
+ *                                   [--out .workspace/output/cull-margin]
+ *
+ * @internal Test/perf-only.
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const args = process.argv.slice(2);
+
+const flag = (name: string): string | undefined => {
+  const index = args.indexOf(`--${name}`);
+
+  return index === -1 ? undefined : args[index + 1];
+};
+
+const list = (name: string, fallback: number[]): number[] => {
+  const raw = flag(name);
+
+  return raw === undefined ? fallback : raw.split(',').map(Number);
+};
+
+const margins = list('margins', [0, 1 / 16, 3 / 32, 1 / 8, 3 / 16, 1 / 4]);
+const nodeCounts = list('nodes', [25_000, 100_000]);
+const speeds = list('speeds', [8]);
+const frames = Number(flag('frames') ?? 300);
+const warmup = Number(flag('warmup') ?? 60);
+const repeats = Number(flag('repeats') ?? 3);
+const out = resolve(flag('out') ?? '.workspace/output/cull-margin');
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cell = resolve(here, 'run-cull-margin-cell.ts');
+const nodeArgs = ['--expose-gc', '--max-old-space-size=8192', '--conditions=@codexo/source', '--import', './scripts/glsl-register.mjs', '--import', 'tsx/esm'];
+
+interface CellResult {
+  margin: number;
+  nodes: number;
+  speed: number;
+  captureAreaFactor: number;
+  tiers: Record<string, number>;
+  query: Record<string, number>;
+  sourceItems: number;
+  perFrame: Record<string, number>;
+  cpuMs: Record<string, number>;
+  replayMs: { count: number; median: number; mean: number; max: number } | null;
+  missMs: { count: number; median: number; mean: number; max: number } | null;
+  heapDeltaBytes: number;
+}
+
+const rows: CellResult[] = [];
+const lines: string[] = [];
+
+for (const nodes of nodeCounts) {
+  for (const speed of speeds) {
+    for (const margin of margins) {
+      for (let repeat = 0; repeat < repeats; repeat++) {
+        const result = spawnSync(
+          process.execPath,
+          [
+            ...nodeArgs,
+            cell,
+            '--margin',
+            String(margin),
+            '--nodes',
+            String(nodes),
+            '--speed',
+            String(speed),
+            '--frames',
+            String(frames),
+            '--warmup',
+            String(warmup),
+            ...(args.includes('--no-slots') ? ['--no-slots'] : []),
+          ],
+          { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+        );
+
+        if (result.status !== 0) {
+          throw new Error(`cell failed (margin=${margin} nodes=${nodes} speed=${speed}):\n${result.stderr}`);
+        }
+
+        const line = result.stdout.trim().split('\n').pop()!;
+
+        lines.push(JSON.stringify({ repeat, ...(JSON.parse(line) as object) }));
+        rows.push(JSON.parse(line) as CellResult);
+
+        process.stderr.write(`. margin=${margin.toFixed(5)} nodes=${nodes} speed=${speed} repeat=${repeat}\n`);
+      }
+    }
+  }
+}
+
+/** Median of a numeric series — the repeats are combined, never averaged. */
+const median = (values: number[]): number => {
+  const sorted = [...values].sort((a, b) => a - b);
+
+  return sorted[Math.floor(sorted.length / 2)]!;
+};
+
+const key = (row: CellResult): string => `${row.nodes}|${row.speed}|${row.margin}`;
+const groups = new Map<string, CellResult[]>();
+
+for (const row of rows) {
+  const bucket = groups.get(key(row)) ?? [];
+
+  bucket.push(row);
+  groups.set(key(row), bucket);
+}
+
+const header =
+  '| margin | area | nodes | speed | replay | miss | collect | drawn/frame | visible/frame | frames/miss | cand/miss | entered/miss | upload B/frame | replay ms | miss ms | CPU mean | CPU p95 |';
+const divider = '| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |';
+const table = [header, divider];
+
+for (const [, bucket] of groups) {
+  const first = bucket[0]!;
+  const misses = median(bucket.map(row => row.tiers.slotReselect! + row.tiers.sourceSelect! + row.tiers.fullCollect!));
+  const missMs = bucket.map(row => row.missMs?.mean).filter((value): value is number => value !== undefined);
+
+  table.push(
+    [
+      `${first.margin.toFixed(5)}`,
+      `${first.captureAreaFactor.toFixed(3)}x`,
+      `${first.nodes}`,
+      `${first.speed}`,
+      `${median(bucket.map(row => row.tiers.slotReplay! + row.tiers.captureReplay!))}`,
+      `${misses}`,
+      `${median(bucket.map(row => row.tiers.fullCollect!))}`,
+      `${median(bucket.map(row => row.perFrame.submittedNodes!)).toFixed(0)}`,
+      `${median(bucket.map(row => row.perFrame.visibleLeaves!)).toFixed(0)}`,
+      `${misses === 0 ? 'n/a' : (frames / misses).toFixed(2)}`,
+      `${misses === 0 ? 'n/a' : (median(bucket.map(row => row.query.candidates!)) / misses).toFixed(0)}`,
+      `${misses === 0 ? 'n/a' : (median(bucket.map(row => row.query.entered!)) / misses).toFixed(0)}`,
+      `${median(bucket.map(row => row.perFrame.uploadedBufferBytes!)).toFixed(0)}`,
+      `${median(bucket.map(row => row.replayMs?.median ?? Number.NaN)).toFixed(4)}`,
+      `${missMs.length === 0 ? 'n/a' : median(missMs).toFixed(4)}`,
+      `${median(bucket.map(row => row.cpuMs.mean!)).toFixed(4)}`,
+      `${median(bucket.map(row => row.cpuMs.p95!)).toFixed(4)}`,
+    ].join(' | '),
+  );
+}
+
+mkdirSync(out, { recursive: true });
+writeFileSync(resolve(out, 'cells.jsonl'), `${lines.join('\n')}\n`);
+writeFileSync(resolve(out, 'sweep.md'), `${table.join('\n')}\n`);
+
+process.stdout.write(`${table.join('\n')}\n\nwritten: ${out}\n`);


### PR DESCRIPTION
Ships the measurement work behind the retained cull-margin decision. The margin
constant is unchanged: `1/16` per view axis stays, and this PR is what makes that
choice checkable instead of remembered.

No production source changes. Tests, a sweep harness and opt-in bench arms only.

## Why a miss is not a collect

A margin miss no longer rebuilds the scene. Measured at 100 000 nodes, `r = 1/16`,
camera speed 8, one cell per process, 400 timed frames after 80 warmup frames:

| tier | replay frame | miss frame | ratio |
| --- | ---: | ---: | ---: |
| slot path (indexed re-selection) | 0.018 ms | 0.667 ms | ~37x |
| capture path (slot path refused) | 0.024 ms | 5.47 ms | ~230x |

The slot-path miss is a spatial-index query over the grown rect plus a bitset
delta plus one slot write per arriving item. The capture tier is reached by any
root whose scope has mixed `zIndex` or a non-group sibling, which a z-sorted
scene qualifies for, and that is where the guard band still buys something large
(19.3 ms per miss at 100 000 nodes).

Both tiers agree that a miss costs *more* the wider the margin is: arrivals per
miss scale as `r*(1 + 2r)` while misses per frame fall as `1/r`.

## Where the knee is

Marginal amortized CPU per step, 100 000 nodes, speed 8:

| step | CPU mean | improvement | drawn/frame | per-frame upload |
| --- | ---: | ---: | ---: | ---: |
| 0 -> 1/64 | 0.3339 -> 0.2034 | -39% | +6% | +6% |
| 1/64 -> 1/32 | 0.2034 -> 0.1314 | -35% | +6% | +6% |
| 1/32 -> 3/64 | 0.1314 -> 0.1072 | -18% | +5% | +5% |
| 3/64 -> 1/16 | 0.1072 -> 0.0987 | -8% | +5% | +5% |
| 1/16 -> 3/32 | 0.0987 -> 0.0925 | -6% | +10% | +10% |
| 3/32 -> 1/8 | 0.0925 -> 0.0869 | -6% | +10% | +10% |
| 1/8 -> 3/16 | 0.0869 -> 0.0712 | -18% | +17% | +17% |
| 3/16 -> 1/4 | 0.0712 -> 0.0774 | +9% | +17% | +17% |

Above `1/16` every further step buys at most 6-18% amortized CPU, all inside the
CPU stub's noise floor, while permanently adding 10-17% to the nodes drawn on
every frame and to the order-stream bytes uploaded on every frame.

## The margin is not overfit to one scroll rate

100 000 nodes, slot tier, CPU mean:

| margin | speed 4 | speed 8 | speed 16 |
| ---: | ---: | ---: | ---: |
| 1/32 | 0.0950 | 0.1314 | 0.2592 |
| **1/16** | **0.0693** | 0.0987 | 0.1836 |
| 1/8 | 0.0707 | **0.0869** | 0.1204 |
| 1/4 | 0.0745 | 0.0774 | **0.0986** |

The optimum moves with scroll rate, as the geometry predicts. At the archetype's
design speed and at half of it, `1/16` is at or below the optimum, and `1/8` and
`1/4` are worse at speed 4 while permanently drawing 56% / 125% more nodes. A
single fixed margin must not be tuned on the fastest case.

## The WebGPU column that must not be cited

The 1 000 000-node WebGPU sweep produced a `frameMsP95` of 122 ms at `r = 1/4`.
That number is a harness artefact, not a margin cost: it is the one-shot
persistent-slot bootstrap upload charged to steady-state timed frames by a
harness that ran its warmup unpaced and then read a cumulative
`queue.onSubmittedWorkDone`. The harness now drains the queue at the
warmup/timing boundary, which drops the worst sample on that cell from 141.6 ms
to 27.2 ms. The decision rests on the knee, the speed sensitivity, the WebGL2
hardware-timer p95 and the miss cost - none of which come from that column.

## What ships

- `test/perf/rendering/cull-margin-correctness.test.ts`,
  `capture-kept-bounds.test.ts`, `cull-margin-probe-fidelity.test.ts` and
  `cullMarginProbe.ts` pin the capture-margin contract and keep the probe honest
  about which tier served a frame.
- `run-cull-margin.ts` / `run-cull-margin-cell.ts` plus
  `perf:renderers:cull-margin` and `perf:renderers:cull-margin:cell` make the
  sweep reproducible. One cell per process, for the reasons the allocation
  harness already documents.
- Opt-in `cull-margin-*` bench arms, deliberately outside `ADAPTER_CAPABILITIES`:
  they answer an engine-tuning question, not a cross-library one, and enter the
  matrix only when `--config` names them.

## Validation

- `pnpm verify:quick` - all 16 gates pass
- `vitest --project=rendering-perf cull-margin capture-kept-bounds` - 24 tests pass
- `pnpm perf:renderers:cull-margin` smoke run on the current base: 17 replay / 3
  miss frames at `r = 1/16`, capture area 1.266x, as expected