### PR TITLE
feat(physics): decompose a concave outline into convex solver shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ release and includes intentional breaking changes; see **Changed** and
 
 ### Added
 
+- **`triangulate` is exported from the core math surface.** The ear-clipping
+  triangulator already backed `MeshBuilder.polygon`, but was module-private, so anything
+  outside core that needed a triangle list for a simple polygon had to reimplement it. It
+  takes a flat `(x, y)` sequence in either winding and returns a `Uint32Array` of triangle
+  indices into it.
+
 - **Bound nodes can be drawn between fixed steps instead of snapping to the latest one.**
   Physics runs at a fixed rate and the display does not, so at 60 Hz physics on a 144 Hz
   screen most frames showed the same fixed state twice and then jumped. `PhysicsBinding`

--- a/packages/exojs-physics/src/shapes/convexParts.ts
+++ b/packages/exojs-physics/src/shapes/convexParts.ts
@@ -1,0 +1,21 @@
+import type { PointLike } from '@codexo/exojs';
+
+import { decomposeToConvexParts } from './decompose';
+import { PolygonShape } from './PolygonShape';
+
+/**
+ * Turn one possibly-concave outline into the convex solver shapes that
+ * represent it. Attach all of them to a single body: together they are the
+ * original area, and a `PolygonShape` stays exactly one convex shape rather
+ * than secretly standing for several.
+ *
+ * The number of shapes and their order follow from the current decomposition
+ * and are not a stable contract; the preserved properties are the area, the
+ * centre of mass and the rotational inertia of the compound.
+ *
+ * @throws RangeError on a non-finite coordinate, on fewer than three distinct
+ * non-collinear vertices, on a self-intersecting outline, or when a part comes
+ * out too degenerate for {@link PolygonShape}.
+ * @internal
+ */
+export const toConvexPolygonShapes = (vertices: ReadonlyArray<Readonly<PointLike>>): PolygonShape[] => decomposeToConvexParts(vertices).map(part => new PolygonShape(part));

