### PR TITLE
feat(physics): draw bound nodes between fixed steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,33 @@ release and includes intentional breaking changes; see **Changed** and
 
 ### Added
 
+- **Bound nodes can be drawn between fixed steps instead of snapping to the latest one.**
+  Physics runs at a fixed rate and the display does not, so at 60 Hz physics on a 144 Hz
+  screen most frames showed the same fixed state twice and then jumped. `PhysicsBinding`
+  wrote the newest fixed transform verbatim and bodies kept no earlier state to blend
+  from, so there was nothing an application could interpolate either.
+
+  A body now brackets its most recent fixed step: `previousX`, `previousY` and
+  `previousAngle` hold the transform that step started from, `x`/`y`/`angle` the one it
+  produced — including when several fixed steps run inside one `step()` call, where the
+  pair describes the last of them. A body that did not move reports `previous === current`
+  rather than a stale pair, and `setTransform()` collapses the pair, because a teleport is
+  a discontinuity and must not be swept across.
+
+  `PhysicsWorld`'s `interpolation` option (default `false`) switches bindings over to
+  placing the node between the two. The blend factor comes from `frameAlphaSource`, which
+  defaults to the world's own accumulator — correct for a world driven with `step()`. A
+  world registered as a `System` goes through `fixedUpdate()` and bypasses that
+  accumulator, so it has to be pointed at the host's own fraction
+  (`() => app.frameAlpha`); physics deliberately does not run a second clock, which would
+  drift from the host's the moment a step is clamped or dropped. Interpolated presentation
+  moves to the world's new variable-rate `update()` phase, since the factor is only final
+  once the frame's last fixed step has run.
+
+  Angles are blended with a plain lerp: body angles are continuous and unbounded, never
+  wrapped into a range, so there is no shortest-arc case. Interpolation is presentation
+  only — the simulation is bit-identical either way.
+
 - **A world-level contact modifier decides what a contact does this step.** There was no
   `preSolve`/`enableContact` anywhere in the physics API, so a one-way platform — solid
   from above, passable from below — could not be expressed at all: collision filters answer

