### PR TITLE
feat(physics): shape-pair dispatch and an exact capsule shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,29 @@ release and includes intentional breaking changes; see **Changed** and
 
 ### Added
 
+- **`CapsuleShape` — exact capsule geometry for characters and rounded bodies.** The shape
+  vocabulary was circle, polygon and box, so the standard character collider had to be
+  approximated by a box (catches on edges) or a polygon (its mass then depends on how many
+  sides you chose).
+
+  A capsule is the set of points within `radius` of a segment, and it is treated that way
+  everywhere: `new CapsuleShape(x0, y0, x1, y1, radius)` takes the two spine endpoints, and
+  the area, centroid and rotational inertia are the closed-form values for a rectangle plus
+  two end caps. Nothing about a capsule depends on a tessellation - the debug overlay draws
+  its arcs with line segments, the solver never sees them.
+
+  Internally a capsule is a two-vertex ring with a radius, which is what lets it share the
+  polygon narrow phase rather than adding a parallel one: capsule/polygon and
+  capsule/capsule run the same SAT-and-clip routine as polygon/polygon, with the radii
+  moving where "touching" begins. A capsule resting on its side therefore gets the same
+  two-point manifold a box does, instead of rocking on a single point. Circle/capsule is
+  its own one-point routine, since a circle meets a rounded surface in one place.
+
+  Point queries, AABB queries, ray casts and `overlapShape` all handle capsules. Continuous
+  collision does not sweep them yet - a bullet body carrying a capsule collider logs a
+  development-build warning and can still tunnel; the remaining shape casts follow with the
+  segment and chain shapes.
+
 - **`triangulate` is exported from the core math surface.** The ear-clipping
   triangulator already backed `MeshBuilder.polygon`, but was module-private, so anything
   outside core that needed a triangle list for a simple polygon had to reimplement it. It

--- a/packages/exojs-physics/src/Collider.ts
+++ b/packages/exojs-physics/src/Collider.ts
@@ -8,6 +8,9 @@ import type { AnyShape } from './shapes/AnyShape';
 import type { CollisionFilter } from './types';
 import { resolveFilter } from './types';
 
