### PR TITLE
feat(physics): add chain shapes with engine-owned edge adjacency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,35 @@ release and includes intentional breaking changes; see **Changed** and
 
 ### Added
 
+- **`ChainShape` — connected boundary geometry that a body can slide along.** Level
+  outlines, terrain and side-scroller ground are runs of connected edges, and building them
+  from independent `SegmentShape`s does not work: at a shared vertex two segments carry two
+  different normals, so a body crossing the seam snags, is launched, or receives a normal
+  pointing into the surface.
+
+  `new ChainShape(vertices, { closed })` is one shape over the whole run, open or closed. It
+  owns the adjacency between its edges and uses it to suppress exactly the contacts that
+  cause that snagging, which is why the adjacency belongs to the engine and not to the
+  caller. Coincident vertices are welded and a repeated closing vertex is dropped; collinear
+  vertices are **kept**, because a straight run is authoring data and removing it would move
+  the adjacency of its neighbours.
+
+  Unlike a segment, a chain is **one-sided**: each edge collides only from the side its
+  outward normal points to, following the polygon winding convention — a counter-clockwise
+  run is solid on the outside, a clockwise run is solid on the inside. It has no interior, so
+  `massProperties` is `null` and a `dynamic` body still needs a mass-bearing collider
+  alongside it; static and kinematic bodies (a moving platform, a rotating level piece) carry
+  one on their own.
+
+  Internally a chain collider fans out into engine-owned per-edge proxies, so a body touching
+  several edges at once produces several solver contacts — which is what the one-manifold-per-
+  pair model requires — without any of that partition becoming public. `body.colliders` lists
+  the authored chain and nothing else, queries report the chain (once, however many edges they
+  overlap), and `collisionStart`/`collisionEnd` and `onSensorEnter`/`onSensorExit` fire once for
+  the whole chain: on the first edge contact that begins and the last that ends. The contact
+  modifier still sees one contact per edge, each carrying the authored collider pair, because
+  that is the granularity it decides at.
+
 - **`SegmentShape` — zero-thickness boundary geometry, and a dynamic body must now carry
   mass.** Level edges and one-off walls had to be modelled as thin boxes, which are solid,
   carry mass, and behave badly once they are thin enough to matter.

--- a/packages/exojs-physics/src/Collider.ts
+++ b/packages/exojs-physics/src/Collider.ts
@@ -5,6 +5,7 @@ import type { Transform } from './math';
 import { applyRotation, applyTransform, composeTransforms, createTransform } from './math';
 import type { PhysicsBody } from './PhysicsBody';
 import type { AnyShape } from './shapes/AnyShape';
+import type { ChainShape } from './shapes/ChainShape';
 import type { CollisionFilter } from './types';
 import { resolveFilter } from './types';
 
@@ -18,6 +19,9 @@ const worldVertexCount = (shape: AnyShape): number => {
       // Two endpoints. Both are a two-vertex ring, with and without a radius.
       return 2;
     case 'circle':
+    case 'chain':
+      // A chain caches nothing of its own: its geometry lives on the per-edge
+      // child proxies, and its AABB is the union of theirs.
       return 0;
   }
 };
@@ -67,6 +71,8 @@ export class Collider {
 
   private _id = -1;
   private _body: PhysicsBody | null = null;
+  private readonly _chainEdges: readonly Collider[] | null;
+  private _chainParent: Collider | null = null;
   private readonly _localTransform: Transform;
   private readonly _worldTransform: Transform = createTransform();
   private readonly _aabb: AabbLike = createAabb();
@@ -112,6 +118,7 @@ export class Collider {
 
     this._worldVertices = new Array<number>(vertexCount * 2).fill(0);
     this._worldNormals = new Array<number>(vertexCount * 2).fill(0);
+    this._chainEdges = this.shape.type === 'chain' ? this._buildChainEdges(this.shape) : null;
   }
 
   /** Stable id, assigned when the owning body joins a world via `world.add()`; `-1` until then. */
@@ -161,6 +168,23 @@ export class Collider {
     return this._worldNormals;
   }
 
+  /**
+   * @internal - the engine-owned edge proxies a chain collider fans out into,
+   * one per chain edge; `null` for every other shape. They are what the broad
+   * phase, the narrow phase and the solver see, so a chain contact reuses the
+   * one-manifold-per-pair model unchanged. They are never part of
+   * `body.colliders`, `world.colliders` or any query result - the authored
+   * collider is the public identity of every contact they produce.
+   */
+  public get chainEdges(): readonly Collider[] | null {
+    return this._chainEdges;
+  }
+
+  /** @internal - the authored chain collider this edge proxy belongs to; `null` for an authored collider. */
+  public get chainParent(): Collider | null {
+    return this._chainParent;
+  }
+
   /** `true` after the owning world has destroyed this collider. */
   public get destroyed(): boolean {
     return this._destroyed;
@@ -189,7 +213,39 @@ export class Collider {
       case 'polygon':
         this._synchronizePolygon(world, this.shape.vertices, this.shape.normals, this.shape.count, 0);
         break;
+      case 'chain':
+        this._synchronizeChain(bodyTransform);
+        break;
     }
+  }
+
+  /**
+   * A chain's world geometry is its edge proxies': each of them shares the
+   * chain's local placement and syncs its own two endpoints, and the chain's own
+   * AABB is their union. Nothing is transformed twice, and no proxy is rebuilt.
+   */
+  private _synchronizeChain(bodyTransform: Transform): void {
+    const edges = this._chainEdges!;
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+
+    for (const edge of edges) {
+      edge.synchronize(bodyTransform);
+
+      const aabb = edge.aabb;
+
+      minX = aabb.minX < minX ? aabb.minX : minX;
+      minY = aabb.minY < minY ? aabb.minY : minY;
+      maxX = aabb.maxX > maxX ? aabb.maxX : maxX;
+      maxY = aabb.maxY > maxY ? aabb.maxY : maxY;
+    }
+
+    this._aabb.minX = minX;
+    this._aabb.minY = minY;
+    this._aabb.maxX = maxX;
+    this._aabb.maxY = maxY;
   }
 
   /** A circle is its transformed centre; the local vertex buffers stay unused. */
@@ -240,8 +296,50 @@ export class Collider {
     this._id = id;
   }
 
+  /**
+   * Fan a chain out into one proxy per edge. Each proxy carries the chain's own
+   * local placement, so it needs no transform of its own, and its shape carries
+   * the adjacency that keeps a body from snagging at a shared vertex.
+   */
+  private _buildChainEdges(chain: ChainShape): readonly Collider[] {
+    const edges: Collider[] = [];
+
+    for (const edgeShape of chain.edges) {
+      const edge = new Collider({
+        shape: edgeShape,
+        offset: { x: this.offsetX, y: this.offsetY },
+        rotation: this.localRotation,
+        // Material, filter and sensor flag stay mutable on the authored collider
+        // and are read from there per pass, so copying them here would only add a
+        // second, staler source of truth.
+        density: 0,
+      });
+
+      edge._chainParent = this;
+      edges.push(edge);
+    }
+
+    return edges;
+  }
+
   /** Internal: mark destroyed (called by the world). */
   public _markDestroyed(): void {
     this._destroyed = true;
+
+    if (this._chainEdges !== null) {
+      for (const edge of this._chainEdges) {
+        edge._destroyed = true;
+      }
+    }
   }
 }
+
+/**
+ * The authored collider a contact, query hit or sweep target belongs to: the
+ * collider itself, or the chain it is an engine-owned edge proxy of. Every
+ * public identity - events, query results, the contact modifier - goes through
+ * this, so a solver-side partition never reaches a caller.
+ *
+ * @internal
+ */
+export const authoredCollider = (collider: Collider): Collider => collider.chainParent ?? collider;

--- a/packages/exojs-physics/src/ContactGraph.ts
+++ b/packages/exojs-physics/src/ContactGraph.ts
@@ -1,5 +1,6 @@
 import type { CandidatePair } from './broadphase/BroadPhase';
 import type { Collider } from './Collider';
+import { authoredCollider } from './Collider';
 import { Manifold } from './collision/Manifold';
 import { collide, testOverlap } from './collision/narrowphase';
 import type { ContactModifier } from './ContactModifier';