--- a/packages/exojs-physics/src/PhysicsBody.ts
+++ b/packages/exojs-physics/src/PhysicsBody.ts
@@ -116,7 +116,14 @@ export class PhysicsBody {
   private _id = -1;
   private _owner: BodyOwner | null = null;
   private _attached = false;
+
   private readonly _transform: Transform;
+  // Transform at the START of the most recent fixed step. Presentation only:
+  // the solver never reads it, and it is captured before the step writes its
+  // delta so a teleport can collapse it onto the current state.
+  private _previousX: number;
+  private _previousY: number;
+  private _previousAngle: number;
   private readonly _colliders: Collider[] = [];
   private _comX = 0;
   private _comY = 0;
@@ -126,6 +133,9 @@ export class PhysicsBody {
   public constructor(options: BodyOptions = {}) {
     this.type = options.type ?? 'dynamic';
     this._transform = createTransform(options.position?.x ?? 0, options.position?.y ?? 0, options.angle ?? 0);
+    this._previousX = this._transform.x;
+    this._previousY = this._transform.y;
+    this._previousAngle = this._transform.angle;
     this.linearDamping = options.linearDamping ?? 0;
     this.angularDamping = options.angularDamping ?? 0;
     this.gravityScale = options.gravityScale ?? 1;
@@ -165,6 +175,29 @@ export class PhysicsBody {
   /** Rotation in radians. */
   public get angle(): number {
     return this._transform.angle;
+  }
+
+  /**
+   * World X at the start of the most recent fixed step. With {@link x} it
+   * brackets the last step, which is what an interpolating presentation blends
+   * between; a teleport collapses it onto {@link x}. Never read by the solver.
+   */
+  public get previousX(): number {
+    return this._previousX;
+  }
+
+  /** World Y at the start of the most recent fixed step; see {@link previousX}. */
+  public get previousY(): number {
+    return this._previousY;
+  }
+
+  /**
+   * Rotation in radians at the start of the most recent fixed step; see
+   * {@link previousX}. Body angles are continuous and unbounded, never wrapped
+   * to a range, so this and {@link angle} can be blended with a plain lerp.
+   */
+  public get previousAngle(): number {
+    return this._previousAngle;
   }
 
   /** A fresh `Vector` copy of the body's world position. */
@@ -257,6 +290,12 @@ export class PhysicsBody {
     this._teleported = true;
 
     setTransform(this._transform, position.x, position.y, angle);
+
+    // A teleport is a discontinuity, not motion - collapsing the pair keeps an
+    // interpolating presentation from sweeping the node across the jump.
+    this._previousX = this._transform.x;
+    this._previousY = this._transform.y;
+    this._previousAngle = this._transform.angle;
 
     for (const collider of this._colliders) {
       collider.synchronize(this._transform);
@@ -435,6 +474,13 @@ export class PhysicsBody {
     this._forceY = 0;
     this._torque = 0;
     this._teleported = false;
+
+    // Captured before the step's delta is applied, and before the no-motion
+    // early return below - a body that did not move must report previous ===
+    // current rather than a stale pair from the last step it did move in.
+    this._previousX = this._transform.x;
+    this._previousY = this._transform.y;
+    this._previousAngle = this._transform.angle;
 
     if (this.type === 'static' || (this._deltaPosX === 0 && this._deltaPosY === 0 && this._deltaAngle === 0)) {
       this._resetDelta();

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -39,6 +39,22 @@ const ccdRestitutionThreshold = 1;
  * push its passengers, and it is exactly that sub-threshold case where nothing
  * else would keep them awake.
  */
+/**
+ * Keep a host-supplied blend factor inside `[0, 1]`. A caller's own accumulator
+ * can hand over a value outside it (a stale read, a custom scheduler), and an
+ * unclamped one extrapolates the node past the simulated state instead of
+ * blending between two known ones.
+ */
+const clampAlpha = (alpha: number): number => {
+  // Written as two comparisons rather than Math.min/Math.max so a NaN factor
+  // lands on 0 instead of propagating into every bound node's transform.
+  if (!(alpha > 0)) {
+    return 0;
+  }
+
+  return alpha < 1 ? alpha : 1;
+};
+
 const isMovingBoundary = (body: PhysicsBody): boolean =>
   body._teleported || body.linearVelocityX !== 0 || body.linearVelocityY !== 0 || body.angularVelocity !== 0;
 
@@ -107,6 +123,25 @@ export interface PhysicsWorldOptions {
    * see {@link PhysicsWorld.contactModifier}. Default none.
    */
   contactModifier?: ContactModifier | null;
+  /**
+   * Place bound nodes between the last two fixed states instead of snapping them
+   * to the latest one, which smooths motion when the fixed rate is below the
+   * frame rate. Default `false`.
+   *
+   * The blend factor comes from {@link frameAlphaSource}; a world driven as a
+   * `System` has to supply one.
+   */
+  interpolation?: boolean;
+  /**
+   * Where interpolated bindings read their blend factor, in `[0, 1)`.
+   *
+   * Defaults to this world's own accumulator - correct when the world is driven
+   * with {@link PhysicsWorld.step}, which is what advances it. A world driven as
+   * a `System` goes through {@link PhysicsWorld.fixedUpdate} and bypasses that
+   * accumulator entirely, so the host owns the fraction: pass
+   * `() => app.frameAlpha`.
+   */
+  frameAlphaSource?: () => number;
   /** Linear speed at or below which a body is a sleep candidate, px/s. Default `5`. */
   sleepLinearVelocity?: number;
   /** Angular speed at or below which a body is a sleep candidate, rad/s. Default `0.06`. */
@@ -239,6 +274,21 @@ export class PhysicsWorld implements BodyOwner {
    */
   public contactModifier: ContactModifier | null;
 
+  /**
+   * Whether bound nodes are placed between the last two fixed states rather than
+   * snapped to the latest one. Toggleable at runtime; switching it off snaps
+   * every bound node back to the current fixed state on the next sync.
+   */
+  public interpolation: boolean;
+
+  /**
+   * Supplies the `[0, 1)` blend factor for interpolated bindings. Defaults to
+   * this world's own accumulator; point it at the host's own fraction
+   * (`() => app.frameAlpha`) when the world runs as a `System`, because
+   * {@link fixedUpdate} never advances the local accumulator.
+   */
+  public frameAlphaSource: () => number;
+
   private readonly _backend: PhysicsBackend = new NativePhysicsBackend();
   private readonly _bodies: PhysicsBody[] = [];
   private readonly _colliders: Collider[] = [];
@@ -305,6 +355,8 @@ export class PhysicsWorld implements BodyOwner {
     this.sleepAngularVelocity = options.sleepAngularVelocity ?? 0.06;
     this.timeToSleep = options.timeToSleep ?? 0.5;
     this.contactModifier = options.contactModifier ?? null;
+    this.interpolation = options.interpolation ?? false;
+    this.frameAlphaSource = options.frameAlphaSource ?? (() => this.timeStepper.alpha);
     this._query = new QueryEngine(this._colliders, this._backend.spatialIndex);
   }
 
@@ -493,7 +545,9 @@ export class PhysicsWorld implements BodyOwner {
       this._dispatchEvents();
     }
 
-    this._bindings.sync();
+    // `step` is called once per rendered frame, so presenting here is already
+    // the variable-rate slot an interpolated binding needs.
+    this._syncBindings();
     this._drainCommands();
   }
 
@@ -520,8 +574,37 @@ export class PhysicsWorld implements BodyOwner {
     this._stepOnce(h, subStepCount, this.gravity.x, this.gravity.y, this.contactHertz, this.dampingRatio, this._joints.length > 0, this._hasBullets());
 
     this._dispatchEvents();
-    this._bindings.sync();
+
+    // Interpolated presentation is a per-FRAME job and moves to `update`; this
+    // phase can run several times per frame, and the blend factor is only final
+    // once the last of them has run.
+    if (!this.interpolation) {
+      this._bindings.sync();
+    }
+
     this._drainCommands();
+  }
+
+  /**
+   * Variable-rate `System` phase: places bound nodes for the frame that is about
+   * to be drawn. Only does work while {@link interpolation} is on - otherwise
+   * {@link fixedUpdate} has already snapped them to the latest fixed state.
+   */
+  public update(_delta: Time): void {
+    this._assertAlive();
+
+    if (this.interpolation) {
+      this._bindings.syncInterpolated(clampAlpha(this.frameAlphaSource()));
+    }
+  }
+
+  /** Present bound nodes, snapping or interpolating according to {@link interpolation}. */
+  private _syncBindings(): void {
+    if (this.interpolation) {
+      this._bindings.syncInterpolated(clampAlpha(this.frameAlphaSource()));
+    } else {
+      this._bindings.sync();
+    }
   }
 
   private _stepOnce(

--- a/packages/exojs-physics/src/binding/BindingRegistry.ts
+++ b/packages/exojs-physics/src/binding/BindingRegistry.ts
@@ -109,6 +109,22 @@ export class BindingRegistry {
     }
   }
 
+  /**
+   * Like {@link sync}, but places each node `alpha` of the way from its body's
+   * previous fixed state to its current one - see
+   * {@link PhysicsBinding.syncInterpolated}. Same destroyed-node pruning.
+   */
+  public syncInterpolated(alpha: number): void {
+    for (const [body, binding] of this._bindings) {
+      if (binding.node.destroyed) {
+        this._bindings.delete(body);
+        continue;
+      }
+
+      binding.syncInterpolated(alpha);
+    }
+  }
+
   /** `true` when at least one binding exists. */
   public get size(): number {
     return this._bindings.size;

--- a/packages/exojs-physics/src/binding/PhysicsBinding.ts
+++ b/packages/exojs-physics/src/binding/PhysicsBinding.ts
@@ -3,11 +3,16 @@ import { MathUtils, type SceneNode } from '@codexo/exojs';
 import type { PhysicsBody } from '../PhysicsBody';
 
 /**
- * A link between a {@link PhysicsBody} and a {@link SceneNode}. After each
- * {@link PhysicsWorld.step}, the body's world position **and rotation** are
- * written onto the node (the body's angle is radians; the node's rotation is
- * degrees). The node must be world-space-rooted; runtime scale is ignored and
- * non-zero skew is rejected at bind time.
+ * A link between a {@link PhysicsBody} and a {@link SceneNode}. The body's world
+ * position **and rotation** are written onto the node (the body's angle is
+ * radians; the node's rotation is degrees). The node must be world-space-rooted;
+ * runtime scale is ignored and non-zero skew is rejected at bind time.
+ *
+ * By default the node snaps to the latest fixed-step state after each step. With
+ * `PhysicsWorld`'s interpolation enabled the node is instead placed between the
+ * body's previous and current fixed states, which smooths motion when the fixed
+ * rate is below the frame rate. Either way this is presentation: nothing written
+ * onto the node is read back into the simulation.
  */
 export class PhysicsBinding {
   public constructor(
@@ -19,5 +24,25 @@ export class PhysicsBinding {
   public sync(): void {
     this.node.setPosition(this.body.x, this.body.y);
     this.node.setRotation(MathUtils.radiansToDegrees(this.body.angle));
+  }
+
+  /**
+   * Place the node `alpha` of the way from the body's previous fixed state to
+   * its current one. `alpha` is the host's leftover sub-step fraction, so `0`
+   * renders the state the last fixed step started from and values approaching
+   * `1` render the state it produced.
+   *
+   * A plain lerp is correct for the angle too: body angles are continuous and
+   * unbounded, never wrapped into a range, so there is no shortest-arc case to
+   * resolve.
+   */
+  public syncInterpolated(alpha: number): void {
+    const body = this.body;
+    const previousX = body.previousX;
+    const previousY = body.previousY;
+    const previousAngle = body.previousAngle;
+
+    this.node.setPosition(previousX + (body.x - previousX) * alpha, previousY + (body.y - previousY) * alpha);
+    this.node.setRotation(MathUtils.radiansToDegrees(previousAngle + (body.angle - previousAngle) * alpha));
   }
 }

--- a/packages/exojs-physics/test/interpolation.test.ts
+++ b/packages/exojs-physics/test/interpolation.test.ts
@@ -1,0 +1,259 @@
+import type { SceneNode } from '@codexo/exojs';
+import { Time } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import { BoxShape, PhysicsBody, PhysicsWorld } from '../src/index';
+
+/**
+ * Fixed-state interpolation. The body brackets its last fixed step with a
+ * previous/current transform pair; an interpolating binding places the node
+ * between them using the host's leftover sub-step fraction. Presentation only -
+ * nothing written onto a node is read back into the simulation.
+ */
+
+interface FakeNode {
+  skewX: number;
+  skewY: number;
+  x: number;
+  y: number;
+  rotation: number;
+  destroyed: boolean;
+  setPosition(x: number, y: number): FakeNode;
+  setRotation(degrees: number): FakeNode;
+}
+
+const fakeNode = (): FakeNode => ({
+  skewX: 0,
+  skewY: 0,
+  x: 0,
+  y: 0,
+  rotation: 0,
+  destroyed: false,
+  setPosition(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+
+    return this;
+  },
+  setRotation(degrees: number) {
+    this.rotation = degrees;
+
+    return this;
+  },
+});
+
+const FIXED = 1 / 60;
+
+/** A dynamic body moving at a constant velocity, so its per-step delta is exact. */
+const movingBody = (world: PhysicsWorld, velocityX: number): PhysicsBody => {
+  const body = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
+
+  body.linearVelocityX = velocityX;
+
+  return body;
+};
+
+describe('previous fixed state', () => {
+  it('brackets the last fixed step', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const body = movingBody(world, 600); // 10px per fixed step
+
+    world.step(FIXED);
+
+    expect(body.previousX).toBeCloseTo(0, 6);
+    expect(body.x).toBeCloseTo(10, 6);
+
+    world.step(FIXED);
+
+    expect(body.previousX).toBeCloseTo(10, 6);
+    expect(body.x).toBeCloseTo(20, 6);
+  });
+
+  it('brackets only the LAST step when one call runs several', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const body = movingBody(world, 600);
+
+    // Three fixed steps in one call.
+    world.step(FIXED * 3);
+
+    expect(body.x).toBeCloseTo(30, 6);
+    expect(body.previousX).toBeCloseTo(20, 6);
+  });
+
+  it('reports previous === current for a body that did not move', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    // Far from the mover's path: nothing touches it, so it never moves.
+    const still = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 400, y: 400 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
+    const mover = movingBody(world, 600);
+
+    world.step(FIXED * 2);
+
+    expect(mover.previousX).not.toBeCloseTo(mover.x, 6);
+    expect(still.previousX).toBeCloseTo(still.x, 6);
+    expect(still.previousY).toBeCloseTo(still.y, 6);
+    expect(still.previousAngle).toBeCloseTo(still.angle, 6);
+  });
+
+  it('collapses the pair on a teleport', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const body = movingBody(world, 600);
+
+    world.step(FIXED);
+    expect(body.previousX).not.toBeCloseTo(body.x, 6);
+
+    body.setTransform({ x: 500, y: 500 }, 1.5);
+
+    expect(body.previousX).toBe(500);
+    expect(body.previousY).toBe(500);
+    expect(body.previousAngle).toBe(1.5);
+  });
+
+  it('starts collapsed at the constructed transform', () => {
+    const body = new PhysicsBody({ type: 'dynamic', position: { x: 3, y: 4 }, angle: 0.25, colliders: [{ shape: new BoxShape(10, 10) }] });
+
+    expect(body.previousX).toBe(3);
+    expect(body.previousY).toBe(4);
+    expect(body.previousAngle).toBe(0.25);
+  });
+});
+
+describe('interpolated bindings', () => {
+  it('snaps to the current fixed state by default', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const body = movingBody(world, 600);
+    const node = fakeNode();
+
+    world.bind(body, node as unknown as SceneNode);
+    // Half a fixed step of leftover, which a snapping binding must ignore.
+    world.step(FIXED * 1.5);
+
+    expect(world.interpolation).toBe(false);
+    expect(node.x).toBeCloseTo(body.x, 6);
+  });
+
+  it('places the node between the two fixed states by the leftover fraction', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 }, interpolation: true });
+    const body = movingBody(world, 600);
+    const node = fakeNode();
+
+    world.bind(body, node as unknown as SceneNode);
+    world.step(FIXED * 1.5);
+
+    // One step ran (x: 0 → 10) and half a step is left over in the accumulator.
+    expect(world.timeStepper.alpha).toBeCloseTo(0.5, 6);
+    expect(body.previousX).toBeCloseTo(0, 6);
+    expect(body.x).toBeCloseTo(10, 6);
+    expect(node.x).toBeCloseTo(5, 6);
+  });
+
+  it('interpolates rotation through the unbounded angle, without wrapping', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 }, interpolation: true, frameAlphaSource: () => 0.5 });
+    const body = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
+    const node = fakeNode();
+
+    // Spin fast enough that the angle runs well past a full turn.
+    body.angularVelocity = 60 * Math.PI; // π rad per fixed step
+    world.bind(body, node as unknown as SceneNode);
+
+    for (let step = 0; step < 5; step++) {
+      world.step(FIXED);
+    }
+
+    expect(body.angle).toBeCloseTo(5 * Math.PI, 4);
+    expect(body.previousAngle).toBeCloseTo(4 * Math.PI, 4);
+    // Halfway between the two, in degrees - continuous, not wrapped into [0, 360).
+    expect(node.rotation).toBeCloseTo((4.5 * Math.PI * 180) / Math.PI, 3);
+  });
+
+  it('does not sweep a node across a teleport', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 }, interpolation: true, frameAlphaSource: () => 0.5 });
+    const body = movingBody(world, 600);
+    const node = fakeNode();
+
+    world.bind(body, node as unknown as SceneNode);
+    world.step(FIXED);
+
+    body.linearVelocityX = 0;
+    body.setTransform({ x: 1000, y: 0 });
+    world.step(FIXED);
+
+    // Placed at the destination, not halfway back towards where it came from.
+    expect(node.x).toBeCloseTo(1000, 6);
+  });
+
+  it('clamps a blend factor supplied outside [0, 1]', () => {
+    const alphas = [-3, 0, 0.25, 1, 4, Number.NaN];
+    const results: number[] = [];
+
+    for (const alpha of alphas) {
+      const world = new PhysicsWorld({ gravity: { x: 0, y: 0 }, interpolation: true, frameAlphaSource: () => alpha });
+      const body = movingBody(world, 600);
+      const node = fakeNode();
+
+      world.bind(body, node as unknown as SceneNode);
+      world.step(FIXED);
+      results.push(node.x);
+    }
+
+    // previous = 0, current = 10 → every result stays inside the bracket.
+    expect(results).toEqual([0, 0, 2.5, 10, 10, 0]);
+  });
+
+  it('can be switched off at runtime and snaps back on the next sync', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 }, interpolation: true, frameAlphaSource: () => 0 });
+    const body = movingBody(world, 600);
+    const node = fakeNode();
+
+    world.bind(body, node as unknown as SceneNode);
+    world.step(FIXED);
+
+    expect(node.x).toBeCloseTo(0, 6); // alpha 0 → the state the step started from
+
+    world.interpolation = false;
+    world.step(FIXED);
+
+    expect(node.x).toBeCloseTo(body.x, 6);
+  });
+});
+
+describe('system-driven interpolation', () => {
+  it('presents once per frame from update(), not per fixed step', () => {
+    let hostAlpha = 0;
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 }, interpolation: true, frameAlphaSource: () => hostAlpha });
+    const body = movingBody(world, 600);
+    const node = fakeNode();
+
+    world.bind(body, node as unknown as SceneNode);
+    node.setPosition(-1, -1);
+
+    // Two fixed steps for this frame: neither may present.
+    world.fixedUpdate(Time.zero);
+    world.fixedUpdate(Time.zero);
+
+    expect(node.x).toBe(-1);
+
+    hostAlpha = 0.25;
+    world.update(Time.zero);
+
+    // previous = 10 (start of the second step), current = 20.
+    expect(body.previousX).toBeCloseTo(10, 6);
+    expect(body.x).toBeCloseTo(20, 6);
+    expect(node.x).toBeCloseTo(12.5, 6);
+  });
+
+  it('still snaps from fixedUpdate() when interpolation is off', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const body = movingBody(world, 600);
+    const node = fakeNode();
+
+    world.bind(body, node as unknown as SceneNode);
+    world.fixedUpdate(Time.zero);
+
+    expect(node.x).toBeCloseTo(body.x, 6);
+
+    const snapped = node.x;
+    world.update(Time.zero);
+
+    expect(node.x).toBe(snapped);
+  });
+});