--- a/packages/exojs-physics/src/shapes/decompose.ts
+++ b/packages/exojs-physics/src/shapes/decompose.ts
@@ -1,0 +1,429 @@
+import type { PointLike } from '@codexo/exojs';
+import { triangulate } from '@codexo/exojs';
+
+/** Vertices closer than this (px) are welded into one. */
+const weldEpsilon = 1e-4;
+/**
+ * Sine-of-turn threshold below which three consecutive vertices count as
+ * collinear. Compared against the normalised cross product so the test is
+ * scale-free: a 10 px polygon and a 10 000 px one accept the same shapes.
+ */
+const collinearEpsilon = 1e-7;
+/**
+ * Fraction of the outline's area below which a triangulation face counts as
+ * empty. Ear clipping emits its last triangle without an orientation test, so a
+ * polygon whose final three vertices end up collinear yields one zero-area face
+ * - it covers nothing and must not become a collider.
+ */
+const degenerateAreaFraction = 1e-9;
+
+/**
+ * Split a simple polygon into convex parts.
+ *
+ * The input may be concave, wound either way, and may carry duplicate or
+ * collinear vertices; it must not intersect itself. The result is a list of
+ * strictly convex, counter-clockwise parts whose union is the input and whose
+ * interiors do not overlap. An already-convex input yields exactly one part.
+ *
+ * Deterministic: the same cleaned input always produces the same parts. The
+ * number of parts and their order are an artefact of the current algorithm and
+ * must not be relied on - assert convexity, preserved area and preserved mass
+ * properties instead.
+ *
+ * Cost is O(n²) in the vertex count (self-intersection check and ear clipping),
+ * which suits import-time geometry rather than a per-step path.
+ *
+ * @throws RangeError if a coordinate is not finite, if fewer than three
+ * distinct non-collinear vertices remain after cleanup, or if the outline
+ * intersects itself.
+ * @internal
+ */
+export const decomposeToConvexParts = (vertices: ReadonlyArray<Readonly<PointLike>>): PointLike[][] => {
+  const points = normalize(vertices);
+  const count = points.length / 2;
+
+  assertSimple(points);
+
+  if (isStrictlyConvex(points)) {
+    return [toPoints(points, sequence(count))];
+  }
+
+  const indices = triangulate(points);
+
+  // Ear clipping stops early rather than throwing when it cannot find an ear,
+  // so a short index list is how a polygon that survived the checks above but is
+  // still numerically degenerate shows up. Accepting it would silently drop area.
+  if (indices.length !== (count - 2) * 3) {
+    throw new RangeError(`decomposeToConvexParts: could not triangulate the outline (${indices.length / 3} of ${count - 2} triangles); check it for near-degenerate geometry.`);
+  }
+
+  const sourceArea = Math.abs(signedArea(points));
+  const cycles = mergeTriangles(points, indices, sourceArea * degenerateAreaFraction);
+  const parts = cycles.map(cycle => toPoints(points, cycle));
+
+  // Post-condition rather than trust: ear clipping and the merge pass both work
+  // on floating-point turns, and any future change that started losing area
+  // would otherwise show up as a silently smaller collider.
+  const partArea = cycles.reduce((sum, cycle) => sum + Math.abs(cycleArea(points, cycle)), 0);
+
+  if (parts.length === 0 || Math.abs(partArea - sourceArea) > sourceArea * 1e-6) {
+    throw new RangeError(`decomposeToConvexParts: the parts cover ${partArea.toFixed(4)} of the outline's ${sourceArea.toFixed(4)}; the outline is too degenerate to decompose.`);
+  }
+
+  return parts;
+};
+
+/**
+ * Weld coincident vertices, drop collinear ones and canonicalise to
+ * counter-clockwise, returning a flat `[x0, y0, x1, y1, ...]` array.
+ */
+const normalize = (vertices: ReadonlyArray<Readonly<PointLike>>): number[] => {
+  const points: number[] = [];
+
+  for (const vertex of vertices) {
+    if (!Number.isFinite(vertex.x) || !Number.isFinite(vertex.y)) {
+      throw new RangeError(`decomposeToConvexParts: vertex has a non-finite component (${vertex.x}, ${vertex.y}).`);
+    }
+
+    if (points.length === 0) {
+      points.push(vertex.x, vertex.y);
+
+      continue;
+    }
+
+    if (Math.hypot(vertex.x - points[points.length - 2]!, vertex.y - points[points.length - 1]!) >= weldEpsilon) {
+      points.push(vertex.x, vertex.y);
+    }
+  }
+
+  // A trailing vertex coinciding with the first closes the ring explicitly; the
+  // ring is implicit here.
+  if (points.length >= 4 && Math.hypot(points[0]! - points[points.length - 2]!, points[1]! - points[points.length - 1]!) < weldEpsilon) {
+    points.length -= 2;
+  }
+
+  if (signedArea(points) < 0) {
+    reverseWinding(points);
+  }
+
+  dropCollinear(points);
+
+  if (points.length < 6) {
+    throw new RangeError(`decomposeToConvexParts: needs at least 3 distinct, non-collinear vertices, received ${points.length / 2} after cleanup.`);
+  }
+
+  if (Math.abs(signedArea(points)) <= weldEpsilon) {
+    throw new RangeError('decomposeToConvexParts: the outline encloses no area.');
+  }
+
+  return points;
+};
+
+/**
+ * Remove every vertex whose two edges are collinear. Repeats until stable: one
+ * removal can make its neighbour collinear in turn.
+ */
+const dropCollinear = (points: number[]): void => {
+  let removed = true;
+
+  while (removed && points.length >= 6) {
+    removed = false;
+
+    for (let i = 0; i < points.length / 2; i++) {
+      const count = points.length / 2;
+
+      if (count < 3) {
+        break;
+      }
+
+      const p = (i + count - 1) % count;
+      const n = (i + 1) % count;
+
+      if (isCollinear(points, p, i, n)) {
+        points.splice(i * 2, 2);
+        removed = true;
+        i--;
+      }
+    }
+  }
+};
+
+const isCollinear = (points: number[], a: number, b: number, c: number): boolean => {
+  const e1x = points[b * 2]! - points[a * 2]!;
+  const e1y = points[b * 2 + 1]! - points[a * 2 + 1]!;
+  const e2x = points[c * 2]! - points[b * 2]!;
+  const e2y = points[c * 2 + 1]! - points[b * 2 + 1]!;
+  const lengths = Math.hypot(e1x, e1y) * Math.hypot(e2x, e2y);
+
+  return lengths === 0 || Math.abs(e1x * e2y - e1y * e2x) <= collinearEpsilon * lengths;
+};
+
+/**
+ * Reject an outline that crosses or touches itself. Every pair of non-adjacent
+ * edges must be disjoint - a shared point between them is exactly what makes a
+ * polygon non-simple, and both ear clipping and the solver assume it cannot
+ * happen.
+ */
+const assertSimple = (points: number[]): void => {
+  const count = points.length / 2;
+
+  for (let i = 0; i < count; i++) {
+    const iNext = (i + 1) % count;
+
+    for (let j = i + 1; j < count; j++) {
+      const jNext = (j + 1) % count;
+
+      // Edges sharing a vertex always "touch" at it; only non-adjacent pairs
+      // carry information.
+      if (i === j || iNext === j || jNext === i) {
+        continue;
+      }
+
+      if (segmentsIntersect(points, i, iNext, j, jNext)) {
+        throw new RangeError('decomposeToConvexParts: the outline intersects itself; only simple polygons can be decomposed.');
+      }
+    }
+  }
+};
+
+/** `true` when segments `a→b` and `c→d` share any point, touching included. */
+const segmentsIntersect = (points: number[], a: number, b: number, c: number, d: number): boolean => {
+  const o1 = orientation(points, a, b, c);
+  const o2 = orientation(points, a, b, d);
+  const o3 = orientation(points, c, d, a);
+  const o4 = orientation(points, c, d, b);
+
+  if (o1 !== o2 && o3 !== o4) {
+    return true;
+  }
+
+  return (
+    (o1 === 0 && onSegment(points, a, b, c)) ||
+    (o2 === 0 && onSegment(points, a, b, d)) ||
+    (o3 === 0 && onSegment(points, c, d, a)) ||
+    (o4 === 0 && onSegment(points, c, d, b))
+  );
+};
+
+/** Sign of the turn `a → b → c`: `1` left, `-1` right, `0` collinear. */
+const orientation = (points: number[], a: number, b: number, c: number): number => {
+  const cross = (points[b * 2]! - points[a * 2]!) * (points[c * 2 + 1]! - points[a * 2 + 1]!) - (points[b * 2 + 1]! - points[a * 2 + 1]!) * (points[c * 2]! - points[a * 2]!);
+  const scale = Math.hypot(points[b * 2]! - points[a * 2]!, points[b * 2 + 1]! - points[a * 2 + 1]!) * Math.hypot(points[c * 2]! - points[a * 2]!, points[c * 2 + 1]! - points[a * 2 + 1]!);
+
+  if (scale === 0 || Math.abs(cross) <= collinearEpsilon * scale) {
+    return 0;
+  }
+
+  return cross > 0 ? 1 : -1;
+};
+
+/** `true` when `p` lies within the bounding box of the collinear segment `a→b`. */
+const onSegment = (points: number[], a: number, b: number, p: number): boolean =>
+  points[p * 2]! >= Math.min(points[a * 2]!, points[b * 2]!) - weldEpsilon &&
+  points[p * 2]! <= Math.max(points[a * 2]!, points[b * 2]!) + weldEpsilon &&
+  points[p * 2 + 1]! >= Math.min(points[a * 2 + 1]!, points[b * 2 + 1]!) - weldEpsilon &&
+  points[p * 2 + 1]! <= Math.max(points[a * 2 + 1]!, points[b * 2 + 1]!) + weldEpsilon;
+
+/**
+ * Hertel-Mehlhorn: start from the triangulation and drop every internal
+ * diagonal whose two faces merge into a still-convex polygon. Diagonals are
+ * visited in a fixed key order, so the outcome depends only on the cleaned
+ * input.
+ */
+const mergeTriangles = (points: number[], indices: Uint32Array, degenerateArea: number): number[][] => {
+  const cycles = new Map<number, number[]>();
+  const owners = new Map<number, number[]>();
+  // Union-find over part ids: a merged part keeps the lower id, and every
+  // diagonal recorded against the absorbed one resolves through here.
+  const parent: number[] = [];
+
+  const find = (id: number): number => {
+    let root = id;
+
+    while (parent[root] !== root) {
+      root = parent[root]!;
+    }
+
+    return root;
+  };
+
+  const stride = points.length / 2;
+  const diagonalKey = (a: number, b: number): number => (a < b ? a * stride + b : b * stride + a);
+
+  for (let t = 0; t < indices.length; t += 3) {
+    const id = t / 3;
+    const cycle = [indices[t]!, indices[t + 1]!, indices[t + 2]!];
+
+    if (Math.abs(cycleArea(points, cycle)) <= degenerateArea) {
+      continue;
+    }
+
+    parent[id] = id;
+    cycles.set(id, cycle);
+
+    for (let e = 0; e < 3; e++) {
+      const key = diagonalKey(cycle[e]!, cycle[(e + 1) % 3]!);
+      const owner = owners.get(key);
+
+      if (owner === undefined) {
+        owners.set(key, [id]);
+      } else {
+        owner.push(id);
+      }
+    }
+  }
+
+  for (const key of [...owners.keys()].sort((x, y) => x - y)) {
+    const owner = owners.get(key)!;
+
+    if (owner.length !== 2) {
+      continue;
+    }
+
+    const rootA = find(owner[0]!);
+    const rootB = find(owner[1]!);
+
+    if (rootA === rootB) {
+      continue;
+    }
+
+    const cycleA = cycles.get(rootA)!;
+    const cycleB = cycles.get(rootB)!;
+    const merged = mergeAcross(points, cycleA, cycleB, Math.floor(key / stride), key % stride);
+
+    if (merged === null) {
+      continue;
+    }
+
+    const keep = rootA < rootB ? rootA : rootB;
+    const drop = rootA < rootB ? rootB : rootA;
+
+    cycles.set(keep, merged);
+    cycles.delete(drop);
+    parent[drop] = keep;
+  }
+
+  return [...cycles.values()];
+};
+
+/**
+ * Join two convex cycles across the shared edge between `u` and `v`, or `null`
+ * when the union would not be strictly convex. Rejecting a merely collinear
+ * junction is deliberate: the resulting part is handed to `PolygonShape`, which
+ * refuses collinear edges.
+ */
+const mergeAcross = (points: number[], cycleA: number[], cycleB: number[], u: number, v: number): number[] | null => {
+  // Both cycles are counter-clockwise and share the undirected edge, so exactly
+  // one of them traverses it as `a → b` and the other as `b → a`.
+  let a = u;
+  let b = v;
+  let start = directedEdgeIndex(cycleA, a, b);
+
+  if (start === -1) {
+    a = v;
+    b = u;
+    start = directedEdgeIndex(cycleA, a, b);
+  }
+
+  const back = start === -1 ? -1 : directedEdgeIndex(cycleB, b, a);
+
+  if (start === -1 || back === -1) {
+    return null;
+  }
+
+  // Walk A once starting at b (so it ends on a), then splice in B's vertices
+  // strictly between a and b.
+  const merged: number[] = [];
+
+  for (let i = 0; i < cycleA.length; i++) {
+    merged.push(cycleA[(start + 1 + i) % cycleA.length]!);
+  }
+
+  for (let i = 2; i < cycleB.length; i++) {
+    merged.push(cycleB[(back + i) % cycleB.length]!);
+  }
+
+  return isCycleStrictlyConvex(points, merged) ? merged : null;
+};
+
+/** Index of `a` in `cycle` when `b` immediately follows it, else `-1`. */
+const directedEdgeIndex = (cycle: number[], a: number, b: number): number => {
+  for (let i = 0; i < cycle.length; i++) {
+    if (cycle[i] === a && cycle[(i + 1) % cycle.length] === b) {
+      return i;
+    }
+  }
+
+  return -1;
+};
+
+const isCycleStrictlyConvex = (points: number[], cycle: number[]): boolean => {
+  for (let i = 0; i < cycle.length; i++) {
+    const a = cycle[i]!;
+    const b = cycle[(i + 1) % cycle.length]!;
+    const c = cycle[(i + 2) % cycle.length]!;
+
+    if (orientation(points, a, b, c) <= 0) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const isStrictlyConvex = (points: number[]): boolean => isCycleStrictlyConvex(points, sequence(points.length / 2));
+
+const sequence = (count: number): number[] => {
+  const out: number[] = [];
+
+  for (let i = 0; i < count; i++) {
+    out.push(i);
+  }
+
+  return out;
+};
+
+const toPoints = (points: number[], cycle: number[]): PointLike[] => cycle.map(index => ({ x: points[index * 2]!, y: points[index * 2 + 1]! }));
+
+/** Shoelace signed area of an index cycle over `points`. */
+const cycleArea = (points: number[], cycle: number[]): number => {
+  let sum = 0;
+
+  for (let i = 0; i < cycle.length; i++) {
+    const a = cycle[i]!;
+    const b = cycle[(i + 1) % cycle.length]!;
+
+    sum += points[a * 2]! * points[b * 2 + 1]! - points[b * 2]! * points[a * 2 + 1]!;
+  }
+
+  return sum / 2;
+};
+
+/** Shoelace signed area of a flat point ring; positive is counter-clockwise. */
+const signedArea = (points: number[]): number => {
+  const count = points.length / 2;
+  let sum = 0;
+
+  for (let i = 0; i < count; i++) {
+    const j = (i + 1) % count;
+
+    sum += points[i * 2]! * points[j * 2 + 1]! - points[j * 2]! * points[i * 2 + 1]!;
+  }
+
+  return sum / 2;
+};
+
+const reverseWinding = (points: number[]): void => {
+  const count = points.length / 2;
+
+  for (let i = 0; i < Math.floor(count / 2); i++) {
+    const j = count - 1 - i;
+    const ix = points[i * 2]!;
+    const iy = points[i * 2 + 1]!;
+
+    points[i * 2] = points[j * 2]!;
+    points[i * 2 + 1] = points[j * 2 + 1]!;
+    points[j * 2] = ix;
+    points[j * 2 + 1] = iy;
+  }
+};

--- a/packages/exojs-physics/test/convex-decomposition.test.ts
+++ b/packages/exojs-physics/test/convex-decomposition.test.ts
@@ -1,0 +1,437 @@
+import type { PointLike } from '@codexo/exojs';
+import { Random } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import { BoxShape, PhysicsBody, PhysicsWorld } from '../src/index';
+import { toConvexPolygonShapes } from '../src/shapes/convexParts';
+import { decomposeToConvexParts } from '../src/shapes/decompose';
+
+/**
+ * Convex decomposition. A simple concave outline becomes several convex
+ * `PolygonShape`s on one body. What is pinned here is the geometry and the mass
+ * model - never the number of parts or their order, which belong to the current
+ * algorithm and may change.
+ */
+
+/** An L, concave at (20, 20). */
+const lShape: PointLike[] = [
+  { x: 0, y: 0 },
+  { x: 60, y: 0 },
+  { x: 60, y: 20 },
+  { x: 20, y: 20 },
+  { x: 20, y: 60 },
+  { x: 0, y: 60 },
+];
+
+/** A four-pointed star: eight vertices, four of them reflex. */
+const star: PointLike[] = [
+  { x: 0, y: -50 },
+  { x: 14, y: -14 },
+  { x: 50, y: 0 },
+  { x: 14, y: 14 },
+  { x: 0, y: 50 },
+  { x: -14, y: 14 },
+  { x: -50, y: 0 },
+  { x: -14, y: -14 },
+];
+
+/** A comb with three teeth - six reflex vertices, one long thin body. */
+const comb: PointLike[] = [
+  { x: 0, y: 0 },
+  { x: 90, y: 0 },
+  { x: 90, y: 60 },
+  { x: 70, y: 60 },
+  { x: 70, y: 20 },
+  { x: 55, y: 20 },
+  { x: 55, y: 60 },
+  { x: 35, y: 60 },
+  { x: 35, y: 20 },
+  { x: 20, y: 20 },
+  { x: 20, y: 60 },
+  { x: 0, y: 60 },
+];
+
+interface MassProperties {
+  area: number;
+  centroidX: number;
+  centroidY: number;
+  /** Second moment of area about the centroid. */
+  unitInertia: number;
+}
+
+/** Shoelace area/centroid/inertia integrals - valid for any simple polygon, concave included. */
+const massPropertiesOf = (polygon: readonly PointLike[]): MassProperties => {
+  const count = polygon.length;
+  let doubleArea = 0;
+  let cx = 0;
+  let cy = 0;
+  let inertiaOrigin = 0;
+
+  for (let i = 0; i < count; i++) {
+    const a = polygon[i]!;
+    const b = polygon[(i + 1) % count]!;
+    const cross = a.x * b.y - b.x * a.y;
+
+    doubleArea += cross;
+    cx += (a.x + b.x) * cross;
+    cy += (a.y + b.y) * cross;
+    inertiaOrigin += cross * (a.x * a.x + a.x * b.x + b.x * b.x + a.y * a.y + a.y * b.y + b.y * b.y);
+  }
+
+  const area = Math.abs(doubleArea / 2);
+  const signedArea = doubleArea / 2;
+
+  cx /= 6 * signedArea;
+  cy /= 6 * signedArea;
+
+  return { area, centroidX: cx, centroidY: cy, unitInertia: Math.abs(inertiaOrigin / 12) - area * (cx * cx + cy * cy) };
+};
+
+/** Aggregate the parts the way a body aggregates its colliders (uniform density 1). */
+const aggregate = (parts: readonly PointLike[][]): MassProperties => {
+  let area = 0;
+  let cx = 0;
+  let cy = 0;
+  let inertiaOrigin = 0;
+
+  for (const part of parts) {
+    const properties = massPropertiesOf(part);
+
+    area += properties.area;
+    cx += properties.area * properties.centroidX;
+    cy += properties.area * properties.centroidY;
+    // Parallel axis back to the origin, so parts with different centroids add up.
+    inertiaOrigin += properties.unitInertia + properties.area * (properties.centroidX * properties.centroidX + properties.centroidY * properties.centroidY);
+  }
+
+  cx /= area;
+  cy /= area;
+
+  return { area, centroidX: cx, centroidY: cy, unitInertia: inertiaOrigin - area * (cx * cx + cy * cy) };
+};
+
+/** Winding-agnostic strict convexity: every turn has the same non-zero sign. */
+const isStrictlyConvex = (polygon: readonly PointLike[]): boolean => {
+  const count = polygon.length;
+  let sign = 0;
+
+  for (let i = 0; i < count; i++) {
+    const a = polygon[i]!;
+    const b = polygon[(i + 1) % count]!;
+    const c = polygon[(i + 2) % count]!;
+    const cross = (b.x - a.x) * (c.y - b.y) - (b.y - a.y) * (c.x - b.x);
+
+    if (cross === 0) {
+      return false;
+    }
+
+    const current = cross > 0 ? 1 : -1;
+
+    if (sign === 0) {
+      sign = current;
+    } else if (sign !== current) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const containsPoint = (polygon: readonly PointLike[], x: number, y: number): boolean => {
+  let inside = false;
+
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const a = polygon[i]!;
+    const b = polygon[j]!;
+
+    if (a.y > y !== b.y > y && x < ((b.x - a.x) * (y - a.y)) / (b.y - a.y) + a.x) {
+      inside = !inside;
+    }
+  }
+
+  return inside;
+};
+
+/** Shortest distance from `(x, y)` to any edge of `polygon`. */
+const distanceToAnyEdge = (polygon: readonly PointLike[], x: number, y: number): number => {
+  let best = Infinity;
+
+  for (let i = 0; i < polygon.length; i++) {
+    const a = polygon[i]!;
+    const b = polygon[(i + 1) % polygon.length]!;
+    const ex = b.x - a.x;
+    const ey = b.y - a.y;
+    const lengthSquared = ex * ex + ey * ey;
+    const t = lengthSquared === 0 ? 0 : Math.max(0, Math.min(1, ((x - a.x) * ex + (y - a.y) * ey) / lengthSquared));
+
+    best = Math.min(best, Math.hypot(x - (a.x + ex * t), y - (a.y + ey * t)));
+  }
+
+  return best;
+};
+
+const boundsOf = (polygon: readonly PointLike[]): { minX: number; minY: number; maxX: number; maxY: number } => {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const point of polygon) {
+    minX = Math.min(minX, point.x);
+    minY = Math.min(minY, point.y);
+    maxX = Math.max(maxX, point.x);
+    maxY = Math.max(maxY, point.y);
+  }
+
+  return { minX, minY, maxX, maxY };
+};
+
+const outlines: [string, PointLike[]][] = [
+  ['L', lShape],
+  ['star', star],
+  ['comb', comb],
+];
+
+describe('convex decomposition', () => {
+  it.each(outlines)('produces only strictly convex parts (%s)', (_name, outline) => {
+    const parts = decomposeToConvexParts(outline);
+
+    expect(parts.length).toBeGreaterThan(1);
+
+    for (const part of parts) {
+      expect(part.length).toBeGreaterThanOrEqual(3);
+      expect(isStrictlyConvex(part)).toBe(true);
+    }
+  });
+
+  it.each(outlines)('preserves the enclosed area exactly (%s)', (_name, outline) => {
+    const source = massPropertiesOf(outline);
+    const parts = decomposeToConvexParts(outline);
+    const total = parts.reduce((sum, part) => sum + massPropertiesOf(part).area, 0);
+
+    // Parts are cut from a triangulation of the outline, so each one lies inside
+    // it. Equal total area therefore rules out both gaps and overlaps at once.
+    expect(total).toBeCloseTo(source.area, 6);
+  });
+
+  it.each(outlines)('covers the source exactly once, point by point (%s)', (_name, outline) => {
+    const parts = decomposeToConvexParts(outline);
+    const bounds = boundsOf(outline);
+    const random = new Random(0x5eed);
+    let inside = 0;
+    let outside = 0;
+
+    for (let sample = 0; sample < 4000; sample++) {
+      const x = random.next(bounds.minX - 5, bounds.maxX + 5);
+      const y = random.next(bounds.minY - 5, bounds.maxY + 5);
+
+      // A point sitting on a shared edge belongs to both neighbours or neither,
+      // depending on which way the parity rule rounds - a measure-zero set the
+      // area assertions already cover. Sample only the clear interior/exterior.
+      if (distanceToAnyEdge(outline, x, y) < 0.05 || parts.some(part => distanceToAnyEdge(part, x, y) < 0.05)) {
+        continue;
+      }
+
+      const hits = parts.filter(part => containsPoint(part, x, y)).length;
+
+      // Exactly one part where the source is solid, none where it is not: no
+      // overlaps, no gaps, and nothing spilling outside the outline.
+      expect(hits).toBe(containsPoint(outline, x, y) ? 1 : 0);
+
+      if (hits === 1) {
+        inside++;
+      } else {
+        outside++;
+      }
+    }
+
+    // Both verdicts have to be exercised, or the assertion above proves nothing.
+    expect(inside).toBeGreaterThan(100);
+    expect(outside).toBeGreaterThan(100);
+  });
+
+  it.each(outlines)('preserves mass, centre of mass and inertia (%s)', (_name, outline) => {
+    const source = massPropertiesOf(outline);
+    const total = aggregate(decomposeToConvexParts(outline));
+
+    expect(total.area).toBeCloseTo(source.area, 6);
+    expect(total.centroidX).toBeCloseTo(source.centroidX, 6);
+    expect(total.centroidY).toBeCloseTo(source.centroidY, 6);
+    expect(total.unitInertia).toBeCloseTo(source.unitInertia, 4);
+  });
+
+  it.each(outlines)('describes the same area whichever way the input is wound (%s)', (_name, outline) => {
+    const forward = aggregate(decomposeToConvexParts(outline));
+    const reversed = aggregate(decomposeToConvexParts([...outline].reverse()));
+
+    expect(reversed.area).toBeCloseTo(forward.area, 6);
+    expect(reversed.centroidX).toBeCloseTo(forward.centroidX, 6);
+    expect(reversed.centroidY).toBeCloseTo(forward.centroidY, 6);
+    expect(reversed.unitInertia).toBeCloseTo(forward.unitInertia, 4);
+  });
+
+  it.each(outlines)('is deterministic for the same input (%s)', (_name, outline) => {
+    expect(decomposeToConvexParts(outline)).toEqual(decomposeToConvexParts(outline));
+  });
+
+  it('returns exactly one part for an already-convex outline', () => {
+    const parts = decomposeToConvexParts([
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+    ]);
+
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toHaveLength(4);
+  });
+
+  it('cleans duplicate and collinear vertices before deciding convexity', () => {
+    const parts = decomposeToConvexParts([
+      { x: 0, y: 0 },
+      { x: 5, y: 0 }, // collinear midpoint
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 10, y: 10 }, // exact duplicate
+      { x: 0, y: 10 },
+      { x: 0, y: 0 }, // explicit ring closure
+    ]);
+
+    expect(parts).toHaveLength(1);
+    expect(parts[0]).toHaveLength(4);
+  });
+
+  it('rejects a self-intersecting outline', () => {
+    // A bow tie: the two crossing edges make it non-simple.
+    expect(() =>
+      decomposeToConvexParts([
+        { x: 0, y: 0 },
+        { x: 40, y: 40 },
+        { x: 40, y: 0 },
+        { x: 0, y: 40 },
+      ]),
+    ).toThrow(RangeError);
+  });
+
+  it('rejects an outline with fewer than three effective vertices', () => {
+    expect(() => decomposeToConvexParts([{ x: 0, y: 0 }, { x: 10, y: 0 }])).toThrow(RangeError);
+    // Three vertices, but all on one line.
+    expect(() =>
+      decomposeToConvexParts([
+        { x: 0, y: 0 },
+        { x: 5, y: 0 },
+        { x: 10, y: 0 },
+      ]),
+    ).toThrow(RangeError);
+  });
+
+  it('rejects a non-finite coordinate', () => {
+    expect(() =>
+      decomposeToConvexParts([
+        { x: 0, y: 0 },
+        { x: Number.NaN, y: 0 },
+        { x: 10, y: 10 },
+      ]),
+    ).toThrow(RangeError);
+  });
+});
+
+describe('convex parts as physics shapes', () => {
+  it.each(outlines)('builds shapes whose aggregate mass model matches the outline (%s)', (_name, outline) => {
+    const source = massPropertiesOf(outline);
+    const shapes = toConvexPolygonShapes(outline);
+
+    let area = 0;
+    let cx = 0;
+    let cy = 0;
+    let inertiaOrigin = 0;
+
+    for (const shape of shapes) {
+      const properties = shape.massProperties;
+
+      area += properties.area;
+      cx += properties.area * properties.centroidX;
+      cy += properties.area * properties.centroidY;
+      inertiaOrigin += properties.unitInertia + properties.area * (properties.centroidX * properties.centroidX + properties.centroidY * properties.centroidY);
+    }
+
+    cx /= area;
+    cy /= area;
+
+    expect(area).toBeCloseTo(source.area, 6);
+    expect(cx).toBeCloseTo(source.centroidX, 6);
+    expect(cy).toBeCloseTo(source.centroidY, 6);
+    expect(inertiaOrigin - area * (cx * cx + cy * cy)).toBeCloseTo(source.unitInertia, 4);
+  });
+
+  it('gives a body the mass model of the concave outline it came from', () => {
+    const source = massPropertiesOf(comb);
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const body = world.add(
+      new PhysicsBody({
+        type: 'dynamic',
+        position: { x: 0, y: 0 },
+        colliders: toConvexPolygonShapes(comb).map(shape => ({ shape, density: 1 })),
+      }),
+    );
+
+    expect(body.mass).toBeCloseTo(source.area, 6);
+    // Body at the origin with zero angle, so the world centre of mass is the local one.
+    expect(body.worldCenterOfMassX).toBeCloseTo(source.centroidX, 6);
+    expect(body.worldCenterOfMassY).toBeCloseTo(source.centroidY, 6);
+    expect(body.inertia).toBeCloseTo(source.unitInertia, 4);
+  });
+
+  it('never contacts itself and still collides with the outside world', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const compound = world.add(
+      new PhysicsBody({
+        type: 'static',
+        position: { x: 0, y: 0 },
+        colliders: toConvexPolygonShapes(comb).map(shape => ({ shape })),
+      }),
+    );
+    const probe = world.add(new PhysicsBody({ type: 'kinematic', position: { x: 45, y: 5 }, colliders: [{ shape: new BoxShape(10, 10) }] }));
+
+    expect(compound.colliders.length).toBeGreaterThan(1);
+
+    world.step(1 / 60);
+
+    const contacts = world.backend.contactGraph.solidContacts;
+
+    expect(contacts.length).toBeGreaterThan(0);
+
+    for (const contact of contacts) {
+      expect(contact.a.body).not.toBe(contact.b.body);
+      expect(new Set([contact.a.body, contact.b.body])).toEqual(new Set([compound, probe]));
+    }
+  });
+
+  it('answers point queries over the whole compound, not just one part', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const compound = world.add(
+      new PhysicsBody({
+        type: 'static',
+        position: { x: 0, y: 0 },
+        colliders: toConvexPolygonShapes(comb).map(shape => ({ shape })),
+      }),
+    );
+
+    world.step(1 / 60);
+
+    // Inside the comb's solid base, and inside one of its teeth.
+    for (const point of [
+      { x: 45, y: 5 },
+      { x: 10, y: 45 },
+    ]) {
+      const hits = world.queryPoint(point);
+
+      expect(hits.length).toBeGreaterThan(0);
+      expect(hits.every(collider => collider.body === compound)).toBe(true);
+    }
+
+    // In a notch between two teeth - outside the outline entirely.
+    expect(world.queryPoint({ x: 27, y: 45 })).toHaveLength(0);
+    expect(world.queryPoint({ x: 62, y: 45 })).toHaveLength(0);
+  });
+});