@@ -16,6 +17,13 @@ import { shouldCollide } from './types';
 export interface ContactRecord {
   readonly a: Collider;
   readonly b: Collider;
+  /**
+   * Authored collider behind {@link a} - itself, unless `a` is an engine-owned
+   * chain edge proxy, in which case it is the chain collider the caller made.
+   * Solver identity is the proxy pair; public identity is the authored pair.
+   */
+  readonly ownerA: Collider;
+  readonly ownerB: Collider;
   readonly isSensor: boolean;
   touching: boolean;
   seen: boolean;
@@ -48,6 +56,11 @@ export interface ContactRecord {
  * Touching solid contacts are also collected into {@link solidContacts} (with a
  * warm-start impulse cache) for the dynamics solver. The graph holds no
  * module-level state - each world owns one.
+ *
+ * Records are keyed on the pair the solver sees, which for a chain collider is
+ * one of its edge proxies. Events are not: a body touching several edges of one
+ * chain is one authored contact, so the graph reference-counts the authored pair
+ * behind its records and emits begin/end only on the first and last of them.
  */
 export class ContactGraph {
   /** Immutable solid-contact begin snapshots produced by the latest {@link update}. */
@@ -64,6 +77,9 @@ export class ContactGraph {
   // Integer pair-keys (`(a.id << 16) | b.id`, a.id < b.id guaranteed by the broad
   // phase) - cheaper than string keys on the per-step solver hot path.
   private readonly _records = new Map<number, ContactRecord>();
+  // Live solver contacts per authored collider pair. Only pairs whose records
+  // are engine-owned proxies appear here; everything else emits directly.
+  private readonly _authoredPairs = new Map<number, number>();
   private readonly _modifierContext = new MutableContactModifierContext();
 
   /** Touching pairs currently tracked (for debug draw). */
@@ -85,14 +101,19 @@ export class ContactGraph {
       const a = pair.a;
       const b = pair.b;
 
-      if (!shouldCollide(a.filter, b.filter)) {
+      // Material, filter and sensor flag live on the authored collider; an edge
+      // proxy carries none of its own, so a chain stays one collider to configure.
+      const ownerA = authoredCollider(a);
+      const ownerB = authoredCollider(b);
+
+      if (!shouldCollide(ownerA.filter, ownerB.filter)) {
         continue;
       }
 
-      const isSensor = a.isSensor || b.isSensor;
+      const isSensor = ownerA.isSensor || ownerB.isSensor;
       const key = pairKey(a.id, b.id);
       const existing = this._records.get(key);
-      const record = existing ?? createRecord(a, b, isSensor);
+      const record = existing ?? createRecord(a, b, ownerA, ownerB, isSensor);
       const touching = isSensor ? testOverlap(a, b) : collide(a, b, record.manifold);
 
       if (touching) {
@@ -112,8 +133,8 @@ export class ContactGraph {
           // pass, so a modifier that skipped a contact last step does not leak
           // into this one.
           record.enabled = true;
-          record.friction = Math.sqrt(a.friction * b.friction);
-          record.restitution = Math.max(a.restitution, b.restitution);
+          record.friction = Math.sqrt(ownerA.friction * ownerB.friction);
+          record.restitution = Math.max(ownerA.restitution, ownerB.restitution);
           warmStartMatch(record);
           this.solidContacts.push(record);
         }
@@ -166,10 +187,18 @@ export class ContactGraph {
     }
   }
 
-  /** Remove every record referencing `collider` (called when a collider is destroyed). */
+  /**
+   * Remove every record referencing `collider` (called when a collider is
+   * destroyed). Passing an authored chain collider also drops the records of
+   * every edge proxy it owns.
+   */
   public removeCollider(collider: Collider): void {
     for (const [key, record] of this._records) {
-      if (record.a === collider || record.b === collider) {
+      if (record.a === collider || record.b === collider || record.ownerA === collider || record.ownerB === collider) {
+        if (record.touching) {
+          this._releaseAuthoredPair(record);
+        }
+
         this._records.delete(key);
       }
     }
@@ -178,22 +207,70 @@ export class ContactGraph {
   /** Drop all records (world reset/destroy). */
   public clear(): void {
     this._records.clear();
+    this._authoredPairs.clear();
   }
 
   private _emitBegin(record: ContactRecord): void {
+    if (!this._retainAuthoredPair(record)) {
+      return;
+    }
+
     if (record.isSensor) {
-      this.sensorEnter.push(makeSensorEvent(record.a, record.b));
+      this.sensorEnter.push(makeSensorEvent(record.ownerA, record.ownerB));
     } else {
-      this.collisionStart.push(makeCollisionEvent(record.a, record.b, record.manifold));
+      this.collisionStart.push(makeCollisionEvent(record.ownerA, record.ownerB, record.manifold));
     }
   }
 
   private _emitEnd(record: ContactRecord): void {
-    if (record.isSensor) {
-      this.sensorExit.push(makeSensorEvent(record.a, record.b));
-    } else {
-      this.collisionEnd.push(makeEndEvent(record.a, record.b));
+    if (!this._releaseAuthoredPair(record)) {
+      return;
     }
+
+    if (record.isSensor) {
+      this.sensorExit.push(makeSensorEvent(record.ownerA, record.ownerB));
+    } else {
+      this.collisionEnd.push(makeEndEvent(record.ownerA, record.ownerB));
+    }
+  }
+
+  /**
+   * Count one more solver contact against the authored pair, reporting whether
+   * it is the first - the only one that may emit a begin event. A record whose
+   * colliders are the authored ones needs no counting at all, so a world without
+   * chains never touches the map.
+   */
+  private _retainAuthoredPair(record: ContactRecord): boolean {
+    if (record.a === record.ownerA && record.b === record.ownerB) {
+      return true;
+    }
+
+    const key = authoredPairKey(record);
+    const count = this._authoredPairs.get(key) ?? 0;
+
+    this._authoredPairs.set(key, count + 1);
+
+    return count === 0;
+  }
+
+  /** Counterpart of {@link _retainAuthoredPair}: `true` on the last contact of the pair. */
+  private _releaseAuthoredPair(record: ContactRecord): boolean {
+    if (record.a === record.ownerA && record.b === record.ownerB) {
+      return true;
+    }
+
+    const key = authoredPairKey(record);
+    const count = (this._authoredPairs.get(key) ?? 1) - 1;
+
+    if (count <= 0) {
+      this._authoredPairs.delete(key);
+
+      return true;
+    }
+
+    this._authoredPairs.set(key, count);
+
+    return false;
   }
 
   /**
@@ -235,9 +312,18 @@ export const pairKeyStride = 0x4000000; // 2^26
  */
 export const pairKey = (aId: number, bId: number): number => aId * pairKeyStride + bId;
 
-const createRecord = (a: Collider, b: Collider, isSensor: boolean): ContactRecord => ({
+const authoredPairKey = (record: ContactRecord): number => {
+  const first = record.ownerA.id;
+  const second = record.ownerB.id;
+
+  return first < second ? pairKey(first, second) : pairKey(second, first);
+};
+
+const createRecord = (a: Collider, b: Collider, ownerA: Collider, ownerB: Collider, isSensor: boolean): ContactRecord => ({
   a,
   b,
+  ownerA,
+  ownerB,
   isSensor,
   touching: false,
   seen: true,

--- a/packages/exojs-physics/src/ContactModifier.ts
+++ b/packages/exojs-physics/src/ContactModifier.ts
@@ -12,6 +12,11 @@ import type { PhysicsBody } from './PhysicsBody';
  *
  * Writing a control affects this step only; the values are re-derived from the
  * two colliders before the modifier runs again.
+ *
+ * A chain collider is solved per edge, so a body touching several edges of one
+ * chain reaches the modifier once per edge, each time with the same authored
+ * collider pair. Decide from the contact's own normal and penetration rather
+ * than from the pair's identity if that distinction matters.
  */
 export interface ContactModifierContext {
   readonly colliderA: Collider;
@@ -80,10 +85,10 @@ export class MutableContactModifierContext implements ContactModifierContext {
   public bind(record: ContactRecord): void {
     const manifold = record.manifold;
 
-    this.colliderA = record.a;
-    this.colliderB = record.b;
-    this.bodyA = record.a.body;
-    this.bodyB = record.b.body;
+    this.colliderA = record.ownerA;
+    this.colliderB = record.ownerB;
+    this.bodyA = record.ownerA.body;
+    this.bodyB = record.ownerB.body;
     this.normalX = manifold.normalX;
     this.normalY = manifold.normalY;
     this.pointCount = manifold.pointCount;

--- a/packages/exojs-physics/src/PhysicsBody.ts
+++ b/packages/exojs-physics/src/PhysicsBody.ts
@@ -267,7 +267,7 @@ export class PhysicsBody {
     // with; `_attachToWorld` does that (and the mass/sync pass) for every held
     // collider. Once attached, mirror the world's create order exactly.
     if (this._attached && this._owner) {
-      instance._attach(this, this._owner._allocateColliderId());
+      attachWithChainEdges(instance, this, this._owner);
       this._recomputeMass();
       this._assertDynamicCarriesMass();
       instance.synchronize(this._transform);
@@ -547,7 +547,7 @@ export class PhysicsBody {
     this._attached = true;
 
     for (const collider of this._colliders) {
-      collider._attach(this, owner._allocateColliderId());
+      attachWithChainEdges(collider, this, owner);
     }
 
     this._recomputeMass();
@@ -645,3 +645,22 @@ export class PhysicsBody {
     this._massReady = mass > 0;
   }
 }
+
+/**
+ * Give a collider its id, and a chain collider's edge proxies theirs. The
+ * proxies are ids in the same space as authored colliders - the contact graph
+ * keys pairs on them - but they never appear in `body.colliders`.
+ */
+const attachWithChainEdges = (collider: Collider, body: PhysicsBody, owner: BodyOwner): void => {
+  collider._attach(body, owner._allocateColliderId());
+
+  const edges = collider.chainEdges;
+
+  if (edges === null) {
+    return;
+  }
+
+  for (const edge of edges) {
+    edge._attach(body, owner._allocateColliderId());
+  }
+};

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -6,7 +6,7 @@ import { NativePhysicsBackend } from './backend/NativePhysicsBackend';
 import type { PhysicsBackend } from './backend/PhysicsBackend';
 import { BindingRegistry } from './binding/BindingRegistry';
 import type { PhysicsBinding } from './binding/PhysicsBinding';
-import { Collider } from './Collider';
+import { authoredCollider, Collider } from './Collider';
 import type { SweepHit } from './collision/sweep';
 import { canSweep, sweepProxies } from './collision/sweep';
 import type { ContactModifier } from './ContactModifier';
@@ -354,6 +354,15 @@ export class PhysicsWorld implements BodyOwner {
   private readonly _backend: PhysicsBackend = new NativePhysicsBackend();
   private readonly _bodies: PhysicsBody[] = [];
   private readonly _colliders: Collider[] = [];
+  /**
+   * What detection actually runs over: the authored colliders, with a chain
+   * replaced by the edge proxies it fans out into. The broad phase, the narrow
+   * phase and the queries all read this list; `_colliders` stays the authored
+   * set every public surface reports.
+   */
+  private readonly _detectionColliders: Collider[] = [];
+  /** Pooled scratch for re-syncing a single body's broad-phase leaves. */
+  private readonly _leafScratch: Collider[] = [];
   private readonly _joints: Joint[] = [];
   private readonly _bindings = new BindingRegistry();
   private readonly _query: QueryEngine;
@@ -419,7 +428,7 @@ export class PhysicsWorld implements BodyOwner {
     this.contactModifier = options.contactModifier ?? null;
     this.interpolation = options.interpolation ?? false;
     this.frameAlphaSource = options.frameAlphaSource ?? (() => this.timeStepper.alpha);
-    this._query = new QueryEngine(this._colliders, this._backend.spatialIndex);
+    this._query = new QueryEngine(this._detectionColliders, this._backend.spatialIndex);
   }
 
   /** Live bodies (read-only view). */
@@ -686,7 +695,7 @@ export class PhysicsWorld implements BodyOwner {
     // Detection runs once per fixed step (collider geometry is already current
     // from the previous frame's finalize / attach / setTransform). TGS-Soft
     // reuses the manifolds across the sub-steps below.
-    this._backend.detect(this._colliders);
+    this._backend.detect(this._detectionColliders);
 
     // The contact modifier runs between detection and the sleep decision: a
     // contact it disables must neither reach the solver nor union its two bodies
@@ -838,6 +847,7 @@ export class PhysicsWorld implements BodyOwner {
 
     this._bodies.length = 0;
     this._colliders.length = 0;
+    this._detectionColliders.length = 0;
     this._joints.length = 0;
     this._commands.length = 0;
     this._bindings.clear();
@@ -856,8 +866,22 @@ export class PhysicsWorld implements BodyOwner {
 
   public _registerCollider(collider: Collider): void {
     this._defer(() => {
-      if (!collider.destroyed) {
-        this._colliders.push(collider);
+      if (collider.destroyed) {
+        return;
+      }
+
+      this._colliders.push(collider);
+
+      const edges = collider.chainEdges;
+
+      if (edges === null) {
+        this._detectionColliders.push(collider);
+
+        return;
+      }
+
+      for (const edge of edges) {
+        this._detectionColliders.push(edge);
       }
     });
   }
@@ -1118,7 +1142,7 @@ export class PhysicsWorld implements BodyOwner {
 
         // The clamp pulled this body back behind the pose the index was synced
         // from; refresh just its own leaves so a later bullet's query still sees it.
-        this._backend.spatialIndex?.sync(body.colliders);
+        this._backend.spatialIndex?.sync(this._detectionLeavesOf(body));
       }
 
       // Reflect about the true surface normal: a slide for a non-bouncy body
@@ -1174,14 +1198,19 @@ export class PhysicsWorld implements BodyOwner {
       // Tree hits are keyed on the leaves' fat AABBs, so the candidate set is a
       // conservative superset - the exact `aabbOverlap` below still decides.
       // A backend without a spatial index falls back to the full collider list.
-      const candidates = spatialIndex === undefined ? this._colliders : spatialIndex.queryAabb(swept, this._ccdCandidates);
+      const candidates = spatialIndex === undefined ? this._detectionColliders : spatialIndex.queryAabb(swept, this._ccdCandidates);
 
       this._ccdBroadPhaseCandidates += candidates.length;
 
       for (const other of candidates) {
+        // A chain edge proxy blocks under its chain's material and filter, and
+        // reports the chain as the blocking collider - the sweep never hands a
+        // caller a solver-side proxy.
+        const target = authoredCollider(other);
+
         // Sweep against every other body (static, kinematic, dynamic) under the
         // discrete narrow phase's rules: sensors never block, filtered pairs never collide.
-        if (other.isSensor || other.body === body || !shouldCollide(collider.filter, other.filter)) {
+        if (target.isSensor || other.body === body || !shouldCollide(collider.filter, target.filter)) {
           continue;
         }
 
@@ -1195,7 +1224,7 @@ export class PhysicsWorld implements BodyOwner {
           best.t = hit.t;
           best.normalX = hit.normalX;
           best.normalY = hit.normalY;
-          blocked = other;
+          blocked = target;
         }
       }
     }
@@ -1274,8 +1303,55 @@ export class PhysicsWorld implements BodyOwner {
     }
 
     this._wakeTouchingBodies(collider);
-    this._backend.removeCollider(collider);
+
+    const edges = collider.chainEdges;
+
+    if (edges === null) {
+      this._removeDetectionCollider(collider);
+    } else {
+      for (const edge of edges) {
+        this._removeDetectionCollider(edge);
+      }
+    }
+
     collider._markDestroyed();
+  }
+
+  /** Drop one broad-phase leaf: an authored collider, or one chain edge proxy. */
+  private _removeDetectionCollider(collider: Collider): void {
+    const index = this._detectionColliders.indexOf(collider);
+
+    if (index !== -1) {
+      this._detectionColliders.splice(index, 1);
+    }
+
+    this._backend.removeCollider(collider);
+  }
+
+  /**
+   * The broad-phase leaves of one body - its colliders, with a chain replaced by
+   * its edge proxies. Returns pooled scratch, valid until the next call.
+   */
+  private _detectionLeavesOf(body: PhysicsBody): Collider[] {
+    const leaves = this._leafScratch;
+
+    leaves.length = 0;
+
+    for (const collider of body.colliders) {
+      const edges = collider.chainEdges;
+
+      if (edges === null) {
+        leaves.push(collider);
+
+        continue;
+      }
+
+      for (const edge of edges) {
+        leaves.push(edge);
+      }
+    }
+
+    return leaves;
   }
 
   /**
@@ -1295,10 +1371,10 @@ export class PhysicsWorld implements BodyOwner {
     for (const contact of this._backend.contactGraph.solidContacts) {
       let other: Collider;
 
-      if (contact.a === collider) {
-        other = contact.b;
-      } else if (contact.b === collider) {
-        other = contact.a;
+      if (contact.ownerA === collider) {
+        other = contact.ownerB;
+      } else if (contact.ownerB === collider) {
+        other = contact.ownerA;
       } else {
         continue;
       }

--- a/packages/exojs-physics/src/collision/dispatch.ts
+++ b/packages/exojs-physics/src/collision/dispatch.ts
@@ -15,6 +15,10 @@ export const shapeKindOrder: Readonly<Record<ShapeType, number>> = {
   capsule: 1,
   segment: 2,
   polygon: 3,
+  // A chain never reaches the narrow phase itself: a chain collider is solved
+  // through its per-edge child proxies, which are segments carrying adjacency.
+  // The slot exists so the tables stay total over `ShapeType`, and stays empty.
+  chain: 4,
 };
 
 export const shapeKindCount = Object.keys(shapeKindOrder).length;

--- a/packages/exojs-physics/src/collision/narrowphase.ts
+++ b/packages/exojs-physics/src/collision/narrowphase.ts
@@ -1,5 +1,6 @@
 import type { PointLike } from '@codexo/exojs';
 
+import { ChainEdgeShape } from '../shapes/ChainEdgeShape';
 import type { CollisionProxy } from './CollisionProxy';
 import type { PairTable } from './dispatch';
 import { needsFlip, symmetricEntry, symmetricTable } from './dispatch';
@@ -41,7 +42,66 @@ export const collide = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold
     return false;
   }
 
-  return needsFlip(ta, tb) ? solver(b, a, manifold, true) : solver(a, b, manifold, false);
+  const touching = needsFlip(ta, tb) ? solver(b, a, manifold, true) : solver(a, b, manifold, false);
+
+  if (!touching) {
+    return false;
+  }
+
+  // The manifold normal points a → b, so it is the direction `a` pushes `b`
+  // away along; from b's side the outward direction is its negation.
+  if (!chainEdgeAdmits(a, manifold.normalX, manifold.normalY) || !chainEdgeAdmits(b, -manifold.normalX, -manifold.normalY)) {
+    manifold.reset();
+
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * Adjacency filter for a chain edge: `true` when this edge owns the contact
+ * whose outward normal is `(nx, ny)`.
+ *
+ * A chain is one-sided, so a normal pointing into the solid side is never this
+ * edge's. Beyond that, the normals around a shared vertex are partitioned by
+ * proximity: the edge whose own normal is closest to the contact normal keeps
+ * the contact, and its neighbours drop it. That is what removes internal vertex
+ * snagging - a body sliding onto the next edge stops producing a contact against
+ * the previous one, instead of receiving two contradicting normals at the seam -
+ * while a body wedged in a concave corner still keeps one contact per wall,
+ * because each wall's own normal is the closest one there.
+ *
+ * A tie (collinear edges) is kept by both, which is what lets a straight run of
+ * chain edges carry a box across the join. A free end has no neighbour on that
+ * side and admits the whole half-plane, so a body can pass around it.
+ *
+ * The neighbour normals are reconstructed from the stored rotations rather than
+ * cached in world space: rotating this edge's world normal by the (transform
+ * invariant) angle to a neighbour's is exact and needs no second sync pass.
+ */
+const chainEdgeAdmits = (proxy: CollisionProxy, nx: number, ny: number): boolean => {
+  const shape = proxy.shape;
+
+  if (!(shape instanceof ChainEdgeShape)) {
+    return true;
+  }
+
+  const ownX = proxy.worldNormals[0]!;
+  const ownY = proxy.worldNormals[1]!;
+  const own = nx * ownX + ny * ownY;
+
+  if (own <= 0) {
+    return false;
+  }
+
+  const cross = ownX * ny - ownY * nx;
+
+  if (shape.hasPrevious && shape.previousCos * own + shape.previousSin * cross > own) {
+    return false;
+  }
+
+  return !(shape.hasNext && shape.nextCos * own + shape.nextSin * cross > own);
 };
 
 // Both helpers stay cast-free and allocation-free. A capsule is a two-vertex
@@ -57,6 +117,8 @@ const countOf = (collider: CollisionProxy): number => {
     case 'segment':
       return 2;
     case 'circle':
+    case 'chain':
+      // A chain is never an operand here - it is solved through its edge proxies.
       return 0;
   }
 };

--- a/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
+++ b/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
@@ -188,6 +188,20 @@ export class PhysicsDebugDraw extends DebugLayer {
       return;
     }
 
+    if (collider.shape.type === 'chain') {
+      // A chain keeps no world geometry of its own - its edge proxies do, and
+      // drawing them is drawing exactly what the solver sees, closing edge
+      // included.
+      for (const edge of collider.chainEdges ?? []) {
+        const ends = edge.worldVertices;
+
+        gfx.moveTo(ends[0]!, ends[1]!);
+        gfx.lineTo(ends[2]!, ends[3]!);
+      }
+
+      return;
+    }
+
     const verts = collider.worldVertices;
     const count = collider.shape.count;
 

--- a/packages/exojs-physics/src/public.ts
+++ b/packages/exojs-physics/src/public.ts
@@ -24,6 +24,7 @@ export type { QueryFilter, RayHit } from './query/QueryEngine';
 export type { AnyShape } from './shapes/AnyShape';
 export { BoxShape } from './shapes/BoxShape';
 export { CapsuleShape } from './shapes/CapsuleShape';
+export { ChainShape, type ChainShapeOptions } from './shapes/ChainShape';
 export { CircleShape } from './shapes/CircleShape';
 export { PolygonShape } from './shapes/PolygonShape';
 export { SegmentShape } from './shapes/SegmentShape';

--- a/packages/exojs-physics/src/query/QueryEngine.ts
+++ b/packages/exojs-physics/src/query/QueryEngine.ts
@@ -2,17 +2,22 @@ import type { AabbLike, PointLike } from '@codexo/exojs';
 
 import { aabbContainsPoint, aabbOverlap, createAabb } from '../Aabb';
 import type { Collider } from '../Collider';
+import { authoredCollider } from '../Collider';
 import type { CollisionProxy } from '../collision/CollisionProxy';
 import { testOverlap } from '../collision/narrowphase';
 import { closestPointOnSegment, pointSegmentDistanceSquared } from '../collision/segments';
 import { applyRotation, applyTransform, createTransform } from '../math';
 import type { PhysicsBody } from '../PhysicsBody';
 import type { AnyShape } from '../shapes/AnyShape';
+import type { ChainShape } from '../shapes/ChainShape';
 import { resolveFilter, shouldCollide } from '../types';
 import type { SpatialIndex } from './SpatialIndex';
 
 /** Reused sink for the closest-point primitives; queries run sequentially. */
 const _pointScratch: PointLike = { x: 0, y: 0 };
+
+/** Every shape kind that can be a collision operand - a chain is solved per edge. */
+type SolverShape = Exclude<AnyShape, ChainShape>;
 
 /** A category/mask/group filter applied to a query. Omitting it matches everything. */
 export type QueryFilter = Partial<{ category: number; mask: number; group: number }>;
@@ -35,12 +40,20 @@ export interface RayHit {
  * body move), so queries always see current placements. Array-returning queries
  * follow the three explicit allocation forms: fresh array, caller-owned `out`,
  * or an allocation-free callback - never a hidden shared buffer.
+ *
+ * The engine scans the geometry the broad phase holds, which for a chain
+ * collider is its per-edge proxies. Every result is reported as the authored
+ * collider, and an overlap query reports a chain once however many of its edges
+ * it touches. A ray still reports one hit per edge it crosses, because those are
+ * distinct intersections.
  */
 export class QueryEngine {
   private readonly _colliders: readonly Collider[];
   private readonly _spatialIndex: SpatialIndex | undefined;
   private readonly _scratchHits: Collider[] = [];
   private readonly _scratchHitsForEach: Collider[] = [];
+  /** Chains already reported by the running `forEachAabbHit`, so one chain is one callback. */
+  private readonly _scratchSeenForEach: Collider[] = [];
   private readonly _scratchAabb: AabbLike = createAabb();
 
   public constructor(colliders: readonly Collider[], spatialIndex?: SpatialIndex) {
@@ -81,6 +94,8 @@ export class QueryEngine {
     bounds.maxX = point.x;
     bounds.maxY = point.y;
 
+    // A chain edge encloses no area, so a chain can never answer a point query
+    // and no de-duplication is needed here.
     for (const collider of this._candidatesFor(bounds, this._scratchHits)) {
       if (resolved && !shouldCollide(resolved, collider.filter)) {
         continue;
@@ -101,12 +116,14 @@ export class QueryEngine {
     const resolved = filter ? resolveFilter(filter) : null;
 
     for (const collider of this._candidatesFor(bounds, this._scratchHits)) {
-      if (resolved && !shouldCollide(resolved, collider.filter)) {
+      const authored = authoredCollider(collider);
+
+      if (resolved && !shouldCollide(resolved, authored.filter)) {
         continue;
       }
 
-      if (aabbOverlap(collider.aabb, bounds)) {
-        result.push(collider);
+      if (aabbOverlap(collider.aabb, bounds) && !alreadyReported(collider, authored, result)) {
+        result.push(authored);
       }
     }
 
@@ -127,15 +144,26 @@ export class QueryEngine {
    */
   public forEachAabbHit(bounds: AabbLike, filter: QueryFilter | undefined, callback: (collider: Collider) => void): void {
     const resolved = filter ? resolveFilter(filter) : null;
+    const reported = this._scratchSeenForEach;
+
+    reported.length = 0;
 
     for (const collider of this._candidatesFor(bounds, this._scratchHitsForEach)) {
-      if (resolved && !shouldCollide(resolved, collider.filter)) {
+      const authored = authoredCollider(collider);
+
+      if (resolved && !shouldCollide(resolved, authored.filter)) {
         continue;
       }
 
-      if (aabbOverlap(collider.aabb, bounds)) {
-        callback(collider);
+      if (!aabbOverlap(collider.aabb, bounds) || alreadyReported(collider, authored, reported)) {
+        continue;
       }
+
+      if (collider !== authored) {
+        reported.push(authored);
+      }
+
+      callback(authored);
     }
   }
 
@@ -153,13 +181,16 @@ export class QueryEngine {
 
     let best: RayHit | null = null;
     const consider = (collider: Collider): void => {
-      if (resolved && !shouldCollide(resolved, collider.filter)) {
+      const authored = authoredCollider(collider);
+
+      if (resolved && !shouldCollide(resolved, authored.filter)) {
         return;
       }
 
       const hit = rayCastCollider(collider, origin.x, origin.y, dx, dy, best ? best.distance : maxDistance);
 
       if (hit && (best === null || hit.distance < best.distance)) {
+        hit.collider = authored;
         best = hit;
       }
     };
@@ -190,13 +221,16 @@ export class QueryEngine {
     const result = out ?? [];
     result.length = 0;
     const consider = (collider: Collider): void => {
-      if (resolved && !shouldCollide(resolved, collider.filter)) {
+      const authored = authoredCollider(collider);
+
+      if (resolved && !shouldCollide(resolved, authored.filter)) {
         return;
       }
 
       const hit = rayCastCollider(collider, origin.x, origin.y, dx, dy, maxDistance);
 
       if (hit) {
+        hit.collider = authored;
         result.push(hit);
       }
     };
@@ -215,20 +249,36 @@ export class QueryEngine {
     return result;
   }
 
-  /** Colliders overlapping `shape` placed at `position`/`angle`. Allocates a fresh array. */
+  /**
+   * Colliders overlapping `shape` placed at `position`/`angle`. Allocates a
+   * fresh array.
+   *
+   * A chain query shape is tested edge by edge, exactly as a chain collider is
+   * solved. Two boundaries have no overlap volume, so a chain - like a segment -
+   * never reports another chain or segment.
+   */
   public overlapShape(shape: AnyShape, position: Readonly<PointLike>, filter?: QueryFilter, angle = 0): Collider[] {
-    const proxy = makeProxy(shape, position.x, position.y, angle);
+    const proxies = queryProxies(shape, position.x, position.y, angle);
     const out: Collider[] = [];
     const resolved = filter ? resolveFilter(filter) : null;
-    const bounds = proxyAabb(shape, proxy, this._scratchAabb);
+    const bounds = proxiesAabb(shape, proxies, this._scratchAabb);
 
     for (const collider of this._candidatesFor(bounds, this._scratchHits)) {
-      if (resolved && !shouldCollide(resolved, collider.filter)) {
+      const authored = authoredCollider(collider);
+
+      if (resolved && !shouldCollide(resolved, authored.filter)) {
         continue;
       }
 
-      if (testOverlap(proxy, collider)) {
-        out.push(collider);
+      if (alreadyReported(collider, authored, out)) {
+        continue;
+      }
+
+      for (const proxy of proxies) {
+        if (testOverlap(proxy, collider)) {
+          out.push(authored);
+          break;
+        }
       }
     }
 
@@ -251,6 +301,12 @@ const pointInCollider = (collider: Collider, px: number, py: number): boolean =>
     const dy = py - c.y;
 
     return dx * dx + dy * dy <= r * r;
+  }
+
+  if (collider.shape.type === 'chain') {
+    // Unreachable through the world's own geometry - a chain is scanned through
+    // its edge proxies - and the same answer as a segment either way.
+    return false;
   }
 
   if (collider.shape.type === 'segment') {
@@ -295,6 +351,9 @@ const rayCastCollider = (collider: Collider, ox: number, oy: number, dx: number,
       return rayCastSegment(collider, ox, oy, dx, dy, maxDistance);
     case 'polygon':
       return rayCastPolygon(collider, ox, oy, dx, dy, maxDistance);
+    case 'chain':
+      // A chain collider is never scanned itself; its edge proxies are.
+      return null;
   }
 };
 
@@ -545,8 +604,58 @@ const rayCastPolygon = (collider: Collider, ox: number, oy: number, dx: number, 
   };
 };
 
+/**
+ * Throwaway collision proxies for a query shape placed at `(x, y)` with `angle`:
+ * one, or one per edge for a chain.
+ */
+const queryProxies = (shape: AnyShape, x: number, y: number, angle: number): readonly CollisionProxy[] => {
+  if (shape.type !== 'chain') {
+    return [makeProxy(shape, x, y, angle)];
+  }
+
+  return shape.edges.map((edge) => makeProxy(edge, x, y, angle));
+};
+
+/** World AABB covering every proxy of a query shape. */
+const proxiesAabb = (shape: AnyShape, proxies: readonly CollisionProxy[], out: AabbLike): AabbLike => {
+  if (shape.type !== 'chain') {
+    return proxyAabb(shape, proxies[0]!, out);
+  }
+
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+
+  for (const proxy of proxies) {
+    const edgeBounds = proxyAabb(proxy.shape as SolverShape, proxy, _scratchEdgeAabb);
+
+    minX = edgeBounds.minX < minX ? edgeBounds.minX : minX;
+    minY = edgeBounds.minY < minY ? edgeBounds.minY : minY;
+    maxX = edgeBounds.maxX > maxX ? edgeBounds.maxX : maxX;
+    maxY = edgeBounds.maxY > maxY ? edgeBounds.maxY : maxY;
+  }
+
+  out.minX = minX;
+  out.minY = minY;
+  out.maxX = maxX;
+  out.maxY = maxY;
+
+  return out;
+};
+
+/** Scratch for the per-edge bounds a chain query shape unions. */
+const _scratchEdgeAabb: AabbLike = createAabb();
+
+/**
+ * `true` when `authored` is already in `reported`. Only a chain can be reached
+ * twice in one query (once per edge proxy), so nothing else pays for the scan.
+ */
+const alreadyReported = (candidate: Collider, authored: Collider, reported: readonly Collider[]): boolean =>
+  candidate !== authored && reported.includes(authored);
+
 /** Build a throwaway collision proxy for a shape placed at `(x, y)` with `angle`. */
-const makeProxy = (shape: AnyShape, x: number, y: number, angle: number): CollisionProxy => {
+const makeProxy = (shape: SolverShape, x: number, y: number, angle: number): CollisionProxy => {
   if (shape.type === 'circle') {
     return { shape, worldCenter: { x, y }, worldVertices: [], worldNormals: [] };
   }
@@ -568,7 +677,7 @@ const makeProxy = (shape: AnyShape, x: number, y: number, angle: number): Collis
 };
 
 /** Compute the world AABB of an already-built collision proxy (reuses its cached vertices/centre - no extra transform work). */
-const proxyAabb = (shape: AnyShape, proxy: CollisionProxy, out: AabbLike): AabbLike => {
+const proxyAabb = (shape: SolverShape, proxy: CollisionProxy, out: AabbLike): AabbLike => {
   if (shape.type === 'circle') {
     const r = shape.radius;
 

--- a/packages/exojs-physics/src/shapes/AnyShape.ts
+++ b/packages/exojs-physics/src/shapes/AnyShape.ts
@@ -1,4 +1,5 @@
 import type { CapsuleShape } from './CapsuleShape';
+import type { ChainShape } from './ChainShape';
 import type { CircleShape } from './CircleShape';
 import type { PolygonShape } from './PolygonShape';
 import type { SegmentShape } from './SegmentShape';
@@ -10,4 +11,4 @@ import type { SegmentShape } from './SegmentShape';
  * needed. {@link BoxShape} is a {@link PolygonShape} subclass and carries
  * `type: 'polygon'`.
  */
-export type AnyShape = CapsuleShape | CircleShape | PolygonShape | SegmentShape;
+export type AnyShape = CapsuleShape | ChainShape | CircleShape | PolygonShape | SegmentShape;

--- a/packages/exojs-physics/src/shapes/ChainEdgeShape.ts
+++ b/packages/exojs-physics/src/shapes/ChainEdgeShape.ts
@@ -1,0 +1,71 @@
+import type { ChainShape } from './ChainShape';
+import { SegmentShape } from './SegmentShape';
+
+/**
+ * One edge of a {@link ChainShape}, the geometry the solver actually sees. Built
+ * and owned by the engine when a chain collider is created; never authored, and
+ * never part of the public collider set.
+ *
+ * It is a segment plus the adjacency of the chain it came from. The adjacency is
+ * stored as the rotation from this edge's outward normal to a neighbour's, which
+ * is invariant under the collider's world transform - so the narrow phase can
+ * compare a world-space contact normal against the neighbouring edges without
+ * knowing the transform and without caching a second set of world normals.
+ *
+ * @internal
+ */
+export class ChainEdgeShape extends SegmentShape {
+  /** Index of this edge within the owning chain. */
+  public readonly index: number;
+
+  /** `false` at the free end of an open chain, where a body may pass around the edge. */
+  public readonly hasPrevious: boolean;
+  public readonly hasNext: boolean;
+
+  /** Rotation (cos, sin) taking this edge's outward normal onto the previous edge's. */
+  public readonly previousCos: number;
+  public readonly previousSin: number;
+
+  /** Rotation (cos, sin) taking this edge's outward normal onto the next edge's. */
+  public readonly nextCos: number;
+  public readonly nextSin: number;
+
+  public constructor(chain: ChainShape, index: number) {
+    const count = chain.count;
+    const v = chain.vertices;
+    const start = index;
+    const end = (index + 1) % count;
+
+    super(v[start * 2]!, v[start * 2 + 1]!, v[end * 2]!, v[end * 2 + 1]!);
+
+    const hasPrevious = chain.closed || index > 0;
+    const hasNext = chain.closed || index < chain.edgeCount - 1;
+    const nx = this.normals[0]!;
+    const ny = this.normals[1]!;
+
+    this.index = index;
+    this.hasPrevious = hasPrevious;
+    this.hasNext = hasNext;
+
+    const previous = hasPrevious ? edgeNormal(v, count, (index - 1 + count) % count) : null;
+    const next = hasNext ? edgeNormal(v, count, (index + 1) % count) : null;
+
+    this.previousCos = previous ? nx * previous.x + ny * previous.y : 1;
+    this.previousSin = previous ? nx * previous.y - ny * previous.x : 0;
+    this.nextCos = next ? nx * next.x + ny * next.y : 1;
+    this.nextSin = next ? nx * next.y - ny * next.x : 0;
+
+    Object.freeze(this);
+  }
+}
+
+/** Outward unit normal of chain edge `index`, in the chain's local space. */
+const edgeNormal = (vertices: readonly number[], count: number, index: number): { x: number; y: number } => {
+  const start = index;
+  const end = (index + 1) % count;
+  const ex = vertices[end * 2]! - vertices[start * 2]!;
+  const ey = vertices[end * 2 + 1]! - vertices[start * 2 + 1]!;
+  const length = Math.hypot(ex, ey);
+
+  return { x: ey / length, y: -ex / length };
+};

--- a/packages/exojs-physics/src/shapes/ChainShape.ts
+++ b/packages/exojs-physics/src/shapes/ChainShape.ts
@@ -1,0 +1,126 @@
+import type { PointLike } from '@codexo/exojs';
+
+import { ChainEdgeShape } from './ChainEdgeShape';
+import { Shape } from './Shape';
+
+/** Vertices closer than this (px) are welded into one. */
+const weldEpsilon = 1e-4;
+
+/** Construction options for a {@link ChainShape}. */
+export interface ChainShapeOptions {
+  /** When `true`, the last vertex connects back to the first. Default `false`. */
+  closed?: boolean;
+}
+
+/**
+ * A connected boundary through a run of local-space vertices: level outlines,
+ * terrain, the ground of a side-scroller. Open (a polyline) or closed (a loop).
+ *
+ * A chain is not an array of {@link SegmentShape}s. At a shared vertex two
+ * independent segments carry two different normals, so a body sliding across the
+ * seam can snag, be launched, or receive a normal pointing into the surface. A
+ * chain owns the adjacency between its edges and uses it to suppress exactly
+ * those contacts, which is why the adjacency belongs to the engine rather than
+ * to the caller.
+ *
+ * Unlike a segment, a chain is **one-sided**: each edge collides only from the
+ * side its outward normal points to. Winding therefore decides which side is
+ * solid, following the polygon convention - a counter-clockwise run is solid on
+ * the outside (an island), a clockwise run is solid on the inside (a container).
+ * Bodies on the hollow side pass through.
+ *
+ * It has no interior, so {@link Shape.massProperties} is `null` and a `dynamic`
+ * body needs at least one mass-bearing collider alongside it. A `static` or
+ * `kinematic` body carries a chain on its own.
+ *
+ * Collinear vertices are kept. A straight run is authoring data, and dropping it
+ * would move the adjacency of the neighbouring edges.
+ */
+export class ChainShape extends Shape {
+  public readonly type = 'chain' as const;
+
+  /** Local-space vertices, flattened, after welding coincident input. */
+  public readonly vertices: readonly number[];
+
+  /** Number of vertices in {@link vertices}. */
+  public readonly count: number;
+
+  /** Number of edges: `count` when {@link closed}, `count - 1` otherwise. */
+  public readonly edgeCount: number;
+
+  public readonly closed: boolean;
+  public readonly boundingRadius: number;
+
+  /** Always `null`: a boundary has no interior and therefore no mass. */
+  public readonly massProperties = null;
+
+  /**
+   * @internal - the per-edge geometry the solver works on, built once with the
+   * chain. Immutable and shared by every collider carrying this shape.
+   */
+  public readonly edges: readonly ChainEdgeShape[];
+
+  public constructor(vertices: ReadonlyArray<Readonly<PointLike>>, options: ChainShapeOptions = {}) {
+    super();
+
+    const closed = options.closed ?? false;
+    const points: number[] = [];
+
+    for (const vertex of vertices) {
+      if (!Number.isFinite(vertex.x) || !Number.isFinite(vertex.y)) {
+        throw new RangeError(`ChainShape: vertex has a non-finite component (${vertex.x}, ${vertex.y}).`);
+      }
+
+      const px = points[points.length - 2];
+      const py = points[points.length - 1];
+
+      if (px !== undefined && py !== undefined && Math.hypot(vertex.x - px, vertex.y - py) < weldEpsilon) {
+        continue;
+      }
+
+      points.push(vertex.x, vertex.y);
+    }
+
+    if (closed && points.length >= 4) {
+      const firstX = points[0]!;
+      const firstY = points[1]!;
+      const lastX = points[points.length - 2]!;
+      const lastY = points[points.length - 1]!;
+
+      // A caller repeating the first vertex to "close" the loop is expressing the
+      // same intent as `closed: true`; keeping it would produce a zero-length edge.
+      if (Math.hypot(lastX - firstX, lastY - firstY) < weldEpsilon) {
+        points.length -= 2;
+      }
+    }
+
+    const count = points.length / 2;
+    const minimum = closed ? 3 : 2;
+
+    if (count < minimum) {
+      throw new RangeError(`ChainShape: ${closed ? 'a closed chain' : 'a chain'} needs at least ${minimum} distinct vertices, received ${count}.`);
+    }
+
+    let boundingRadius = 0;
+
+    for (let i = 0; i < count; i++) {
+      boundingRadius = Math.max(boundingRadius, Math.hypot(points[i * 2]!, points[i * 2 + 1]!));
+    }
+
+    this.vertices = Object.freeze(points);
+    this.count = count;
+    this.edgeCount = closed ? count : count - 1;
+    this.closed = closed;
+    this.boundingRadius = boundingRadius;
+
+    const edges: ChainEdgeShape[] = [];
+
+    for (let i = 0; i < this.edgeCount; i++) {
+      edges.push(new ChainEdgeShape(this, i));
+    }
+
+    this.edges = Object.freeze(edges);
+
+    Object.freeze(this);
+  }
+}

--- a/packages/exojs-physics/src/shapes/SegmentShape.ts
+++ b/packages/exojs-physics/src/shapes/SegmentShape.ts
@@ -60,6 +60,10 @@ export class SegmentShape extends Shape {
     this.normals = Object.freeze([nx, ny, -nx, -ny]);
     this.boundingRadius = Math.max(Math.hypot(x0, y0), Math.hypot(x1, y1));
 
-    Object.freeze(this);
+    // A subclass still has its own fields to write, so it freezes itself once
+    // its constructor is done.
+    if (new.target === SegmentShape) {
+      Object.freeze(this);
+    }
   }
 }

--- a/packages/exojs-physics/src/shapes/Shape.ts
+++ b/packages/exojs-physics/src/shapes/Shape.ts
@@ -1,5 +1,5 @@
 /** Discriminant for the concrete shape kinds supported in the MVP. */
-export type ShapeType = 'circle' | 'capsule' | 'segment' | 'polygon';
+export type ShapeType = 'circle' | 'capsule' | 'segment' | 'polygon' | 'chain';
 
 /**
  * Area-based mass properties of a solid shape, from which a {@link Collider}'s

--- a/packages/exojs-physics/src/shapes/index.ts
+++ b/packages/exojs-physics/src/shapes/index.ts
@@ -1,6 +1,7 @@
 export type { AnyShape } from './AnyShape';
 export { BoxShape } from './BoxShape';
 export { CapsuleShape } from './CapsuleShape';
+export { ChainShape, type ChainShapeOptions } from './ChainShape';
 export { CircleShape } from './CircleShape';
 export { PolygonShape } from './PolygonShape';
 export { SegmentShape } from './SegmentShape';

--- a/packages/exojs-physics/test/chain.test.ts
+++ b/packages/exojs-physics/test/chain.test.ts
@@ -1,0 +1,430 @@
+import type { PointLike } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import { Collider } from '../src/Collider';
+import type { CollisionEvent, SensorEvent } from '../src/events';
+import { BoxShape, ChainShape, CircleShape, PhysicsBody, PhysicsWorld } from '../src/index';
+import { measureAllocationRate } from './allocationSampler';
+
+/**
+ * Chains: connected boundary geometry. One authored collider, one solver contact
+ * per touched edge, and a single pair of begin/end events for the whole chain.
+ */
+
+const DT = 1 / 60;
+
+const points = (...coordinates: number[]): PointLike[] => {
+  const out: PointLike[] = [];
+
+  for (let i = 0; i < coordinates.length; i += 2) {
+    out.push({ x: coordinates[i]!, y: coordinates[i + 1]! });
+  }
+
+  return out;
+};
+
+/**
+ * A flat floor of three 100px chain edges from (-150, 0) to (150, 0). Left to
+ * right, so the outward normals point up and the chain is solid from above.
+ */
+const flatFloor = (): ChainShape => new ChainShape(points(-150, 0, -50, 0, 50, 0, 150, 0));
+
+const settle = (world: PhysicsWorld, steps: number): void => {
+  for (let i = 0; i < steps; i++) {
+    world.step(DT);
+  }
+};
+
+describe('ChainShape', () => {
+  it('is boundary geometry with one edge per vertex pair', () => {
+    const chain = new ChainShape(points(0, 0, 10, 0, 20, 0));
+
+    expect(chain.type).toBe('chain');
+    expect(chain.massProperties).toBeNull();
+    expect(chain.count).toBe(3);
+    expect(chain.edgeCount).toBe(2);
+    expect(chain.closed).toBe(false);
+    expect(chain.boundingRadius).toBeCloseTo(20);
+    expect(Object.isFrozen(chain)).toBe(true);
+  });
+
+  it('closes the loop with one extra edge', () => {
+    const loop = new ChainShape(points(0, 0, 10, 0, 10, 10), { closed: true });
+
+    expect(loop.edgeCount).toBe(3);
+  });
+
+  it('welds coincident vertices and drops a repeated closing vertex', () => {
+    const welded = new ChainShape(points(0, 0, 0, 0, 10, 0));
+    const loop = new ChainShape(points(0, 0, 10, 0, 10, 10, 0, 0), { closed: true });
+
+    expect(welded.count).toBe(2);
+    expect(loop.count).toBe(3);
+    expect(loop.edgeCount).toBe(3);
+  });
+
+  it('keeps collinear vertices, unlike a polygon', () => {
+    const chain = new ChainShape(points(0, 0, 10, 0, 20, 0, 30, 0));
+
+    expect(chain.count).toBe(4);
+    expect(chain.edgeCount).toBe(3);
+  });
+
+  it('rejects under-specified and non-finite input', () => {
+    expect(() => new ChainShape(points(0, 0))).toThrow(RangeError);
+    expect(() => new ChainShape(points(0, 0, 0, 0))).toThrow(RangeError);
+    expect(() => new ChainShape(points(0, 0, 10, 0), { closed: true })).toThrow(RangeError);
+    expect(() => new ChainShape([{ x: 0, y: 0 }, { x: Number.NaN, y: 0 }])).toThrow(RangeError);
+  });
+});
+
+describe('a chain collider fans out into engine-owned edge proxies', () => {
+  it('keeps the authored collider as the only public one', () => {
+    const world = new PhysicsWorld();
+    const collider = new Collider({ shape: flatFloor() });
+    const body = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 }, colliders: [collider] }));
+
+    world.step(DT);
+
+    expect(body.colliders).toHaveLength(1);
+    expect(world.colliders).toEqual([collider]);
+    expect(collider.chainEdges).toHaveLength(3);
+  });
+
+  it('spans the whole chain with its AABB and moves with a kinematic body', () => {
+    const world = new PhysicsWorld();
+    const collider = new Collider({ shape: flatFloor() });
+    const body = world.add(new PhysicsBody({ type: 'kinematic', position: { x: 0, y: 0 }, colliders: [collider] }));
+
+    expect(collider.aabb.minX).toBeCloseTo(-150);
+    expect(collider.aabb.maxX).toBeCloseTo(150);
+
+    body.setTransform({ x: 100, y: 25 }, 0);
+
+    expect(collider.aabb.minX).toBeCloseTo(-50);
+    expect(collider.aabb.maxX).toBeCloseTo(250);
+    expect(collider.aabb.minY).toBeCloseTo(25);
+  });
+
+  it('refuses to carry a dynamic body on its own', () => {
+    const world = new PhysicsWorld();
+    const body = new PhysicsBody({ type: 'dynamic', colliders: [{ shape: flatFloor() }] });
+
+    expect(() => world.add(body)).toThrow(/at least one collider with mass/);
+  });
+});
+
+describe('chain collision', () => {
+  it('supports a box across several edges', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 100 }, colliders: [{ shape: flatFloor() }] }));
+
+    const box = world.add(
+      new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 40 }, colliders: [{ shape: new BoxShape(120, 20), density: 1 }] }),
+    );
+
+    settle(world, 120);
+
+    expect(box.y).toBeCloseTo(90, 0);
+    expect(Math.abs(box.linearVelocityY)).toBeLessThan(1);
+  });
+
+  it('is solid on one side only', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+
+    // Reversed winding: the outward normals point down, so the chain is solid
+    // from below and a body falling onto it passes straight through.
+    world.add(
+      new PhysicsBody({
+        type: 'static',
+        position: { x: 0, y: 100 },
+        colliders: [{ shape: new ChainShape(points(150, 0, 50, 0, -50, 0, -150, 0)) }],
+      }),
+    );
+
+    const box = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 40 }, colliders: [{ shape: new BoxShape(20, 20), density: 1 }] }));
+
+    settle(world, 120);
+
+    expect(box.y).toBeGreaterThan(200);
+  });
+
+  it('carries a body across a shared vertex without snagging', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 100 }, colliders: [{ shape: flatFloor() }] }));
+
+    const box = world.add(
+      new PhysicsBody({ type: 'dynamic', position: { x: -120, y: 88 }, colliders: [{ shape: new BoxShape(20, 20), density: 1, friction: 0 }] }),
+    );
+
+    settle(world, 30);
+
+    box.linearVelocityX = 600;
+
+    let maxUpwards = 0;
+
+    // Crosses both interior vertices. A seam contact carrying the wrong normal
+    // shows up as an upward kick the moment the box passes over one.
+    for (let i = 0; i < 30; i++) {
+      world.step(DT);
+      maxUpwards = Math.max(maxUpwards, -box.linearVelocityY);
+    }
+
+    expect(box.x).toBeGreaterThan(0);
+    expect(maxUpwards).toBeLessThan(20);
+  });
+
+  it('lets a body rest in a concave corner, where both walls keep their contact', () => {
+    const world = new PhysicsWorld({ gravity: { x: -200, y: 1000 } });
+
+    // A wall coming down, then a floor running right: solid above the floor and
+    // to the right of the wall, which is the inside of the corner.
+    world.add(
+      new PhysicsBody({
+        type: 'static',
+        position: { x: 0, y: 0 },
+        colliders: [{ shape: new ChainShape(points(-100, -100, -100, 0, 100, 0)) }],
+      }),
+    );
+
+    const box = world.add(
+      new PhysicsBody({ type: 'dynamic', position: { x: -60, y: -40 }, colliders: [{ shape: new BoxShape(20, 20), density: 1 }] }),
+    );
+
+    settle(world, 180);
+
+    expect(box.y).toBeCloseTo(-10, 0);
+    expect(box.x).toBeCloseTo(-90, 0);
+  });
+
+  it('does not collide with another chain', () => {
+    const world = new PhysicsWorld();
+    let started = 0;
+
+    world.onCollisionStart.add(() => {
+      started++;
+    });
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 }, colliders: [{ shape: flatFloor() }] }));
+    world.add(new PhysicsBody({ type: 'kinematic', position: { x: 0, y: 0 }, colliders: [{ shape: new ChainShape(points(0, -50, 0, 50)) }] }));
+
+    settle(world, 5);
+
+    expect(started).toBe(0);
+  });
+});
+
+describe('chain events use the authored collider', () => {
+  it('fires one begin and one end however many edges are touched', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+    const chain = new Collider({ shape: flatFloor() });
+
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 100 }, colliders: [chain] }));
+
+    const box = world.add(
+      new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 40 }, colliders: [{ shape: new BoxShape(120, 20), density: 1 }] }),
+    );
+
+    const started: CollisionEvent[] = [];
+    const ended: CollisionEvent[] = [];
+
+    world.onCollisionStart.add((event) => started.push(event));
+    world.onCollisionEnd.add((event) => ended.push(event));
+
+    settle(world, 120);
+
+    expect(started).toHaveLength(1);
+    expect(started[0]!.colliderA === chain || started[0]!.colliderB === chain).toBe(true);
+    expect(started[0]!.colliderA.chainParent).toBeNull();
+    expect(started[0]!.colliderB.chainParent).toBeNull();
+    expect(ended).toHaveLength(0);
+
+    // Lift the box clear of every edge at once.
+    box.setTransform({ x: 0, y: -500 }, 0);
+    settle(world, 2);
+
+    expect(ended).toHaveLength(1);
+    expect(started).toHaveLength(1);
+  });
+
+  it('aggregates sensor enter/exit the same way', () => {
+    const world = new PhysicsWorld();
+    const chain = new Collider({ shape: flatFloor(), isSensor: true });
+
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 }, colliders: [chain] }));
+
+    const box = world.add(
+      new PhysicsBody({ type: 'kinematic', position: { x: 0, y: 0 }, colliders: [{ shape: new BoxShape(120, 20) }] }),
+    );
+
+    const entered: SensorEvent[] = [];
+    const exited: SensorEvent[] = [];
+
+    world.onSensorEnter.add((event) => entered.push(event));
+    world.onSensorExit.add((event) => exited.push(event));
+
+    settle(world, 2);
+
+    expect(entered).toHaveLength(1);
+    expect(entered[0]!.sensor).toBe(chain);
+
+    box.setTransform({ x: 0, y: -500 }, 0);
+    settle(world, 2);
+
+    expect(exited).toHaveLength(1);
+    expect(exited[0]!.sensor).toBe(chain);
+  });
+
+  it('applies the chain collider material and filter to every edge', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+    const chain = new Collider({ shape: flatFloor(), filter: { category: 0x0002, mask: 0x0002 } });
+
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 100 }, colliders: [chain] }));
+
+    const box = world.add(
+      new PhysicsBody({
+        type: 'dynamic',
+        position: { x: 0, y: 40 },
+        colliders: [{ shape: new BoxShape(20, 20), density: 1, filter: { category: 0x0001, mask: 0x0001 } }],
+      }),
+    );
+
+    settle(world, 60);
+
+    // Filtered out by the chain's own filter, which the edge proxies carry none of.
+    expect(box.y).toBeGreaterThan(200);
+  });
+
+  it('reaches the contact modifier once per edge, always with the authored pair', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+    const chain = new Collider({ shape: flatFloor() });
+    let calls = 0;
+
+    world.contactModifier = (contact) => {
+      calls++;
+      expect(contact.colliderA === chain || contact.colliderB === chain).toBe(true);
+    };
+
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 100 }, colliders: [chain] }));
+    world.add(new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 40 }, colliders: [{ shape: new BoxShape(120, 20), density: 1 }] }));
+
+    settle(world, 120);
+
+    expect(calls).toBeGreaterThan(1);
+  });
+});
+
+describe('chain queries report the chain, never a proxy', () => {
+  const world = new PhysicsWorld();
+  const chain = new Collider({ shape: flatFloor() });
+
+  world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 }, colliders: [chain] }));
+  world.step(DT);
+
+  it('answers no point query, having no interior', () => {
+    expect(world.queryPoint({ x: 0, y: 0 })).toEqual([]);
+  });
+
+  it('reports the chain once for an AABB overlapping several edges', () => {
+    const bounds = { minX: -200, minY: -10, maxX: 200, maxY: 10 };
+
+    expect(world.queryAabb(bounds)).toEqual([chain]);
+
+    const seen: Collider[] = [];
+
+    world.forEachAabbHit(bounds, undefined, (hit) => seen.push(hit));
+
+    expect(seen).toEqual([chain]);
+  });
+
+  it('reports the chain once for a shape overlap across several edges', () => {
+    expect(world.overlapShape(new BoxShape(200, 20), { x: 0, y: 0 })).toEqual([chain]);
+  });
+
+  it('finds a body with a chain query shape', () => {
+    const other = new PhysicsWorld();
+    const box = new Collider({ shape: new BoxShape(20, 20) });
+
+    other.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 }, colliders: [box] }));
+    other.step(DT);
+
+    expect(other.overlapShape(flatFloor(), { x: 0, y: 0 })).toEqual([box]);
+  });
+
+  it('returns the chain from a ray cast', () => {
+    const hit = world.rayCast({ x: 0, y: -50 }, { x: 0, y: 1 });
+
+    expect(hit?.collider).toBe(chain);
+    expect(hit?.point.y).toBeCloseTo(0);
+    expect(hit?.normal.y).toBeCloseTo(-1);
+  });
+});
+
+describe('chain lifecycle', () => {
+  it('drops every edge proxy when the collider is destroyed', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+    const chain = new Collider({ shape: flatFloor() });
+
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 100 }, colliders: [chain] }));
+
+    const box = world.add(
+      new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 40 }, colliders: [{ shape: new BoxShape(120, 20), density: 1 }] }),
+    );
+
+    settle(world, 120);
+    expect(box.y).toBeCloseTo(90, 0);
+
+    world.destroyCollider(chain);
+    settle(world, 60);
+
+    expect(chain.destroyed).toBe(true);
+    expect(world.queryAabb({ minX: -200, minY: -200, maxX: 200, maxY: 200 })).not.toContain(chain);
+    expect(box.y).toBeGreaterThan(150);
+  });
+});
+
+describe('chain performance', () => {
+  it('adds no per-step allocation over the equivalent solid floor', async () => {
+    const build = (floor: () => ChainShape | BoxShape, floorY: number): PhysicsWorld => {
+      const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+
+      world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: floorY }, colliders: [{ shape: floor() }] }));
+
+      for (let i = 0; i < 20; i++) {
+        world.add(
+          new PhysicsBody({
+            type: 'dynamic',
+            position: { x: -140 + i * 14, y: 40 },
+            colliders: [{ shape: new CircleShape(6), density: 1, friction: 0.4 }],
+          }),
+        );
+      }
+
+      return world;
+    };
+
+    const chainWorld = build(flatFloor, 100);
+    const boxWorld = build(() => new BoxShape(300, 20), 110);
+
+    settle(chainWorld, 240);
+    settle(boxWorld, 240);
+
+    if (chainWorld.step.toString().includes('cov_')) {
+      console.log('allocation comparison skipped under coverage (instrumentation inflates the measurement)');
+
+      return;
+    }
+
+    const chainRate = await measureAllocationRate(() => chainWorld.step(DT), { iterations: 200 });
+    const boxRate = await measureAllocationRate(() => boxWorld.step(DT), { iterations: 200 });
+
+    console.log(
+      `${(chainRate.bytesPerIteration / 1024).toFixed(2)} KB/step chain floor vs ${(boxRate.bytesPerIteration / 1024).toFixed(2)} KB/step box floor`,
+    );
+
+    // A chain that rebuilt its edge geometry per step would allocate a multiple
+    // of the solid floor's rate; sharing the proxies keeps the two comparable.
+    expect(chainRate.bytesPerIteration).toBeLessThan(boxRate.bytesPerIteration * 2 + 64 * 1024);
+  });
+});