+/** Number of world-space vertices a shape kind caches on its collider. */
+const worldVertexCount = (shape: AnyShape): number => (shape.type === 'polygon' ? shape.count : 0);
+
 /** Construction options for a collider. */
 export interface ColliderOptions {
   /** The collision geometry. */
@@ -94,14 +97,10 @@ export class Collider {
     this.filter = resolveFilter(options.filter);
     this._localTransform = createTransform(this.offsetX, this.offsetY, this.localRotation);
 
-    if (this.shape.type === 'polygon') {
-      const polygon = this.shape;
-      this._worldVertices = new Array<number>(polygon.count * 2).fill(0);
-      this._worldNormals = new Array<number>(polygon.count * 2).fill(0);
-    } else {
-      this._worldVertices = [];
-      this._worldNormals = [];
-    }
+    const vertexCount = worldVertexCount(this.shape);
+
+    this._worldVertices = new Array<number>(vertexCount * 2).fill(0);
+    this._worldNormals = new Array<number>(vertexCount * 2).fill(0);
   }
 
   /** Stable id, assigned when the owning body joins a world via `world.add()`; `-1` until then. */
@@ -164,29 +163,41 @@ export class Collider {
   public synchronize(bodyTransform: Transform): void {
     const world = composeTransforms(bodyTransform, this._localTransform, this._worldTransform);
 
-    if (this.shape.type === 'circle') {
-      const radius = this.shape.radius;
+    switch (this.shape.type) {
+      case 'circle':
+        this._synchronizeCircle(world, this.shape.radius);
 
-      this._worldCenter.x = world.x;
-      this._worldCenter.y = world.y;
-      this._aabb.minX = world.x - radius;
-      this._aabb.minY = world.y - radius;
-      this._aabb.maxX = world.x + radius;
-      this._aabb.maxY = world.y + radius;
+        return;
+      case 'polygon':
+        this._synchronizePolygon(world, this.shape.vertices, this.shape.normals, this.shape.count, 0);
 
-      return;
+        
     }
+  }
 
-    const polygon = this.shape;
-    const local = polygon.vertices;
-    const normals = polygon.normals;
+  /** A circle is its transformed centre; the local vertex buffers stay unused. */
+  private _synchronizeCircle(world: Transform, radius: number): void {
+    this._worldCenter.x = world.x;
+    this._worldCenter.y = world.y;
+    this._aabb.minX = world.x - radius;
+    this._aabb.minY = world.y - radius;
+    this._aabb.maxX = world.x + radius;
+    this._aabb.maxY = world.y + radius;
+  }
+
+  /**
+   * Transform a local vertex/normal ring into the world buffers and take the
+   * AABB while doing it. `radius` inflates the box for a rounded outline (a
+   * capsule's spine); it is `0` for a plain polygon.
+   */
+  private _synchronizePolygon(world: Transform, local: readonly number[], normals: readonly number[], count: number, radius: number): void {
     const out = this._syncScratch;
     let minX = Infinity;
     let minY = Infinity;
     let maxX = -Infinity;
     let maxY = -Infinity;
 
-    for (let i = 0; i < polygon.count; i++) {
+    for (let i = 0; i < count; i++) {
       applyTransform(world, local[i * 2]!, local[i * 2 + 1]!, out);
       this._worldVertices[i * 2] = out.x;
       this._worldVertices[i * 2 + 1] = out.y;
@@ -200,10 +211,10 @@ export class Collider {
       this._worldNormals[i * 2 + 1] = out.y;
     }
 
-    this._aabb.minX = minX;
-    this._aabb.minY = minY;
-    this._aabb.maxX = maxX;
-    this._aabb.maxY = maxY;
+    this._aabb.minX = minX - radius;
+    this._aabb.minY = minY - radius;
+    this._aabb.maxX = maxX + radius;
+    this._aabb.maxY = maxY + radius;
   }
 
   /** @internal - bind this collider to its body and id (called when the body joins a world). */

--- a/packages/exojs-physics/src/Collider.ts
+++ b/packages/exojs-physics/src/Collider.ts
@@ -9,7 +9,17 @@ import type { CollisionFilter } from './types';
 import { resolveFilter } from './types';
 
 /** Number of world-space vertices a shape kind caches on its collider. */
-const worldVertexCount = (shape: AnyShape): number => (shape.type === 'polygon' ? shape.count : 0);
+const worldVertexCount = (shape: AnyShape): number => {
+  switch (shape.type) {
+    case 'polygon':
+      return shape.count;
+    case 'capsule':
+      // The spine endpoints; a capsule is a two-vertex ring plus a radius.
+      return 2;
+    case 'circle':
+      return 0;
+  }
+};
 
 /** Construction options for a collider. */
 export interface ColliderOptions {
@@ -166,12 +176,15 @@ export class Collider {
     switch (this.shape.type) {
       case 'circle':
         this._synchronizeCircle(world, this.shape.radius);
-
-        return;
+        break;
+      case 'capsule':
+        // A capsule is a two-vertex ring plus a radius, so it rides the polygon
+        // path and only the AABB inflation differs.
+        this._synchronizePolygon(world, this.shape.vertices, this.shape.normals, 2, this.shape.radius);
+        break;
       case 'polygon':
         this._synchronizePolygon(world, this.shape.vertices, this.shape.normals, this.shape.count, 0);
-
-        
+        break;
     }
   }
 

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -1,5 +1,5 @@
 import type { AabbLike, PointLike, SceneNode, Time } from '@codexo/exojs';
-import { Signal, Vector } from '@codexo/exojs';
+import { logger, Signal, Vector } from '@codexo/exojs';
 
 import { aabbOverlap, createAabb } from './Aabb';
 import { NativePhysicsBackend } from './backend/NativePhysicsBackend';
@@ -8,7 +8,7 @@ import { BindingRegistry } from './binding/BindingRegistry';
 import type { PhysicsBinding } from './binding/PhysicsBinding';
 import { Collider } from './Collider';
 import type { SweepHit } from './collision/sweep';
-import { sweepProxies } from './collision/sweep';
+import { canSweep, sweepProxies } from './collision/sweep';
 import type { ContactModifier } from './ContactModifier';
 import type { CollisionEvent, SensorEvent } from './events';
 import type { Joint } from './joints/Joint';
@@ -53,6 +53,29 @@ const clampAlpha = (alpha: number): number => {
   }
 
   return alpha < 1 ? alpha : 1;
+};
+
+/** Shape kinds already reported as unswept, so the warning fires once per kind. */
+const warnedUnsweptKinds = new Set<string>();
+
+/**
+ * Dev-only: a bullet body carrying a shape the sweep has no implementation for
+ * is not protected against tunnelling. Reporting it beats a silent pass-through
+ * while the remaining shape casts are still being filled in.
+ */
+const warnUnsweptBulletShape = (collider: Collider): void => {
+  const kind = collider.shape.type;
+
+  if (canSweep(kind, 'polygon') || warnedUnsweptKinds.has(kind)) {
+    return;
+  }
+
+  warnedUnsweptKinds.add(kind);
+  logger.warn(
+    `PhysicsWorld: a bullet body carries a '${kind}' collider, which continuous collision does not sweep yet — ` +
+      'this body can still tunnel through thin geometry. Use a circle or polygon collider for fast projectiles.',
+    { source: 'physics' },
+  );
 };
 
 const isMovingBoundary = (body: PhysicsBody): boolean =>
@@ -1090,6 +1113,10 @@ export class PhysicsWorld implements BodyOwner {
     for (const collider of body.colliders) {
       if (collider.isSensor) {
         continue; // Sensors never block — not even their own body's motion.
+      }
+
+      if (__DEV__) {
+        warnUnsweptBulletShape(collider);
       }
 
       // The collider's end-pose AABB unioned with its start pose; anything

--- a/packages/exojs-physics/src/collision/dispatch.ts
+++ b/packages/exojs-physics/src/collision/dispatch.ts
@@ -1,0 +1,72 @@
+import type { ShapeType } from '../shapes/Shape';
+
+/**
+ * Canonical order of the shape kinds, roundest first. Two things depend on it
+ * and nothing else should: a pair table stores each unordered pair once, under
+ * the lower kind, and a mixed pair is always solved with the lower kind as the
+ * first operand plus a flip flag that reverses the resulting normal. One
+ * implementation per pair, never two mirrored copies.
+ *
+ * Inserting a kind changes only which slot a pair lands in, never which
+ * implementation runs.
+ */
+export const shapeKindOrder: Readonly<Record<ShapeType, number>> = {
+  circle: 0,
+  polygon: 1,
+};
+
+export const shapeKindCount = Object.keys(shapeKindOrder).length;
+
+/**
+ * Flat `kind × kind` table. Symmetric tables fill only the upper triangle and
+ * are read through {@link symmetricEntry}; ordered ones (a sweep distinguishes
+ * the moving operand from the target) fill both halves and are read directly
+ * with {@link orderedEntry}.
+ */
+export type PairTable<T> = Array<T | undefined>;
+
+const emptyTable = <T>(): PairTable<T> => new Array<T | undefined>(shapeKindCount * shapeKindCount).fill();
+
+/** Build a table holding one entry per **unordered** pair. */
+export const symmetricTable = <T>(entries: ReadonlyArray<readonly [ShapeType, ShapeType, T]>): PairTable<T> => {
+  const table = emptyTable<T>();
+
+  for (const [first, second, value] of entries) {
+    const a = shapeKindOrder[first];
+    const b = shapeKindOrder[second];
+
+    table[Math.min(a, b) * shapeKindCount + Math.max(a, b)] = value;
+  }
+
+  return table;
+};
+
+/** Build a table holding one entry per **ordered** pair. */
+export const orderedTable = <T>(entries: ReadonlyArray<readonly [ShapeType, ShapeType, T]>): PairTable<T> => {
+  const table = emptyTable<T>();
+
+  for (const [first, second, value] of entries) {
+    table[shapeKindOrder[first] * shapeKindCount + shapeKindOrder[second]] = value;
+  }
+
+  return table;
+};
+
+/**
+ * Entry for the unordered pair `(first, second)`. `undefined` means the pair is
+ * deliberately unsupported - callers must treat that as "no contact", never as
+ * an approximation.
+ */
+export const symmetricEntry = <T>(table: PairTable<T>, first: ShapeType, second: ShapeType): T | undefined => {
+  const a = shapeKindOrder[first];
+  const b = shapeKindOrder[second];
+
+  return table[Math.min(a, b) * shapeKindCount + Math.max(a, b)];
+};
+
+/** `true` when the operands have to be swapped to reach the canonical order. */
+export const needsFlip = (first: ShapeType, second: ShapeType): boolean => shapeKindOrder[first] > shapeKindOrder[second];
+
+/** Entry for the ordered pair `(first, second)`; see {@link symmetricEntry} on `undefined`. */
+export const orderedEntry = <T>(table: PairTable<T>, first: ShapeType, second: ShapeType): T | undefined =>
+  table[shapeKindOrder[first] * shapeKindCount + shapeKindOrder[second]];

--- a/packages/exojs-physics/src/collision/dispatch.ts
+++ b/packages/exojs-physics/src/collision/dispatch.ts
@@ -12,7 +12,8 @@ import type { ShapeType } from '../shapes/Shape';
  */
 export const shapeKindOrder: Readonly<Record<ShapeType, number>> = {
   circle: 0,
-  polygon: 1,
+  capsule: 1,
+  polygon: 2,
 };
 
 export const shapeKindCount = Object.keys(shapeKindOrder).length;
@@ -25,7 +26,15 @@ export const shapeKindCount = Object.keys(shapeKindOrder).length;
  */
 export type PairTable<T> = Array<T | undefined>;
 
-const emptyTable = <T>(): PairTable<T> => new Array<T | undefined>(shapeKindCount * shapeKindCount).fill();
+const emptyTable = <T>(): PairTable<T> => {
+  const table: PairTable<T> = [];
+
+  for (let i = 0; i < shapeKindCount * shapeKindCount; i++) {
+    table.push(undefined);
+  }
+
+  return table;
+};
 
 /** Build a table holding one entry per **unordered** pair. */
 export const symmetricTable = <T>(entries: ReadonlyArray<readonly [ShapeType, ShapeType, T]>): PairTable<T> => {

--- a/packages/exojs-physics/src/collision/narrowphase.ts
+++ b/packages/exojs-physics/src/collision/narrowphase.ts
@@ -1,9 +1,15 @@
+import type { PointLike } from '@codexo/exojs';
+
 import type { CollisionProxy } from './CollisionProxy';
 import type { PairTable } from './dispatch';
 import { needsFlip, symmetricEntry, symmetricTable } from './dispatch';
 import type { Manifold } from './Manifold';
+import { closestPointOnSegment, pointSegmentDistanceSquared } from './segments';
 
 const eps = 1e-9;
+
+/** Reused closest-point sink; the narrow phase is single-threaded and non-reentrant. */
+const _segmentScratch: PointLike = { x: 0, y: 0 };
 
 /**
  * Solves one unordered shape pair. `a` is always the operand of the lower shape
@@ -38,11 +44,21 @@ export const collide = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold
   return needsFlip(ta, tb) ? solver(b, a, manifold, true) : solver(a, b, manifold, false);
 };
 
-// radiusOf/countOf are only ever called after the `collide` dispatch has matched
-// the shape kind, so the discriminant always holds; the fallback is unreachable
-// but keeps these allocation-free helpers cast-free and type-safe.
-const radiusOf = (collider: CollisionProxy): number => (collider.shape.type === 'circle' ? collider.shape.radius : 0);
-const countOf = (collider: CollisionProxy): number => (collider.shape.type === 'polygon' ? collider.shape.count : 0);
+// Both helpers stay cast-free and allocation-free. A capsule is a two-vertex
+// ring with a radius, which is exactly why it shares the polygon routines: the
+// ring supplies `count` and `worldVertices`/`worldNormals`, the radius rounds
+// the result off.
+const radiusOf = (collider: CollisionProxy): number => (collider.shape.type === 'polygon' ? 0 : collider.shape.radius);
+const countOf = (collider: CollisionProxy): number => {
+  switch (collider.shape.type) {
+    case 'polygon':
+      return collider.shape.count;
+    case 'capsule':
+      return 2;
+    case 'circle':
+      return 0;
+  }
+};
 
 const collideCircles: CollidePair = (a, b, manifold) => {
   const ca = a.worldCenter;
@@ -369,24 +385,37 @@ const copyClip = (from: ClipVertex, to: ClipVertex): void => {
 const encodeId = (flip: boolean, refEdge: number, incidentId: number): number =>
   (flip ? 1 << 20 : 0) | ((refEdge & 0xff) << 12) | (incidentId & 0xfff);
 
-/** Convex polygon vs convex polygon: SAT reference face + Sutherland-Hodgman clip. */
-const collidePolygons: CollidePair = (a, b, manifold) => {
+/**
+ * Convex ring vs convex ring: SAT reference face + Sutherland-Hodgman clip, with
+ * each operand allowed a radius that rounds its outline off.
+ *
+ * The separations the SAT computes are between the two **cores**; the radii only
+ * move where touching begins, and since both candidate axes shift by the same
+ * sum, the reference face the SAT picks is unaffected. A capsule is a two-vertex
+ * core with a radius and a polygon a many-vertex core without one, so
+ * polygon/polygon, capsule/polygon and capsule/capsule are all this one routine.
+ */
+const collideRoundedPolygons: CollidePair = (a, b, manifold, callerFlip) => {
+  const totalRadius = radiusOf(a) + radiusOf(b);
   const sepA = findMaxSeparation(a, b, _sepA);
 
-  if (sepA.separation >= 0) {
+  if (sepA.separation >= totalRadius) {
     return false;
   }
 
   const sepB = findMaxSeparation(b, a, _sepB);
 
-  if (sepB.separation >= 0) {
+  if (sepB.separation >= totalRadius) {
     return false;
   }
 
   let ref: CollisionProxy;
   let inc: CollisionProxy;
   let refEdge: number;
-  let flip: boolean;
+  // Whether the REFERENCE role went to `b`. Distinct from `callerFlip`, which
+  // records that the caller's own operands were swapped to reach the canonical
+  // order; the final normal has to undo both.
+  let refSwapped: boolean;
 
   // Bias toward keeping A as the reference for stability (reduces ref/incident
   // role flapping when a body rocks slightly).
@@ -394,12 +423,12 @@ const collidePolygons: CollidePair = (a, b, manifold) => {
     ref = a;
     inc = b;
     refEdge = sepA.edge;
-    flip = false;
+    refSwapped = false;
   } else {
     ref = b;
     inc = a;
     refEdge = sepB.edge;
-    flip = true;
+    refSwapped = true;
   }
 
   const rv = ref.worldVertices;
@@ -432,20 +461,23 @@ const collidePolygons: CollidePair = (a, b, manifold) => {
 
   const clipped1 = _clipped1Scratch;
 
-  if (clipSegment(-tx, -ty, negSide, incident, clipped1, encodeId(flip, refEdge, 0xffe)) < 2) {
+  if (clipSegment(-tx, -ty, negSide, incident, clipped1, encodeId(refSwapped, refEdge, 0xffe)) < 2) {
     return false;
   }
 
   const clipped2 = _clipped2Scratch;
 
-  if (clipSegment(tx, ty, posSide, clipped1, clipped2, encodeId(flip, refEdge, 0xfff)) < 2) {
+  if (clipSegment(tx, ty, posSide, clipped1, clipped2, encodeId(refSwapped, refEdge, 0xfff)) < 2) {
     return false;
   }
 
-  manifold.normalX = flip ? -refNx : refNx;
-  manifold.normalY = flip ? -refNy : refNy;
+  const flipNormal = refSwapped !== callerFlip;
+
+  manifold.normalX = flipNormal ? -refNx : refNx;
+  manifold.normalY = flipNormal ? -refNy : refNy;
 
   const refC = refNx * v1x + refNy * v1y;
+  const incidentRadius = radiusOf(inc);
   const points = manifold.points;
   let cp = 0;
 
@@ -454,13 +486,17 @@ const collidePolygons: CollidePair = (a, b, manifold) => {
     const cv = k === 0 ? clipped2[0] : clipped2[1];
     const separation = refNx * cv.x + refNy * cv.y - refC;
 
-    if (separation <= 0) {
+    if (separation <= totalRadius) {
+      // The clip vertex lies on the incident CORE; pulling it back along the
+      // reference normal by the incident radius puts it on that shape's real
+      // surface. A radius-free incident polygon shifts by zero, so the point is
+      // the clip vertex exactly as it was before capsules existed.
       // cp reaches at most 2 (one per clip vertex); points[0]/points[1] exist.
       const point = cp === 0 ? points[0] : points[1];
-      point.x = cv.x;
-      point.y = cv.y;
-      point.penetration = -separation;
-      point.id = encodeId(flip, refEdge, cv.id);
+      point.x = cv.x - refNx * incidentRadius;
+      point.y = cv.y - refNy * incidentRadius;
+      point.penetration = totalRadius - separation;
+      point.id = encodeId(refSwapped, refEdge, cv.id);
       cp++;
     }
   }
@@ -496,7 +532,70 @@ const circlesOverlap: OverlapPair = (a, b) => {
   return dx * dx + dy * dy <= rsum * rsum;
 };
 
-const polygonsOverlap: OverlapPair = (a, b) => findMaxSeparation(a, b, _sepA).separation < 0 && findMaxSeparation(b, a, _sepB).separation < 0;
+const roundedPolygonsOverlap: OverlapPair = (a, b) => {
+  const totalRadius = radiusOf(a) + radiusOf(b);
+
+  return findMaxSeparation(a, b, _sepA).separation < totalRadius && findMaxSeparation(b, a, _sepB).separation < totalRadius;
+};
+
+/**
+ * Circle vs capsule: a capsule is every point within its radius of the spine, so
+ * this is a circle/circle test against the spine point nearest the circle centre.
+ * One contact point - a circle meets a rounded surface in one place, and a second
+ * would be invented noise for the solver.
+ */
+const collideCircleCapsule: CollidePair = (circle, capsule, manifold, flip) => {
+  const spine = capsule.worldVertices;
+  const centre = circle.worldCenter;
+  const circleRadius = radiusOf(circle);
+  const radiusSum = circleRadius + radiusOf(capsule);
+
+  closestPointOnSegment(centre.x, centre.y, spine[0]!, spine[1]!, spine[2]!, spine[3]!, _segmentScratch);
+
+  let nx = _segmentScratch.x - centre.x;
+  let ny = _segmentScratch.y - centre.y;
+  const distanceSquared = nx * nx + ny * ny;
+
+  if (distanceSquared > radiusSum * radiusSum) {
+    return false;
+  }
+
+  const distance = Math.sqrt(distanceSquared);
+
+  if (distance > eps) {
+    nx /= distance;
+    ny /= distance;
+  } else {
+    // Centre exactly on the spine: the direction is undefined, so take the
+    // capsule's own side normal. It is stable from frame to frame, which an
+    // axis-aligned guess would not be.
+    nx = capsule.worldNormals[0]!;
+    ny = capsule.worldNormals[1]!;
+  }
+
+  manifold.normalX = flip ? -nx : nx;
+  manifold.normalY = flip ? -ny : ny;
+
+  const point = manifold.points[0];
+  // Midway between the two surfaces along the contact normal.
+  const along = circleRadius + (distance - radiusSum) * 0.5;
+
+  point.x = centre.x + nx * along;
+  point.y = centre.y + ny * along;
+  point.penetration = radiusSum - distance;
+  point.id = 0;
+  manifold.pointCount = 1;
+
+  return true;
+};
+
+const circleCapsuleOverlap: OverlapPair = (circle, capsule) => {
+  const spine = capsule.worldVertices;
+  const centre = circle.worldCenter;
+  const radiusSum = radiusOf(circle) + radiusOf(capsule);
+
+  return pointSegmentDistanceSquared(centre.x, centre.y, spine[0]!, spine[1]!, spine[2]!, spine[3]!, _segmentScratch) <= radiusSum * radiusSum;
+};
 
 const circlePolygonOverlap: OverlapPair = (circle, polygon) => {
   const c = circle.worldCenter;
@@ -559,12 +658,18 @@ const circlePolygonOverlap: OverlapPair = (circle, polygon) => {
 // supports appears exactly once; anything absent reports no contact.
 const collideTable: PairTable<CollidePair> = symmetricTable<CollidePair>([
   ['circle', 'circle', collideCircles],
+  ['circle', 'capsule', collideCircleCapsule],
   ['circle', 'polygon', collideCirclePolygon],
-  ['polygon', 'polygon', collidePolygons],
+  ['capsule', 'capsule', collideRoundedPolygons],
+  ['capsule', 'polygon', collideRoundedPolygons],
+  ['polygon', 'polygon', collideRoundedPolygons],
 ]);
 
 const overlapTable: PairTable<OverlapPair> = symmetricTable<OverlapPair>([
   ['circle', 'circle', circlesOverlap],
+  ['circle', 'capsule', circleCapsuleOverlap],
   ['circle', 'polygon', circlePolygonOverlap],
-  ['polygon', 'polygon', polygonsOverlap],
+  ['capsule', 'capsule', roundedPolygonsOverlap],
+  ['capsule', 'polygon', roundedPolygonsOverlap],
+  ['polygon', 'polygon', roundedPolygonsOverlap],
 ]);

--- a/packages/exojs-physics/src/collision/narrowphase.ts
+++ b/packages/exojs-physics/src/collision/narrowphase.ts
@@ -1,25 +1,41 @@
 import type { CollisionProxy } from './CollisionProxy';
+import type { PairTable } from './dispatch';
+import { needsFlip, symmetricEntry, symmetricTable } from './dispatch';
 import type { Manifold } from './Manifold';
 
 const eps = 1e-9;
 
 /**
+ * Solves one unordered shape pair. `a` is always the operand of the lower shape
+ * kind; `flip` is `true` when the caller's operands were swapped to get there,
+ * and the routine must reverse the manifold normal so it still points from the
+ * caller's `a` toward its `b`.
+ */
+type CollidePair = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold, flip: boolean) => boolean;
+
+/** Boolean form of {@link CollidePair}; no normal, so no flip to honour. */
+type OverlapPair = (a: CollisionProxy, b: CollisionProxy) => boolean;
+
+/**
  * Generate the contact manifold for `a` vs `b`, writing into `manifold` and
  * returning `true` when the colliders touch. The manifold normal is oriented
- * from `a` toward `b`. Dispatches on shape pair; polygon/circle is handled by
- * the circle/polygon routine with a `flip` so the normal stays `a → b`.
+ * from `a` toward `b`.
+ *
+ * A pair with no entry in the table is deliberately unsupported and reports no
+ * contact rather than an approximation.
  */
 export const collide = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold): boolean => {
   manifold.reset();
 
   const ta = a.shape.type;
   const tb = b.shape.type;
+  const solver = symmetricEntry(collideTable, ta, tb);
 
-  if (ta === 'circle') {
-    return tb === 'circle' ? collideCircles(a, b, manifold) : collideCirclePolygon(a, b, manifold, false);
+  if (solver === undefined) {
+    return false;
   }
 
-  return tb === 'circle' ? collideCirclePolygon(b, a, manifold, true) : collidePolygons(a, b, manifold);
+  return needsFlip(ta, tb) ? solver(b, a, manifold, true) : solver(a, b, manifold, false);
 };
 
 // radiusOf/countOf are only ever called after the `collide` dispatch has matched
@@ -28,7 +44,7 @@ export const collide = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold
 const radiusOf = (collider: CollisionProxy): number => (collider.shape.type === 'circle' ? collider.shape.radius : 0);
 const countOf = (collider: CollisionProxy): number => (collider.shape.type === 'polygon' ? collider.shape.count : 0);
 
-const collideCircles = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold): boolean => {
+const collideCircles: CollidePair = (a, b, manifold) => {
   const ca = a.worldCenter;
   const cb = b.worldCenter;
   const ra = radiusOf(a);
@@ -72,7 +88,7 @@ const collideCircles = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold
  * the circle toward the polygon; when `flip` is set (the polygon is collider A),
  * the normal is negated so it stays `a → b`.
  */
-const collideCirclePolygon = (circle: CollisionProxy, polygon: CollisionProxy, manifold: Manifold, flip: boolean): boolean => {
+const collideCirclePolygon: CollidePair = (circle, polygon, manifold, flip) => {
   const c = circle.worldCenter;
   const r = radiusOf(circle);
   const verts = polygon.worldVertices;
@@ -354,7 +370,7 @@ const encodeId = (flip: boolean, refEdge: number, incidentId: number): number =>
   (flip ? 1 << 20 : 0) | ((refEdge & 0xff) << 12) | (incidentId & 0xfff);
 
 /** Convex polygon vs convex polygon: SAT reference face + Sutherland-Hodgman clip. */
-const collidePolygons = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold): boolean => {
+const collidePolygons: CollidePair = (a, b, manifold) => {
   const sepA = findMaxSeparation(a, b, _sepA);
 
   if (sepA.separation >= 0) {
@@ -461,29 +477,28 @@ const collidePolygons = (a: CollisionProxy, b: CollisionProxy, manifold: Manifol
 export const testOverlap = (a: CollisionProxy, b: CollisionProxy): boolean => {
   const ta = a.shape.type;
   const tb = b.shape.type;
+  const test = symmetricEntry(overlapTable, ta, tb);
 
-  if (ta === 'circle') {
-    if (tb === 'circle') {
-      const ca = a.worldCenter;
-      const cb = b.worldCenter;
-      const rsum = radiusOf(a) + radiusOf(b);
-      const dx = cb.x - ca.x;
-      const dy = cb.y - ca.y;
-
-      return dx * dx + dy * dy <= rsum * rsum;
-    }
-
-    return circlePolygonOverlap(a, b);
+  if (test === undefined) {
+    return false;
   }
 
-  if (tb === 'circle') {
-    return circlePolygonOverlap(b, a);
-  }
-
-  return findMaxSeparation(a, b, _sepA).separation < 0 && findMaxSeparation(b, a, _sepB).separation < 0;
+  return needsFlip(ta, tb) ? test(b, a) : test(a, b);
 };
 
-const circlePolygonOverlap = (circle: CollisionProxy, polygon: CollisionProxy): boolean => {
+const circlesOverlap: OverlapPair = (a, b) => {
+  const ca = a.worldCenter;
+  const cb = b.worldCenter;
+  const rsum = radiusOf(a) + radiusOf(b);
+  const dx = cb.x - ca.x;
+  const dy = cb.y - ca.y;
+
+  return dx * dx + dy * dy <= rsum * rsum;
+};
+
+const polygonsOverlap: OverlapPair = (a, b) => findMaxSeparation(a, b, _sepA).separation < 0 && findMaxSeparation(b, a, _sepB).separation < 0;
+
+const circlePolygonOverlap: OverlapPair = (circle, polygon) => {
   const c = circle.worldCenter;
   const r = radiusOf(circle);
   const verts = polygon.worldVertices;
@@ -539,3 +554,17 @@ const circlePolygonOverlap = (circle: CollisionProxy, polygon: CollisionProxy): 
 
   return maxSep <= r;
 };
+
+// Pair tables, built once at module init. Every unordered pair the engine
+// supports appears exactly once; anything absent reports no contact.
+const collideTable: PairTable<CollidePair> = symmetricTable<CollidePair>([
+  ['circle', 'circle', collideCircles],
+  ['circle', 'polygon', collideCirclePolygon],
+  ['polygon', 'polygon', collidePolygons],
+]);
+
+const overlapTable: PairTable<OverlapPair> = symmetricTable<OverlapPair>([
+  ['circle', 'circle', circlesOverlap],
+  ['circle', 'polygon', circlePolygonOverlap],
+  ['polygon', 'polygon', polygonsOverlap],
+]);

--- a/packages/exojs-physics/src/collision/segments.ts
+++ b/packages/exojs-physics/src/collision/segments.ts
@@ -1,0 +1,134 @@
+import type { PointLike } from '@codexo/exojs';
+
+// Closest-feature primitives shared by every rounded shape. A capsule is a
+// segment with a radius and a chain edge is a segment without one, so all of
+// them reduce to these two questions - point-to-segment and segment-to-segment.
+// Kept as free functions taking output sinks, like the transform helpers, so the
+// narrow phase, the queries and the sweep can all use them allocation-free.
+
+/** Below this squared length a segment is treated as a single point. */
+const degenerateLengthSquared = 1e-12;
+
+/**
+ * Closest point on the segment `a → b` to `(px, py)`, written into `out`.
+ * Returns the parameter along the segment, clamped to `[0, 1]`.
+ */
+export const closestPointOnSegment = (px: number, py: number, ax: number, ay: number, bx: number, by: number, out: PointLike): number => {
+  const ex = bx - ax;
+  const ey = by - ay;
+  const lengthSquared = ex * ex + ey * ey;
+
+  if (lengthSquared <= degenerateLengthSquared) {
+    out.x = ax;
+    out.y = ay;
+
+    return 0;
+  }
+
+  const t = clamp01(((px - ax) * ex + (py - ay) * ey) / lengthSquared);
+
+  out.x = ax + ex * t;
+  out.y = ay + ey * t;
+
+  return t;
+};
+
+/** Squared distance from `(px, py)` to the segment `a → b`. */
+export const pointSegmentDistanceSquared = (px: number, py: number, ax: number, ay: number, bx: number, by: number, scratch: PointLike): number => {
+  closestPointOnSegment(px, py, ax, ay, bx, by, scratch);
+
+  const dx = px - scratch.x;
+  const dy = py - scratch.y;
+
+  return dx * dx + dy * dy;
+};
+
+/**
+ * Closest points between the segments `a0 → a1` and `b0 → b1`, written into
+ * `outA` and `outB`. Returns the squared distance between them.
+ *
+ * Parallel and overlapping segments have a whole interval of closest pairs; this
+ * returns one of them, chosen deterministically. Callers that need a stable
+ * two-point manifold for such a case must derive it from the face geometry, not
+ * from this single pair.
+ */
+export const segmentSegmentDistanceSquared = (
+  a0x: number,
+  a0y: number,
+  a1x: number,
+  a1y: number,
+  b0x: number,
+  b0y: number,
+  b1x: number,
+  b1y: number,
+  outA: PointLike,
+  outB: PointLike,
+): number => {
+  const dax = a1x - a0x;
+  const day = a1y - a0y;
+  const dbx = b1x - b0x;
+  const dby = b1y - b0y;
+  const rx = a0x - b0x;
+  const ry = a0y - b0y;
+  const aa = dax * dax + day * day;
+  const bb = dbx * dbx + dby * dby;
+  const f = dbx * rx + dby * ry;
+
+  let s: number;
+  let t: number;
+
+  if (aa <= degenerateLengthSquared && bb <= degenerateLengthSquared) {
+    outA.x = a0x;
+    outA.y = a0y;
+    outB.x = b0x;
+    outB.y = b0y;
+
+    return rx * rx + ry * ry;
+  }
+
+  if (aa <= degenerateLengthSquared) {
+    s = 0;
+    t = clamp01(f / bb);
+  } else {
+    const c = dax * rx + day * ry;
+
+    if (bb <= degenerateLengthSquared) {
+      t = 0;
+      s = clamp01(-c / aa);
+    } else {
+      const b = dax * dbx + day * dby;
+      const denom = aa * bb - b * b;
+
+      // Parallel segments leave `denom` at zero; pinning s = 0 picks the pair at
+      // a0, which is deterministic and as good as any other on the interval.
+      s = denom > 0 ? clamp01((b * f - c * bb) / denom) : 0;
+      t = (b * s + f) / bb;
+
+      if (t < 0) {
+        t = 0;
+        s = clamp01(-c / aa);
+      } else if (t > 1) {
+        t = 1;
+        s = clamp01((b - c) / aa);
+      }
+    }
+  }
+
+  outA.x = a0x + dax * s;
+  outA.y = a0y + day * s;
+  outB.x = b0x + dbx * t;
+  outB.y = b0y + dby * t;
+
+  const dx = outA.x - outB.x;
+  const dy = outA.y - outB.y;
+
+  return dx * dx + dy * dy;
+};
+
+const clamp01 = (value: number): number => {
+  if (value < 0) {
+    return 0;
+  }
+
+  return value > 1 ? 1 : value;
+};

--- a/packages/exojs-physics/src/collision/sweep.ts
+++ b/packages/exojs-physics/src/collision/sweep.ts
@@ -2,7 +2,10 @@ import type { PointLike } from '@codexo/exojs';
 
 import type { AnyShape } from '../shapes/AnyShape';
 import { CircleShape } from '../shapes/CircleShape';
+import type { ShapeType } from '../shapes/Shape';
 import type { CollisionProxy } from './CollisionProxy';
+import type { PairTable } from './dispatch';
+import { orderedEntry, orderedTable } from './dispatch';
 import { testOverlap } from './narrowphase';
 
 /**
@@ -46,12 +49,16 @@ const _circleProxy: { shape: AnyShape; worldCenter: PointLike; worldVertices: nu
  * and the discrete solver owns them. Allocation-free.
  */
 export const sweepProxies = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy, out: SweepHit): boolean => {
-  if (moving.shape.type === 'circle') {
-    return target.shape.type === 'circle' ? sweepCircleCircle(moving, dx, dy, target, out) : sweepCirclePolygon(moving, dx, dy, target, out);
-  }
+  const cast = orderedEntry(sweepTable, moving.shape.type, target.shape.type);
 
-  return target.shape.type === 'circle' ? sweepPolygonCircle(moving, dx, dy, target, out) : sweepPolygonPolygon(moving, dx, dy, target, out);
+  // Unlike the narrow phase, the sweep distinguishes its operands, so this table
+  // is filled for both orders. A missing entry reports no impact - the pair is
+  // not swept at all rather than swept approximately.
+  return cast === undefined ? false : cast(moving, dx, dy, target, out);
 };
+
+/** `true` when {@link sweepProxies} has an implementation for this ordered pair. */
+export const canSweep = (moving: ShapeType, target: ShapeType): boolean => orderedEntry(sweepTable, moving, target) !== undefined;
 
 // Only called after the dispatch above has matched the shape kind; the fallback
 // is unreachable but keeps the helper cast-free.
@@ -383,3 +390,13 @@ const sweptSatAxes = (
 
   return true;
 };
+
+/** One ordered `(moving, target)` shape cast. */
+type SweepPair = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy, out: SweepHit) => boolean;
+
+const sweepTable: PairTable<SweepPair> = orderedTable<SweepPair>([
+  ['circle', 'circle', sweepCircleCircle],
+  ['circle', 'polygon', sweepCirclePolygon],
+  ['polygon', 'circle', sweepPolygonCircle],
+  ['polygon', 'polygon', sweepPolygonPolygon],
+]);

--- a/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
+++ b/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
@@ -173,6 +173,12 @@ export class PhysicsDebugDraw extends DebugLayer {
       return;
     }
 
+    if (collider.shape.type === 'capsule') {
+      this._strokeCapsule(gfx, collider.worldVertices, collider.shape.radius);
+
+      return;
+    }
+
     const verts = collider.worldVertices;
     const count = collider.shape.count;
 
@@ -182,6 +188,35 @@ export class PhysicsDebugDraw extends DebugLayer {
       const j = i % count;
 
       gfx.lineTo(verts[j * 2]!, verts[j * 2 + 1]!);
+    }
+  }
+
+  /**
+   * Capsule outline: the two straight sides offset from the spine, joined by a
+   * half-circle at each end. The arcs are approximated - a visualisation may
+   * tessellate, the solver never does.
+   */
+  private _strokeCapsule(gfx: Graphics, spine: readonly number[], radius: number): void {
+    const ax = spine[0]!;
+    const ay = spine[1]!;
+    const bx = spine[2]!;
+    const by = spine[3]!;
+    const along = Math.atan2(by - ay, bx - ax);
+    const arcSegments = 12;
+
+    gfx.moveTo(ax + Math.cos(along + Math.PI / 2) * radius, ay + Math.sin(along + Math.PI / 2) * radius);
+    gfx.lineTo(bx + Math.cos(along + Math.PI / 2) * radius, by + Math.sin(along + Math.PI / 2) * radius);
+
+    for (let i = 1; i <= arcSegments; i++) {
+      const angle = along + Math.PI / 2 - (Math.PI * i) / arcSegments;
+
+      gfx.lineTo(bx + Math.cos(angle) * radius, by + Math.sin(angle) * radius);
+    }
+
+    for (let i = 1; i <= arcSegments; i++) {
+      const angle = along - Math.PI / 2 - (Math.PI * i) / arcSegments;
+
+      gfx.lineTo(ax + Math.cos(angle) * radius, ay + Math.sin(angle) * radius);
     }
   }
 

--- a/packages/exojs-physics/src/public.ts
+++ b/packages/exojs-physics/src/public.ts
@@ -23,6 +23,7 @@ export { PhysicsWorld } from './PhysicsWorld';
 export type { QueryFilter, RayHit } from './query/QueryEngine';
 export type { AnyShape } from './shapes/AnyShape';
 export { BoxShape } from './shapes/BoxShape';
+export { CapsuleShape } from './shapes/CapsuleShape';
 export { CircleShape } from './shapes/CircleShape';
 export { PolygonShape } from './shapes/PolygonShape';
 export type { ShapeMassProperties, ShapeType } from './shapes/Shape';

--- a/packages/exojs-physics/src/query/QueryEngine.ts
+++ b/packages/exojs-physics/src/query/QueryEngine.ts
@@ -4,11 +4,15 @@ import { aabbContainsPoint, aabbOverlap, createAabb } from '../Aabb';
 import type { Collider } from '../Collider';
 import type { CollisionProxy } from '../collision/CollisionProxy';
 import { testOverlap } from '../collision/narrowphase';
+import { closestPointOnSegment, pointSegmentDistanceSquared } from '../collision/segments';
 import { applyRotation, applyTransform, createTransform } from '../math';
 import type { PhysicsBody } from '../PhysicsBody';
 import type { AnyShape } from '../shapes/AnyShape';
 import { resolveFilter, shouldCollide } from '../types';
 import type { SpatialIndex } from './SpatialIndex';
+
+/** Reused sink for the closest-point primitives; queries run sequentially. */
+const _pointScratch: PointLike = { x: 0, y: 0 };
 
 /** A category/mask/group filter applied to a query. Omitting it matches everything. */
 export type QueryFilter = Partial<{ category: number; mask: number; group: number }>;
@@ -249,6 +253,12 @@ const pointInCollider = (collider: Collider, px: number, py: number): boolean =>
     return dx * dx + dy * dy <= r * r;
   }
 
+  if (collider.shape.type === 'capsule') {
+    const spine = collider.worldVertices;
+
+    return pointSegmentDistanceSquared(px, py, spine[0]!, spine[1]!, spine[2]!, spine[3]!, _pointScratch) <= collider.shape.radius * collider.shape.radius;
+  }
+
   const verts = collider.worldVertices;
   const normals = collider.worldNormals;
   const count = collider.shape.count;
@@ -269,11 +279,120 @@ const pointInCollider = (collider: Collider, px: number, py: number): boolean =>
 
 /** Cast the (normalised) ray against one collider, returning the entry hit or `null`. */
 const rayCastCollider = (collider: Collider, ox: number, oy: number, dx: number, dy: number, maxDistance: number): RayHit | null => {
-  if (collider.shape.type === 'circle') {
-    return rayCastCircle(collider, ox, oy, dx, dy, maxDistance);
+  switch (collider.shape.type) {
+    case 'circle':
+      return rayCastCircle(collider, ox, oy, dx, dy, maxDistance);
+    case 'capsule':
+      return rayCastCapsule(collider, collider.shape.radius, ox, oy, dx, dy, maxDistance);
+    case 'polygon':
+      return rayCastPolygon(collider, ox, oy, dx, dy, maxDistance);
+  }
+};
+
+/**
+ * Ray against a capsule: the first point along the ray whose distance to the
+ * spine equals the radius.
+ *
+ * Found by scanning for the first sample inside and bisecting the bracket that
+ * produced it, rather than by three closed-form feature tests (two caps and the
+ * side slab). The distance-to-spine function is continuous and, approaching the
+ * capsule from outside, monotone up to the first touch, so the bracket is valid;
+ * a fixed 40 bisections put the result far below the engine's contact slop. The
+ * cost is a query-path concern only - the solver never runs this.
+ */
+const rayCastCapsule = (collider: Collider, radius: number, ox: number, oy: number, dx: number, dy: number, maxDistance: number): RayHit | null => {
+  const spine = collider.worldVertices;
+  const ax = spine[0]!;
+  const ay = spine[1]!;
+  const bx = spine[2]!;
+  const by = spine[3]!;
+  const radiusSquared = radius * radius;
+
+  // An origin already inside the solid has no entry point, matching the circle
+  // and polygon paths.
+  if (pointSegmentDistanceSquared(ox, oy, ax, ay, bx, by, _pointScratch) <= radiusSquared) {
+    return null;
   }
 
-  return rayCastPolygon(collider, ox, oy, dx, dy, maxDistance);
+  // Bound the scan by where the ray crosses the collider's AABB. `maxDistance`
+  // is routinely Infinity, and the box already carries the capsule's radius, so
+  // this is both finite and tight.
+  const box = collider.aabb;
+  let near = 0;
+  let far = maxDistance;
+
+  for (let axis = 0; axis < 2; axis++) {
+    const origin = axis === 0 ? ox : oy;
+    const direction = axis === 0 ? dx : dy;
+    const lo = axis === 0 ? box.minX : box.minY;
+    const hi = axis === 0 ? box.maxX : box.maxY;
+
+    if (Math.abs(direction) < 1e-12) {
+      if (origin < lo || origin > hi) {
+        return null;
+      }
+
+      continue;
+    }
+
+    const t0 = (lo - origin) / direction;
+    const t1 = (hi - origin) / direction;
+
+    near = Math.max(near, Math.min(t0, t1));
+    far = Math.min(far, Math.max(t0, t1));
+  }
+
+  if (near > far) {
+    return null;
+  }
+
+  const steps = 32;
+  const stepLength = (far - near) / steps;
+  let entered = -1;
+
+  for (let i = 1; i <= steps; i++) {
+    const t = near + i * stepLength;
+
+    if (pointSegmentDistanceSquared(ox + dx * t, oy + dy * t, ax, ay, bx, by, _pointScratch) <= radiusSquared) {
+      entered = t;
+
+      break;
+    }
+  }
+
+  if (entered < 0) {
+    return null;
+  }
+
+  let lo = entered - stepLength;
+  let hi = entered;
+
+  for (let i = 0; i < 40; i++) {
+    const mid = (lo + hi) / 2;
+
+    if (pointSegmentDistanceSquared(ox + dx * mid, oy + dy * mid, ax, ay, bx, by, _pointScratch) <= radiusSquared) {
+      hi = mid;
+    } else {
+      lo = mid;
+    }
+  }
+
+  const hitX = ox + dx * hi;
+  const hitY = oy + dy * hi;
+
+  closestPointOnSegment(hitX, hitY, ax, ay, bx, by, _pointScratch);
+
+  const nx = hitX - _pointScratch.x;
+  const ny = hitY - _pointScratch.y;
+  const length = Math.hypot(nx, ny) || 1;
+
+  return {
+    collider,
+    body: collider.body,
+    point: { x: hitX, y: hitY },
+    normal: { x: nx / length, y: ny / length },
+    distance: hi,
+  };
 };
 
 const rayCastCircle = (collider: Collider, ox: number, oy: number, dx: number, dy: number, maxDistance: number): RayHit | null => {
@@ -382,16 +501,16 @@ const makeProxy = (shape: AnyShape, x: number, y: number, angle: number): Collis
     return { shape, worldCenter: { x, y }, worldVertices: [], worldNormals: [] };
   }
 
-  const polygon = shape;
+  const count = shape.type === 'capsule' ? 2 : shape.count;
   const transform = createTransform(x, y, angle);
   const worldVertices: number[] = [];
   const worldNormals: number[] = [];
   const out: PointLike = { x: 0, y: 0 };
 
-  for (let i = 0; i < polygon.count; i++) {
-    applyTransform(transform, polygon.vertices[i * 2]!, polygon.vertices[i * 2 + 1]!, out);
+  for (let i = 0; i < count; i++) {
+    applyTransform(transform, shape.vertices[i * 2]!, shape.vertices[i * 2 + 1]!, out);
     worldVertices.push(out.x, out.y);
-    applyRotation(transform, polygon.normals[i * 2]!, polygon.normals[i * 2 + 1]!, out);
+    applyRotation(transform, shape.normals[i * 2]!, shape.normals[i * 2 + 1]!, out);
     worldNormals.push(out.x, out.y);
   }
 
@@ -427,10 +546,12 @@ const proxyAabb = (shape: AnyShape, proxy: CollisionProxy, out: AabbLike): AabbL
     maxY = y > maxY ? y : maxY;
   }
 
-  out.minX = minX;
-  out.minY = minY;
-  out.maxX = maxX;
-  out.maxY = maxY;
+  const radius = shape.type === 'capsule' ? shape.radius : 0;
+
+  out.minX = minX - radius;
+  out.minY = minY - radius;
+  out.maxX = maxX + radius;
+  out.maxY = maxY + radius;
 
   return out;
 };

--- a/packages/exojs-physics/src/shapes/AnyShape.ts
+++ b/packages/exojs-physics/src/shapes/AnyShape.ts
@@ -1,10 +1,12 @@
+import type { CapsuleShape } from './CapsuleShape';
 import type { CircleShape } from './CircleShape';
 import type { PolygonShape } from './PolygonShape';
 
 /**
  * Discriminated union of the concrete shape kinds. Narrow via the literal
- * `shape.type` discriminant (`'circle'` → {@link CircleShape}, `'polygon'` →
- * {@link PolygonShape}) - no `as` casts needed. {@link BoxShape} is a
- * {@link PolygonShape} subclass and carries `type: 'polygon'`.
+ * `shape.type` discriminant (`'circle'` → {@link CircleShape}, `'capsule'` →
+ * {@link CapsuleShape}, `'polygon'` → {@link PolygonShape}) - no `as` casts
+ * needed. {@link BoxShape} is a {@link PolygonShape} subclass and carries
+ * `type: 'polygon'`.
  */
-export type AnyShape = CircleShape | PolygonShape;
+export type AnyShape = CapsuleShape | CircleShape | PolygonShape;

--- a/packages/exojs-physics/src/shapes/CapsuleShape.ts
+++ b/packages/exojs-physics/src/shapes/CapsuleShape.ts
@@ -1,0 +1,100 @@
+import type { ShapeMassProperties } from './Shape';
+import { Shape } from './Shape';
+
+/** Spines shorter than this (px) have no well-defined orientation. */
+const minimumLength = 1e-3;
+
+/**
+ * A capsule: the set of points within `radius` of the segment between two
+ * local-space endpoints. Exact geometry, never a polygon approximation - the
+ * mass model and the narrow phase both work on the spine and the radius, so
+ * nothing about a capsule depends on a tessellation constant.
+ *
+ * The spine is given as two points rather than a centre, a half-height and an
+ * angle: every consumer needs the two endpoints, and the collider already
+ * carries a local rotation, so an angle on the shape would be a second and
+ * redundant orientation.
+ *
+ * A zero-length spine is rejected rather than quietly becoming a circle - use
+ * {@link CircleShape} to say that.
+ */
+export class CapsuleShape extends Shape {
+  public readonly type = 'capsule' as const;
+
+  /** Local spine endpoints, flattened - the same layout a polygon uses. */
+  public readonly vertices: readonly number[];
+
+  /** Outward unit normals of the two spine sides, flattened. */
+  public readonly normals: readonly number[];
+
+  public readonly radius: number;
+
+  /** Spine length; the capsule is `length + 2 × radius` long overall. */
+  public readonly length: number;
+
+  public readonly boundingRadius: number;
+  public readonly massProperties: ShapeMassProperties;
+
+  public constructor(x0: number, y0: number, x1: number, y1: number, radius: number) {
+    super();
+
+    if (!Number.isFinite(x0) || !Number.isFinite(y0) || !Number.isFinite(x1) || !Number.isFinite(y1)) {
+      throw new RangeError(`CapsuleShape: spine endpoints must be finite, received (${x0}, ${y0}) and (${x1}, ${y1}).`);
+    }
+
+    if (!Number.isFinite(radius) || radius <= 0) {
+      throw new RangeError(`CapsuleShape: radius must be a positive finite number, received ${radius}.`);
+    }
+
+    const ex = x1 - x0;
+    const ey = y1 - y0;
+    const length = Math.hypot(ex, ey);
+
+    if (length < minimumLength) {
+      throw new RangeError(`CapsuleShape: the spine is degenerate (length ${length}); use CircleShape for a round collider.`);
+    }
+
+    // Same convention as PolygonShape: for the counter-clockwise edge i → i+1 the
+    // outward normal is (eY, -eX). A two-vertex ring has two opposite edges, so
+    // the second normal is the negation of the first.
+    const nx = ey / length;
+    const ny = -ex / length;
+
+    this.radius = radius;
+    this.length = length;
+    this.vertices = Object.freeze([x0, y0, x1, y1]);
+    this.normals = Object.freeze([nx, ny, -nx, -ny]);
+    this.boundingRadius = Math.max(Math.hypot(x0, y0), Math.hypot(x1, y1)) + radius;
+    this.massProperties = Object.freeze(capsuleMassProperties(x0, y0, x1, y1, length, radius));
+
+    Object.freeze(this);
+  }
+}
+
+/**
+ * Exact area-based mass properties: a `2r × L` rectangle plus the two end
+ * caps, which together are a full disc of radius `r` displaced to the ends.
+ *
+ * The second moment about the centroid is the sum of
+ * - the rectangle's polar moment `A·((2r)² + L²)/12`, and
+ * - the two caps', each shifted from its own centroid to the capsule centre by
+ *   the parallel-axis theorem. A half-disc's polar moment about the centre of
+ *   its flat edge is `π r⁴/4`, and its centroid sits `4r/(3π)` from that edge.
+ *
+ * At `L → 0` the cap terms alone give `π r⁴/2`, the disc value {@link CircleShape}
+ * computes - which is the check that pins the constants.
+ */
+const capsuleMassProperties = (x0: number, y0: number, x1: number, y1: number, length: number, radius: number): ShapeMassProperties => {
+  const rectangleArea = 2 * radius * length;
+  const capArea = Math.PI * radius * radius;
+  const rectangleInertia = (rectangleArea * (4 * radius * radius + length * length)) / 12;
+  const capInertia = (Math.PI * radius ** 4) / 2 + (Math.PI * radius * radius * length * length) / 4 + (4 * radius ** 3 * length) / 3;
+
+  return {
+    area: rectangleArea + capArea,
+    // Both the rectangle and the cap pair are symmetric about the spine midpoint.
+    centroidX: (x0 + x1) / 2,
+    centroidY: (y0 + y1) / 2,
+    unitInertia: rectangleInertia + capInertia,
+  };
+};

--- a/packages/exojs-physics/src/shapes/Shape.ts
+++ b/packages/exojs-physics/src/shapes/Shape.ts
@@ -1,5 +1,5 @@
 /** Discriminant for the concrete shape kinds supported in the MVP. */
-export type ShapeType = 'circle' | 'polygon';
+export type ShapeType = 'circle' | 'capsule' | 'polygon';
 
 /**
  * Area-based mass properties of a solid shape, from which a {@link Collider}'s

--- a/packages/exojs-physics/src/shapes/index.ts
+++ b/packages/exojs-physics/src/shapes/index.ts
@@ -1,5 +1,6 @@
 export type { AnyShape } from './AnyShape';
 export { BoxShape } from './BoxShape';
+export { CapsuleShape } from './CapsuleShape';
 export { CircleShape } from './CircleShape';
 export { PolygonShape } from './PolygonShape';
 export { Shape, type ShapeType } from './Shape';

--- a/packages/exojs-physics/test/capsule.test.ts
+++ b/packages/exojs-physics/test/capsule.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from 'vitest';
+
+import { Manifold } from '../src/collision/Manifold';
+import { collide, testOverlap } from '../src/collision/narrowphase';
+import { BoxShape, CapsuleShape, CircleShape, PhysicsBody, PhysicsWorld } from '../src/index';
+import { colliderAt } from './support';
+
+/**
+ * Capsules. Exact geometry throughout - the mass model and the narrow phase both
+ * work on the spine and the radius, so nothing here depends on a tessellation.
+ */
+
+const DT = 1 / 60;
+
+/** Second moment of area about the centroid, integrated on a grid. */
+const integratedInertia = (shape: CapsuleShape, samples = 1200): number => {
+  const ax = shape.vertices[0]!;
+  const ay = shape.vertices[1]!;
+  const bx = shape.vertices[2]!;
+  const by = shape.vertices[3]!;
+  const r = shape.radius;
+  const minX = Math.min(ax, bx) - r;
+  const maxX = Math.max(ax, bx) + r;
+  const minY = Math.min(ay, by) - r;
+  const maxY = Math.max(ay, by) + r;
+  const cx = shape.massProperties.centroidX;
+  const cy = shape.massProperties.centroidY;
+  const cell = ((maxX - minX) / samples) * ((maxY - minY) / samples);
+  let inertia = 0;
+
+  for (let ix = 0; ix < samples; ix++) {
+    const x = minX + ((ix + 0.5) * (maxX - minX)) / samples;
+
+    for (let iy = 0; iy < samples; iy++) {
+      const y = minY + ((iy + 0.5) * (maxY - minY)) / samples;
+      const ex = bx - ax;
+      const ey = by - ay;
+      const lengthSquared = ex * ex + ey * ey;
+      const t = Math.max(0, Math.min(1, ((x - ax) * ex + (y - ay) * ey) / lengthSquared));
+      const dx = x - (ax + ex * t);
+      const dy = y - (ay + ey * t);
+
+      if (dx * dx + dy * dy <= r * r) {
+        inertia += ((x - cx) * (x - cx) + (y - cy) * (y - cy)) * cell;
+      }
+    }
+  }
+
+  return inertia;
+};
+
+const relativeError = (value: number, reference: number): number => Math.abs(value - reference) / Math.abs(reference);
+
+describe('CapsuleShape', () => {
+  it('exposes the spine, its length and a bounding radius', () => {
+    const capsule = new CapsuleShape(-15, 0, 15, 0, 5);
+
+    expect(capsule.type).toBe('capsule');
+    expect(capsule.length).toBeCloseTo(30);
+    expect(capsule.radius).toBe(5);
+    expect(capsule.boundingRadius).toBeCloseTo(20);
+    expect([...capsule.vertices]).toEqual([-15, 0, 15, 0]);
+  });
+
+  it('carries two opposite side normals, like a two-vertex ring', () => {
+    const capsule = new CapsuleShape(-10, 0, 10, 0, 4);
+    const normals = [...capsule.normals];
+
+    expect(Math.hypot(normals[0]!, normals[1]!)).toBeCloseTo(1);
+    expect(normals[2]).toBeCloseTo(-normals[0]!);
+    expect(normals[3]).toBeCloseTo(-normals[1]!);
+  });
+
+  it('computes the exact area of a rectangle plus two caps', () => {
+    const capsule = new CapsuleShape(0, -12, 0, 12, 3);
+
+    expect(capsule.massProperties.area).toBeCloseTo(2 * 3 * 24 + Math.PI * 9, 9);
+  });
+
+  it('puts the centroid at the spine midpoint', () => {
+    const capsule = new CapsuleShape(10, 20, 30, 60, 6);
+
+    expect(capsule.massProperties.centroidX).toBeCloseTo(20);
+    expect(capsule.massProperties.centroidY).toBeCloseTo(40);
+  });
+
+  it('matches a circle of the same radius as the spine shrinks', () => {
+    const disc = new CircleShape(7);
+    const nearlyDisc = new CapsuleShape(0, 0, 0.002, 0, 7);
+
+    expect(nearlyDisc.massProperties.area).toBeCloseTo(disc.massProperties.area, 1);
+    // Not exactly equal: a 0.002 px spine still carries a sliver of extra
+    // material. Within a thousandth is the honest statement.
+    expect(relativeError(nearlyDisc.massProperties.unitInertia, disc.massProperties.unitInertia)).toBeLessThan(1e-3);
+  });
+
+  it('agrees with a numerically integrated inertia', () => {
+    for (const capsule of [new CapsuleShape(-20, 0, 20, 0, 6), new CapsuleShape(0, -5, 0, 5, 9), new CapsuleShape(-8, -8, 8, 8, 4)]) {
+      // The reference is a grid integration, so the comparison is relative:
+      // the residual is the sampling error, not a disagreement about the shape.
+      expect(relativeError(capsule.massProperties.unitInertia, integratedInertia(capsule))).toBeLessThan(1e-3);
+    }
+  });
+
+  it('rejects a degenerate spine and a non-positive radius', () => {
+    expect(() => new CapsuleShape(0, 0, 0, 0, 5)).toThrow(RangeError);
+    expect(() => new CapsuleShape(0, 0, 10, 0, 0)).toThrow(RangeError);
+    expect(() => new CapsuleShape(0, 0, 10, 0, -1)).toThrow(RangeError);
+    expect(() => new CapsuleShape(0, 0, Number.NaN, 0, 5)).toThrow(RangeError);
+  });
+
+  it('is frozen, like every other shape', () => {
+    expect(Object.isFrozen(new CapsuleShape(0, 0, 10, 0, 2))).toBe(true);
+  });
+});
+
+describe('capsule colliders', () => {
+  it('takes an AABB from the spine inflated by the radius', () => {
+    const world = new PhysicsWorld();
+    const collider = colliderAt(world, new CapsuleShape(-10, 0, 10, 0, 4), { x: 100, y: 50 });
+
+    expect(collider.aabb.minX).toBeCloseTo(86);
+    expect(collider.aabb.maxX).toBeCloseTo(114);
+    expect(collider.aabb.minY).toBeCloseTo(46);
+    expect(collider.aabb.maxY).toBeCloseTo(54);
+  });
+
+  it('rotates its spine with the body', () => {
+    const world = new PhysicsWorld();
+    const collider = colliderAt(world, new CapsuleShape(-10, 0, 10, 0, 4), { x: 0, y: 0 }, Math.PI / 2);
+
+    // A quarter turn puts the spine on the Y axis, so the box is tall, not wide.
+    expect(collider.aabb.maxX - collider.aabb.minX).toBeCloseTo(8);
+    expect(collider.aabb.maxY - collider.aabb.minY).toBeCloseTo(28);
+  });
+});
+
+describe('capsule narrow phase', () => {
+  const manifold = new Manifold();
+
+  it('meets a circle at one point, with the normal along the shortest link', () => {
+    const world = new PhysicsWorld();
+    const capsule = colliderAt(world, new CapsuleShape(-20, 0, 20, 0, 5), { x: 0, y: 0 });
+    const circle = colliderAt(world, new CircleShape(4), { x: 0, y: 8 });
+
+    expect(collide(capsule, circle, manifold)).toBe(true);
+    expect(manifold.pointCount).toBe(1);
+    // A → B is capsule → circle, so the normal points along +Y.
+    expect(manifold.normalX).toBeCloseTo(0);
+    expect(manifold.normalY).toBeCloseTo(1);
+    expect(manifold.points[0].penetration).toBeCloseTo(1);
+  });
+
+  it('reverses the normal when the operands are swapped', () => {
+    const world = new PhysicsWorld();
+    const capsule = colliderAt(world, new CapsuleShape(-20, 0, 20, 0, 5), { x: 0, y: 0 });
+    const circle = colliderAt(world, new CircleShape(4), { x: 0, y: 8 });
+
+    expect(collide(circle, capsule, manifold)).toBe(true);
+    expect(manifold.normalY).toBeCloseTo(-1);
+  });
+
+  it('misses a circle just out of reach and touches one just in reach', () => {
+    const world = new PhysicsWorld();
+    const capsule = colliderAt(world, new CapsuleShape(-20, 0, 20, 0, 5), { x: 0, y: 0 });
+    const far = colliderAt(world, new CircleShape(4), { x: 0, y: 9.5 });
+    const near = colliderAt(world, new CircleShape(4), { x: 0, y: 8.5 });
+
+    expect(collide(capsule, far, manifold)).toBe(false);
+    expect(collide(capsule, near, manifold)).toBe(true);
+    expect(testOverlap(capsule, far)).toBe(false);
+    expect(testOverlap(capsule, near)).toBe(true);
+  });
+
+  it('rests on a box with two contact points', () => {
+    const world = new PhysicsWorld();
+    // Spine parallel to the box's top face, overlapping it slightly.
+    const box = colliderAt(world, new BoxShape(200, 20), { x: 0, y: 100 });
+    const capsule = colliderAt(world, new CapsuleShape(-15, 0, 15, 0, 6), { x: 0, y: 85 });
+
+    expect(collide(box, capsule, manifold)).toBe(true);
+    // A flat rounded side against a face has to produce two points, or the
+    // capsule rocks on a single one.
+    expect(manifold.pointCount).toBe(2);
+    expect(manifold.normalY).toBeCloseTo(-1);
+    expect(manifold.points[0].penetration).toBeGreaterThan(0);
+    expect(manifold.points[1].penetration).toBeGreaterThan(0);
+  });
+
+  it('meets a parallel capsule with two contact points', () => {
+    const world = new PhysicsWorld();
+    const lower = colliderAt(world, new CapsuleShape(-20, 0, 20, 0, 5), { x: 0, y: 0 });
+    const upper = colliderAt(world, new CapsuleShape(-20, 0, 20, 0, 5), { x: 0, y: 9 });
+
+    expect(collide(lower, upper, manifold)).toBe(true);
+    expect(manifold.pointCount).toBe(2);
+    expect(manifold.normalY).toBeCloseTo(1);
+  });
+
+  it('separates a capsule pair that only nearly touches', () => {
+    const world = new PhysicsWorld();
+    const a = colliderAt(world, new CapsuleShape(-20, 0, 20, 0, 5), { x: 0, y: 0 });
+    const b = colliderAt(world, new CapsuleShape(-20, 0, 20, 0, 5), { x: 0, y: 10.5 });
+
+    expect(collide(a, b, manifold)).toBe(false);
+    expect(testOverlap(a, b)).toBe(false);
+  });
+
+  it('leaves polygon against polygon exactly as it was', () => {
+    const world = new PhysicsWorld();
+    const floor = colliderAt(world, new BoxShape(200, 20), { x: 0, y: 100 });
+    const box = colliderAt(world, new BoxShape(20, 20), { x: 0, y: 85 });
+
+    expect(collide(floor, box, manifold)).toBe(true);
+    expect(manifold.pointCount).toBe(2);
+
+    // Radius-free operands must not pick up the rounded-shape offset: the points
+    // stay exactly on a face plane (the floor's top at y = 90 or the box's
+    // bottom at y = 95), never half-way between them.
+    for (const point of [manifold.points[0], manifold.points[1]]) {
+      expect(Math.min(Math.abs(point.y - 90), Math.abs(point.y - 95))).toBeLessThan(1e-9);
+    }
+  });
+});
+
+describe('capsule in a world', () => {
+  it('gives a dynamic body the capsule mass model', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const shape = new CapsuleShape(-12, 0, 12, 0, 5);
+    const body = world.add(new PhysicsBody({ type: 'dynamic', colliders: [{ shape, density: 2 }] }));
+
+    expect(body.mass).toBeCloseTo(2 * shape.massProperties.area);
+    expect(body.inertia).toBeCloseTo(2 * shape.massProperties.unitInertia);
+  });
+
+  it('comes to rest on a floor instead of sinking through it', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 320 }, colliders: [{ shape: new BoxShape(1200, 40) }] }));
+
+    // Released just above its resting height, the way the sleeping suite drops
+    // its boxes. A long fall is a different question - see the note below.
+    const body = world.add(
+      new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 288 }, colliders: [{ shape: new CapsuleShape(-15, 0, 15, 0, 8) }] }),
+    );
+
+    for (let frame = 0; frame < 180; frame++) {
+      world.step(DT);
+    }
+
+    // Floor surface at y = 300 and a radius of 8, so the spine rests at 292 plus
+    // the solver's contact slop - the capsule stands on its side, not its core.
+    expect(body.y).toBeGreaterThan(291.5);
+    expect(body.y).toBeLessThan(293);
+    expect(Math.abs(body.linearVelocityY)).toBeLessThan(1);
+  });
+
+  it('answers point queries against the rounded outline, not the spine box', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+
+    colliderAt(world, new CapsuleShape(-20, 0, 20, 0, 5), { x: 0, y: 0 });
+    world.step(DT);
+
+    expect(world.queryPoint({ x: 0, y: 0 })).toHaveLength(1); // on the spine
+    expect(world.queryPoint({ x: 24, y: 0 })).toHaveLength(1); // inside the end cap
+    expect(world.queryPoint({ x: 0, y: 4.9 })).toHaveLength(1); // just inside a side
+    expect(world.queryPoint({ x: 0, y: 5.1 })).toHaveLength(0); // just outside a side
+    // Inside the AABB corner but outside the rounded cap.
+    expect(world.queryPoint({ x: 24.5, y: 4.5 })).toHaveLength(0);
+  });
+
+  it('ray casts against the caps and the sides', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+
+    colliderAt(world, new CapsuleShape(-20, 0, 20, 0, 5), { x: 0, y: 0 });
+    world.step(DT);
+
+    const side = world.rayCast({ x: 0, y: -50 }, { x: 0, y: 1 });
+
+    expect(side).not.toBeNull();
+    expect(side!.distance).toBeCloseTo(45, 3);
+    expect(side!.normal.y).toBeCloseTo(-1, 3);
+
+    const cap = world.rayCast({ x: -80, y: 0 }, { x: 1, y: 0 });
+
+    expect(cap).not.toBeNull();
+    expect(cap!.distance).toBeCloseTo(55, 3);
+    expect(cap!.normal.x).toBeCloseTo(-1, 3);
+
+    // Passes above the capsule entirely.
+    expect(world.rayCast({ x: -80, y: -6 }, { x: 1, y: 0 })).toBeNull();
+  });
+
+  it('overlaps a capsule query shape against the world', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const box = colliderAt(world, new BoxShape(20, 20), { x: 0, y: 0 });
+
+    world.step(DT);
+
+    expect(world.overlapShape(new CapsuleShape(-30, 0, 30, 0, 4), { x: 0, y: 12 })).toContain(box);
+    expect(world.overlapShape(new CapsuleShape(-30, 0, 30, 0, 4), { x: 0, y: 30 })).toHaveLength(0);
+  });
+});

--- a/site/src/content/api/any-shape.json
+++ b/site/src/content/api/any-shape.json
@@ -1,6 +1,6 @@
 {
   "title": "AnyShape",
-  "description": "Discriminated union of the concrete shape kinds. Narrow via the literal `shape.type` discriminant (`'circle'` → CircleShape, `'polygon'` → PolygonShape) - no `as` casts needed. BoxShape is a PolygonShape subclass and carries `type: 'polygon'`.",
+  "description": "Discriminated union of the concrete shape kinds. Narrow via the literal `shape.type` discriminant (`'circle'` → CircleShape, `'capsule'` → CapsuleShape, `'polygon'` → PolygonShape) - no `as` casts needed. BoxShape is a PolygonShape subclass and carries `type: 'polygon'`.",
   "symbol": "AnyShape",
   "kind": "type",
   "subsystem": "physics",
@@ -19,7 +19,7 @@
       "title": "Import",
       "members": [],
       "paragraphs": [
-        "Discriminated union of the concrete shape kinds. Narrow via the literal `shape.type` discriminant (`'circle'` → CircleShape, `'polygon'` → PolygonShape) - no `as` casts needed. BoxShape is a PolygonShape subclass and carries `type: 'polygon'`."
+        "Discriminated union of the concrete shape kinds. Narrow via the literal `shape.type` discriminant (`'circle'` → CircleShape, `'capsule'` → CapsuleShape, `'polygon'` → PolygonShape) - no `as` casts needed. BoxShape is a PolygonShape subclass and carries `type: 'polygon'`."
       ],
       "importLine": "import { AnyShape } from '@codexo/exojs-physics'",
       "sourceLink": null
@@ -30,8 +30,16 @@
       "members": [
         {
           "name": "AnyShape",
-          "signature": "CircleShape | PolygonShape",
+          "signature": "CapsuleShape | CircleShape | PolygonShape",
           "signatureTokens": [
+            {
+              "text": "CapsuleShape",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
             {
               "text": "CircleShape",
               "kind": "type"

--- a/site/src/content/api/capsule-shape.json
+++ b/site/src/content/api/capsule-shape.json
@@ -1,0 +1,363 @@
+{
+  "title": "CapsuleShape",
+  "description": "A capsule: the set of points within `radius` of the segment between two local-space endpoints. Exact geometry, never a polygon approximation - the mass model and the narrow phase both work on the spine and the radius, so nothing about a capsule depends on a tessellation constant. The spine is given as two points rather than a centre, a half-height and an angle: every consumer needs the two endpoints, and the collider already carries a local rotation, so an angle on the shape would be a second and redundant orientation. A zero-length spine is rejected rather than quietly becoming a circle - use CircleShape to say that.",
+  "symbol": "CapsuleShape",
+  "kind": "class",
+  "subsystem": "physics",
+  "importPath": "@codexo/exojs-physics",
+  "tier": "stable",
+  "memberCount": 8,
+  "counts": {
+    "constructors": 1,
+    "methods": 0,
+    "properties": 7,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "A capsule: the set of points within `radius` of the segment between two local-space endpoints. Exact geometry, never a polygon approximation - the mass model and the narrow phase both work on the spine and the radius, so nothing about a capsule depends on a tessellation constant.",
+        "The spine is given as two points rather than a centre, a half-height and an angle: every consumer needs the two endpoints, and the collider already carries a local rotation, so an angle on the shape would be a second and redundant orientation.",
+        "A zero-length spine is rejected rather than quietly becoming a circle - use CircleShape to say that."
+      ],
+      "importLine": "import { CapsuleShape } from '@codexo/exojs-physics'",
+      "sourceLink": null
+    },
+    {
+      "id": "constructors",
+      "title": "Constructors",
+      "members": [
+        {
+          "name": "new",
+          "signature": "new(x0: number, y0: number, x1: number, y1: number, radius: number): CapsuleShape",
+          "signatureTokens": [
+            {
+              "text": "new",
+              "kind": "keyword"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "x0",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "y0",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "x1",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "y1",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "radius",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "CapsuleShape",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "x0",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "y0",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "x1",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "y1",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "radius",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "CapsuleShape",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "boundingRadius",
+          "signature": "boundingRadius: number",
+          "signatureTokens": [
+            {
+              "text": "boundingRadius",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Radius of the smallest circle about the local origin enclosing the shape."
+        },
+        {
+          "name": "length",
+          "signature": "length: number",
+          "signatureTokens": [
+            {
+              "text": "length",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Spine length; the capsule is length + 2 × radius long overall."
+        },
+        {
+          "name": "massProperties",
+          "signature": "massProperties: ShapeMassProperties",
+          "signatureTokens": [
+            {
+              "text": "massProperties",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ShapeMassProperties",
+              "kind": "type"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Area-based mass properties, or null for boundary geometry with no interior."
+        },
+        {
+          "name": "normals",
+          "signature": "normals: readonly number[]",
+          "signatureTokens": [
+            {
+              "text": "normals",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Outward unit normals of the two spine sides, flattened."
+        },
+        {
+          "name": "radius",
+          "signature": "radius: number",
+          "signatureTokens": [
+            {
+              "text": "radius",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "type",
+          "signature": "type: \"capsule\"",
+          "signatureTokens": [
+            {
+              "text": "type",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"capsule\"",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "vertices",
+          "signature": "vertices: readonly number[]",
+          "signatureTokens": [
+            {
+              "text": "vertices",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Local spine endpoints, flattened - the same layout a polygon uses."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-physics/src/shapes/CapsuleShape.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/CapsuleShape.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-physics/src/shapes/CapsuleShape.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/CapsuleShape.ts"
+}

--- a/site/src/content/api/shape-type.json
+++ b/site/src/content/api/shape-type.json
@@ -30,8 +30,16 @@
       "members": [
         {
           "name": "ShapeType",
-          "signature": "\"circle\" | \"polygon\"",
+          "signature": "\"capsule\" | \"circle\" | \"polygon\"",
           "signatureTokens": [
+            {
+              "text": "\"capsule\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
             {
               "text": "\"circle\"",
               "kind": "keyword"


### PR DESCRIPTION
HI-19 slice 1 of 3 — the dispatch groundwork, the shared segment primitives, and `CapsuleShape`. Spec: `.workspace/specs/2026-08-23-physics-hi19-shape-completion.md`.

Two commits, deliberately separate.

## 1 — `refactor(physics): dispatch collision on a shape-pair table`

Shape-kind branching sits in five places (collider synchronisation, narrow phase, sweep, query engine, debug draw) and every one was a binary if/else over the two kinds that existed. Growing them one shape at a time rebuilds the same branching three times and invalidates the tests written against the previous shape each round — so the dispatch grows once, **before** any new shape exists.

`dispatch.ts` fixes a canonical order over the shape kinds and builds flat pair tables from it. The narrow phase and the overlap test store one entry per **unordered** pair and reach a mixed pair by swapping the operands and flipping the normal — which is what the circle/polygon routine already did by hand. The sweep distinguishes its moving operand from its target, so its table is filled for both orders.

**A pair with no entry reports no contact.** That is the shape of the contract, not a gap for an approximation to fill: segment↔segment will stay empty on purpose, and an unimplemented sweep must report no impact rather than a guess.

Behaviour-identical by construction (circle stays before polygon, so every pair resolves to the same routine with the same flip) and verified: all 326 physics tests pass unchanged on that commit alone.

## 2 — `feat(physics): add an exact capsule shape`

`new CapsuleShape(x0, y0, x1, y1, radius)` — two spine endpoints, not centre + half-height + angle. Every consumer needs the endpoints, and the collider already carries a local rotation, so an angle on the shape would be a second, redundant orientation.

Mass is closed form (rectangle + two caps). At a vanishing spine the cap terms alone reduce to the disc value `CircleShape` computes — that limit is what pins the constants, and a grid-integrated reference confirms the general case to within 0.1%. A zero-length spine throws rather than quietly becoming a circle.

**A capsule is a two-vertex ring with a radius.** That is what lets it share the polygon narrow phase instead of adding a parallel one: the SAT separations are between the two *cores*, and since both candidate axes shift by the same radius sum, the reference face the SAT picks is unaffected. So capsule/polygon and capsule/capsule are the polygon routine with radii, and a capsule resting on its side gets the same **two-point manifold** a box does rather than rocking on one. Circle/capsule stays its own one-point routine — a circle meets a rounded surface in one place. Contact points are pulled back along the reference normal by the incident radius, which is zero for a polygon, so radius-free pairs are byte-for-byte untouched.

Queries, AABB, ray cast and `overlapShape` all handle capsules. The capsule ray cast brackets its scan with the collider's AABB rather than the ray's length, which is routinely `Infinity`.

### A latent bug this surfaced

`collidePolygons` declared its own `flip` for the reference/incident role, shadowing the caller's flip parameter. With only polygon↔polygon reaching it the caller's flip was always `false`, so it never mattered; the first mixed pair through that routine would have had its normal inverted. Both are honoured now (`refSwapped !== callerFlip`).

## Known gap, deliberately scoped

Continuous collision does not sweep capsules yet — CCD is step 8 of the spec, after queries, so it can consume the same closest-point primitives instead of re-deriving them. A bullet body carrying a capsule collider logs a **development-build warning** rather than silently tunnelling.

## Validation

`pnpm verify:quick` 16/16 · `pnpm test` 10 643 passed · API docs regenerated · 22 new capsule cases covering the shape, mass (including the disc limit and a numerically integrated reference), collider AABB and rotation, all three narrow-phase pairs with normals/point counts/near-miss thresholds, the mass model on a body, resting on a floor, point queries against the rounded outline rather than the AABB, ray casts into a cap and a side, and `overlapShape`.

One assertion is worth calling out: a polygon↔polygon case pins that the contact points stay exactly on a face plane, so a radius-free pair can never pick up the rounded-shape offset.

https://claude.ai/code/session_01R4RHfm7nhMPXAuxFrpgrqj