--- a/site/src/content/api/functions.json
+++ b/site/src/content/api/functions.json
@@ -6,10 +6,10 @@
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 38,
+  "memberCount": 39,
   "counts": {
     "constructors": 0,
-    "methods": 29,
+    "methods": 30,
     "properties": 9,
     "events": 0
   },
@@ -1623,6 +1623,65 @@
           ],
           "returnType": "number",
           "description": "Return the sign of value as -1, 0, or 1. Unlike Math.sign, returns 0 only for strict zero (not -0)."
+        },
+        {
+          "name": "triangulate",
+          "signature": "triangulate(vertices: ArrayLike<number>): Uint32Array",
+          "signatureTokens": [
+            {
+              "text": "triangulate",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "vertices",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ArrayLike",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Uint32Array",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "vertices",
+              "type": "ArrayLike<number>",
+              "optional": false
+            }
+          ],
+          "returnType": "Uint32Array",
+          "description": "Triangulate a simple 2D polygon by ear-clipping. Input: vertices is a flat sequence of (x, y) pairs (length must be even, minimum 6 = 3 vertices). Polygon may be CW or CCW; the algorithm normalises to CCW internally. Output: a Uint32Array of indices in groups of 3 (per triangle), referencing vertex positions (the i-th vertex spans vertices[2*i], vertices[2*i + 1]). Polygons that are degenerate (all collinear), zero-area, or self-intersecting may produce incomplete output but must not throw or hang."
         }
       ],
       "paragraphs": [],

