### PR TITLE
feat(physics)!: add segment shapes and require mass on dynamic bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,32 @@ release and includes intentional breaking changes; see **Changed** and
 
 ### Added
 
+- **`SegmentShape` — zero-thickness boundary geometry, and a dynamic body must now carry
+  mass.** Level edges and one-off walls had to be modelled as thin boxes, which are solid,
+  carry mass, and behave badly once they are thin enough to matter.
+
+  A `SegmentShape` is a boundary between two local endpoints. It has no interior, so its
+  `massProperties` is `null` and it contributes collision only; it blocks from **both**
+  sides, because there is no inside for it to be outside of. One-way behaviour is the
+  contact modifier's job, not a flag on the geometry. Internally a segment is the same
+  two-vertex ring a capsule is, minus the radius, so segment/polygon and segment/capsule are
+  the routine capsules already added.
+
+  Segment against segment is deliberately **unsupported**: two zero-thickness boundaries
+  have no overlap volume, so there is no stable manifold to report. `collide` produces none
+  and `testOverlap` is `false` — not "sometimes detected but not solved".
+
+  `queryPoint` never hits a segment, at any distance. Answering within an epsilon would make
+  the result depend on an engine constant rather than the authored geometry; AABB queries
+  and ray casts are the meaningful questions, and both work.
+
+  **BREAKING — a `dynamic` body must own at least one collider with mass.** Until now such a
+  body silently ended up with `mass = 0` and `invMass = 0`, which the solver cannot tell
+  apart from a static body; `isMassReady` recorded it and nothing read it. Adding a dynamic
+  body whose colliders are all boundary geometry (or all zero-density) now throws, as does
+  destroying the last mass-bearing collider of a body that still holds others. Removing a
+  body's only collider is still fine — a body with no geometry is one still being assembled.
+
 - **`CapsuleShape` — exact capsule geometry for characters and rounded bodies.** The shape
   vocabulary was circle, polygon and box, so the standard character collider had to be
   approximated by a box (catches on edges) or a polygon (its mass then depends on how many

--- a/packages/exojs-physics/src/Collider.ts
+++ b/packages/exojs-physics/src/Collider.ts
@@ -14,7 +14,8 @@ const worldVertexCount = (shape: AnyShape): number => {
     case 'polygon':
       return shape.count;
     case 'capsule':
-      // The spine endpoints; a capsule is a two-vertex ring plus a radius.
+    case 'segment':
+      // Two endpoints. Both are a two-vertex ring, with and without a radius.
       return 2;
     case 'circle':
       return 0;
@@ -181,6 +182,9 @@ export class Collider {
         // A capsule is a two-vertex ring plus a radius, so it rides the polygon
         // path and only the AABB inflation differs.
         this._synchronizePolygon(world, this.shape.vertices, this.shape.normals, 2, this.shape.radius);
+        break;
+      case 'segment':
+        this._synchronizePolygon(world, this.shape.vertices, this.shape.normals, 2, 0);
         break;
       case 'polygon':
         this._synchronizePolygon(world, this.shape.vertices, this.shape.normals, this.shape.count, 0);

--- a/packages/exojs-physics/src/PhysicsBody.ts
+++ b/packages/exojs-physics/src/PhysicsBody.ts
@@ -269,6 +269,7 @@ export class PhysicsBody {
     if (this._attached && this._owner) {
       instance._attach(this, this._owner._allocateColliderId());
       this._recomputeMass();
+      this._assertDynamicCarriesMass();
       instance.synchronize(this._transform);
       this._owner._registerCollider(instance);
     }
@@ -550,6 +551,7 @@ export class PhysicsBody {
     }
 
     this._recomputeMass();
+    this._assertDynamicCarriesMass();
 
     for (const collider of this._colliders) {
       collider.synchronize(this._transform);
@@ -563,6 +565,23 @@ export class PhysicsBody {
   /** Internal: mark destroyed (called by the world). */
   public _markDestroyed(): void {
     this._destroyed = true;
+  }
+
+  /**
+   * A dynamic body has to carry mass. Boundary geometry (a segment, a chain)
+   * reports no mass properties, and a collider may also be given zero density,
+   * so a dynamic body can end up with none at all - which the solver cannot tell
+   * apart from a static body, since both have `invMass === 0`. Rejecting it is
+   * the difference between a clear error and a body that silently stops moving.
+   */
+  private _assertDynamicCarriesMass(): void {
+    if (this.type !== 'dynamic' || this._massReady || this._colliders.length === 0) {
+      return;
+    }
+
+    throw new Error(
+      'PhysicsBody: a dynamic body must carry at least one collider with mass — every collider it holds is either boundary geometry (a segment or chain, which has no interior) or has zero density. Add a solid collider, or make the body static or kinematic.',
+    );
   }
 
   /** Recompute mass, centre of mass and rotational inertia from the colliders. */
@@ -586,13 +605,10 @@ export class PhysicsBody {
     const point = { x: 0, y: 0 };
 
     for (const collider of this._colliders) {
-      // Read against the base `Shape` contract, not the current `AnyShape` union.
-      // Every shipped shape is solid, so the compiler proves this branch dead
-      // today; boundary geometry (segment, chain) reports no mass properties, and
-      // adding it to the union must not silently feed NaN into the mass model.
+      // Boundary geometry (a segment, later a chain) has no interior and reports
+      // no mass properties; it contributes collision only.
       const massProperties: ShapeMassProperties | null = collider.shape.massProperties;
 
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- guards the not-yet-shipped boundary shapes
       if (massProperties === null) {
         continue;
       }

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -32,14 +32,6 @@ const ccdEmbed = 0.05;
 const ccdRestitutionThreshold = 1;
 
 /**
- * `true` when a static/kinematic body - an island boundary, never an island
- * member - is being driven this step, either through its velocity or by a
- * {@link PhysicsBody.setTransform} teleport. Speed is deliberately not compared
- * against the sleep thresholds: a platform creeping along at 1 px/s still has to
- * push its passengers, and it is exactly that sub-threshold case where nothing
- * else would keep them awake.
- */
-/**
  * Keep a host-supplied blend factor inside `[0, 1]`. A caller's own accumulator
  * can hand over a value outside it (a stale read, a custom scheduler), and an
  * unclamped one extrapolates the node past the simulated state instead of
@@ -53,6 +45,45 @@ const clampAlpha = (alpha: number): number => {
   }
 
   return alpha < 1 ? alpha : 1;
+};
+
+/**
+ * Reject removing the last collider a dynamic body's mass rests on while it still
+ * holds others. Such a body keeps colliding but has `invMass === 0`, which the
+ * solver cannot tell apart from a static body - the same state `PhysicsBody`
+ * refuses to be constructed in.
+ *
+ * Removing the body's *only* collider is fine: a body with no geometry at all is
+ * a body still being assembled, not a silently broken one.
+ */
+const assertBodyKeepsItsMass = (collider: Collider): void => {
+  const body = collider.body;
+
+  if (body.type !== 'dynamic' || collider.shape.massProperties === null || collider.density <= 0) {
+    return;
+  }
+
+  let remaining = 0;
+
+  for (const other of body.colliders) {
+    if (other === collider) {
+      continue;
+    }
+
+    if (other.shape.massProperties !== null && other.density > 0) {
+      return;
+    }
+
+    remaining++;
+  }
+
+  if (remaining === 0) {
+    return;
+  }
+
+  throw new Error(
+    'PhysicsWorld.destroyCollider: this is the only collider carrying mass for a dynamic body — removing it would leave the body colliding but massless. Destroy the body instead, or give it another solid collider first.',
+  );
 };
 
 /** Shape kinds already reported as unswept, so the warning fires once per kind. */
@@ -78,6 +109,14 @@ const warnUnsweptBulletShape = (collider: Collider): void => {
   );
 };
 
+/**
+ * `true` when a static/kinematic body - an island boundary, never an island
+ * member - is being driven this step, either through its velocity or by a
+ * {@link PhysicsBody.setTransform} teleport. Speed is deliberately not compared
+ * against the sleep thresholds: a platform creeping along at 1 px/s still has to
+ * push its passengers, and it is exactly that sub-threshold case where nothing
+ * else would keep them awake.
+ */
 const isMovingBoundary = (body: PhysicsBody): boolean =>
   body._teleported || body.linearVelocityX !== 0 || body.linearVelocityY !== 0 || body.angularVelocity !== 0;
 
@@ -478,6 +517,10 @@ export class PhysicsWorld implements BodyOwner {
    * called inside a callback.
    */
   public destroyCollider(collider: Collider): void {
+    // Checked here rather than in the deferred removal so the error surfaces at
+    // the call site that caused it, not out of the middle of a `step()`.
+    assertBodyKeepsItsMass(collider);
+
     this._defer(() => this._removeCollider(collider));
   }
 

--- a/packages/exojs-physics/src/collision/dispatch.ts
+++ b/packages/exojs-physics/src/collision/dispatch.ts
@@ -13,7 +13,8 @@ import type { ShapeType } from '../shapes/Shape';
 export const shapeKindOrder: Readonly<Record<ShapeType, number>> = {
   circle: 0,
   capsule: 1,
-  polygon: 2,
+  segment: 2,
+  polygon: 3,
 };
 
 export const shapeKindCount = Object.keys(shapeKindOrder).length;

--- a/packages/exojs-physics/src/collision/narrowphase.ts
+++ b/packages/exojs-physics/src/collision/narrowphase.ts
@@ -48,12 +48,13 @@ export const collide = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold
 // ring with a radius, which is exactly why it shares the polygon routines: the
 // ring supplies `count` and `worldVertices`/`worldNormals`, the radius rounds
 // the result off.
-const radiusOf = (collider: CollisionProxy): number => (collider.shape.type === 'polygon' ? 0 : collider.shape.radius);
+const radiusOf = (collider: CollisionProxy): number => (collider.shape.type === 'circle' || collider.shape.type === 'capsule' ? collider.shape.radius : 0);
 const countOf = (collider: CollisionProxy): number => {
   switch (collider.shape.type) {
     case 'polygon':
       return collider.shape.count;
     case 'capsule':
+    case 'segment':
       return 2;
     case 'circle':
       return 0;
@@ -544,11 +545,11 @@ const roundedPolygonsOverlap: OverlapPair = (a, b) => {
  * One contact point - a circle meets a rounded surface in one place, and a second
  * would be invented noise for the solver.
  */
-const collideCircleCapsule: CollidePair = (circle, capsule, manifold, flip) => {
-  const spine = capsule.worldVertices;
+const collideCircleSpine: CollidePair = (circle, spineShape, manifold, flip) => {
+  const spine = spineShape.worldVertices;
   const centre = circle.worldCenter;
   const circleRadius = radiusOf(circle);
-  const radiusSum = circleRadius + radiusOf(capsule);
+  const radiusSum = circleRadius + radiusOf(spineShape);
 
   closestPointOnSegment(centre.x, centre.y, spine[0]!, spine[1]!, spine[2]!, spine[3]!, _segmentScratch);
 
@@ -569,8 +570,8 @@ const collideCircleCapsule: CollidePair = (circle, capsule, manifold, flip) => {
     // Centre exactly on the spine: the direction is undefined, so take the
     // capsule's own side normal. It is stable from frame to frame, which an
     // axis-aligned guess would not be.
-    nx = capsule.worldNormals[0]!;
-    ny = capsule.worldNormals[1]!;
+    nx = spineShape.worldNormals[0]!;
+    ny = spineShape.worldNormals[1]!;
   }
 
   manifold.normalX = flip ? -nx : nx;
@@ -589,10 +590,10 @@ const collideCircleCapsule: CollidePair = (circle, capsule, manifold, flip) => {
   return true;
 };
 
-const circleCapsuleOverlap: OverlapPair = (circle, capsule) => {
-  const spine = capsule.worldVertices;
+const circleSpineOverlap: OverlapPair = (circle, spineShape) => {
+  const spine = spineShape.worldVertices;
   const centre = circle.worldCenter;
-  const radiusSum = radiusOf(circle) + radiusOf(capsule);
+  const radiusSum = radiusOf(circle) + radiusOf(spineShape);
 
   return pointSegmentDistanceSquared(centre.x, centre.y, spine[0]!, spine[1]!, spine[2]!, spine[3]!, _segmentScratch) <= radiusSum * radiusSum;
 };
@@ -658,18 +659,25 @@ const circlePolygonOverlap: OverlapPair = (circle, polygon) => {
 // supports appears exactly once; anything absent reports no contact.
 const collideTable: PairTable<CollidePair> = symmetricTable<CollidePair>([
   ['circle', 'circle', collideCircles],
-  ['circle', 'capsule', collideCircleCapsule],
+  ['circle', 'capsule', collideCircleSpine],
+  ['circle', 'segment', collideCircleSpine],
   ['circle', 'polygon', collideCirclePolygon],
   ['capsule', 'capsule', collideRoundedPolygons],
+  ['capsule', 'segment', collideRoundedPolygons],
   ['capsule', 'polygon', collideRoundedPolygons],
+  // segment/segment is deliberately absent - see `collide`.
+  ['segment', 'polygon', collideRoundedPolygons],
   ['polygon', 'polygon', collideRoundedPolygons],
 ]);
 
 const overlapTable: PairTable<OverlapPair> = symmetricTable<OverlapPair>([
   ['circle', 'circle', circlesOverlap],
-  ['circle', 'capsule', circleCapsuleOverlap],
+  ['circle', 'capsule', circleSpineOverlap],
+  ['circle', 'segment', circleSpineOverlap],
   ['circle', 'polygon', circlePolygonOverlap],
   ['capsule', 'capsule', roundedPolygonsOverlap],
+  ['capsule', 'segment', roundedPolygonsOverlap],
   ['capsule', 'polygon', roundedPolygonsOverlap],
+  ['segment', 'polygon', roundedPolygonsOverlap],
   ['polygon', 'polygon', roundedPolygonsOverlap],
 ]);

--- a/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
+++ b/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
@@ -179,6 +179,15 @@ export class PhysicsDebugDraw extends DebugLayer {
       return;
     }
 
+    if (collider.shape.type === 'segment') {
+      const ends = collider.worldVertices;
+
+      gfx.moveTo(ends[0]!, ends[1]!);
+      gfx.lineTo(ends[2]!, ends[3]!);
+
+      return;
+    }
+
     const verts = collider.worldVertices;
     const count = collider.shape.count;
 

--- a/packages/exojs-physics/src/public.ts
+++ b/packages/exojs-physics/src/public.ts
@@ -26,6 +26,7 @@ export { BoxShape } from './shapes/BoxShape';
 export { CapsuleShape } from './shapes/CapsuleShape';
 export { CircleShape } from './shapes/CircleShape';
 export { PolygonShape } from './shapes/PolygonShape';
+export { SegmentShape } from './shapes/SegmentShape';
 export type { ShapeMassProperties, ShapeType } from './shapes/Shape';
 export { Shape } from './shapes/Shape';
 export type { TimeStepperOptions } from './TimeStepper';

--- a/packages/exojs-physics/src/query/QueryEngine.ts
+++ b/packages/exojs-physics/src/query/QueryEngine.ts
@@ -253,6 +253,13 @@ const pointInCollider = (collider: Collider, px: number, py: number): boolean =>
     return dx * dx + dy * dy <= r * r;
   }
 
+  if (collider.shape.type === 'segment') {
+    // A boundary encloses no area. Reporting a hit within some epsilon would make
+    // the answer depend on an engine constant rather than the authored geometry;
+    // ray casts and AABB queries are the meaningful questions for a segment.
+    return false;
+  }
+
   if (collider.shape.type === 'capsule') {
     const spine = collider.worldVertices;
 
@@ -284,9 +291,52 @@ const rayCastCollider = (collider: Collider, ox: number, oy: number, dx: number,
       return rayCastCircle(collider, ox, oy, dx, dy, maxDistance);
     case 'capsule':
       return rayCastCapsule(collider, collider.shape.radius, ox, oy, dx, dy, maxDistance);
+    case 'segment':
+      return rayCastSegment(collider, ox, oy, dx, dy, maxDistance);
     case 'polygon':
       return rayCastPolygon(collider, ox, oy, dx, dy, maxDistance);
   }
+};
+
+/**
+ * Ray against a segment: a plain segment/segment crossing. The reported normal is
+ * the segment's own side normal, flipped to face the incoming ray - a boundary
+ * blocks from both sides, so which of its two normals applies is decided by where
+ * the ray comes from.
+ */
+const rayCastSegment = (collider: Collider, ox: number, oy: number, dx: number, dy: number, maxDistance: number): RayHit | null => {
+  const ends = collider.worldVertices;
+  const ax = ends[0]!;
+  const ay = ends[1]!;
+  const ex = ends[2]! - ax;
+  const ey = ends[3]! - ay;
+  const denominator = dx * ey - dy * ex;
+
+  // Parallel (or collinear): no single crossing point to report.
+  if (Math.abs(denominator) < 1e-12) {
+    return null;
+  }
+
+  const rx = ax - ox;
+  const ry = ay - oy;
+  const distance = (rx * ey - ry * ex) / denominator;
+  const along = (rx * dy - ry * dx) / denominator;
+
+  if (distance < 0 || distance > maxDistance || along < 0 || along > 1) {
+    return null;
+  }
+
+  const nx = collider.worldNormals[0]!;
+  const ny = collider.worldNormals[1]!;
+  const facing = nx * dx + ny * dy > 0 ? -1 : 1;
+
+  return {
+    collider,
+    body: collider.body,
+    point: { x: ox + dx * distance, y: oy + dy * distance },
+    normal: { x: nx * facing, y: ny * facing },
+    distance,
+  };
 };
 
 /**
@@ -501,7 +551,7 @@ const makeProxy = (shape: AnyShape, x: number, y: number, angle: number): Collis
     return { shape, worldCenter: { x, y }, worldVertices: [], worldNormals: [] };
   }
 
-  const count = shape.type === 'capsule' ? 2 : shape.count;
+  const count = shape.type === 'polygon' ? shape.count : 2;
   const transform = createTransform(x, y, angle);
   const worldVertices: number[] = [];
   const worldNormals: number[] = [];

--- a/packages/exojs-physics/src/shapes/AnyShape.ts
+++ b/packages/exojs-physics/src/shapes/AnyShape.ts
@@ -1,6 +1,7 @@
 import type { CapsuleShape } from './CapsuleShape';
 import type { CircleShape } from './CircleShape';
 import type { PolygonShape } from './PolygonShape';
+import type { SegmentShape } from './SegmentShape';
 
 /**
  * Discriminated union of the concrete shape kinds. Narrow via the literal
@@ -9,4 +10,4 @@ import type { PolygonShape } from './PolygonShape';
  * needed. {@link BoxShape} is a {@link PolygonShape} subclass and carries
  * `type: 'polygon'`.
  */
-export type AnyShape = CapsuleShape | CircleShape | PolygonShape;
+export type AnyShape = CapsuleShape | CircleShape | PolygonShape | SegmentShape;

--- a/packages/exojs-physics/src/shapes/SegmentShape.ts
+++ b/packages/exojs-physics/src/shapes/SegmentShape.ts
@@ -1,0 +1,65 @@
+import { Shape } from './Shape';
+
+/** Segments shorter than this (px) have no well-defined orientation. */
+const minimumLength = 1e-3;
+
+/**
+ * A zero-thickness boundary between two local-space endpoints: level edges,
+ * one-off walls, the geometry a body may not cross.
+ *
+ * It has no interior, so {@link Shape.massProperties} is `null` and the shape
+ * contributes collision only - a `dynamic` body needs at least one mass-bearing
+ * collider alongside it.
+ *
+ * A segment blocks from **both** sides. There is no inside for it to be outside
+ * of, and a one-sided segment would be a gameplay rule in a geometry costume:
+ * express that with the world's `contactModifier`, which decides per contact and
+ * per step whether it is solved.
+ *
+ * Being zero-thickness makes it the worst case for discrete detection - a body
+ * that crosses it entirely within one fixed step misses it. Continuous collision
+ * covers a fast body against a segment; a fast segment is not swept.
+ */
+export class SegmentShape extends Shape {
+  public readonly type = 'segment' as const;
+
+  /** Local endpoints, flattened - the same layout a polygon uses. */
+  public readonly vertices: readonly number[];
+
+  /** The two opposite outward unit normals, flattened. */
+  public readonly normals: readonly number[];
+
+  public readonly length: number;
+  public readonly boundingRadius: number;
+
+  /** Always `null`: a boundary has no interior and therefore no mass. */
+  public readonly massProperties = null;
+
+  public constructor(x0: number, y0: number, x1: number, y1: number) {
+    super();
+
+    if (!Number.isFinite(x0) || !Number.isFinite(y0) || !Number.isFinite(x1) || !Number.isFinite(y1)) {
+      throw new RangeError(`SegmentShape: endpoints must be finite, received (${x0}, ${y0}) and (${x1}, ${y1}).`);
+    }
+
+    const ex = x1 - x0;
+    const ey = y1 - y0;
+    const length = Math.hypot(ex, ey);
+
+    if (length < minimumLength) {
+      throw new RangeError(`SegmentShape: the endpoints are coincident (length ${length}).`);
+    }
+
+    // Same convention as PolygonShape: the outward normal of the counter-clockwise
+    // edge i → i+1 is (eY, -eX). A two-vertex ring has two opposite edges.
+    const nx = ey / length;
+    const ny = -ex / length;
+
+    this.length = length;
+    this.vertices = Object.freeze([x0, y0, x1, y1]);
+    this.normals = Object.freeze([nx, ny, -nx, -ny]);
+    this.boundingRadius = Math.max(Math.hypot(x0, y0), Math.hypot(x1, y1));
+
+    Object.freeze(this);
+  }
+}

--- a/packages/exojs-physics/src/shapes/Shape.ts
+++ b/packages/exojs-physics/src/shapes/Shape.ts
@@ -1,5 +1,5 @@
 /** Discriminant for the concrete shape kinds supported in the MVP. */
-export type ShapeType = 'circle' | 'capsule' | 'polygon';
+export type ShapeType = 'circle' | 'capsule' | 'segment' | 'polygon';
 
 /**
  * Area-based mass properties of a solid shape, from which a {@link Collider}'s

--- a/packages/exojs-physics/src/shapes/index.ts
+++ b/packages/exojs-physics/src/shapes/index.ts
@@ -3,4 +3,5 @@ export { BoxShape } from './BoxShape';
 export { CapsuleShape } from './CapsuleShape';
 export { CircleShape } from './CircleShape';
 export { PolygonShape } from './PolygonShape';
+export { SegmentShape } from './SegmentShape';
 export { Shape, type ShapeType } from './Shape';

--- a/packages/exojs-physics/test/segment.test.ts
+++ b/packages/exojs-physics/test/segment.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+
+import { Manifold } from '../src/collision/Manifold';
+import { collide, testOverlap } from '../src/collision/narrowphase';
+import { BoxShape, CapsuleShape, CircleShape, PhysicsBody, PhysicsWorld, SegmentShape } from '../src/index';
+import { colliderAt } from './support';
+
+/**
+ * Segments: zero-thickness boundary geometry. No interior, therefore no mass, no
+ * point-query hit, and no contact with another segment.
+ */
+
+const DT = 1 / 60;
+
+describe('SegmentShape', () => {
+  it('is boundary geometry and reports no mass properties', () => {
+    const segment = new SegmentShape(-20, 0, 20, 0);
+
+    expect(segment.type).toBe('segment');
+    expect(segment.massProperties).toBeNull();
+    expect(segment.length).toBeCloseTo(40);
+    expect(segment.boundingRadius).toBeCloseTo(20);
+    expect([...segment.vertices]).toEqual([-20, 0, 20, 0]);
+  });
+
+  it('carries two opposite normals, one per side', () => {
+    const segment = new SegmentShape(0, 0, 10, 0);
+    const normals = [...segment.normals];
+
+    expect(Math.hypot(normals[0]!, normals[1]!)).toBeCloseTo(1);
+    expect(normals[2]).toBeCloseTo(-normals[0]!);
+    expect(normals[3]).toBeCloseTo(-normals[1]!);
+  });
+
+  it('rejects coincident and non-finite endpoints', () => {
+    expect(() => new SegmentShape(5, 5, 5, 5)).toThrow(RangeError);
+    expect(() => new SegmentShape(0, 0, Number.POSITIVE_INFINITY, 0)).toThrow(RangeError);
+  });
+
+  it('is frozen, like every other shape', () => {
+    expect(Object.isFrozen(new SegmentShape(0, 0, 10, 0))).toBe(true);
+  });
+});
+
+describe('a dynamic body must carry mass', () => {
+  it('rejects a dynamic body whose colliders are all boundary geometry', () => {
+    const world = new PhysicsWorld();
+    const body = new PhysicsBody({ type: 'dynamic', colliders: [{ shape: new SegmentShape(-10, 0, 10, 0) }] });
+
+    expect(() => world.add(body)).toThrow(/at least one collider with mass/);
+  });
+
+  it('rejects a dynamic body whose only solid collider has zero density', () => {
+    const world = new PhysicsWorld();
+    const body = new PhysicsBody({ type: 'dynamic', colliders: [{ shape: new BoxShape(10, 10), density: 0 }] });
+
+    expect(() => world.add(body)).toThrow(/at least one collider with mass/);
+  });
+
+  it('accepts a boundary collider alongside a solid one', () => {
+    const world = new PhysicsWorld();
+    const body = world.add(
+      new PhysicsBody({ type: 'dynamic', colliders: [{ shape: new BoxShape(10, 10) }, { shape: new SegmentShape(-10, 0, 10, 0) }] }),
+    );
+
+    // The segment contributes collision only; the mass is the box's alone.
+    expect(body.mass).toBeCloseTo(100);
+  });
+
+  it('accepts boundary geometry on static and kinematic bodies', () => {
+    const world = new PhysicsWorld();
+
+    expect(() => world.add(new PhysicsBody({ type: 'static', colliders: [{ shape: new SegmentShape(-10, 0, 10, 0) }] }))).not.toThrow();
+    expect(() => world.add(new PhysicsBody({ type: 'kinematic', colliders: [{ shape: new SegmentShape(0, -10, 0, 10) }] }))).not.toThrow();
+  });
+
+  it('rejects removing the one collider a dynamic body draws its mass from', () => {
+    const world = new PhysicsWorld();
+    const body = world.add(new PhysicsBody({ type: 'dynamic', colliders: [{ shape: new BoxShape(10, 10) }] }));
+    const solid = body.colliders[0]!;
+
+    body.addCollider({ shape: new SegmentShape(-10, 0, 10, 0) });
+
+    // Dropping the box would leave the body colliding through its segment while
+    // being massless, which the solver cannot tell apart from a static body.
+    expect(() => world.destroyCollider(solid)).toThrow(/only collider carrying mass/);
+  });
+
+  it('still allows removing the only collider a dynamic body has', () => {
+    const world = new PhysicsWorld();
+    const body = world.add(new PhysicsBody({ type: 'dynamic', colliders: [{ shape: new BoxShape(10, 10) }] }));
+
+    expect(() => world.destroyCollider(body.colliders[0]!)).not.toThrow();
+  });
+});
+
+describe('segment narrow phase', () => {
+  const manifold = new Manifold();
+
+  it('blocks a circle from either side', () => {
+    const world = new PhysicsWorld();
+    const segment = colliderAt(world, new SegmentShape(-40, 0, 40, 0), { x: 0, y: 0 });
+    const above = colliderAt(world, new CircleShape(6), { x: 0, y: -4 });
+    const below = colliderAt(world, new CircleShape(6), { x: 0, y: 4 });
+
+    expect(collide(segment, above, manifold)).toBe(true);
+    expect(manifold.normalY).toBeCloseTo(-1);
+    expect(manifold.points[0].penetration).toBeCloseTo(2);
+
+    expect(collide(segment, below, manifold)).toBe(true);
+    expect(manifold.normalY).toBeCloseTo(1);
+  });
+
+  it('misses a circle beyond its radius', () => {
+    const world = new PhysicsWorld();
+    const segment = colliderAt(world, new SegmentShape(-40, 0, 40, 0), { x: 0, y: 0 });
+    const clear = colliderAt(world, new CircleShape(6), { x: 0, y: -6.5 });
+
+    expect(collide(segment, clear, manifold)).toBe(false);
+    expect(testOverlap(segment, clear)).toBe(false);
+  });
+
+  it('meets a box with two contact points', () => {
+    const world = new PhysicsWorld();
+    const segment = colliderAt(world, new SegmentShape(-40, 0, 40, 0), { x: 0, y: 0 });
+    const box = colliderAt(world, new BoxShape(20, 20), { x: 0, y: -8 });
+
+    expect(collide(segment, box, manifold)).toBe(true);
+    expect(manifold.pointCount).toBe(2);
+    expect(manifold.normalY).toBeCloseTo(-1);
+  });
+
+  it('meets a capsule', () => {
+    const world = new PhysicsWorld();
+    const segment = colliderAt(world, new SegmentShape(-40, 0, 40, 0), { x: 0, y: 0 });
+    const capsule = colliderAt(world, new CapsuleShape(-10, 0, 10, 0, 6), { x: 0, y: -4 });
+
+    expect(collide(segment, capsule, manifold)).toBe(true);
+    expect(manifold.normalY).toBeCloseTo(-1);
+    expect(testOverlap(segment, capsule)).toBe(true);
+  });
+
+  it('never reports a contact between two segments', () => {
+    const world = new PhysicsWorld();
+    // Crossing at the origin: as overlapping as two zero-thickness boundaries get.
+    const horizontal = colliderAt(world, new SegmentShape(-40, 0, 40, 0), { x: 0, y: 0 });
+    const vertical = colliderAt(world, new SegmentShape(0, -40, 0, 40), { x: 0, y: 0 });
+
+    expect(collide(horizontal, vertical, manifold)).toBe(false);
+    expect(manifold.pointCount).toBe(0);
+    expect(testOverlap(horizontal, vertical)).toBe(false);
+  });
+});
+
+describe('segments in a world', () => {
+  it('holds up a falling box', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 300 }, colliders: [{ shape: new SegmentShape(-400, 0, 400, 0) }] }));
+
+    const box = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 288 }, colliders: [{ shape: new BoxShape(20, 20) }] }));
+
+    for (let frame = 0; frame < 180; frame++) {
+      world.step(DT);
+    }
+
+    expect(box.y).toBeGreaterThan(289);
+    expect(box.y).toBeLessThan(291);
+  });
+
+  it('never answers a point query, however close the point is', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+
+    colliderAt(world, new SegmentShape(-40, 0, 40, 0), { x: 0, y: 0 });
+    world.step(DT);
+
+    // Exactly on the boundary and just off it: a segment encloses no area, so
+    // neither is inside anything.
+    expect(world.queryPoint({ x: 0, y: 0 })).toHaveLength(0);
+    expect(world.queryPoint({ x: 0, y: 0.0001 })).toHaveLength(0);
+  });
+
+  it('still answers AABB queries', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+    const segment = colliderAt(world, new SegmentShape(-40, 0, 40, 0), { x: 0, y: 0 });
+
+    world.step(DT);
+
+    expect(world.queryAabb({ minX: -5, minY: -5, maxX: 5, maxY: 5 })).toContain(segment);
+    expect(world.queryAabb({ minX: 100, minY: 100, maxX: 200, maxY: 200 })).toHaveLength(0);
+  });
+
+  it('ray casts from either side, with the normal facing the ray', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+
+    colliderAt(world, new SegmentShape(-40, 0, 40, 0), { x: 0, y: 0 });
+    world.step(DT);
+
+    const fromAbove = world.rayCast({ x: 0, y: -50 }, { x: 0, y: 1 });
+
+    expect(fromAbove).not.toBeNull();
+    expect(fromAbove!.distance).toBeCloseTo(50, 6);
+    expect(fromAbove!.normal.y).toBeCloseTo(-1);
+
+    const fromBelow = world.rayCast({ x: 0, y: 50 }, { x: 0, y: -1 });
+
+    expect(fromBelow).not.toBeNull();
+    expect(fromBelow!.normal.y).toBeCloseTo(1);
+
+    // Past the end of the segment, and parallel to it.
+    expect(world.rayCast({ x: 60, y: -50 }, { x: 0, y: 1 })).toBeNull();
+    expect(world.rayCast({ x: -60, y: 0 }, { x: 1, y: 0 })).toBeNull();
+  });
+});

--- a/site/src/content/api/any-shape.json
+++ b/site/src/content/api/any-shape.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "AnyShape",
-          "signature": "CapsuleShape | CircleShape | PolygonShape",
+          "signature": "CapsuleShape | CircleShape | PolygonShape | SegmentShape",
           "signatureTokens": [
             {
               "text": "CapsuleShape",
@@ -50,6 +50,14 @@
             },
             {
               "text": "PolygonShape",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SegmentShape",
               "kind": "type"
             }
           ],

--- a/site/src/content/api/segment-shape.json
+++ b/site/src/content/api/segment-shape.json
@@ -1,0 +1,322 @@
+{
+  "title": "SegmentShape",
+  "description": "A zero-thickness boundary between two local-space endpoints: level edges, one-off walls, the geometry a body may not cross. It has no interior, so Shape.massProperties is `null` and the shape contributes collision only - a `dynamic` body needs at least one mass-bearing collider alongside it. A segment blocks from **both** sides. There is no inside for it to be outside of, and a one-sided segment would be a gameplay rule in a geometry costume: express that with the world's `contactModifier`, which decides per contact and per step whether it is solved. Being zero-thickness makes it the worst case for discrete detection - a body that crosses it entirely within one fixed step misses it. Continuous collision covers a fast body against a segment; a fast segment is not swept.",
+  "symbol": "SegmentShape",
+  "kind": "class",
+  "subsystem": "physics",
+  "importPath": "@codexo/exojs-physics",
+  "tier": "stable",
+  "memberCount": 7,
+  "counts": {
+    "constructors": 1,
+    "methods": 0,
+    "properties": 6,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "A zero-thickness boundary between two local-space endpoints: level edges, one-off walls, the geometry a body may not cross.",
+        "It has no interior, so Shape.massProperties is `null` and the shape contributes collision only - a `dynamic` body needs at least one mass-bearing collider alongside it.",
+        "A segment blocks from **both** sides. There is no inside for it to be outside of, and a one-sided segment would be a gameplay rule in a geometry costume: express that with the world's `contactModifier`, which decides per contact and per step whether it is solved.",
+        "Being zero-thickness makes it the worst case for discrete detection - a body that crosses it entirely within one fixed step misses it. Continuous collision covers a fast body against a segment; a fast segment is not swept."
+      ],
+      "importLine": "import { SegmentShape } from '@codexo/exojs-physics'",
+      "sourceLink": null
+    },
+    {
+      "id": "constructors",
+      "title": "Constructors",
+      "members": [
+        {
+          "name": "new",
+          "signature": "new(x0: number, y0: number, x1: number, y1: number): SegmentShape",
+          "signatureTokens": [
+            {
+              "text": "new",
+              "kind": "keyword"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "x0",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "y0",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "x1",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "y1",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "SegmentShape",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "x0",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "y0",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "x1",
+              "type": "number",
+              "optional": false
+            },
+            {
+              "name": "y1",
+              "type": "number",
+              "optional": false
+            }
+          ],
+          "returnType": "SegmentShape",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "boundingRadius",
+          "signature": "boundingRadius: number",
+          "signatureTokens": [
+            {
+              "text": "boundingRadius",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Radius of the smallest circle about the local origin enclosing the shape."
+        },
+        {
+          "name": "length",
+          "signature": "length: number",
+          "signatureTokens": [
+            {
+              "text": "length",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "massProperties",
+          "signature": "massProperties: null",
+          "signatureTokens": [
+            {
+              "text": "massProperties",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Always null: a boundary has no interior and therefore no mass."
+        },
+        {
+          "name": "normals",
+          "signature": "normals: readonly number[]",
+          "signatureTokens": [
+            {
+              "text": "normals",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "The two opposite outward unit normals, flattened."
+        },
+        {
+          "name": "type",
+          "signature": "type: \"segment\"",
+          "signatureTokens": [
+            {
+              "text": "type",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"segment\"",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "vertices",
+          "signature": "vertices: readonly number[]",
+          "signatureTokens": [
+            {
+              "text": "vertices",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Local endpoints, flattened - the same layout a polygon uses."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-physics/src/shapes/SegmentShape.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/SegmentShape.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-physics/src/shapes/SegmentShape.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/SegmentShape.ts"
+}

--- a/site/src/content/api/shape-type.json
+++ b/site/src/content/api/shape-type.json
@@ -30,7 +30,7 @@
       "members": [
         {
           "name": "ShapeType",
-          "signature": "\"capsule\" | \"circle\" | \"polygon\"",
+          "signature": "\"capsule\" | \"circle\" | \"polygon\" | \"segment\"",
           "signatureTokens": [
             {
               "text": "\"capsule\"",
@@ -50,6 +50,14 @@
             },
             {
               "text": "\"polygon\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"segment\"",
               "kind": "keyword"
             }
           ],


### PR DESCRIPTION
HI-19 slice 2, part 1 — `SegmentShape` and the massless-dynamic-body invariant (spec steps 4–5). `ChainShape` follows in its own PR; it is the part that needs adjacency, ghost vertices and the aggregated public-identity layer, and it does not belong in the same diff.

## `SegmentShape`

Level edges and one-off walls had to be thin boxes — solid, mass-carrying, and worst behaved exactly when they are thin enough to be the right choice.

A segment is a boundary between two local endpoints. `massProperties` is `null`, so it contributes collision only — this is the shape the mass-neutral `Shape` base from #583 existed for. It blocks from **both** sides: there is no inside for it to be outside of, and one-way behaviour belongs to the contact modifier (#584), not to a flag on the geometry.

Internally a segment is the two-vertex ring a capsule already is, minus the radius, so segment/polygon and segment/capsule are the routine #587 added. Nothing new was written for either pair.

## Segment ↔ segment is unsupported, explicitly

Two zero-thickness boundaries have no overlap volume, so no stable manifold exists. The pair is simply absent from the tables, which the dispatch reports as no contact:

```
collide(segment, segment)     → false, empty manifold
testOverlap(segment, segment) → false
```

Not "sometimes detected but not solved" — a half-supported semantics would be worse than either alternative. In practice both operands are level geometry and neither pushes the other.

## `queryPoint` never hits a segment

At any distance. Answering within some epsilon would make a query result depend on an engine constant rather than the authored geometry, and disagree with what the solver calls a contact. AABB queries and ray casts are the meaningful questions and both work; the ray cast reports whichever of the two side normals faces the incoming ray.

## BREAKING — a dynamic body must carry mass

Until now a `dynamic` body with no mass-bearing collider silently ended up with `mass = 0`, `invMass = 0` — indistinguishable from a static body at the solver level. `isMassReady` recorded it and **nothing in the package read it**. Segments make that state reachable from the public API for the first time, so it is closed now:

| | |
|---|---|
| `static` + segment | ✅ |
| `kinematic` + segment | ✅ |
| `dynamic` + box + segment | ✅ — the segment collides, the box carries the mass |
| `dynamic` + segment only | ❌ throws |
| `dynamic` + zero-density collider only | ❌ throws |

Checked on both mutation paths, as agreed: at `world.add(body)` / `body.addCollider(...)`, and eagerly in `world.destroyCollider(...)` so the error surfaces at the call site rather than out of the middle of a `step()`.

Removing a body's **only** collider stays legal — a body with no geometry is one still being assembled, not a silently broken one. Only removing the last *mass-bearing* collider while others remain is rejected.

## A dead lint suppression died on its own

`PhysicsBody._recomputeMass` carried an `eslint-disable` for `no-unnecessary-condition`: with every shipped shape solid, the compiler could prove the `massProperties === null` branch dead. Adding `SegmentShape` to `AnyShape` made the branch live and the suppression obsolete — the linter said so, and it is gone.

## Validation

`pnpm verify:quick` 16/16 · `pnpm test` 10 663 passed · API docs regenerated · 19 new segment cases: the shape and its normals, both rejection cases, all six mass-invariant scenarios above, circle/box/capsule contact from either side with near-miss thresholds, the segment/segment non-contact, a box resting on a segment floor, the point-query refusal, AABB queries, and ray casts from both sides including the past-the-end and parallel misses.

https://claude.ai/code/session_01R4RHfm7nhMPXAuxFrpgrqj