### PR TITLE
feat(physics): decide per contact what it does this step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ release and includes intentional breaking changes; see **Changed** and
 
 ### Added
 
+- **A world-level contact modifier decides what a contact does this step.** There was no
+  `preSolve`/`enableContact` anywhere in the physics API, so a one-way platform — solid
+  from above, passable from below — could not be expressed at all: collision filters answer
+  "may these two touch", not "should this particular contact push right now".
+
+  `PhysicsWorld.contactModifier` runs once per solid contact per fixed step, after contact
+  generation and before island building and the solver. It gets the two colliders, the two
+  bodies, the A→B normal, the manifold point count and the deepest penetration, and it may
+  change three things: `enabled`, `friction` and `restitution`. All three are re-derived
+  from the two colliders before every step, so a change applies to that step only.
+
+  Disabling a contact skips it in the solver without touching detection: it stays
+  geometrically touching and `onCollisionStart`/`onCollisionEnd` still describe the real
+  geometry. It also does not join its two bodies into one sleeping island — which is why
+  the hook runs before the sleep pass, not after — and its warm-start impulses are dropped,
+  so re-enabling it starts from zero rather than releasing a stale impulse. Sensors never
+  reach the modifier; they produce no contact to solve.
+
+  There is at most one modifier per world. It mutates simulation state, so a multi-listener
+  signal would make the outcome depend on registration order.
+
 - **Particles are addressed by channel, and a death is a snapshot.** The whole
   particle SoA was public and the guide recommended mutating it, which made the
   CPU/GPU packing a permanent contract — and on the GPU path it was not even

--- a/packages/exojs-physics/src/ContactGraph.ts
+++ b/packages/exojs-physics/src/ContactGraph.ts
@@ -2,6 +2,8 @@ import type { CandidatePair } from './broadphase/BroadPhase';
 import type { Collider } from './Collider';
 import { Manifold } from './collision/Manifold';
 import { collide, testOverlap } from './collision/narrowphase';
+import type { ContactModifier } from './ContactModifier';
+import { MutableContactModifierContext } from './ContactModifier';
 import type { CollisionEvent, ContactPoint, SensorEvent } from './events';
 import { sortInPlace } from './sort';
 import { shouldCollide } from './types';