--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -30,5 +30,6 @@ export * from './RectangleLike';
 export * from './Size';
 export type { SweptHit } from './swept-collision';
 export { Sweep } from './swept-collision';
+export { triangulate } from './triangulate';
 export { clamp, inRange, isPowerOfTwo, lerp, MathUtils, sign, TAU } from './utils';
 export * from './Vector';

--- a/test/core/__snapshots__/root-index-snapshot.test.ts.snap
+++ b/test/core/__snapshots__/root-index-snapshot.test.ts.snap
@@ -265,5 +265,6 @@ exports[`root index export surface snapshot > sorted runtime export names match 
   "registerSerializer",
   "resetRenderStats",
   "sign",
+  "triangulate",
 ]
 `;

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -579,5 +579,6 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "registerSerializer: function",
   "resetRenderStats: variable",
   "sign: variable",
+  "triangulate: function",
 ]
 `;


### PR DESCRIPTION
Concave import geometry had nowhere to go: `PolygonShape` refuses a non-convex outline, and the example Tiled bridge simply skipped such objects. The pieces were all there — `triangulate` already backed the mesh builders — but nothing turned a triangulation back into convex colliders. Hertel-Mehlhorn does not produce the minimal decomposition and this does not claim to: it merges across diagonals deterministically for as long as the union stays strictly convex, and the part count is explicitly not a contract.

## Three separable steps

```
simple concave outline
   → normalize / validate      (physics)
   → triangulate               (core, now exported)
   → merge across diagonals    (physics)
   → N convex PolygonShape     (physics semantics)