--- a/site/src/content/api/physics-binding.json
+++ b/site/src/content/api/physics-binding.json
@@ -1,15 +1,15 @@
 {
   "title": "PhysicsBinding",
-  "description": "A link between a PhysicsBody and a SceneNode. After each PhysicsWorld.step, the body's world position **and rotation** are written onto the node (the body's angle is radians; the node's rotation is degrees). The node must be world-space-rooted; runtime scale is ignored and non-zero skew is rejected at bind time.",
+  "description": "A link between a PhysicsBody and a SceneNode. The body's world position **and rotation** are written onto the node (the body's angle is radians; the node's rotation is degrees). The node must be world-space-rooted; runtime scale is ignored and non-zero skew is rejected at bind time. By default the node snaps to the latest fixed-step state after each step. With `PhysicsWorld`'s interpolation enabled the node is instead placed between the body's previous and current fixed states, which smooths motion when the fixed rate is below the frame rate. Either way this is presentation: nothing written onto the node is read back into the simulation.",
   "symbol": "PhysicsBinding",
   "kind": "class",
   "subsystem": "physics",
   "importPath": "@codexo/exojs-physics",
   "tier": "stable",
-  "memberCount": 4,
+  "memberCount": 5,
   "counts": {
     "constructors": 1,
-    "methods": 1,
+    "methods": 2,
     "properties": 2,
     "events": 0
   },
@@ -19,7 +19,8 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "A link between a PhysicsBody and a SceneNode. After each PhysicsWorld.step, the body's world position **and rotation** are written onto the node (the body's angle is radians; the node's rotation is degrees). The node must be world-space-rooted; runtime scale is ignored and non-zero skew is rejected at bind time."
+        "A link between a PhysicsBody and a SceneNode. The body's world position **and rotation** are written onto the node (the body's angle is radians; the node's rotation is degrees). The node must be world-space-rooted; runtime scale is ignored and non-zero skew is rejected at bind time.",
+        "By default the node snaps to the latest fixed-step state after each step. With `PhysicsWorld`'s interpolation enabled the node is instead placed between the body's previous and current fixed states, which smooths motion when the fixed rate is below the frame rate. Either way this is presentation: nothing written onto the node is read back into the simulation."
       ],
       "importLine": "import { PhysicsBinding } from '@codexo/exojs-physics'",
       "sourceLink": null