@@ -17,6 +19,15 @@ export interface ContactRecord {
   readonly isSensor: boolean;
   touching: boolean;
   seen: boolean;
+  /**
+   * Per-step solver participation. Re-derived to `true` for every touching solid
+   * contact each pass, then optionally cleared by the world's `ContactModifier`.
+   */
+  enabled: boolean;
+  /** Per-step Coulomb friction, re-derived from the two colliders each pass. */
+  friction: number;
+  /** Per-step restitution, re-derived from the two colliders each pass. */
+  restitution: number;
   /** Persistent manifold (solid contacts), refreshed each pass by the narrow phase. */
   readonly manifold: Manifold;
   /** Accumulated normal impulse per contact point, carried across steps (warm-start). */
@@ -53,6 +64,7 @@ export class ContactGraph {
   // Integer pair-keys (`(a.id << 16) | b.id`, a.id < b.id guaranteed by the broad
   // phase) - cheaper than string keys on the per-step solver hot path.
   private readonly _records = new Map<number, ContactRecord>();
+  private readonly _modifierContext = new MutableContactModifierContext();
 
   /** Touching pairs currently tracked (for debug draw). */
   public get recordCount(): number {
@@ -96,6 +108,12 @@ export class ContactGraph {
         }
 
         if (!isSensor) {
+          // Per-step controls start from the collider-derived defaults every
+          // pass, so a modifier that skipped a contact last step does not leak
+          // into this one.
+          record.enabled = true;
+          record.friction = Math.sqrt(a.friction * b.friction);
+          record.restitution = Math.max(a.restitution, b.restitution);
           warmStartMatch(record);
           this.solidContacts.push(record);
         }
@@ -120,6 +138,32 @@ export class ContactGraph {
     sortInPlace(this.sensorEnter, bySensorPair);
     sortInPlace(this.sensorExit, bySensorPair);
     sortInPlace(this.solidContacts, byRecordPair);
+  }
+
+  /**
+   * Run `modifier` over every touching solid contact of this pass. Called after
+   * detection and before island building, so a contact the modifier disables
+   * neither reaches the solver nor couples its two bodies into one sleeping
+   * island. A disabled contact's warm-start cache is dropped, so re-enabling it
+   * later starts from zero instead of releasing a stale impulse.
+   */
+  public applyModifier(modifier: ContactModifier): void {
+    const context = this._modifierContext;
+
+    for (const record of this.solidContacts) {
+      context.bind(record);
+      modifier(context);
+      context.flush(record);
+
+      if (!record.enabled) {
+        record.normalImpulse[0] = 0;
+        record.normalImpulse[1] = 0;
+        record.tangentImpulse[0] = 0;
+        record.tangentImpulse[1] = 0;
+        record.pointIds[0] = 0;
+        record.pointIds[1] = 0;
+      }
+    }
   }
 
   /** Remove every record referencing `collider` (called when a collider is destroyed). */
@@ -197,6 +241,9 @@ const createRecord = (a: Collider, b: Collider, isSensor: boolean): ContactRecor
   isSensor,
   touching: false,
   seen: true,
+  enabled: true,
+  friction: 0,
+  restitution: 0,
   manifold: new Manifold(),
   normalImpulse: [0, 0],
   tangentImpulse: [0, 0],

--- a/packages/exojs-physics/src/ContactModifier.ts
+++ b/packages/exojs-physics/src/ContactModifier.ts
@@ -1,0 +1,112 @@
+import type { Collider } from './Collider';
+import type { ContactRecord } from './ContactGraph';
+import type { PhysicsBody } from './PhysicsBody';
+
+/**
+ * A solid contact as the world's {@link ContactModifier} sees it: the pair that
+ * produced it, the contact normal, and the three per-step controls the modifier
+ * may change. Everything else is read-only.
+ *
+ * The object is reused for every contact and is only valid for the duration of
+ * the callback - read what you need, write the controls, do not retain it.
+ *
+ * Writing a control affects this step only; the values are re-derived from the
+ * two colliders before the modifier runs again.
+ */
+export interface ContactModifierContext {
+  readonly colliderA: Collider;
+  readonly colliderB: Collider;
+  readonly bodyA: PhysicsBody;
+  readonly bodyB: PhysicsBody;
+  /** X of the unit contact normal, pointing from A towards B. */
+  readonly normalX: number;
+  /** Y of the unit contact normal, pointing from A towards B. */
+  readonly normalY: number;
+  /** Manifold points backing this contact: `1` for a vertex/face hit, `2` for a face/face hit. */
+  readonly pointCount: number;
+  /** Deepest penetration across the manifold points, in px. */
+  readonly maxPenetration: number;
+  /**
+   * Set to `false` to skip this contact in the solver for this step. The
+   * contact stays geometrically touching, so `collisionStart`/`collisionEnd`
+   * still describe the real geometry; it just applies no impulse, and it does
+   * not join the two bodies into one sleeping island. Its warm-start impulses
+   * are dropped while it is disabled, so re-enabling it starts cold rather than
+   * releasing a stale impulse.
+   */
+  enabled: boolean;
+  /**
+   * Coulomb friction for this step. Defaults to `√(a.friction × b.friction)`
+   * over the two colliders.
+   */
+  friction: number;
+  /**
+   * Restitution for this step. Defaults to `max(a.restitution, b.restitution)`
+   * over the two colliders.
+   */
+  restitution: number;
+}
+
+/**
+ * Called once per solid contact per fixed step, after contact generation and
+ * before the solver runs, to adjust that contact for this step - the hook
+ * one-way platforms, conditional friction and per-pair material overrides are
+ * built on.
+ *
+ * A world has at most one modifier. It runs before islands are built, so
+ * disabling a contact also keeps the two bodies from sleeping as one.
+ */
+export type ContactModifier = (contact: ContactModifierContext) => void;
+
+/**
+ * The single reused {@link ContactModifierContext} instance. Bound to one record
+ * at a time so a step over thousands of contacts allocates nothing.
+ * @internal
+ */
+export class MutableContactModifierContext implements ContactModifierContext {
+  public colliderA!: Collider;
+  public colliderB!: Collider;
+  public bodyA!: PhysicsBody;
+  public bodyB!: PhysicsBody;
+  public normalX = 0;
+  public normalY = 0;
+  public pointCount = 0;
+  public maxPenetration = 0;
+  public enabled = true;
+  public friction = 0;
+  public restitution = 0;
+
+  /** Point this context at `record` and load its current per-step values. */
+  public bind(record: ContactRecord): void {
+    const manifold = record.manifold;
+
+    this.colliderA = record.a;
+    this.colliderB = record.b;
+    this.bodyA = record.a.body;
+    this.bodyB = record.b.body;
+    this.normalX = manifold.normalX;
+    this.normalY = manifold.normalY;
+    this.pointCount = manifold.pointCount;
+
+    let deepest = 0;
+
+    for (let i = 0; i < manifold.pointCount; i++) {
+      // i < pointCount <= 2, so the point exists.
+      const penetration = (i === 0 ? manifold.points[0] : manifold.points[1]).penetration;
+
+      deepest = penetration > deepest ? penetration : deepest;
+    }
+
+    this.maxPenetration = deepest;
+    this.enabled = record.enabled;
+    this.friction = record.friction;
+    this.restitution = record.restitution;
+  }
+
+  /** Write the (possibly modified) controls back onto the bound record. */
+  public flush(record: ContactRecord): void {
+    record.enabled = this.enabled;
+    record.friction = this.friction;
+    record.restitution = this.restitution;
+  }
+}

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -9,6 +9,7 @@ import type { PhysicsBinding } from './binding/PhysicsBinding';
 import { Collider } from './Collider';
 import type { SweepHit } from './collision/sweep';
 import { sweepProxies } from './collision/sweep';
+import type { ContactModifier } from './ContactModifier';
 import type { CollisionEvent, SensorEvent } from './events';
 import type { Joint } from './joints/Joint';
 import type { BodyOwner } from './PhysicsBody';
@@ -100,6 +101,12 @@ export interface PhysicsWorldOptions {
   dampingRatio?: number;
   /** Put resting bodies to sleep so they skip integration and solving. Default `true`. */
   enableSleeping?: boolean;
+  /**
+   * Adjust each solid contact for the coming step (one-way platforms,
+   * conditional friction, per-pair material overrides). At most one per world;
+   * see {@link PhysicsWorld.contactModifier}. Default none.
+   */
+  contactModifier?: ContactModifier | null;
   /** Linear speed at or below which a body is a sleep candidate, px/s. Default `5`. */
   sleepLinearVelocity?: number;
   /** Angular speed at or below which a body is a sleep candidate, rad/s. Default `0.06`. */
@@ -220,6 +227,18 @@ export class PhysicsWorld implements BodyOwner {
   /** Seconds below the thresholds before a body sleeps. */
   public readonly timeToSleep: number;
 
+  /**
+   * Runs once per solid contact per fixed step, after contact generation and
+   * before island building and the solver, so a contact it disables applies no
+   * impulse and does not couple its two bodies into one sleeping island.
+   *
+   * At most one modifier per world - it mutates simulation state, so a
+   * multi-listener signal would make the outcome depend on registration order.
+   * Set to `null` to remove it; the per-contact values then stay at the
+   * defaults derived from the two colliders.
+   */
+  public contactModifier: ContactModifier | null;
+
   private readonly _backend: PhysicsBackend = new NativePhysicsBackend();
   private readonly _bodies: PhysicsBody[] = [];
   private readonly _colliders: Collider[] = [];
@@ -285,6 +304,7 @@ export class PhysicsWorld implements BodyOwner {
     this.sleepLinearVelocity = options.sleepLinearVelocity ?? 5;
     this.sleepAngularVelocity = options.sleepAngularVelocity ?? 0.06;
     this.timeToSleep = options.timeToSleep ?? 0.5;
+    this.contactModifier = options.contactModifier ?? null;
     this._query = new QueryEngine(this._colliders, this._backend.spatialIndex);
   }
 
@@ -519,6 +539,13 @@ export class PhysicsWorld implements BodyOwner {
     // reuses the manifolds across the sub-steps below.
     this._backend.detect(this._colliders);
 
+    // The contact modifier runs between detection and the sleep decision: a
+    // contact it disables must neither reach the solver nor union its two bodies
+    // into one island, and both of those are decided below.
+    if (this.contactModifier !== null) {
+      this._backend.applyContactModifier(this.contactModifier);
+    }
+
     // Sleep decision runs after detection (islands need the current contact
     // set) and before the solver (so sleeping contacts are skipped, and a
     // sleeping island touched by an awake body is woken first).
@@ -752,25 +779,7 @@ export class PhysicsWorld implements BodyOwner {
     parent.length = count;
     minSleep.length = count;
 
-    // Union dynamic↔dynamic solid contacts into islands. A dynamic body touching
-    // a MOVING static/kinematic body has its sleep timer reset instead: those
-    // types are island boundaries, not members, so nothing else would keep the
-    // passenger of a slow-moving platform awake - and the solver skips a contact
-    // whose dynamic side is asleep, letting the platform drive straight through it.
-    for (const contact of this._backend.contactGraph.solidContacts) {
-      const bodyA = contact.a.body;
-      const bodyB = contact.b.body;
-      const dynamicA = bodyA.type === 'dynamic';
-      const dynamicB = bodyB.type === 'dynamic';
-
-      if (dynamicA && dynamicB) {
-        this._union(bodyA._islandIndex, bodyB._islandIndex);
-      } else if (dynamicA && isMovingBoundary(bodyB)) {
-        bodyA._sleepTime = 0;
-      } else if (dynamicB && isMovingBoundary(bodyA)) {
-        bodyB._sleepTime = 0;
-      }
-    }
+    this._unionContactIslands();
 
     // Joints couple their two bodies into the same island (sleep/wake together).
     for (const joint of this._joints) {
@@ -804,6 +813,36 @@ export class PhysicsWorld implements BodyOwner {
 
       if (body.type === 'dynamic') {
         body._setSleeping(minSleep[this._find(i)]! >= timeToSleep);
+      }
+    }
+  }
+
+  /**
+   * Union dynamic↔dynamic solid contacts into islands. A dynamic body touching a
+   * MOVING static/kinematic body has its sleep timer reset instead: those types
+   * are island boundaries, not members, so nothing else would keep the passenger
+   * of a slow-moving platform awake - and the solver skips a contact whose
+   * dynamic side is asleep, letting the platform drive straight through it.
+   */
+  private _unionContactIslands(): void {
+    for (const contact of this._backend.contactGraph.solidContacts) {
+      // A contact the modifier disabled carries no load this step, so it neither
+      // forms an island nor keeps a passenger of a moving platform awake.
+      if (!contact.enabled) {
+        continue;
+      }
+
+      const bodyA = contact.a.body;
+      const bodyB = contact.b.body;
+      const dynamicA = bodyA.type === 'dynamic';
+      const dynamicB = bodyB.type === 'dynamic';
+
+      if (dynamicA && dynamicB) {
+        this._union(bodyA._islandIndex, bodyB._islandIndex);
+      } else if (dynamicA && isMovingBoundary(bodyB)) {
+        bodyA._sleepTime = 0;
+      } else if (dynamicB && isMovingBoundary(bodyA)) {
+        bodyB._sleepTime = 0;
       }
     }
   }

--- a/packages/exojs-physics/src/backend/NativePhysicsBackend.ts
+++ b/packages/exojs-physics/src/backend/NativePhysicsBackend.ts
@@ -2,6 +2,7 @@ import { AabbTreeBroadPhase } from '../broadphase/AabbTreeBroadPhase';
 import type { CandidatePair } from '../broadphase/BroadPhase';
 import type { Collider } from '../Collider';
 import { ContactGraph } from '../ContactGraph';
+import type { ContactModifier } from '../ContactModifier';
 import type { SpatialIndex } from '../query/SpatialIndex';
 import { ContactSolver } from '../solver/ContactSolver';
 import type { PhysicsBackend } from './PhysicsBackend';
@@ -27,6 +28,10 @@ export class NativePhysicsBackend implements PhysicsBackend {
   public detect(colliders: readonly Collider[]): void {
     this._broadPhase.computePairs(colliders, this._pairs);
     this.contactGraph.update(this._pairs);
+  }
+
+  public applyContactModifier(modifier: ContactModifier): void {
+    this.contactGraph.applyModifier(modifier);
   }
 
   public prepareSolve(h: number, contactHertz: number, dampingRatio: number): void {

--- a/packages/exojs-physics/src/backend/PhysicsBackend.ts
+++ b/packages/exojs-physics/src/backend/PhysicsBackend.ts
@@ -1,6 +1,7 @@
 import type { CandidatePair } from '../broadphase/BroadPhase';
 import type { Collider } from '../Collider';
 import type { ContactGraph } from '../ContactGraph';
+import type { ContactModifier } from '../ContactModifier';
 import type { SpatialIndex } from '../query/SpatialIndex';
 
 /**
@@ -20,6 +21,8 @@ export interface PhysicsBackend {
   readonly spatialIndex?: SpatialIndex;
   /** Run one detection pass over `colliders`, refreshing the contact graph. Once per frame (TGS reuses the manifolds across sub-steps). */
   detect(colliders: readonly Collider[]): void;
+  /** Run the world's contact modifier over this pass's solid contacts. Call between {@link detect} and island building. */
+  applyContactModifier(modifier: ContactModifier): void;
   /** Build the per-frame contact constraints from the solid contacts. `h` is the sub-step duration; the soft factors derive from it plus `contactHertz`/`dampingRatio`. Call once per frame after {@link detect}. */
   prepareSolve(h: number, contactHertz: number, dampingRatio: number): void;
   /** Re-apply the cached warm-start impulses to the contacting bodies (first sub-step only). */

--- a/packages/exojs-physics/src/public.ts
+++ b/packages/exojs-physics/src/public.ts
@@ -6,6 +6,7 @@
 export { PhysicsBinding } from './binding/PhysicsBinding';
 export type { ColliderOptions } from './Collider';
 export { Collider } from './Collider';
+export type { ContactModifier, ContactModifierContext } from './ContactModifier';
 export type { CollisionEvent, ContactPoint, SensorEvent } from './events';
 export { DistanceJoint, type DistanceJointOptions } from './joints/DistanceJoint';
 export { Joint } from './joints/Joint';

--- a/packages/exojs-physics/src/solver/ContactSolver.ts
+++ b/packages/exojs-physics/src/solver/ContactSolver.ts
@@ -127,7 +127,9 @@ export class ContactSolver {
       const manifold = contact.manifold;
       const pointCount = manifold.pointCount;
 
-      if (pointCount === 0) {
+      // A contact the world's `ContactModifier` disabled for this step stays
+      // touching geometrically but applies no impulse.
+      if (pointCount === 0 || !contact.enabled) {
         continue;
       }
 
@@ -155,8 +157,10 @@ export class ContactSolver {
       constraint.ny = ny;
       constraint.tx = tx;
       constraint.ty = ty;
-      constraint.friction = Math.sqrt(contact.a.friction * contact.b.friction);
-      constraint.restitution = Math.max(contact.a.restitution, contact.b.restitution);
+      // Per-step values: derived from the two colliders each pass, then possibly
+      // overridden by the world's `ContactModifier`.
+      constraint.friction = contact.friction;
+      constraint.restitution = contact.restitution;
       constraint.pointCount = pointCount;
       constraint.block = false;
       constraint.biasRate = biasRate;

--- a/packages/exojs-physics/test/contact-modifier.test.ts
+++ b/packages/exojs-physics/test/contact-modifier.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CollisionEvent, ContactModifierContext } from '../src/index';
+import { BoxShape, PhysicsBody, PhysicsWorld } from '../src/index';
+
+/**
+ * The world-level contact modifier: one hook, run once per solid contact per
+ * fixed step, after contact generation and before island building and the
+ * solver. Default solver config, +Y down.
+ */
+
+const GRAVITY = 1000; // px/s²
+const FRAME = 1 / 60;
+
+const advance = (world: PhysicsWorld, seconds: number): void => {
+  const frames = Math.round(seconds / FRAME);
+
+  for (let frame = 0; frame < frames; frame++) {
+    world.step(FRAME);
+  }
+};
+
+/** A wide static floor whose top surface sits at `topY`. */
+const addFloor = (world: PhysicsWorld, topY: number): PhysicsBody =>
+  world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: topY + 20 }, colliders: [{ shape: new BoxShape(1200, 40) }] }));
+
+/** A 20×20 dynamic box centred at `(x, y)`. */
+const addBox = (world: PhysicsWorld, x: number, y: number, friction = 0.2, restitution = 0): PhysicsBody =>
+  world.add(new PhysicsBody({ type: 'dynamic', position: { x, y }, colliders: [{ shape: new BoxShape(20, 20), friction, restitution }] }));
+
+describe('contact modifier', () => {
+  it('sees every solid contact once per step, with the A→B normal and both sides', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    const floor = addFloor(world, 100);
+    const box = addBox(world, 0, 60);
+
+    const seen: { a: unknown; b: unknown; normalY: number; pointCount: number }[] = [];
+    world.contactModifier = contact => {
+      seen.push({ a: contact.bodyA, b: contact.bodyB, normalY: contact.normalY, pointCount: contact.pointCount });
+    };
+
+    advance(world, 0.5);
+
+    expect(seen.length).toBeGreaterThan(0);
+
+    for (const entry of seen) {
+      expect(new Set([entry.a, entry.b])).toEqual(new Set([box, floor]));
+      // Resting box on a floor: one face/face manifold, normal along ±Y.
+      expect(entry.pointCount).toBe(2);
+      expect(Math.abs(entry.normalY)).toBeCloseTo(1);
+    }
+  });
+
+  it('leaves the simulation untouched when no modifier is set', () => {
+    const withoutModifier = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    addFloor(withoutModifier, 100);
+    const a = addBox(withoutModifier, 0, 0);
+
+    const withNoopModifier = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY }, contactModifier: () => undefined });
+    addFloor(withNoopModifier, 100);
+    const b = addBox(withNoopModifier, 0, 0);
+
+    advance(withoutModifier, 1.5);
+    advance(withNoopModifier, 1.5);
+
+    expect(b.x).toBeCloseTo(a.x, 6);
+    expect(b.y).toBeCloseTo(a.y, 6);
+  });
+
+  it('a disabled contact applies no impulse but stays a real collision event', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    addFloor(world, 100);
+    const box = addBox(world, 0, 0);
+
+    const starts: CollisionEvent[] = [];
+    world.onCollisionStart.add(event => starts.push(event));
+    world.contactModifier = contact => {
+      contact.enabled = false;
+    };
+
+    advance(world, 1.5);
+
+    // The box falls straight through the floor it geometrically touches.
+    expect(box.y).toBeGreaterThan(200);
+    expect(starts).toHaveLength(1);
+    expect(starts[0]!.points.length).toBeGreaterThan(0);
+  });
+
+  it('re-derives the controls from the colliders before every step', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    addFloor(world, 100);
+    addBox(world, 0, 60, 0.36, 0.5);
+
+    const observed: { friction: number; restitution: number; enabled: boolean }[] = [];
+    let step = 0;
+    world.contactModifier = contact => {
+      observed.push({ friction: contact.friction, restitution: contact.restitution, enabled: contact.enabled });
+
+      // Scribble over the controls on the first observed step only; the next
+      // step must start from the collider-derived defaults again.
+      if (step++ === 0) {
+        contact.friction = 0;
+        contact.restitution = 0;
+        contact.enabled = false;
+      }
+    };
+
+    advance(world, 0.6);
+
+    expect(observed.length).toBeGreaterThan(1);
+
+    for (const entry of observed) {
+      // Floor friction/restitution are the collider defaults (0.2 / 0).
+      expect(entry.friction).toBeCloseTo(Math.sqrt(0.36 * 0.2));
+      expect(entry.restitution).toBeCloseTo(0.5);
+      expect(entry.enabled).toBe(true);
+    }
+  });
+
+  it('a disabled contact does not union two bodies into one sleeping island', () => {
+    // Two boxes stacked on a static floor. The top one is kept in slow motion so
+    // it can never sleep; whether the bottom one sleeps is decided purely by
+    // whether their shared contact unions them into one island.
+    const run = (disableStackContact: boolean): { lower: PhysicsBody; upper: PhysicsBody } => {
+      const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY }, timeToSleep: 0.2 });
+      const floor = addFloor(world, 300);
+      const lower = addBox(world, 0, 300 - 10, 0);
+      const upper = addBox(world, 0, 300 - 30, 0);
+
+      if (disableStackContact) {
+        world.contactModifier = contact => {
+          if (contact.bodyA !== floor && contact.bodyB !== floor) {
+            contact.enabled = false;
+          }
+        };
+      }
+
+      advance(world, 1);
+
+      // 10 px/s is above the 5 px/s sleep threshold, so the top box stays awake.
+      // It has already fallen asleep by now, and writing a velocity onto a
+      // sleeping body does nothing - it has to be woken first, exactly as a game
+      // driving a body would.
+      for (let frame = 0; frame < 120; frame++) {
+        upper.wake();
+        upper.linearVelocityX = 10;
+        world.step(FRAME);
+      }
+
+      return { lower, upper };
+    };
+
+    const coupled = run(false);
+
+    expect(coupled.upper.isSleeping).toBe(false);
+    expect(coupled.lower.isSleeping).toBe(false);
+
+    const decoupled = run(true);
+
+    expect(decoupled.upper.isSleeping).toBe(false);
+    expect(decoupled.lower.isSleeping).toBe(true);
+  });
+
+  it('a disabled contact stops a moving platform from waking its passenger', () => {
+    // The other half of the island rule: a static/kinematic body is an island
+    // boundary, so a moving one resets its passenger's sleep timer instead of
+    // being unioned with it. A disabled contact must not do that either.
+    const run = (disableContact: boolean): PhysicsBody => {
+      const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+      const platform = world.add(new PhysicsBody({ type: 'kinematic', position: { x: 0, y: 320 }, colliders: [{ shape: new BoxShape(1200, 40), friction: 0 }] }));
+      const box = addBox(world, 0, 300 - 12, 0);
+
+      advance(world, 2);
+      expect(box.isSleeping).toBe(true);
+
+      if (disableContact) {
+        world.contactModifier = contact => {
+          contact.enabled = false;
+        };
+      }
+
+      // Purely horizontal, so the platform never drives into the passenger - the
+      // only reason the box could wake is the moving-boundary rule.
+      platform.linearVelocityX = 3;
+      advance(world, 1);
+
+      return box;
+    };
+
+    expect(run(false).isSleeping).toBe(false);
+    expect(run(true).isSleeping).toBe(true);
+  });
+
+  it('drops the warm-start cache while a contact is disabled', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+    addFloor(world, 100);
+    addBox(world, 0, 60);
+
+    // Let the resting contact accumulate a warm-start impulse first.
+    advance(world, 1);
+
+    const graph = world.backend.contactGraph;
+    const record = graph.solidContacts[0]!;
+
+    expect(Math.abs(record.normalImpulse[0]) + Math.abs(record.normalImpulse[1])).toBeGreaterThan(0);
+
+    world.contactModifier = contact => {
+      contact.enabled = false;
+    };
+    world.step(FRAME);
+
+    expect(record.normalImpulse).toEqual([0, 0]);
+    expect(record.tangentImpulse).toEqual([0, 0]);
+    expect(record.pointIds).toEqual([0, 0]);
+  });
+
+  it('never hands a sensor overlap to the modifier', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(40, 40), isSensor: true }] }));
+    world.add(new PhysicsBody({ type: 'kinematic', position: { x: 5, y: 0 }, colliders: [{ shape: new BoxShape(20, 20) }] }));
+
+    const modifier = vi.fn<(contact: ContactModifierContext) => void>();
+    world.contactModifier = modifier;
+
+    advance(world, 0.5);
+
+    expect(modifier).not.toHaveBeenCalled();
+  });
+
+  it('expresses a one-way platform: solid from above, passable from below', () => {
+    // The real-world rule: sample the direction of travel once at the start of
+    // the step and ignore the contact while the body is moving upward. Reading
+    // the live velocity inside the modifier instead would flip as soon as the
+    // solver's push-out gives the body a hair of upward speed.
+    const run = (startY: number, velocityY: number, seconds: number): PhysicsBody => {
+      const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+      world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 100 }, colliders: [{ shape: new BoxShape(400, 10) }] }));
+      const box = addBox(world, 0, startY);
+
+      box.linearVelocityY = velocityY;
+
+      let movingUp = false;
+      world.contactModifier = contact => {
+        if (movingUp) {
+          contact.enabled = false;
+        }
+      };
+
+      const frames = Math.round(seconds / FRAME);
+
+      for (let frame = 0; frame < frames; frame++) {
+        movingUp = box.linearVelocityY < -10;
+        world.step(FRAME);
+      }
+
+      return box;
+    };
+
+    // Dropped from above: caught on the platform's top face (y = 95) and at rest.
+    // The exact resting depth is the solver's business (a 300 px/s impact leaves
+    // a couple of px of penetration the soft bias works off) - what this pins is
+    // that the box is still on top of the platform and no longer moving.
+    const landed = run(40, 300, 1.5);
+
+    expect(landed.y).toBeGreaterThan(80);
+    expect(landed.y).toBeLessThan(95);
+    expect(landed.linearVelocityY).toBeCloseTo(0, 1);
+
+    // Launched from below: passes straight through instead of being blocked.
+    // 0.4 s is the apex of the throw, by which point the box has cleared the
+    // platform's top face entirely; blocked, it would have stalled below it.
+    const passed = run(160, -400, 0.4);
+
+    expect(passed.y).toBeLessThan(85);
+  });
+});