```

- **`triangulate` stays core geometry** and is now exported from `@codexo/exojs`. Physics reaches it through the public entry point rather than growing a second copy of the same polygon numerics.
- **`decompose.ts`** — normalize (weld coincident vertices, drop collinear ones, canonicalise winding), reject anything non-simple, triangulate, then **Hertel–Mehlhorn**: drop every internal diagonal whose two faces merge into a still-convex polygon. Diagonals are visited in a fixed key order, so the result depends only on the cleaned input.
- **`convexParts.ts`** — the physics semantics: one outline becomes N `PolygonShape`s for one body. A `PolygonShape` stays *exactly one convex shape*, never a hidden compound.

## Two things the geometry forced

**Merges must be strictly convex.** `PolygonShape` refuses collinear edges, so a merely collinear junction has to stay split — otherwise the decomposition would emit parts its own shape constructor rejects.

**Ear clipping emits its final triangle without an orientation test**, so an outline whose last three vertices end up collinear yields a zero-area face. Those are dropped before the merge pass instead of becoming a degenerate collider. A post-condition then checks that the parts still cover the outline's area, so any future change that started losing area fails loudly rather than shipping a silently smaller collider.

## What is and is not pinned

The part count and part order are deliberately **not** a contract. The tests assert:

- every part is strictly convex;
- **pointwise coverage** — sampling the bounding box, a point is inside exactly one part where the outline is solid and inside none where it is not (edge-adjacent samples skipped as measure-zero);
- area, centre of mass and rotational inertia of the compound match the concave outline it came from, both as raw parts and as a real `PhysicsBody`;
- winding independence (CW and CCW describe the same physical area, not the same part list);
- determinism for the same input;
- already-convex → exactly one part; duplicates and collinear vertices cleaned;
- self-intersection, fewer than three effective vertices, and non-finite coordinates all throw;
- a compound body never contacts itself, still collides with an external body, and answers point queries across all its parts including a miss in a notch.

Three outlines are exercised: an L, a four-pointed star (four reflex vertices), and a three-tooth comb (six reflex vertices).

## Nothing is exported from the physics package yet

The consumer is the tilemap and import bridge; exposing this before that exists would mean guessing at its shape. No `PolygonShape.fromConcave`, no `ConcavePolygonShape`.

## Validation

`pnpm verify:quick` 16/16 · `pnpm test` 10 622 passed · API docs regenerated · root-index snapshots updated (one addition: `triangulate`).

https://claude.ai/code/session_01R4RHfm7nhMPXAuxFrpgrqj