--- a/packages/exojs-physics/test/dynamics.test.ts
+++ b/packages/exojs-physics/test/dynamics.test.ts
@@ -659,6 +659,8 @@ describe('ContactSolver internals', () => {
     const record: ContactRecord = {
       a: colliderA,
       b: colliderB,
+      ownerA: colliderA,
+      ownerB: colliderB,
       isSensor: false,
       touching: true,
       seen: true,

--- a/site/src/content/api/any-shape.json
+++ b/site/src/content/api/any-shape.json
@@ -30,10 +30,18 @@
       "members": [
         {
           "name": "AnyShape",
-          "signature": "CapsuleShape | CircleShape | PolygonShape | SegmentShape",
+          "signature": "CapsuleShape | ChainShape | CircleShape | PolygonShape | SegmentShape",
           "signatureTokens": [
             {
               "text": "CapsuleShape",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ChainShape",
               "kind": "type"
             },
             {

--- a/site/src/content/api/chain-shape-options.json
+++ b/site/src/content/api/chain-shape-options.json
@@ -1,0 +1,75 @@
+{
+  "title": "ChainShapeOptions",
+  "description": "Construction options for a ChainShape.",
+  "symbol": "ChainShapeOptions",
+  "kind": "interface",
+  "subsystem": "physics",
+  "importPath": "@codexo/exojs-physics",
+  "tier": "stable",
+  "memberCount": 1,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 1,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Construction options for a ChainShape."
+      ],
+      "importLine": "import { ChainShapeOptions } from '@codexo/exojs-physics'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "closed",
+          "signature": "closed?: boolean",
+          "signatureTokens": [
+            {
+              "text": "closed",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "When true, the last vertex connects back to the first. Default false."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-physics/src/shapes/ChainShape.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/ChainShape.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-physics/src/shapes/ChainShape.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/ChainShape.ts"
+}

--- a/site/src/content/api/chain-shape.json
+++ b/site/src/content/api/chain-shape.json
@@ -1,0 +1,314 @@
+{
+  "title": "ChainShape",
+  "description": "A connected boundary through a run of local-space vertices: level outlines, terrain, the ground of a side-scroller. Open (a polyline) or closed (a loop). A chain is not an array of SegmentShapes. At a shared vertex two independent segments carry two different normals, so a body sliding across the seam can snag, be launched, or receive a normal pointing into the surface. A chain owns the adjacency between its edges and uses it to suppress exactly those contacts, which is why the adjacency belongs to the engine rather than to the caller. Unlike a segment, a chain is **one-sided**: each edge collides only from the side its outward normal points to. Winding therefore decides which side is solid, following the polygon convention - a counter-clockwise run is solid on the outside (an island), a clockwise run is solid on the inside (a container). Bodies on the hollow side pass through. It has no interior, so Shape.massProperties is `null` and a `dynamic` body needs at least one mass-bearing collider alongside it. A `static` or `kinematic` body carries a chain on its own. Collinear vertices are kept. A straight run is authoring data, and dropping it would move the adjacency of the neighbouring edges.",
+  "symbol": "ChainShape",
+  "kind": "class",
+  "subsystem": "physics",
+  "importPath": "@codexo/exojs-physics",
+  "tier": "stable",
+  "memberCount": 8,
+  "counts": {
+    "constructors": 1,
+    "methods": 0,
+    "properties": 7,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "A connected boundary through a run of local-space vertices: level outlines, terrain, the ground of a side-scroller. Open (a polyline) or closed (a loop).",
+        "A chain is not an array of SegmentShapes. At a shared vertex two independent segments carry two different normals, so a body sliding across the seam can snag, be launched, or receive a normal pointing into the surface. A chain owns the adjacency between its edges and uses it to suppress exactly those contacts, which is why the adjacency belongs to the engine rather than to the caller.",
+        "Unlike a segment, a chain is **one-sided**: each edge collides only from the side its outward normal points to. Winding therefore decides which side is solid, following the polygon convention - a counter-clockwise run is solid on the outside (an island), a clockwise run is solid on the inside (a container). Bodies on the hollow side pass through.",
+        "It has no interior, so Shape.massProperties is `null` and a `dynamic` body needs at least one mass-bearing collider alongside it. A `static` or `kinematic` body carries a chain on its own.",
+        "Collinear vertices are kept. A straight run is authoring data, and dropping it would move the adjacency of the neighbouring edges."
+      ],
+      "importLine": "import { ChainShape } from '@codexo/exojs-physics'",
+      "sourceLink": null
+    },
+    {
+      "id": "constructors",
+      "title": "Constructors",
+      "members": [
+        {
+          "name": "new",
+          "signature": "new(vertices: readonly Readonly<PointLike>[], options: ChainShapeOptions): ChainShape",
+          "signatureTokens": [
+            {
+              "text": "new",
+              "kind": "keyword"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "vertices",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Readonly",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "PointLike",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "options",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ChainShapeOptions",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ChainShape",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "vertices",
+              "type": "readonly Readonly<PointLike>[]",
+              "optional": false
+            },
+            {
+              "name": "options",
+              "type": "ChainShapeOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "ChainShape",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "boundingRadius",
+          "signature": "boundingRadius: number",
+          "signatureTokens": [
+            {
+              "text": "boundingRadius",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Radius of the smallest circle about the local origin enclosing the shape."
+        },
+        {
+          "name": "closed",
+          "signature": "closed: boolean",
+          "signatureTokens": [
+            {
+              "text": "closed",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "boolean",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "count",
+          "signature": "count: number",
+          "signatureTokens": [
+            {
+              "text": "count",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Number of vertices in vertices."
+        },
+        {
+          "name": "edgeCount",
+          "signature": "edgeCount: number",
+          "signatureTokens": [
+            {
+              "text": "edgeCount",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Number of edges: count when closed, count - 1 otherwise."
+        },
+        {
+          "name": "massProperties",
+          "signature": "massProperties: null",
+          "signatureTokens": [
+            {
+              "text": "massProperties",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Always null: a boundary has no interior and therefore no mass."
+        },
+        {
+          "name": "type",
+          "signature": "type: \"chain\"",
+          "signatureTokens": [
+            {
+              "text": "type",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"chain\"",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "vertices",
+          "signature": "vertices: readonly number[]",
+          "signatureTokens": [
+            {
+              "text": "vertices",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "readonly",
+              "kind": "keyword"
+            },
+            {
+              "text": " ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "[]",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Local-space vertices, flattened, after welding coincident input."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "packages/exojs-physics/src/shapes/ChainShape.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/ChainShape.ts"
+      }
+    }
+  ],
+  "sourcePath": "packages/exojs-physics/src/shapes/ChainShape.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/packages/exojs-physics/src/shapes/ChainShape.ts"
+}

--- a/site/src/content/api/contact-modifier-context.json
+++ b/site/src/content/api/contact-modifier-context.json
@@ -1,6 +1,6 @@
 {
   "title": "ContactModifierContext",
-  "description": "A solid contact as the world's ContactModifier sees it: the pair that produced it, the contact normal, and the three per-step controls the modifier may change. Everything else is read-only. The object is reused for every contact and is only valid for the duration of the callback - read what you need, write the controls, do not retain it. Writing a control affects this step only; the values are re-derived from the two colliders before the modifier runs again.",
+  "description": "A solid contact as the world's ContactModifier sees it: the pair that produced it, the contact normal, and the three per-step controls the modifier may change. Everything else is read-only. The object is reused for every contact and is only valid for the duration of the callback - read what you need, write the controls, do not retain it. Writing a control affects this step only; the values are re-derived from the two colliders before the modifier runs again. A chain collider is solved per edge, so a body touching several edges of one chain reaches the modifier once per edge, each time with the same authored collider pair. Decide from the contact's own normal and penetration rather than from the pair's identity if that distinction matters.",
   "symbol": "ContactModifierContext",
   "kind": "interface",
   "subsystem": "physics",
@@ -21,7 +21,8 @@
       "paragraphs": [
         "A solid contact as the world's ContactModifier sees it: the pair that produced it, the contact normal, and the three per-step controls the modifier may change. Everything else is read-only.",
         "The object is reused for every contact and is only valid for the duration of the callback - read what you need, write the controls, do not retain it.",
-        "Writing a control affects this step only; the values are re-derived from the two colliders before the modifier runs again."
+        "Writing a control affects this step only; the values are re-derived from the two colliders before the modifier runs again.",
+        "A chain collider is solved per edge, so a body touching several edges of one chain reaches the modifier once per edge, each time with the same authored collider pair. Decide from the contact's own normal and penetration rather than from the pair's identity if that distinction matters."
       ],
       "importLine": "import { ContactModifierContext } from '@codexo/exojs-physics'",
       "sourceLink": null

--- a/site/src/content/api/shape-type.json
+++ b/site/src/content/api/shape-type.json
@@ -30,10 +30,18 @@
       "members": [
         {
           "name": "ShapeType",
-          "signature": "\"capsule\" | \"circle\" | \"polygon\" | \"segment\"",
+          "signature": "\"capsule\" | \"chain\" | \"circle\" | \"polygon\" | \"segment\"",
           "signatureTokens": [
             {
               "text": "\"capsule\"",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "\"chain\"",
               "kind": "keyword"
             },
             {


### PR DESCRIPTION
Level outlines, terrain and side-scroller ground are runs of connected edges, and an array of independent `SegmentShape`s does not express one: at a shared vertex two segments carry two different normals, so a body crossing the seam snags, is launched, or receives a normal pointing into the surface.

`new ChainShape(vertices, { closed })` is one shape over the whole run, open or closed. It owns the adjacency between its edges and drops exactly the contacts that cause that snagging: the normals around a shared vertex are partitioned by proximity, so the edge whose own normal is closest keeps the contact and its neighbours yield. A collinear join is a tie and both edges keep theirs, which is what carries a box across a straight run. Coincident vertices are welded and a repeated closing vertex dropped; collinear vertices are kept, because removing them would move the adjacency of their neighbours.

The adjacency is stored as the rotation from an edge's own outward normal to its neighbours', which is invariant under the collider's world transform. The narrow phase reconstructs the neighbour normals from the world normal it already has - no second sync pass, no world-space ghost state, and `CollisionProxy` is unchanged.

Unlike a segment, a chain is one-sided: each edge collides only from the side its outward normal points to, following the polygon winding convention. It has no interior, so `massProperties` is `null`; a `dynamic` body still needs a mass-bearing collider alongside it, while static and kinematic bodies carry one on their own.

## Ownership

A chain collider fans out into engine-owned per-edge proxies. A body touching several edges at once is several solver contacts - which is what one manifold per collider pair requires - and none of that partition is public: the proxies never appear in `body.colliders`, `world.colliders` or a query result. `Manifold`, `ContactRecord`, the warm-start cache and the feature-id scheme are untouched.

The contact graph reference-counts the authored pair behind its per-proxy records, so `collisionStart`/`collisionEnd` and sensor enter/exit fire once for the whole chain - on the first edge contact that begins and the last that ends. Material, filter and sensor flag are read from the authored collider each pass rather than copied onto the proxies, so a chain stays one collider to configure. The contact modifier still runs per edge contact, each carrying the authored pair, because that is the granularity it decides at.

Queries resolve every hit to the authored collider and report a chain once however many of its edges they overlap; a ray still reports one hit per edge it crosses, because those are distinct intersections. `overlapShape` accepts a chain as the query shape and tests it edge by edge.

## Allocation

The edge proxies are built once with the shape and updated in place by `Collider.synchronize`, so a chain allocates nothing per step. A regression test compares the steady-state allocation rate of a chain floor against the equivalent solid floor.

## Validation

`pnpm test` (10,687 passed / 33 skipped), `pnpm verify:quick` (16/16 gates), package lint and both typechecks, `git diff --check`. The three load-bearing mechanisms were each neutralised in turn to confirm the tests fail without them: the adjacency filter (one-sidedness + seam), the authored-pair aggregation (begin/end and sensor events), and the query de-duplication.

## Not in this slice

Query/ray-cast refinement beyond what the edge proxies give for free, CCD/sweep (a chain edge is not a sweep target, exactly as a plain segment is not today), and the cross-shape/allocation matrix.

https://claude.ai/code/session_01R4RHfm7nhMPXAuxFrpgrqj