--- a/packages/exojs-physics/test/dynamics.test.ts
+++ b/packages/exojs-physics/test/dynamics.test.ts
@@ -662,6 +662,9 @@ describe('ContactSolver internals', () => {
       isSensor: false,
       touching: true,
       seen: true,
+      enabled: true,
+      friction: 0.2,
+      restitution: 0,
       manifold: new Manifold(), // freshly constructed — pointCount stays 0
       normalImpulse: [0, 0],
       tangentImpulse: [0, 0],

--- a/site/src/content/api/contact-modifier-context.json
+++ b/site/src/content/api/contact-modifier-context.json
@@ -1,0 +1,283 @@
+{
+  "title": "ContactModifierContext",
+  "description": "A solid contact as the world's ContactModifier sees it: the pair that produced it, the contact normal, and the three per-step controls the modifier may change. Everything else is read-only. The object is reused for every contact and is only valid for the duration of the callback - read what you need, write the controls, do not retain it. Writing a control affects this step only; the values are re-derived from the two colliders before the modifier runs again.",
+  "symbol": "ContactModifierContext",
+  "kind": "interface",
+  "subsystem": "physics",
+  "importPath": "@codexo/exojs-physics",
+  "tier": "stable",
+  "memberCount": 11,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 11,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "A solid contact as the world's ContactModifier sees it: the pair that produced it, the contact normal, and the three per-step controls the modifier may change. Everything else is read-only.",
+        "The object is reused for every contact and is only valid for the duration of the callback - read what you need, write the controls, do not retain it.",
+        "Writing a control affects this step only; the values are re-derived from the two colliders before the modifier runs again."
+      ],
+      "importLine": "import { ContactModifierContext } from '@codexo/exojs-physics'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "bodyA",
+          "signature": "bodyA: PhysicsBody",
+          "signatureTokens": [
+            {
+              "text": "bodyA",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PhysicsBody",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "bodyB",
+          "signature": "bodyB: PhysicsBody",
+          "signatureTokens": [
+            {
+              "text": "bodyB",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PhysicsBody",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "colliderA",
+          "signature": "colliderA: Collider",
+          "signatureTokens": [
+            {
+              "text": "colliderA",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Collider",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "colliderB",
+          "signature": "colliderB: Collider",
+          "signatureTokens": [
+            {
+              "text": "colliderB",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Collider",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "enabled",
+          "signature": "enabled: boolean",
+          "signatureTokens": [
+            {
+              "text": "enabled",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Set to false to skip this contact in the solver for this step. The contact stays geometrically touching, so collisionStart/collisionEnd still describe the real geometry; it just applies no impulse, and it does not join the two bodies into one sleeping island. Its warm-start impulses are dropped while it is disabled, so re-enabling it starts cold rather than releasing a stale impulse."
+        },
+        {
+          "name": "friction",
+          "signature": "friction: number",
+          "signatureTokens": [
+            {
+              "text": "friction",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Coulomb friction for this step. Defaults to √(a.friction × b.friction) over the two colliders."
+        },
+        {
+          "name": "maxPenetration",
+          "signature": "maxPenetration: number",
+          "signatureTokens": [
+            {
+              "text": "maxPenetration",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Deepest penetration across the manifold points, in px."
+        },
+        {
+          "name": "normalX",
+          "signature": "normalX: number",
+          "signatureTokens": [
+            {
+              "text": "normalX",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "X of the unit contact normal, pointing from A towards B."
+        },
+        {
+          "name": "normalY",
+          "signature": "normalY: number",
+          "signatureTokens": [
+            {
+              "text": "normalY",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Y of the unit contact normal, pointing from A towards B."
+        },
+        {
+          "name": "pointCount",
+          "signature": "pointCount: number",
+          "signatureTokens": [
+            {
+              "text": "pointCount",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Manifold points backing this contact: 1 for a vertex/face hit, 2 for a face/face hit."
+        },
+        {
+          "name": "restitution",
+          "signature": "restitution: number",
+          "signatureTokens": [
+            {
+              "text": "restitution",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Restitution for this step. Defaults to max(a.restitution, b.restitution) over the two colliders."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-physics/src/ContactModifier.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/ContactModifier.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-physics/src/ContactModifier.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/ContactModifier.ts"
+}

--- a/site/src/content/api/contact-modifier.json
+++ b/site/src/content/api/contact-modifier.json
@@ -1,0 +1,84 @@
+{
+  "title": "ContactModifier",
+  "description": "Called once per solid contact per fixed step, after contact generation and before the solver runs, to adjust that contact for this step - the hook one-way platforms, conditional friction and per-pair material overrides are built on. A world has at most one modifier. It runs before islands are built, so disabling a contact also keeps the two bodies from sleeping as one.",
+  "symbol": "ContactModifier",
+  "kind": "type",
+  "subsystem": "physics",
+  "importPath": "@codexo/exojs-physics",
+  "tier": "stable",
+  "memberCount": 0,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Called once per solid contact per fixed step, after contact generation and before the solver runs, to adjust that contact for this step - the hook one-way platforms, conditional friction and per-pair material overrides are built on.",
+        "A world has at most one modifier. It runs before islands are built, so disabling a contact also keeps the two bodies from sleeping as one."
+      ],
+      "importLine": "import { ContactModifier } from '@codexo/exojs-physics'",
+      "sourceLink": null
+    },
+    {
+      "id": "definition",
+      "title": "Definition",
+      "members": [
+        {
+          "name": "ContactModifier",
+          "signature": "(contact: ContactModifierContext) => void",
+          "signatureTokens": [
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "contact",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ContactModifierContext",
+              "kind": "type"
+            },
+            {
+              "text": ") => ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-physics/src/ContactModifier.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/ContactModifier.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-physics/src/ContactModifier.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/ContactModifier.ts"
+}

--- a/site/src/content/api/physics-world-options.json
+++ b/site/src/content/api/physics-world-options.json
@@ -6,11 +6,11 @@
   "subsystem": "physics",
   "importPath": "@codexo/exojs-physics",
   "tier": "stable",
-  "memberCount": 10,
+  "memberCount": 11,
   "counts": {
     "constructors": 0,
     "methods": 0,
-    "properties": 10,
+    "properties": 11,
     "events": 0
   },
   "sections": [
@@ -52,6 +52,39 @@
           "params": [],
           "returnType": null,
           "description": "Soft-contact stiffness in Hz (the contact behaves as a damped spring at this frequency). Default 30."
+        },
+        {
+          "name": "contactModifier",
+          "signature": "contactModifier?: ContactModifier | null",
+          "signatureTokens": [
+            {
+              "text": "contactModifier",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ContactModifier",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Adjust each solid contact for the coming step (one-way platforms, conditional friction, per-pair material overrides). At most one per world; see PhysicsWorld.contactModifier. Default none."
         },
         {
           "name": "dampingRatio",

--- a/site/src/content/api/physics-world.json
+++ b/site/src/content/api/physics-world.json
@@ -6,11 +6,11 @@
   "subsystem": "physics",
   "importPath": "@codexo/exojs-physics",
   "tier": "stable",
-  "memberCount": 37,
+  "memberCount": 38,
   "counts": {
     "constructors": 1,
     "methods": 19,
-    "properties": 13,
+    "properties": 14,
     "events": 4
   },
   "sections": [
@@ -1861,6 +1861,35 @@
           "params": [],
           "returnType": null,
           "description": "Soft-contact stiffness in Hz."
+        },
+        {
+          "name": "contactModifier",
+          "signature": "contactModifier: ContactModifier | null",
+          "signatureTokens": [
+            {
+              "text": "contactModifier",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ContactModifier",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Runs once per solid contact per fixed step, after contact generation and before island building and the solver, so a contact it disables applies no impulse and does not couple its two bodies into one sleeping island. At most one modifier per world - it mutates simulation state, so a multi-listener signal would make the outcome depend on registration order. Set to null to remove it; the per-contact values then stay at the defaults derived from the two colliders."
         },
         {
           "name": "dampingRatio",

--- a/site/src/content/guide/physics/joints-and-dynamics.mdx
+++ b/site/src/content/guide/physics/joints-and-dynamics.mdx
@@ -256,6 +256,83 @@ bodies; sensors never block.
 This is ideal for small, point-like projectiles (bullets, pellets), but a **large** fast body can still clip a corner because only its centre is swept. For those, raise [`subStepCount`](/ExoJS/en/api/physics-world/) (or the step rate) so each step covers less distance, or thicken the geometry it must not pass. A full swept-shape time-of-impact for large bodies is a future enhancement.
 </Callout>
 
+## Contact modifier
+
+Filters decide **whether** two colliders may touch at all; the contact modifier decides what
+a contact that already exists **does this step**. It runs once per solid contact per fixed
+step, after collision detection and before the solver, and it is where one-way platforms,
+conditional friction and per-pair material overrides live.
+
+A world has at most one modifier — it mutates simulation state, so a multi-listener signal
+would make the result depend on registration order:
+
+```ts
+import { PhysicsWorld } from '@codexo/exojs-physics';
+
+const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+
+world.contactModifier = contact => {
+  // Ice: no friction wherever the icy collider is involved.
+  if (contact.colliderA.isSensor || contact.colliderB.isSensor) {
+    return;
+  }
+
+  contact.friction = 0;
+  contact.restitution = 0.1;
+};
+```
+
+`enabled`, `friction` and `restitution` are the three controls. Everything else on the
+contact — the two colliders, the two bodies, the A→B normal, the manifold point count and
+the deepest penetration — is read-only, and the object itself is reused for every contact,
+so read what you need inside the callback rather than storing it.
+
+The values are re-derived from the two colliders before every step (`√(fA × fB)` for
+friction, `max(rA, rB)` for restitution), so a change applies to that step only and nothing
+leaks into the next one.
+
+Setting `enabled = false` skips the contact in the solver: no impulse, no push-out. The
+contact is still geometrically touching, so `onCollisionStart`/`onCollisionEnd` keep
+describing the real geometry — the modifier changes the response, not the detection. A
+disabled contact also does **not** join its two bodies into one sleeping island, and its
+warm-start impulses are dropped, so re-enabling it starts from zero instead of releasing a
+stale impulse.
+
+That is the whole of a one-way platform. Sample the direction of travel at the start of the
+step and ignore the contact while the character is moving upward:
+
+```ts
+import { BoxShape, PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
+
+const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+const platform = world.add(
+  new PhysicsBody({ type: 'static', position: { x: 0, y: 300 }, colliders: [{ shape: new BoxShape(400, 10) }] }),
+);
+const player = world.add(
+  new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 100 }, colliders: [{ shape: new BoxShape(20, 40) }] }),
+);
+
+let jumpingUp = false;
+
+world.contactModifier = contact => {
+  const involvesPlatform = contact.bodyA === platform || contact.bodyB === platform;
+
+  if (involvesPlatform && jumpingUp) {
+    contact.enabled = false;
+  }
+};
+
+// In your update, before stepping the world:
+jumpingUp = player.linearVelocityY < -10;
+```
+
+<Callout type="warning" title="Sample velocity before the step, not inside the modifier">
+Reading `player.linearVelocityY` *inside* the callback looks equivalent but is not: the solver's push-out gives a resting body a hair of upward velocity, which flips the rule on and off every step and leaves the character sunk into the platform. Decide once per step from the state you already have.
+</Callout>
+
+The modifier never sees sensor overlaps — a sensor produces no contact to solve. Use
+`onSensorEnter`/`onSensorExit` for those.
+
 ## Where to go next
 
 - **API reference:** [`DistanceJoint`](/ExoJS/en/api/distance-joint/),


### PR DESCRIPTION
There was no `preSolve`/`enableContact` anywhere in the physics API, so a one-way platform — solid from above, passable from below — could not be expressed at all. Collision filters answer "may these two touch"; nothing answered "should this particular contact push right now".

## The hook

`PhysicsWorld.contactModifier` runs once per solid contact per fixed step, between contact generation and the sleep pass:

```
backend.detect()          // broad phase + narrow phase + contact graph diff
  → contactModifier       // ← here
  → _updateSleeping()     // islands, sleep decision
  → backend.prepareSolve()
```

It receives the two colliders, the two bodies, the A→B normal, the manifold point count and the deepest penetration, and may change three things: `enabled`, `friction`, `restitution`. All three are re-derived from the two colliders before every step (`√(fA × fB)`, `max(rA, rB)`, `true`), so a change applies to that step only and nothing leaks into the next one.

Everything else on the context is read-only, and the object is reused across contacts — a step over thousands of them allocates nothing.

## What disabling a contact means

- **No impulse, no push-out** — the solver skips it.
- **Detection is untouched**: it stays geometrically touching, and `onCollisionStart`/`onCollisionEnd` keep describing the real geometry.
- **It does not join its two bodies into one sleeping island.** This is why the hook runs *before* `_updateSleeping` rather than after; the island pass now skips a disabled contact for both its union branch and its moving-boundary branch.
- **Its warm-start impulses are dropped**, so re-enabling it later starts from zero instead of releasing a stale impulse.
- **Sensors never reach the modifier** — they produce no contact to solve.

## One modifier, not a signal

The hook mutates simulation state, so with several listeners the outcome would depend on registration order. A world has at most one; `null` removes it.

## Validation

`pnpm verify:quick` 16/16 · `pnpm test` 10 580 passed · API docs regenerated · guide section added to *Joints, sleeping & CCD* (typechecked).

New `contact-modifier.test.ts` covers: every solid contact seen once per step with the A→B normal; a no-op modifier changing nothing; a disabled contact applying no impulse while still firing `collisionStart`; the controls being re-derived each step; both island branches (dynamic↔dynamic union, and a moving platform waking its passenger); the warm-start cache being dropped; sensors never reaching the modifier; and a full one-way platform, solid from above and passable from below.

https://claude.ai/code/session_01R4RHfm7nhMPXAuxFrpgrqj