@@ -133,6 +134,53 @@
           "params": [],
           "returnType": "void",
           "description": "Write the body's current transform (position + rotation) onto the bound node."
+        },
+        {
+          "name": "syncInterpolated",
+          "signature": "syncInterpolated(alpha: number): void",
+          "signatureTokens": [
+            {
+              "text": "syncInterpolated",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "alpha",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "alpha",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Place the node alpha of the way from the body's previous fixed state to its current one. alpha is the host's leftover sub-step fraction, so 0 renders the state the last fixed step started from and values approaching 1 render the state it produced. A plain lerp is correct for the angle too: body angles are continuous and unbounded, never wrapped into a range, so there is no shortest-arc case to resolve."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/physics-body.json
+++ b/site/src/content/api/physics-body.json
@@ -6,11 +6,11 @@
   "subsystem": "physics",
   "importPath": "@codexo/exojs-physics",
   "tier": "stable",
-  "memberCount": 39,
+  "memberCount": 42,
   "counts": {
     "constructors": 1,
     "methods": 9,
-    "properties": 29,
+    "properties": 32,
     "events": 0
   },
   "sections": [
@@ -1110,6 +1110,69 @@
           "params": [],
           "returnType": null,
           "description": "A fresh Vector copy of the body's world position."
+        },
+        {
+          "name": "previousAngle",
+          "signature": "previousAngle: number",
+          "signatureTokens": [
+            {
+              "text": "previousAngle",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Rotation in radians at the start of the most recent fixed step; see previousX. Body angles are continuous and unbounded, never wrapped to a range, so this and angle can be blended with a plain lerp."
+        },
+        {
+          "name": "previousX",
+          "signature": "previousX: number",
+          "signatureTokens": [
+            {
+              "text": "previousX",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "World X at the start of the most recent fixed step. With x it brackets the last step, which is what an interpolating presentation blends between; a teleport collapses it onto x. Never read by the solver."
+        },
+        {
+          "name": "previousY",
+          "signature": "previousY: number",
+          "signatureTokens": [
+            {
+              "text": "previousY",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "World Y at the start of the most recent fixed step; see previousX."
         },
         {
           "name": "transform",

--- a/site/src/content/api/physics-world-options.json
+++ b/site/src/content/api/physics-world-options.json
@@ -6,11 +6,11 @@
   "subsystem": "physics",
   "importPath": "@codexo/exojs-physics",
   "tier": "stable",
-  "memberCount": 11,
+  "memberCount": 13,
   "counts": {
     "constructors": 0,
     "methods": 0,
-    "properties": 11,
+    "properties": 13,
     "events": 0
   },
   "sections": [
@@ -162,6 +162,39 @@
           "description": "Fixed timestep in seconds. Default 1 / 60."
         },
         {
+          "name": "frameAlphaSource",
+          "signature": "frameAlphaSource?: () => number",
+          "signatureTokens": [
+            {
+              "text": "frameAlphaSource",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ") => ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Where interpolated bindings read their blend factor, in [0, 1). Defaults to this world's own accumulator - correct when the world is driven with PhysicsWorld.step, which is what advances it. A world driven as a System goes through PhysicsWorld.fixedUpdate and bypasses that accumulator entirely, so the host owns the fraction: pass () => app.frameAlpha."
+        },
+        {
           "name": "gravity",
           "signature": "gravity?: Readonly<PointLike>",
           "signatureTokens": [
@@ -197,6 +230,31 @@
           "params": [],
           "returnType": null,
           "description": "Gravity in px/s² (+Y down). Integrated each sub-step. Default (0, 0)."
+        },
+        {
+          "name": "interpolation",
+          "signature": "interpolation?: boolean",
+          "signatureTokens": [
+            {
+              "text": "interpolation",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Place bound nodes between the last two fixed states instead of snapping them to the latest one, which smooths motion when the fixed rate is below the frame rate. Default false. The blend factor comes from frameAlphaSource; a world driven as a System has to supply one."
         },
         {
           "name": "maxSubSteps",

--- a/site/src/content/api/physics-world.json
+++ b/site/src/content/api/physics-world.json
@@ -6,11 +6,11 @@
   "subsystem": "physics",
   "importPath": "@codexo/exojs-physics",
   "tier": "stable",
-  "memberCount": 38,
+  "memberCount": 41,
   "counts": {
     "constructors": 1,
-    "methods": 19,
-    "properties": 14,
+    "methods": 20,
+    "properties": 16,
     "events": 4
   },
   "sections": [
@@ -1831,6 +1831,53 @@
           ],
           "returnType": "void",
           "description": "Remove a body↔node link."
+        },
+        {
+          "name": "update",
+          "signature": "update(_delta: Time): void",
+          "signatureTokens": [
+            {
+              "text": "update",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "_delta",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Time",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "void",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "_delta",
+              "type": "Time",
+              "optional": false
+            }
+          ],
+          "returnType": "void",
+          "description": "Variable-rate System phase: places bound nodes for the frame that is about to be drawn. Only does work while interpolation is on - otherwise fixedUpdate has already snapped them to the latest fixed state."
         }
       ],
       "paragraphs": [],
@@ -1934,6 +1981,35 @@
           "description": "Whether resting bodies are put to sleep."
         },
         {
+          "name": "frameAlphaSource",
+          "signature": "frameAlphaSource: () => number",
+          "signatureTokens": [
+            {
+              "text": "frameAlphaSource",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ") => ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Supplies the [0, 1) blend factor for interpolated bindings. Defaults to this world's own accumulator; point it at the host's own fraction (() => app.frameAlpha) when the world runs as a System, because fixedUpdate never advances the local accumulator."
+        },
+        {
           "name": "gravity",
           "signature": "gravity: Vector",
           "signatureTokens": [
@@ -1953,6 +2029,27 @@
           "params": [],
           "returnType": null,
           "description": "World gravity (px/s², +Y down). Integrated each sub-step."
+        },
+        {
+          "name": "interpolation",
+          "signature": "interpolation: boolean",
+          "signatureTokens": [
+            {
+              "text": "interpolation",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Whether bound nodes are placed between the last two fixed states rather than snapped to the latest one. Toggleable at runtime; switching it off snaps every bound node back to the current fixed state on the next sync."
         },
         {
           "name": "sleepAngularVelocity",

--- a/site/src/content/guide/physics/physics-basics.mdx
+++ b/site/src/content/guide/physics/physics-basics.mdx
@@ -234,6 +234,59 @@ sprite.setPosition(body.x, body.y);
 sprite.setRotation(MathUtils.radiansToDegrees(body.angle));
 ```
 
+## Smoothing motion between fixed steps
+
+Physics runs at a fixed rate; the screen does not. At 60 Hz physics on a 144 Hz
+display most frames show the same fixed state twice, then jump — visible judder on
+anything that moves fast. The fix is not a faster simulation but **interpolation**:
+draw the body somewhere between the last two fixed states, using the fraction of a
+step the frame landed on.
+
+Every body brackets its most recent fixed step with `previousX`/`previousY`/
+`previousAngle` and `x`/`y`/`angle`. Turn on `interpolation` and bindings place the
+node between them instead of snapping to the latest one:
+
+```ts
+import { CircleShape, PhysicsWorld } from '@codexo/exojs-physics';
+
+const world = new PhysicsWorld({
+  gravity: { x: 0, y: 1000 },
+  interpolation: true,
+});
+```
+
+That is enough when you drive the world yourself with `world.step(delta)` — the
+world owns the accumulator, so it already knows the leftover fraction.
+
+A world registered as a **system** is different: the engine's scheduler owns the
+fixed-step accumulator, and `fixedUpdate` bypasses the world's own. Point the world
+at the host's fraction:
+
+```ts
+import { Application, SystemOrder } from '@codexo/exojs';
+import { PhysicsWorld } from '@codexo/exojs-physics';
+
+const app = new Application({ fixedTimeStep: 1 / 60 });
+const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+
+app.systems.add(world, { order: SystemOrder.Physics });
+
+world.interpolation = true;
+world.frameAlphaSource = () => app.frameAlpha;
+```
+
+<Callout type="warning" title="A system-driven world needs frameAlphaSource">
+Without it the world falls back to its own accumulator, which `fixedUpdate` never advances — the factor stays `0` and every bound node renders a full fixed step behind. There is deliberately no second clock inside physics to paper over this: two accumulators would drift apart the moment the host clamps or drops a step.
+</Callout>
+
+Interpolation is **presentation only**. Nothing written onto a node is read back, the
+simulation is bit-identical either way, and `body.x`/`body.y` remain the authoritative
+fixed-step values. The trade is latency: a bound node renders up to one fixed step
+behind the newest state, which is what makes the motion continuous.
+
+A teleport is not motion, so `setTransform()` collapses the pair — the node appears at
+the destination instead of sweeping across the jump.
+
 ## Worked example: a ball drops onto a floor
 
 Putting it together — a static floor, a dynamic ball bound to a sprite, stepped from


### PR DESCRIPTION
Physics runs at a fixed rate and the display does not, so at 60 Hz physics on a 144 Hz screen most frames showed the same fixed state twice and then jumped. `PhysicsBinding` wrote the newest fixed transform verbatim, and bodies kept no earlier state — so an application could not interpolate for itself either.

## The bracket

A body now brackets its most recent fixed step:

| | |
|---|---|
| `previousX` / `previousY` / `previousAngle` | the transform that step **started from** |
| `x` / `y` / `angle` | the transform it **produced** |

The pair is captured in `_finalizePosition`, before the step's delta is applied and before its no-motion early return. Two consequences that are the point of doing it there:

- a body that did not move reports `previous === current`, not a stale pair from the last step it *did* move in;
- several fixed steps inside one `step()` call leave the pair describing the **last** of them.

`setTransform()` collapses the pair — a teleport is a discontinuity, not motion, and must not be swept across.

## Turning it on

`PhysicsWorld.interpolation` (default `false`) switches bindings from snapping to blending:

```ts
const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 }, interpolation: true });
```

The blend factor comes from `frameAlphaSource`, which defaults to the world's own accumulator — correct for a world driven with `step()`, since that is what advances it.

A world registered as a **System** goes through `fixedUpdate()` and bypasses that accumulator, so it has to be pointed at the host's own fraction:

```ts
world.frameAlphaSource = () => app.frameAlpha;
```

Physics deliberately does **not** run a second clock to avoid that wiring: a private accumulator would drift from the host's the moment a step is clamped or dropped. Interpolated presentation therefore moves to the world's new variable-rate `update()` phase — the factor is only final once the frame's last fixed step has run, so `fixedUpdate()` (which can run several times per frame) is the wrong slot for it.

## Details

- Angles blend with a plain lerp: body angles are continuous and unbounded, never wrapped into a range, so there is no shortest-arc case to resolve.
- A host-supplied factor is clamped to `[0, 1]`, and `NaN` maps to `0` — a stale or custom accumulator would otherwise extrapolate the node past the simulated state instead of blending between two known ones.
- Interpolation is presentation only. The simulation is bit-identical either way, and `body.x`/`body.y` remain the authoritative fixed-step values. The trade is latency: a bound node renders up to one fixed step behind the newest state, which is what makes the motion continuous.

## Validation

`pnpm verify:quick` 16/16 · `pnpm test` 10 593 passed · API docs regenerated · guide section added to *Physics basics* (typechecked, no new `no-check` blocks).

New `interpolation.test.ts` (13 cases) covers the bracket over one and several steps, an unmoved body, the teleport collapse, the constructed initial state, snapping by default, blending by the leftover fraction, unbounded-angle rotation past a full turn, a teleport not being swept, factor clamping including `NaN`, switching interpolation off at runtime, and the system-driven split between `fixedUpdate()` and `update()`.

https://claude.ai/code/session_01R4RHfm7nhMPXAuxFrpgrqj