### PR TITLE
feat(physics): sweep, draw and pin every shape combination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,31 @@ release and includes intentional breaking changes; see **Changed** and
 
 ### Added
 
+- **Continuous collision now covers the whole shape set.** A bullet was only ever swept
+  against circles and polygons, so a fast body crossed a capsule, a segment or a chain
+  within one step exactly as if `isBullet` had never been set — the shapes most likely to
+  be the thin wall a projectile must not pass.
+
+  Every mass-bearing shape is now cast against every shape kind:
+
+  | Moving shape                                             | Swept against                                |
+  | -------------------------------------------------------- | -------------------------------------------- |
+  | `CircleShape`, `CapsuleShape`, `PolygonShape`/`BoxShape` | circle, capsule, polygon/box, segment, chain |
+  | `SegmentShape`, `ChainShape`                             | not swept as the moving operand              |
+
+  The cast stays exact for a translation. A pair carrying a radius is solved as one
+  configuration-space ring — the Minkowski sum of the target's core and the moving shape's
+  negated start-pose core, cast as a point inflated by both radii — so a capsule meets a
+  corner on its cap arc rather than a radius short of it, which a radius-inflated
+  separating-axis test would report. Radius-free pairs keep the existing swept SAT.
+
+  A chain is swept through its edge proxies and blocks under the same one-sided adjacency
+  rule the discrete narrow phase applies, so a bullet arriving from the hollow side passes
+  through exactly as a slow body does, and the blocking collider handed back is always the
+  authored chain. Boundary geometry as the _moving_ operand stays deliberately unswept: a
+  segment or chain is level structure, and a development build warns once per shape kind if
+  a bullet body carries one.
+
 - **`ChainShape` — connected boundary geometry that a body can slide along.** Level
   outlines, terrain and side-scroller ground are runs of connected edges, and building them
   from independent `SegmentShape`s does not work: at a shared vertex two segments carry two
@@ -567,6 +592,17 @@ state, claims, inFlight, background }` — for diagnostics and support bundles.
   `unregister`, and no scene-level scope.
 
 ### Fixed
+
+- **The physics debug overlay draws the geometry the broad phase actually holds.** Its
+  AABB, broad-phase and contact overlays all scanned `world.colliders`, which is the
+  authored set: a chain contributed one union box that no phase ever tests, and its
+  contacts could not be drawn at all, because an authored chain collider is not a
+  narrow-phase operand. All three now scan the solver-side geometry — a chain as its
+  per-edge leaves — so the boxes are the real leaves, a chain links per overlapping edge,
+  and contacts against a chain appear. Internal edge geometry being visible in a debug
+  overlay does not make it public: `world.colliders`, `body.colliders` and every query
+  result are unchanged. The same pass also stops drawing contacts between two colliders of
+  one body, which the simulation itself has never formed.
 
 - **Two colliders on the same body no longer collide with each other.** Neither
   the broad phase nor the contact graph excluded a pair whose colliders belong

--- a/packages/exojs-physics/README.md
+++ b/packages/exojs-physics/README.md
@@ -1,13 +1,13 @@
 # @codexo/exojs-physics
 
-Native 2D **collision, query and sensor** runtime for [ExoJS](https://github.com/Exoridus/ExoJS).
+Native 2D **rigid-body** runtime for [ExoJS](https://github.com/Exoridus/ExoJS).
 
-Zero production dependencies, ESM-only, version-locked with the core engine. This
-first release ships a complete **collision/query world without dynamics**:
-shapes, colliders, bodies, a broad phase, a manifold-generating narrow phase,
-collision filters, sensors, events, spatial queries, scene-node binding and a
-debug overlay. Forces, impulses and gravity integration (the rigid-body solver)
-arrive in a follow-up — the public surface here is forward-compatible with it.
+Zero production dependencies, ESM-only, version-locked with the core engine.
+It ships a fixed-step world with a warm-started **TGS-Soft** solver: shapes,
+colliders, bodies, a dynamic-AABB broad phase, a manifold-generating narrow
+phase, joints, sleeping islands, continuous collision for fast bodies, a
+per-contact modifier, collision filters, sensors, events, spatial queries,
+scene-node binding with interpolation, and a debug overlay.
 
 > **Library, not an extension.** Physics contributes no renderer or asset
 > bindings, so there is no `/register` entry. Construct a `PhysicsWorld`
@@ -63,12 +63,16 @@ class GameScene extends Scene {
 | Bodies | `new PhysicsBody` + `world.add` (`dynamic`/`static`/`kinematic`), `setTransform`, mass/inertia from colliders |
 | Colliders | `new Collider` + `body.addCollider` / `colliders: [...]`, density/friction/restitution, `isSensor`, filter, offset |
 | Attach | `world.attach(node, def)` — body + collider + `bind` in one call |
-| Shapes | `CircleShape`, `PolygonShape` (convex-validated), `BoxShape` |
+| Shapes | solid: `CircleShape`, `CapsuleShape`, `PolygonShape` (convex-validated), `BoxShape`; boundary: `SegmentShape`, `ChainShape` |
+| Dynamics | fixed-step TGS-Soft solver, gravity, forces/impulses, friction/restitution, sleeping islands |
+| Joints | `DistanceJoint`, `RevoluteJoint`, `PrismaticJoint`, `WheelJoint`, `WeldJoint`, `MouseJoint` |
+| Continuous collision | `body.isBullet` — exact translational shape cast of the whole shape, not just its centre |
+| Contact policy | `world.contactModifier` — per-contact material/enable decisions (one-way platforms, conditional friction) |
 | Filtering | `CollisionFilter` (category/mask/group), `shouldCollide` |
 | Events | `onCollisionStart` / `onCollisionEnd` / `onSensorEnter` / `onSensorExit` — immutable snapshots |
 | Queries | `queryPoint`, `queryAabb` (+ `out` / `forEachAabbHit`), `rayCast`, `rayCastAll`, `overlapShape` |
 | Binding | `bind(body, node)` — node tracks the body's position each step |
-| Debug | `@codexo/exojs-physics/debug` → `PhysicsDebugDraw` (shapes/AABBs/contacts/normals/centres/broad-phase) |
+| Debug | `@codexo/exojs-physics/debug` → `PhysicsDebugDraw` (shapes/AABBs/contacts/normals/centres/broad-phase/joints) |
 
 ## Determinism & non-goals
 
@@ -94,10 +98,14 @@ tracks how much actually moved rather than the total live collider count
 (there's still a cheap linear pass over all live colliders each step). Scales
 to tens of thousands of simultaneously-live colliders.
 
-This release contains **no dynamics solver**: bodies move only via
-`setTransform`. The narrow phase already produces full contact manifolds (normal,
-1–2 points, stable feature ids) so the solver can be added without changing the
-public API.
+**Solid and boundary geometry.** `CircleShape`, `CapsuleShape`, `PolygonShape`
+and `BoxShape` enclose an area and carry mass; `SegmentShape` and `ChainShape`
+are boundaries with no interior, so they contribute collision only and a
+`dynamic` body needs at least one solid collider alongside them. A chain is one
+authored collider that the engine solves edge by edge with shared-vertex
+adjacency, so a body slides across a seam without snagging. Two boundaries never
+collide with each other, and a boundary is never the *moving* operand of a
+continuous shape cast — level structure is swept against, not swept.
 
 ## License
 

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -90,9 +90,9 @@ const assertBodyKeepsItsMass = (collider: Collider): void => {
 const warnedUnsweptKinds = new Set<string>();
 
 /**
- * Dev-only: a bullet body carrying a shape the sweep has no implementation for
- * is not protected against tunnelling. Reporting it beats a silent pass-through
- * while the remaining shape casts are still being filled in.
+ * Dev-only: boundary geometry is never swept as the moving operand, so a bullet
+ * body carrying it is not protected against tunnelling on that collider.
+ * Reporting it beats a silent pass-through.
  */
 const warnUnsweptBulletShape = (collider: Collider): void => {
   const kind = collider.shape.type;
@@ -103,8 +103,9 @@ const warnUnsweptBulletShape = (collider: Collider): void => {
 
   warnedUnsweptKinds.add(kind);
   logger.warn(
-    `PhysicsWorld: a bullet body carries a '${kind}' collider, which continuous collision does not sweep yet — ` +
-      'this body can still tunnel through thin geometry. Use a circle or polygon collider for fast projectiles.',
+    `PhysicsWorld: a bullet body carries a '${kind}' collider. Boundary geometry is level structure and is only ever a ` +
+      'sweep target, never the moving operand, so this collider can still cross thin geometry within one step. ' +
+      'Give a fast body a solid collider (circle, capsule or polygon).',
     { source: 'physics' },
   );
 };
@@ -439,6 +440,16 @@ export class PhysicsWorld implements BodyOwner {
   /** Live colliders (read-only view). */
   public get colliders(): readonly Collider[] {
     return this._colliders;
+  }
+
+  /**
+   * @internal - the geometry the broad phase and the narrow phase actually hold:
+   * every authored collider, with a chain replaced by its per-edge proxies.
+   * Consumed by the debug draw layer, which visualises what the solver sees;
+   * public identity stays {@link colliders}.
+   */
+  public get detectionGeometry(): readonly Collider[] {
+    return this._detectionColliders;
   }
 
   // ── lifecycle ──────────────────────────────────────────────────────────

--- a/packages/exojs-physics/src/collision/chainAdjacency.ts
+++ b/packages/exojs-physics/src/collision/chainAdjacency.ts
@@ -1,0 +1,52 @@
+import { ChainEdgeShape } from '../shapes/ChainEdgeShape';
+import type { CollisionProxy } from './CollisionProxy';
+
+/**
+ * Adjacency filter for a chain edge: `true` when this edge owns the contact
+ * whose outward normal is `(nx, ny)`. Any other shape admits everything.
+ *
+ * A chain is one-sided, so a normal pointing into the solid side is never this
+ * edge's. Beyond that, the normals around a shared vertex are partitioned by
+ * proximity: the edge whose own normal is closest to the contact normal keeps
+ * the contact, and its neighbours drop it. That is what removes internal vertex
+ * snagging - a body sliding onto the next edge stops producing a contact against
+ * the previous one, instead of receiving two contradicting normals at the seam -
+ * while a body wedged in a concave corner still keeps one contact per wall,
+ * because each wall's own normal is the closest one there.
+ *
+ * A tie (collinear edges) is kept by both, which is what lets a straight run of
+ * chain edges carry a box across the join. A free end has no neighbour on that
+ * side and admits the whole half-plane, so a body can pass around it.
+ *
+ * The neighbour normals are reconstructed from the stored rotations rather than
+ * cached in world space: rotating this edge's world normal by the (transform
+ * invariant) angle to a neighbour's is exact and needs no second sync pass.
+ *
+ * The discrete narrow phase and the sweep both apply it, so a fast body meets
+ * the same one-sided, seam-free chain a slow one does.
+ *
+ * @internal
+ */
+export const chainEdgeAdmits = (proxy: CollisionProxy, nx: number, ny: number): boolean => {
+  const shape = proxy.shape;
+
+  if (!(shape instanceof ChainEdgeShape)) {
+    return true;
+  }
+
+  const ownX = proxy.worldNormals[0]!;
+  const ownY = proxy.worldNormals[1]!;
+  const own = nx * ownX + ny * ownY;
+
+  if (own <= 0) {
+    return false;
+  }
+
+  const cross = ownX * ny - ownY * nx;
+
+  if (shape.hasPrevious && shape.previousCos * own + shape.previousSin * cross > own) {
+    return false;
+  }
+
+  return !(shape.hasNext && shape.nextCos * own + shape.nextSin * cross > own);
+};

--- a/packages/exojs-physics/src/collision/narrowphase.ts
+++ b/packages/exojs-physics/src/collision/narrowphase.ts
@@ -1,6 +1,6 @@
 import type { PointLike } from '@codexo/exojs';
 
-import { ChainEdgeShape } from '../shapes/ChainEdgeShape';
+import { chainEdgeAdmits } from './chainAdjacency';
 import type { CollisionProxy } from './CollisionProxy';
 import type { PairTable } from './dispatch';
 import { needsFlip, symmetricEntry, symmetricTable } from './dispatch';
@@ -57,51 +57,6 @@ export const collide = (a: CollisionProxy, b: CollisionProxy, manifold: Manifold
   }
 
   return true;
-};
-
-/**
- * Adjacency filter for a chain edge: `true` when this edge owns the contact
- * whose outward normal is `(nx, ny)`.
- *
- * A chain is one-sided, so a normal pointing into the solid side is never this
- * edge's. Beyond that, the normals around a shared vertex are partitioned by
- * proximity: the edge whose own normal is closest to the contact normal keeps
- * the contact, and its neighbours drop it. That is what removes internal vertex
- * snagging - a body sliding onto the next edge stops producing a contact against
- * the previous one, instead of receiving two contradicting normals at the seam -
- * while a body wedged in a concave corner still keeps one contact per wall,
- * because each wall's own normal is the closest one there.
- *
- * A tie (collinear edges) is kept by both, which is what lets a straight run of
- * chain edges carry a box across the join. A free end has no neighbour on that
- * side and admits the whole half-plane, so a body can pass around it.
- *
- * The neighbour normals are reconstructed from the stored rotations rather than
- * cached in world space: rotating this edge's world normal by the (transform
- * invariant) angle to a neighbour's is exact and needs no second sync pass.
- */
-const chainEdgeAdmits = (proxy: CollisionProxy, nx: number, ny: number): boolean => {
-  const shape = proxy.shape;
-
-  if (!(shape instanceof ChainEdgeShape)) {
-    return true;
-  }
-
-  const ownX = proxy.worldNormals[0]!;
-  const ownY = proxy.worldNormals[1]!;
-  const own = nx * ownX + ny * ownY;
-
-  if (own <= 0) {
-    return false;
-  }
-
-  const cross = ownX * ny - ownY * nx;
-
-  if (shape.hasPrevious && shape.previousCos * own + shape.previousSin * cross > own) {
-    return false;
-  }
-
-  return !(shape.hasNext && shape.nextCos * own + shape.nextSin * cross > own);
 };
 
 // Both helpers stay cast-free and allocation-free. A capsule is a two-vertex

--- a/packages/exojs-physics/src/collision/sweep.ts
+++ b/packages/exojs-physics/src/collision/sweep.ts
@@ -1,12 +1,11 @@
 import type { PointLike } from '@codexo/exojs';
 
-import type { AnyShape } from '../shapes/AnyShape';
-import { CircleShape } from '../shapes/CircleShape';
 import type { ShapeType } from '../shapes/Shape';
+import { chainEdgeAdmits } from './chainAdjacency';
 import type { CollisionProxy } from './CollisionProxy';
 import type { PairTable } from './dispatch';
 import { orderedEntry, orderedTable } from './dispatch';
-import { testOverlap } from './narrowphase';
+import { pointSegmentDistanceSquared } from './segments';
 
 /**
  * First time of impact of a translation-only shape cast, written by
@@ -23,18 +22,10 @@ export interface SweepHit {
 
 const eps = 1e-9;
 
-// Module-local scratch circle proxy used for the start-overlap pre-check of the
-// circle↔polygon sweeps (it borrows the real circle's shape, so no per-call
-// allocation). Like the narrow-phase clip scratch, the sweep is single-threaded
-// and non-reentrant - the world's CCD pass calls `sweepProxies` strictly
-// sequentially - so module-global scratch is safe.
-const _circleStart: PointLike = { x: 0, y: 0 };
-const _circleProxy: { shape: AnyShape; worldCenter: PointLike; worldVertices: number[]; worldNormals: number[] } = {
-  shape: new CircleShape(1),
-  worldCenter: _circleStart,
-  worldVertices: [],
-  worldNormals: [],
-};
+// Module-local scratch shared by the casts below. Like the narrow-phase clip
+// scratch, the sweep is single-threaded and non-reentrant - the world's CCD pass
+// calls `sweepProxies` strictly sequentially - so module-global scratch is safe.
+const _pointScratch: PointLike = { x: 0, y: 0 };
 
 /**
  * Translation-only shape cast of `moving` against a static `target`: `moving`
@@ -47,6 +38,11 @@ const _circleProxy: { shape: AnyShape; worldCenter: PointLike; worldVertices: nu
  * written into `out`. Pairs already overlapping (or exactly touching) at the
  * start of the motion return `false` - they cannot tunnel within this motion
  * and the discrete solver owns them. Allocation-free.
+ *
+ * Boundary geometry (a segment, a chain edge) is a target, never the moving
+ * operand: a chain edge blocks a bullet under the same one-sided adjacency rule
+ * the discrete narrow phase applies, while a fast segment or chain is not swept
+ * at all.
  */
 export const sweepProxies = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy, out: SweepHit): boolean => {
   const cast = orderedEntry(sweepTable, moving.shape.type, target.shape.type);
@@ -54,16 +50,42 @@ export const sweepProxies = (moving: CollisionProxy, dx: number, dy: number, tar
   // Unlike the narrow phase, the sweep distinguishes its operands, so this table
   // is filled for both orders. A missing entry reports no impact - the pair is
   // not swept at all rather than swept approximately.
-  return cast === undefined ? false : cast(moving, dx, dy, target, out);
+  if (cast === undefined) {
+    return false;
+  }
+
+  if (!cast(moving, dx, dy, target, out)) {
+    return false;
+  }
+
+  // `out` holds the outward normal on the target, which is the direction a chain
+  // edge has to admit for the hit to be its own.
+  return chainEdgeAdmits(target, out.normalX, out.normalY);
 };
 
 /** `true` when {@link sweepProxies} has an implementation for this ordered pair. */
 export const canSweep = (moving: ShapeType, target: ShapeType): boolean => orderedEntry(sweepTable, moving, target) !== undefined;
 
-// Only called after the dispatch above has matched the shape kind; the fallback
-// is unreachable but keeps the helper cast-free.
-const radiusOf = (proxy: CollisionProxy): number => (proxy.shape.type === 'circle' ? proxy.shape.radius : 0);
-const countOf = (proxy: CollisionProxy): number => (proxy.shape.type === 'polygon' ? proxy.shape.count : 0);
+/**
+ * Vertex count of a proxy's **core**: the geometry left once its radius is taken
+ * off. A circle is a point (no core ring), a capsule and a segment are both a
+ * two-vertex ring - with and without a radius - and a polygon is its own ring.
+ */
+const coreCount = (proxy: CollisionProxy): number => {
+  switch (proxy.shape.type) {
+    case 'polygon':
+      return proxy.shape.count;
+    case 'capsule':
+    case 'segment':
+      return 2;
+    case 'circle':
+    case 'chain':
+      // A chain is never an operand here - it is swept through its edge proxies.
+      return 0;
+  }
+};
+
+const radiusOf = (proxy: CollisionProxy): number => (proxy.shape.type === 'circle' || proxy.shape.type === 'capsule' ? proxy.shape.radius : 0);
 
 /** Moving circle vs static circle: a ray against the Minkowski-summed circle. */
 const sweepCircleCircle = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy, out: SweepHit): boolean => {
@@ -109,49 +131,52 @@ const sweepCircleCircle = (moving: CollisionProxy, dx: number, dy: number, targe
   return true;
 };
 
-/** Moving circle vs static polygon: a ray against the radius-inflated (rounded) polygon. */
-const sweepCirclePolygon = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy, out: SweepHit): boolean => {
-  const r = radiusOf(moving);
+/**
+ * Moving circle vs a static core ring (polygon, capsule or segment): a ray
+ * against that ring inflated by both radii - offset faces plus vertex arcs, the
+ * exact swept geometry.
+ */
+const sweepCircleRing = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy, out: SweepHit): boolean => {
+  const rsum = radiusOf(moving) + radiusOf(target);
   const ox = moving.worldCenter.x - dx;
   const oy = moving.worldCenter.y - dy;
+  const verts = target.worldVertices;
+  const normals = target.worldNormals;
+  const count = coreCount(target);
 
   // Already overlapping/touching at the start: the discrete solver owns it.
-  _circleProxy.shape = moving.shape;
-  _circleStart.x = ox;
-  _circleStart.y = oy;
-
-  if (testOverlap(_circleProxy, target)) {
+  if (pointRingDistanceSquared(ox, oy, verts, normals, count) <= rsum * rsum) {
     return false;
   }
 
-  return castCircleAtPolygon(ox, oy, dx, dy, r, target, out);
+  return castPointAtRing(ox, oy, dx, dy, rsum, verts, normals, count, out);
 };
 
 /**
- * Moving polygon vs static circle, solved in the polygon's frame: the circle
- * sweeps backward (`−d`) from a start displaced by `+d`, against the polygon's
- * end-pose geometry - the same relative motion, so the same time of impact.
+ * Moving core ring (polygon or capsule) vs static circle, solved in the moving
+ * shape's frame: the circle sweeps backward (`−d`) from a start displaced by
+ * `+d`, against the ring's end-pose geometry - the same relative motion, so the
+ * same time of impact.
  */
-const sweepPolygonCircle = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy, out: SweepHit): boolean => {
-  const r = radiusOf(target);
+const sweepRingCircle = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy, out: SweepHit): boolean => {
+  const rsum = radiusOf(moving) + radiusOf(target);
   const ox = target.worldCenter.x + dx;
   const oy = target.worldCenter.y + dy;
+  const verts = moving.worldVertices;
+  const normals = moving.worldNormals;
+  const count = coreCount(moving);
 
   // Already overlapping/touching at the start: the discrete solver owns it.
-  _circleProxy.shape = target.shape;
-  _circleStart.x = ox;
-  _circleStart.y = oy;
-
-  if (testOverlap(_circleProxy, moving)) {
+  if (pointRingDistanceSquared(ox, oy, verts, normals, count) <= rsum * rsum) {
     return false;
   }
 
-  if (!castCircleAtPolygon(ox, oy, -dx, -dy, r, moving, out)) {
+  if (!castPointAtRing(ox, oy, -dx, -dy, rsum, verts, normals, count, out)) {
     return false;
   }
 
-  // The cast reports the normal on the polygon (the bullet) toward the circle
-  // (the obstacle); the caller wants the obstacle-surface normal, so flip it.
+  // The cast reports the normal on the moving shape toward the circle; the
+  // caller wants the obstacle-surface normal, so flip it.
   out.normalX = -out.normalX;
   out.normalY = -out.normalY;
 
@@ -159,26 +184,66 @@ const sweepPolygonCircle = (moving: CollisionProxy, dx: number, dy: number, targ
 };
 
 /**
- * Cast the point `(ox, oy)` along `(dx, dy)` (t ∈ [0, 1]) against `polygon`
- * inflated by `r`: offset faces plus vertex arcs - the exact swept-circle
- * geometry. Writes the earliest hit into `out`; the normal points from the
- * polygon surface toward the circle.
+ * Two core rings of which at least one carries a radius (any pair involving a
+ * capsule): built as one configuration-space ring and cast as a point, which is
+ * exact where a radius-inflated SAT would square off the rounded corners.
  */
-const castCircleAtPolygon = (ox: number, oy: number, dx: number, dy: number, r: number, polygon: CollisionProxy, out: SweepHit): boolean => {
+const sweepRoundedRings = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy, out: SweepHit): boolean => {
+  const rsum = radiusOf(moving) + radiusOf(target);
+
+  if (!buildConfigurationRing(moving, dx, dy, target)) {
+    return false;
+  }
+
+  const verts = _configurationRing.vertices;
+  const normals = _configurationRing.normals;
+  const count = _configurationRing.count;
+
+  // Already overlapping/touching at the start: the discrete solver owns it.
+  if (pointRingDistanceSquared(0, 0, verts, normals, count) <= rsum * rsum) {
+    return false;
+  }
+
+  return castPointAtRing(0, 0, dx, dy, rsum, verts, normals, count, out);
+};
+
+/**
+ * Cast the point `(ox, oy)` along `(dx, dy)` (t ∈ [0, 1]) against `count`-vertex
+ * convex ring inflated by `r`: offset faces plus vertex arcs - the exact swept
+ * geometry. Writes the earliest hit into `out`; the normal points from the ring
+ * surface toward the point.
+ */
+const castPointAtRing = (
+  ox: number,
+  oy: number,
+  dx: number,
+  dy: number,
+  r: number,
+  verts: readonly number[],
+  normals: readonly number[],
+  count: number,
+  out: SweepHit,
+): boolean => {
   // Both passes only improve `out` when they beat the current `out.t`.
   out.t = Infinity;
-  castAtOffsetFaces(ox, oy, dx, dy, r, polygon, out);
-  castAtVertexArcs(ox, oy, dx, dy, r, polygon, out);
+  castAtOffsetFaces(ox, oy, dx, dy, r, verts, normals, count, out);
+  castAtVertexArcs(ox, oy, dx, dy, r, verts, count, out);
 
   return out.t !== Infinity;
 };
 
-/** Offset-face pass of {@link castCircleAtPolygon}: the face plane pushed out by `r`, hits valid within the edge span. */
-const castAtOffsetFaces = (ox: number, oy: number, dx: number, dy: number, r: number, polygon: CollisionProxy, out: SweepHit): void => {
-  const verts = polygon.worldVertices;
-  const normals = polygon.worldNormals;
-  const count = countOf(polygon);
-
+/** Offset-face pass of {@link castPointAtRing}: the face plane pushed out by `r`, hits valid within the edge span. */
+const castAtOffsetFaces = (
+  ox: number,
+  oy: number,
+  dx: number,
+  dy: number,
+  r: number,
+  verts: readonly number[],
+  normals: readonly number[],
+  count: number,
+  out: SweepHit,
+): void => {
   for (let i = 0; i < count; i++) {
     // Loop indices are provably in-bounds (0..count-1); the `!` is zero-cost.
     const nx = normals[i * 2]!;
@@ -216,10 +281,12 @@ const castAtOffsetFaces = (ox: number, oy: number, dx: number, dy: number, r: nu
   }
 };
 
-/** Vertex-arc pass of {@link castCircleAtPolygon}: a ray against the circle of radius `r` around each vertex. */
-const castAtVertexArcs = (ox: number, oy: number, dx: number, dy: number, r: number, polygon: CollisionProxy, out: SweepHit): void => {
-  const verts = polygon.worldVertices;
-  const count = countOf(polygon);
+/** Vertex-arc pass of {@link castPointAtRing}: a ray against the circle of radius `r` around each vertex. */
+const castAtVertexArcs = (ox: number, oy: number, dx: number, dy: number, r: number, verts: readonly number[], count: number, out: SweepHit): void => {
+  if (r <= 0) {
+    return; // A radius-free ring has no arcs; its faces meet at the vertices.
+  }
+
   const a = dx * dx + dy * dy;
 
   for (let i = 0; i < count; i++) {
@@ -257,7 +324,204 @@ const castAtVertexArcs = (ox: number, oy: number, dx: number, dy: number, r: num
   }
 };
 
-// Swept-SAT accumulator shared by sweepPolygonPolygon's two axis passes.
+/**
+ * Squared distance from `(px, py)` to a convex core ring, `0` inside it. A
+ * two-vertex ring has no interior, so it is always the distance to the segment.
+ */
+const pointRingDistanceSquared = (px: number, py: number, verts: readonly number[], normals: readonly number[], count: number): number => {
+  if (count >= 3) {
+    let inside = true;
+
+    for (let i = 0; i < count && inside; i++) {
+      inside = normals[i * 2]! * (px - verts[i * 2]!) + normals[i * 2 + 1]! * (py - verts[i * 2 + 1]!) <= 0;
+    }
+
+    if (inside) {
+      return 0;
+    }
+  }
+
+  let best = Infinity;
+
+  for (let i = 0; i < count; i++) {
+    const j = (i + 1) % count;
+    const distance = pointSegmentDistanceSquared(px, py, verts[i * 2]!, verts[i * 2 + 1]!, verts[j * 2]!, verts[j * 2 + 1]!, _pointScratch);
+
+    best = distance < best ? distance : best;
+  }
+
+  return best;
+};
+
+/** A convex ring in world space: the only geometry the casts above work on. */
+interface Ring {
+  vertices: number[];
+  normals: number[];
+  count: number;
+}
+
+// Scratch for the configuration-space ring and its hull pass. The arrays grow
+// to the largest pair seen and are then written in place, so a steady-state
+// bullet against known geometry allocates nothing.
+const _configurationRing: Ring = { vertices: [], normals: [], count: 0 };
+const _sumPoints: number[] = [];
+const _sumOrder: number[] = [];
+const _hull: number[] = [];
+
+/**
+ * Build the pair's configuration-space obstacle into {@link _configurationRing}:
+ * the Minkowski sum of the target's core and the negated start-pose core of the
+ * moving shape. A translational cast of the pair is then a cast of the origin
+ * point against that single ring, inflated by the two radii - which is why every
+ * rounded pair reduces to {@link castPointAtRing} instead of its own algorithm.
+ */
+const buildConfigurationRing = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy): boolean => {
+  const movingCount = coreCount(moving);
+  const targetCount = coreCount(target);
+
+  if (movingCount < 2 || targetCount < 2) {
+    return false;
+  }
+
+  const movingVerts = moving.worldVertices;
+  const targetVerts = target.worldVertices;
+  const total = movingCount * targetCount;
+
+  grow(_sumPoints, total * 2);
+  grow(_sumOrder, total);
+
+  for (let j = 0, k = 0; j < targetCount; j++) {
+    for (let i = 0; i < movingCount; i++, k++) {
+      // The moving core at the start of the motion is its end pose minus (dx, dy).
+      _sumPoints[k * 2] = targetVerts[j * 2]! - (movingVerts[i * 2]! - dx);
+      _sumPoints[k * 2 + 1] = targetVerts[j * 2 + 1]! - (movingVerts[i * 2 + 1]! - dy);
+      _sumOrder[k] = k;
+    }
+  }
+
+  const count = convexHull(total);
+
+  if (count < 2) {
+    return false;
+  }
+
+  grow(_configurationRing.vertices, count * 2);
+  grow(_configurationRing.normals, count * 2);
+  _configurationRing.count = count;
+
+  const verts = _configurationRing.vertices;
+  const normals = _configurationRing.normals;
+
+  for (let i = 0; i < count; i++) {
+    const point = _hull[i]!;
+
+    verts[i * 2] = _sumPoints[point * 2]!;
+    verts[i * 2 + 1] = _sumPoints[point * 2 + 1]!;
+  }
+
+  // Same convention as every authored ring: the outward normal of the
+  // counter-clockwise edge i → i+1 is (eY, -eX). A two-vertex ring gets the two
+  // opposite normals out of the same loop.
+  for (let i = 0; i < count; i++) {
+    const j = (i + 1) % count;
+    const ex = verts[j * 2]! - verts[i * 2]!;
+    const ey = verts[j * 2 + 1]! - verts[i * 2 + 1]!;
+    const length = Math.sqrt(ex * ex + ey * ey) || 1;
+
+    normals[i * 2] = ey / length;
+    normals[i * 2 + 1] = -ex / length;
+  }
+
+  return true;
+};
+
+/**
+ * Counter-clockwise convex hull of the first `total` points in
+ * {@link _sumPoints} (Andrew's monotone chain), written as point indices into
+ * {@link _hull}; returns the hull size. Collinear points are dropped, so a
+ * degenerate sum - two parallel spines - comes out as a two-vertex ring rather
+ * than a zero-area polygon.
+ */
+const convexHull = (total: number): number => {
+  // Insertion sort by (x, y): the point sets here are a handful of vertices, and
+  // sorting in place over the index scratch keeps the pass allocation-free.
+  for (let i = 1; i < total; i++) {
+    const value = _sumOrder[i]!;
+    let j = i - 1;
+
+    while (j >= 0 && comparePoints(_sumOrder[j]!, value) > 0) {
+      _sumOrder[j + 1] = _sumOrder[j]!;
+      j--;
+    }
+
+    _sumOrder[j + 1] = value;
+  }
+
+  grow(_hull, total * 2 + 1);
+
+  let size = 0;
+
+  for (let i = 0; i < total; i++) {
+    size = pushHullPoint(_sumOrder[i]!, size, 2);
+  }
+
+  // The upper chain may not eat into the lower one, so it keeps one more point
+  // than the lower chain left behind.
+  const upperFloor = size + 1;
+
+  for (let i = total - 2; i >= 0; i--) {
+    size = pushHullPoint(_sumOrder[i]!, size, upperFloor);
+  }
+
+  // The chain closes on its starting point, which is already the first entry.
+  return size > 1 ? size - 1 : size;
+};
+
+/** One monotone-chain step: drop hull points that a left turn onto `point` makes interior. */
+const pushHullPoint = (point: number, size: number, floor: number): number => {
+  while (size >= floor && cross(_hull[size - 2]!, _hull[size - 1]!, point) <= 0) {
+    size--;
+  }
+
+  _hull[size] = point;
+
+  return size + 1;
+};
+
+const comparePoints = (a: number, b: number): number => {
+  const ax = _sumPoints[a * 2]!;
+  const bx = _sumPoints[b * 2]!;
+
+  if (ax !== bx) {
+    return ax < bx ? -1 : 1;
+  }
+
+  const ay = _sumPoints[a * 2 + 1]!;
+  const by = _sumPoints[b * 2 + 1]!;
+
+  if (ay === by) {
+    return 0;
+  }
+
+  return ay < by ? -1 : 1;
+};
+
+/** Cross product of `o → a` and `o → b`; positive for a counter-clockwise turn. */
+const cross = (o: number, a: number, b: number): number => {
+  const ox = _sumPoints[o * 2]!;
+  const oy = _sumPoints[o * 2 + 1]!;
+
+  return (_sumPoints[a * 2]! - ox) * (_sumPoints[b * 2 + 1]! - oy) - (_sumPoints[a * 2 + 1]! - oy) * (_sumPoints[b * 2]! - ox);
+};
+
+/** Extend a scratch array to `length`, keeping it a plain packed number array. */
+const grow = (array: number[], length: number): void => {
+  while (array.length < length) {
+    array.push(0);
+  }
+};
+
+// Swept-SAT accumulator shared by sweepRings's two axis passes.
 // Module-local scratch under the same single-threaded/non-reentrant contract
 // as the rest of this file.
 interface SweptSatState {
@@ -270,20 +534,20 @@ interface SweptSatState {
 const _satState: SweptSatState = { tEnter: 0, tLeave: 0, normalX: 0, normalY: 0 };
 
 /**
- * Moving convex polygon vs static convex polygon via swept SAT: for every
- * candidate axis (both polygons' face normals) intersect the moving projection
+ * Two radius-free core rings (polygon or segment) via swept SAT: for every
+ * candidate axis (both rings' face normals) intersect the moving projection
  * interval with the static one over t ∈ [0, 1]; the latest entry over all axes
  * is the time of impact, and its axis (oriented against the motion) the normal.
  * Exact for linear motion of convex shapes.
  */
-const sweepPolygonPolygon = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy, out: SweepHit): boolean => {
+const sweepRings = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy, out: SweepHit): boolean => {
   const state = _satState;
 
   state.tEnter = -Infinity;
   state.tLeave = Infinity;
 
-  // Two passes: axes from the target, then from the moving polygon. Either
-  // pass may prove the pair never meets within the motion.
+  // Two passes: axes from the target, then from the moving ring. Either pass may
+  // prove the pair never meets within the motion.
   if (!sweptSatAxes(target, moving, dx, dy, target, state) || !sweptSatAxes(moving, moving, dx, dy, target, state)) {
     return false;
   }
@@ -316,11 +580,11 @@ const sweptSatAxes = (
   state: SweptSatState,
 ): boolean => {
   const axes = axisOwner.worldNormals;
-  const axisCount = countOf(axisOwner);
+  const axisCount = coreCount(axisOwner);
   const mv = moving.worldVertices;
-  const mc = countOf(moving);
+  const mc = coreCount(moving);
   const tv = target.worldVertices;
-  const tc = countOf(target);
+  const tc = coreCount(target);
 
   for (let i = 0; i < axisCount; i++) {
     // Loop indices are provably in-bounds; the `!` is zero-cost.
@@ -328,7 +592,7 @@ const sweptSatAxes = (
     const ny = axes[i * 2 + 1]!;
     const dn = nx * dx + ny * dy;
 
-    // Project the moving polygon (end pose), then shift to its start pose.
+    // Project the moving ring (end pose), then shift to its start pose.
     let minA = Infinity;
     let maxA = -Infinity;
 
@@ -394,9 +658,20 @@ const sweptSatAxes = (
 /** One ordered `(moving, target)` shape cast. */
 type SweepPair = (moving: CollisionProxy, dx: number, dy: number, target: CollisionProxy, out: SweepHit) => boolean;
 
+// Every ordered pair a mass-bearing shape can move as. Boundary geometry
+// (segment, chain) appears only as a target: level structure is not swept, and
+// a fast body that needs protection carries a solid shape.
 const sweepTable: PairTable<SweepPair> = orderedTable<SweepPair>([
   ['circle', 'circle', sweepCircleCircle],
-  ['circle', 'polygon', sweepCirclePolygon],
-  ['polygon', 'circle', sweepPolygonCircle],
-  ['polygon', 'polygon', sweepPolygonPolygon],
+  ['circle', 'capsule', sweepCircleRing],
+  ['circle', 'segment', sweepCircleRing],
+  ['circle', 'polygon', sweepCircleRing],
+  ['capsule', 'circle', sweepRingCircle],
+  ['capsule', 'capsule', sweepRoundedRings],
+  ['capsule', 'segment', sweepRoundedRings],
+  ['capsule', 'polygon', sweepRoundedRings],
+  ['polygon', 'circle', sweepRingCircle],
+  ['polygon', 'capsule', sweepRoundedRings],
+  ['polygon', 'segment', sweepRings],
+  ['polygon', 'polygon', sweepRings],
 ]);

--- a/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
+++ b/packages/exojs-physics/src/debug/PhysicsDebugDraw.ts
@@ -7,6 +7,7 @@ import type { RenderBackend } from '@codexo/exojs/renderer-sdk';
 import { aabbOverlap } from '../Aabb';
 import type { CandidatePair } from '../broadphase/BroadPhase';
 import type { Collider } from '../Collider';
+import { authoredCollider } from '../Collider';
 import { Manifold } from '../collision/Manifold';
 import { collide } from '../collision/narrowphase';
 import type { PhysicsWorld } from '../PhysicsWorld';
@@ -16,7 +17,7 @@ import type { BodyType } from '../types';
 export interface PhysicsDebugDrawOptions {
   /** Collider shape outlines, coloured by body type. Default `true`. */
   drawShapes?: boolean;
-  /** Collider world AABBs. Default `false`. */
+  /** World AABBs of the geometry the broad phase holds - a chain as its per-edge leaves. Default `false`. */
   drawAabb?: boolean;
   /** Contact points. Default `false`. */
   drawContacts?: boolean;
@@ -24,7 +25,7 @@ export interface PhysicsDebugDrawOptions {
   drawNormals?: boolean;
   /** Body origins (centre markers). Default `false`. */
   drawCenters?: boolean;
-  /** Broad-phase candidate links between AABB-overlapping colliders. Default `false`. */
+  /** Broad-phase candidate links between AABB-overlapping leaves - a chain links per edge. Default `false`. */
   drawBroadphase?: boolean;
   /** Tint sleeping bodies distinctly (applies to the shape outline). Default `false`. */
   drawSleeping?: boolean;
@@ -98,7 +99,9 @@ export class PhysicsDebugDraw extends DebugLayer {
     }
 
     if (options.drawAabb) {
-      for (const collider of this._world.colliders) {
+      // The solver-side geometry, so a chain shows the leaves the broad phase
+      // actually holds rather than the union box no phase ever tests.
+      for (const collider of this._world.detectionGeometry) {
         this._strokeAabb(gfx, collider);
       }
     }
@@ -284,7 +287,9 @@ export class PhysicsDebugDraw extends DebugLayer {
    * correctness - it touches no state outside this method.
    */
   private _collectPairs(): void {
-    const colliders = this._world.colliders;
+    // The solver-side geometry: a chain contributes one leaf per edge, which is
+    // both what the broad phase pairs and what the narrow phase can solve.
+    const colliders = this._world.detectionGeometry;
     const pairs = this._pairs;
 
     pairs.length = 0;
@@ -295,7 +300,7 @@ export class PhysicsDebugDraw extends DebugLayer {
       for (let j = i + 1; j < colliders.length; j++) {
         const b = colliders[j]!;
 
-        if (aabbOverlap(a.aabb, b.aabb)) {
+        if (a.body !== b.body && aabbOverlap(a.aabb, b.aabb)) {
           pairs.push(a.id < b.id ? { a, b } : { a: b, b: a });
         }
       }
@@ -322,7 +327,9 @@ export class PhysicsDebugDraw extends DebugLayer {
       const a = pair.a;
       const b = pair.b;
 
-      if (a.isSensor || b.isSensor) {
+      // Material and sensor state live on the authored collider; an edge proxy
+      // reads them from its chain.
+      if (authoredCollider(a).isSensor || authoredCollider(b).isSensor) {
         continue;
       }
 

--- a/packages/exojs-physics/test/ccd-shapes.test.ts
+++ b/packages/exojs-physics/test/ccd-shapes.test.ts
@@ -1,0 +1,391 @@
+import type { PointLike } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import type { Collider } from '../src/Collider';
+import { canSweep, type SweepHit, sweepProxies } from '../src/collision/sweep';
+import { BoxShape, CapsuleShape, ChainShape, CircleShape, PhysicsBody, PhysicsWorld, SegmentShape } from '../src/index';
+import type { AnyShape } from '../src/shapes/AnyShape';
+import type { ShapeType } from '../src/shapes/Shape';
+import { measureAllocationRate } from './allocationSampler';
+import { colliderAt } from './support';
+
+/**
+ * Continuous collision across the whole shape matrix. Every mass-bearing shape
+ * sweeps against every target shape; boundary geometry is a target only.
+ *
+ * The casts below place the moving collider at its END pose and sweep it back
+ * over `(dx, dy)`, which is the contract `sweepProxies` is called under.
+ */
+
+const DT = 1 / 60;
+
+const hit: SweepHit = { t: 0, normalX: 0, normalY: 0 };
+
+const movers: readonly ShapeType[] = ['circle', 'capsule', 'polygon'];
+const targets: readonly ShapeType[] = ['circle', 'capsule', 'segment', 'polygon'];
+
+const points = (...coordinates: number[]): PointLike[] => {
+  const out: PointLike[] = [];
+
+  for (let i = 0; i < coordinates.length; i += 2) {
+    out.push({ x: coordinates[i]!, y: coordinates[i + 1]! });
+  }
+
+  return out;
+};
+
+/** A collider swept 100px to the right, from `x = 0` to the pose it is created at. */
+const movingRightFrom = (world: PhysicsWorld, shape: ConstructorParameters<typeof Collider>[0]['shape'], y = 0): Collider =>
+  colliderAt(world, shape, { x: 100, y });
+
+/** A vertical boundary/obstacle centred on `x = 50`. */
+const obstacleAt = (world: PhysicsWorld, shape: ConstructorParameters<typeof Collider>[0]['shape'], y = 0): Collider =>
+  colliderAt(world, shape, { x: 50, y });
+
+describe('the sweep matrix', () => {
+  it('casts every mass-bearing shape against every target shape', () => {
+    for (const moving of movers) {
+      for (const target of targets) {
+        expect([moving, target, canSweep(moving, target)]).toEqual([moving, target, true]);
+      }
+    }
+  });
+
+  it('never casts boundary geometry as the moving operand', () => {
+    for (const target of [...targets, 'chain' as const]) {
+      expect([target, canSweep('segment', target)]).toEqual([target, false]);
+      expect([target, canSweep('chain', target)]).toEqual([target, false]);
+    }
+  });
+
+  it('never dispatches a chain itself - a chain is swept through its edge proxies', () => {
+    for (const moving of movers) {
+      expect([moving, canSweep(moving, 'chain')]).toEqual([moving, false]);
+    }
+  });
+});
+
+describe('exact time of impact per pair', () => {
+  /**
+   * Every case fires the moving shape from `x = 0` to `x = 100` at an obstacle
+   * whose facing surface sits at `x = 50`, so the expected impact fraction is
+   * `(50 − targetRadius − movingExtent) / 100` and the surface normal is `(−1, 0)`.
+   */
+  const expectImpactAt = (moving: Collider, target: Collider, t: number): void => {
+    expect(sweepProxies(moving, 100, 0, target, hit)).toBe(true);
+    expect(hit.t).toBeCloseTo(t, 6);
+    expect(hit.normalX).toBeCloseTo(-1, 6);
+    expect(hit.normalY).toBeCloseTo(0, 6);
+  };
+
+  it('circle against a segment', () => {
+    const world = new PhysicsWorld();
+
+    expectImpactAt(movingRightFrom(world, new CircleShape(5)), obstacleAt(world, new SegmentShape(0, -20, 0, 20)), 0.45);
+  });
+
+  it('circle against a capsule', () => {
+    const world = new PhysicsWorld();
+
+    expectImpactAt(movingRightFrom(world, new CircleShape(5)), obstacleAt(world, new CapsuleShape(0, -20, 0, 20, 3)), 0.42);
+  });
+
+  it('circle against a polygon', () => {
+    const world = new PhysicsWorld();
+
+    expectImpactAt(movingRightFrom(world, new CircleShape(5)), obstacleAt(world, new BoxShape(10, 40)), 0.4);
+  });
+
+  it('polygon against a segment', () => {
+    const world = new PhysicsWorld();
+
+    expectImpactAt(movingRightFrom(world, new BoxShape(10, 40)), obstacleAt(world, new SegmentShape(0, -20, 0, 20)), 0.45);
+  });
+
+  it('polygon against a capsule', () => {
+    const world = new PhysicsWorld();
+
+    expectImpactAt(movingRightFrom(world, new BoxShape(10, 40)), obstacleAt(world, new CapsuleShape(0, -20, 0, 20, 3)), 0.42);
+  });
+
+  it('capsule against a circle', () => {
+    const world = new PhysicsWorld();
+
+    expectImpactAt(movingRightFrom(world, new CapsuleShape(0, -10, 0, 10, 4)), obstacleAt(world, new CircleShape(6)), 0.4);
+  });
+
+  it('capsule against a polygon', () => {
+    const world = new PhysicsWorld();
+
+    expectImpactAt(movingRightFrom(world, new CapsuleShape(0, -10, 0, 10, 4)), obstacleAt(world, new BoxShape(10, 40)), 0.41);
+  });
+
+  it('capsule against a capsule', () => {
+    const world = new PhysicsWorld();
+
+    expectImpactAt(movingRightFrom(world, new CapsuleShape(0, -10, 0, 10, 4)), obstacleAt(world, new CapsuleShape(0, -20, 0, 20, 3)), 0.43);
+  });
+
+  it('capsule against a segment', () => {
+    const world = new PhysicsWorld();
+
+    expectImpactAt(movingRightFrom(world, new CapsuleShape(0, -10, 0, 10, 4)), obstacleAt(world, new SegmentShape(0, -20, 0, 20)), 0.46);
+  });
+
+  it('meets a boundary endpoint on the cap arc, not on a squared-off corner', () => {
+    // The capsule's spine ends at y = 10 and the boundary starts at (50, 13), so
+    // the first touch is cap arc against endpoint: |(50, 13) − (46, 10)| = 5 at
+    // t = 0.46. A radius-inflated SAT would square the cap off and stop the
+    // capsule a full radius short, at t = 0.45.
+    const world = new PhysicsWorld();
+    const moving = movingRightFrom(world, new CapsuleShape(0, -10, 0, 10, 5));
+    const target = colliderAt(world, new SegmentShape(0, 0, 50, 0), { x: 50, y: 13 });
+
+    expect(sweepProxies(moving, 100, 0, target, hit)).toBe(true);
+    expect(hit.t).toBeCloseTo(0.46, 6);
+    expect(hit.normalX).toBeCloseTo(-0.8, 6);
+    expect(hit.normalY).toBeCloseTo(-0.6, 6);
+  });
+});
+
+describe('sweep invariants across the matrix', () => {
+  it('reports no impact for a pair already overlapping at the start of the motion', () => {
+    const world = new PhysicsWorld();
+    // End pose x = 100, motion 20 - the cast starts at x = 80, deep inside the
+    // obstacle, which the discrete solver owns.
+    const moving = colliderAt(world, new CapsuleShape(0, -10, 0, 10, 4), { x: 100, y: 0 });
+    const target = colliderAt(world, new SegmentShape(0, -20, 0, 20), { x: 80, y: 0 });
+
+    expect(sweepProxies(moving, 20, 0, target, hit)).toBe(false);
+  });
+
+  it('reports no impact for a near miss past the end of a boundary', () => {
+    const world = new PhysicsWorld();
+    // The capsule's outermost point reaches y = 15; the boundary starts at y = 16.
+    const moving = movingRightFrom(world, new CapsuleShape(0, -10, 0, 10, 5));
+    const target = colliderAt(world, new SegmentShape(0, 0, 50, 0), { x: 50, y: 16 });
+
+    expect(sweepProxies(moving, 100, 0, target, hit)).toBe(false);
+  });
+
+  it('keeps the impact fraction in (0, 1] and stops short of a target beyond the motion', () => {
+    const world = new PhysicsWorld();
+    const moving = colliderAt(world, new CapsuleShape(0, -10, 0, 10, 4), { x: 40, y: 0 });
+
+    expect(sweepProxies(moving, 40, 0, obstacleAt(world, new SegmentShape(0, -20, 0, 20)), hit)).toBe(false);
+    expect(sweepProxies(colliderAt(world, new CapsuleShape(0, -10, 0, 10, 4), { x: 46, y: 0 }), 46, 0, obstacleAt(world, new SegmentShape(0, -20, 0, 20)), hit)).toBe(
+      true,
+    );
+    expect(hit.t).toBeGreaterThan(0);
+    expect(hit.t).toBeLessThanOrEqual(1);
+  });
+
+  it('gives the same impact for either operand order, with the normal from the target', () => {
+    const world = new PhysicsWorld();
+    const capsuleMoving = movingRightFrom(world, new CapsuleShape(0, -10, 0, 10, 4));
+    const boxTarget = obstacleAt(world, new BoxShape(10, 40));
+
+    expect(sweepProxies(capsuleMoving, 100, 0, boxTarget, hit)).toBe(true);
+
+    const forwardT = hit.t;
+
+    // The mirror image: a box swept left onto a static capsule.
+    const mirrored = new PhysicsWorld();
+    const boxMoving = colliderAt(mirrored, new BoxShape(10, 40), { x: -100, y: 0 });
+    const capsuleTarget = colliderAt(mirrored, new CapsuleShape(0, -10, 0, 10, 4), { x: -50, y: 0 });
+
+    expect(sweepProxies(boxMoving, -100, 0, capsuleTarget, hit)).toBe(true);
+    expect(hit.t).toBeCloseTo(forwardT, 6);
+    expect(hit.normalX).toBeCloseTo(1, 6);
+    expect(hit.normalY).toBeCloseTo(0, 6);
+  });
+
+  it('takes the earliest of several candidate impacts', () => {
+    const world = new PhysicsWorld();
+    const moving = movingRightFrom(world, new CircleShape(5));
+    const near = obstacleAt(world, new SegmentShape(0, -20, 0, 20));
+    const far = colliderAt(world, new SegmentShape(0, -20, 0, 20), { x: 70, y: 0 });
+
+    expect(sweepProxies(moving, 100, 0, far, hit)).toBe(true);
+    expect(hit.t).toBeCloseTo(0.65, 6);
+    expect(sweepProxies(moving, 100, 0, near, hit)).toBe(true);
+    expect(hit.t).toBeCloseTo(0.45, 6);
+  });
+});
+
+describe('sweeping a chain', () => {
+  /** A flat floor of three 100px edges from (-150, 0) to (150, 0); solid from above. */
+  const flatFloor = (): ChainShape => new ChainShape(points(-150, 0, -50, 0, 50, 0, 150, 0));
+
+  const chainEdges = (world: PhysicsWorld): readonly Collider[] => {
+    const chain = colliderAt(world, flatFloor(), { x: 0, y: 0 });
+
+    return chain.chainEdges!;
+  };
+
+  it('blocks a body arriving on the solid side', () => {
+    const world = new PhysicsWorld();
+    const edge = chainEdges(world)[1]!;
+    const moving = colliderAt(world, new CircleShape(5), { x: 0, y: 0 });
+
+    // Swept downward from y = -100 onto the floor at y = 0.
+    expect(sweepProxies(moving, 0, 100, edge, hit)).toBe(true);
+    expect(hit.t).toBeCloseTo(0.95, 6);
+    expect(hit.normalY).toBeCloseTo(-1, 6);
+  });
+
+  it('lets a body through from the hollow side, exactly as the discrete phase does', () => {
+    const world = new PhysicsWorld();
+    const edge = chainEdges(world)[1]!;
+    const moving = colliderAt(world, new CircleShape(5), { x: 0, y: 0 });
+
+    // Swept upward from y = 100 through the same edge.
+    expect(sweepProxies(moving, 0, -100, edge, hit)).toBe(false);
+  });
+
+  it('hands a shared vertex to exactly one edge', () => {
+    const world = new PhysicsWorld();
+    const edges = chainEdges(world);
+    // Straight down onto the vertex the first two edges share, at (-50, 0).
+    const moving = colliderAt(world, new CircleShape(5), { x: -50, y: 0 });
+    let blocking = 0;
+
+    for (const edge of edges) {
+      if (sweepProxies(moving, 0, 100, edge, hit)) {
+        blocking++;
+        expect(hit.t).toBeCloseTo(0.95, 6);
+      }
+    }
+
+    // A collinear seam is a tie both edges keep - what carries a body across a
+    // straight run - so the vertex is never a gap and never a double stop with
+    // conflicting normals.
+    expect(blocking).toBeGreaterThan(0);
+    expect(blocking).toBeLessThanOrEqual(2);
+  });
+
+  it('stops a fast bullet that would otherwise cross the chain within one step', () => {
+    const fire = (bullet: boolean): PhysicsBody => {
+      const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+
+      world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 100 }, colliders: [{ shape: flatFloor() }] }));
+
+      const ball = new PhysicsBody({ type: 'dynamic', position: { x: 0, y: -100 }, colliders: [{ shape: new CircleShape(5), density: 1 }] });
+      ball.isBullet = bullet;
+      world.add(ball);
+      ball.linearVelocityY = 9000; // 150px per fixed step: no step lands near the floor, and one step crosses it
+
+      for (let frame = 0; frame < 5; frame++) {
+        world.step(DT);
+      }
+
+      return ball;
+    };
+
+    expect(fire(false).y).toBeGreaterThan(150); // discrete detection misses it
+    expect(fire(true).y).toBeLessThan(100);
+  });
+
+  it('stops a fast bullet against a plain segment as well', () => {
+    const fire = (bullet: boolean): PhysicsBody => {
+      const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+
+      world.add(new PhysicsBody({ type: 'static', position: { x: 200, y: 0 }, colliders: [{ shape: new SegmentShape(0, -200, 0, 200) }] }));
+
+      const ball = new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: new CircleShape(6), density: 1 }] });
+      ball.isBullet = bullet;
+      world.add(ball);
+      ball.linearVelocityX = 9000; // 150px per fixed step: no step lands near the boundary, and one step crosses it
+
+      for (let frame = 0; frame < 5; frame++) {
+        world.step(DT);
+      }
+
+      return ball;
+    };
+
+    expect(fire(false).x).toBeGreaterThan(220);
+    expect(fire(true).x).toBeLessThan(200);
+  });
+
+  it('protects a fast capsule the same way it protects a circle', () => {
+    const fire = (bullet: boolean): PhysicsBody => {
+      const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+
+      world.add(new PhysicsBody({ type: 'static', position: { x: 200, y: 0 }, colliders: [{ shape: new SegmentShape(0, -200, 0, 200) }] }));
+
+      const body = new PhysicsBody({
+        type: 'dynamic',
+        position: { x: 0, y: 0 },
+        colliders: [{ shape: new CapsuleShape(-10, 0, 10, 0, 5), density: 1 }],
+      });
+      body.isBullet = bullet;
+      world.add(body);
+      body.linearVelocityX = 9000;
+
+      for (let frame = 0; frame < 5; frame++) {
+        world.step(DT);
+      }
+
+      return body;
+    };
+
+    expect(fire(false).x).toBeGreaterThan(220);
+    expect(fire(true).x).toBeLessThan(200);
+  });
+});
+
+describe('sweeping the new shapes costs no per-step allocation', () => {
+  /**
+   * A bullet ping-ponging between two walls sweeps on every single step, so the
+   * steady-state rate is the shape cast's own. The capsule/boundary pairs build
+   * a configuration-space ring per cast; growing that scratch once must not turn
+   * into an allocation per step.
+   */
+  const pingPong = (wall: () => AnyShape, bullet: () => AnyShape): PhysicsWorld => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+
+    for (const x of [-200, 200]) {
+      world.add(new PhysicsBody({ type: 'static', position: { x, y: 0 }, colliders: [{ shape: wall(), restitution: 1 }] }));
+    }
+
+    const body = new PhysicsBody({ type: 'dynamic', position: { x: 0, y: 0 }, colliders: [{ shape: bullet(), density: 1, restitution: 1 }] });
+    body.isBullet = true;
+    world.add(body);
+    body.linearVelocityX = 9000;
+
+    return world;
+  };
+
+  it('stays within the rate of the shapes that already shipped', async () => {
+    const boundary = pingPong(
+      () => new SegmentShape(0, -200, 0, 200),
+      () => new CapsuleShape(-10, 0, 10, 0, 5),
+    );
+    const solid = pingPong(
+      () => new BoxShape(10, 400),
+      () => new CircleShape(6),
+    );
+
+    for (let frame = 0; frame < 120; frame++) {
+      boundary.step(DT);
+      solid.step(DT);
+    }
+
+    if (boundary.step.toString().includes('cov_')) {
+      console.log('allocation comparison skipped under coverage (instrumentation inflates the measurement)');
+
+      return;
+    }
+
+    const boundaryRate = await measureAllocationRate(() => boundary.step(DT), { iterations: 200 });
+    const solidRate = await measureAllocationRate(() => solid.step(DT), { iterations: 200 });
+
+    console.log(
+      `${(boundaryRate.bytesPerIteration / 1024).toFixed(2)} KB/step capsule vs segment sweep, ` +
+        `${(solidRate.bytesPerIteration / 1024).toFixed(2)} KB/step circle vs box sweep`,
+    );
+
+    expect(boundaryRate.bytesPerIteration).toBeLessThan(solidRate.bytesPerIteration * 2 + 64 * 1024);
+  });
+});

--- a/packages/exojs-physics/test/chain-seam.test.ts
+++ b/packages/exojs-physics/test/chain-seam.test.ts
@@ -1,0 +1,164 @@
+import type { PointLike } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import { BoxShape, CapsuleShape, ChainShape, CircleShape, PhysicsBody, PhysicsWorld } from '../src/index';
+import type { AnyShape } from '../src/shapes/AnyShape';
+
+/**
+ * Seam behaviour where two chain edges meet. The adjacency filter keeps both
+ * contacts of a collinear join - a deliberate duplicate for one flat surface -
+ * so what matters is that the duplicate never reaches the body as an impulse:
+ * a body crossing a seam at constant velocity must not be kicked, slowed,
+ * spun or woken/put to sleep by the crossing.
+ *
+ * The traces below record the whole transient, not just the end pose: a seam
+ * defect is a single-step spike that a position check averages away.
+ */
+
+const DT = 1 / 60;
+const SPEED = 600;
+
+const points = (...coordinates: number[]): PointLike[] => {
+  const out: PointLike[] = [];
+
+  for (let i = 0; i < coordinates.length; i += 2) {
+    out.push({ x: coordinates[i]!, y: coordinates[i + 1]! });
+  }
+
+  return out;
+};
+
+/** Three collinear 100px edges from (-150, 0) to (150, 0), solid from above. */
+const flatFloor = (): ChainShape => new ChainShape(points(-150, 0, -50, 0, 50, 0, 150, 0));
+
+interface SlideTrace {
+  /** Largest upward speed seen during the slide (+Y is down, so this is `-vy`). */
+  maxUpward: number;
+  /** Largest angular speed seen during the slide. */
+  maxSpin: number;
+  /** Lowest forward speed seen during the slide - a friction spike shows up here. */
+  minForward: number;
+  /** Sleep state changes during the slide. */
+  sleepToggles: number;
+  x: number;
+  y: number;
+}
+
+/**
+ * Settle `shape` on `chain`, launch it at a constant speed and record the whole
+ * crossing. Friction is zero on both sides, so an ideal run keeps `SPEED`
+ * exactly and never leaves the surface.
+ */
+const slideAcross = (shape: AnyShape, chain: ChainShape, startX = -120, steps = 40): SlideTrace => {
+  const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+
+  world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 100 }, colliders: [{ shape: chain, friction: 0 }] }));
+
+  const body = world.add(
+    new PhysicsBody({ type: 'dynamic', position: { x: startX, y: 60 }, colliders: [{ shape, density: 1, friction: 0 }] }),
+  );
+
+  for (let i = 0; i < 90; i++) {
+    world.step(DT);
+  }
+
+  body.wake();
+  body.linearVelocityX = SPEED;
+
+  const trace: SlideTrace = { maxUpward: 0, maxSpin: 0, minForward: Infinity, sleepToggles: 0, x: body.x, y: body.y };
+  let sleeping = body.isSleeping;
+
+  for (let i = 0; i < steps; i++) {
+    world.step(DT);
+
+    trace.maxUpward = Math.max(trace.maxUpward, -body.linearVelocityY);
+    trace.maxSpin = Math.max(trace.maxSpin, Math.abs(body.angularVelocity));
+    trace.minForward = Math.min(trace.minForward, body.linearVelocityX);
+
+    if (body.isSleeping !== sleeping) {
+      sleeping = body.isSleeping;
+      trace.sleepToggles++;
+    }
+  }
+
+  trace.x = body.x;
+  trace.y = body.y;
+
+  return trace;
+};
+
+const shapes = [
+  { kind: 'box', shape: (): AnyShape => new BoxShape(20, 20) },
+  { kind: 'circle', shape: (): AnyShape => new CircleShape(10) },
+  { kind: 'capsule', shape: (): AnyShape => new CapsuleShape(-10, 0, 10, 0, 5) },
+];
+
+describe('a collinear chain seam', () => {
+  it.each(shapes)('carries a $kind across at constant velocity', ({ shape }) => {
+    const trace = slideAcross(shape(), flatFloor());
+
+    // Both interior vertices are crossed within these 40 steps.
+    expect(trace.x).toBeGreaterThan(50);
+    expect(trace.maxUpward).toBeLessThan(5);
+    expect(trace.maxSpin).toBeLessThan(0.5);
+    expect(trace.minForward).toBeGreaterThan(SPEED - 5);
+    expect(trace.sleepToggles).toBe(0);
+  });
+
+  it('is the same crossing whether the seam is there or not', () => {
+    const seamed = slideAcross(new BoxShape(20, 20), flatFloor());
+    const single = slideAcross(new BoxShape(20, 20), new ChainShape(points(-150, 0, 150, 0)));
+
+    expect(seamed.x).toBeCloseTo(single.x, 3);
+    expect(seamed.y).toBeCloseTo(single.y, 3);
+  });
+});
+
+describe('a chain joint that is not collinear', () => {
+  it('does not kick a body at a shallow convex joint', () => {
+    // Flat, then a gentle drop away: the surface falls out from under the body,
+    // which may leave it briefly airborne but must never push it up.
+    const trace = slideAcross(new BoxShape(20, 20), new ChainShape(points(-150, 0, 0, 0, 150, 20)));
+
+    expect(trace.x).toBeGreaterThan(50);
+    expect(trace.maxUpward).toBeLessThan(5);
+    expect(trace.minForward).toBeGreaterThan(SPEED - 20);
+    // No spin bound here: a box running over a ridge onto a downward slope tips
+    // forward, and that rotation is the surface, not a seam artefact.
+  });
+
+  it('does not kick or snag a body at a shallow concave joint', () => {
+    // A gentle ramp down into a flat run: the body lands on the flat part with
+    // the vertical speed the ramp gave it, and keeps going.
+    const trace = slideAcross(new BoxShape(20, 20), new ChainShape(points(-150, -20, 0, 0, 150, 0)), -120, 40);
+
+    expect(trace.x).toBeGreaterThan(50);
+    expect(trace.maxUpward).toBeLessThan(20);
+    expect(trace.minForward).toBeGreaterThan(SPEED - 40);
+  });
+
+  it('lets a body run off a free end instead of catching on it', () => {
+    // The chain stops at x = 0; past it the body is in free fall, not stopped.
+    const trace = slideAcross(new BoxShape(20, 20), new ChainShape(points(-150, 0, -50, 0, 0, 0)), -120, 40);
+
+    expect(trace.x).toBeGreaterThan(100);
+    expect(trace.y).toBeGreaterThan(120); // fell past the floor line
+    expect(trace.minForward).toBeGreaterThan(SPEED - 5);
+    expect(trace.maxUpward).toBeLessThan(5);
+  });
+});
+
+describe('a closed chain', () => {
+  it('carries a body across the closing seam like any other', () => {
+    // A closed room whose floor is split at x = 0 by the closing edge, so the
+    // seam under the sliding body is the wrap-around one.
+    const room = new ChainShape(points(0, 100, 150, 100, 150, -100, -150, -100, -150, 100), { closed: true });
+    // Stops short of the right-hand wall, so the trace is the seam crossing only.
+    const trace = slideAcross(new BoxShape(20, 20), room, -120, 20);
+
+    expect(trace.x).toBeGreaterThan(20);
+    expect(trace.maxUpward).toBeLessThan(5);
+    expect(trace.maxSpin).toBeLessThan(0.5);
+    expect(trace.minForward).toBeGreaterThan(SPEED - 5);
+  });
+});

--- a/packages/exojs-physics/test/debug.test.ts
+++ b/packages/exojs-physics/test/debug.test.ts
@@ -1,8 +1,9 @@
-import type { Application } from '@codexo/exojs';
-import { describe, expect, it, vi } from 'vitest';
+import type { Application, PointLike } from '@codexo/exojs';
+import { Graphics } from '@codexo/exojs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { PhysicsDebugDraw } from '../src/debug/PhysicsDebugDraw';
-import { BoxShape, CircleShape, DistanceJoint, PhysicsBody, PhysicsWorld } from '../src/index';
+import { BoxShape, CapsuleShape, ChainShape, CircleShape, DistanceJoint, PhysicsBody, PhysicsWorld, SegmentShape } from '../src/index';
 import { colliderAt } from './support';
 
 const fakeApp = {} as Application;
@@ -272,5 +273,121 @@ describe('PhysicsDebugDraw', () => {
       expect(() => debug.destroy()).not.toThrow();
       expect(() => debug.destroy()).not.toThrow();
     });
+  });
+});
+
+describe('PhysicsDebugDraw over the whole shape set', () => {
+  /**
+   * These count strokes rather than asserting the render did not throw: what a
+   * chain contributes to each overlay is the question, and every wrong answer
+   * (a union box, a missing contact) renders perfectly happily.
+   */
+  const strokes = () => vi.spyOn(Graphics.prototype, 'lineTo');
+
+  const points = (...coordinates: number[]): PointLike[] => {
+    const out: PointLike[] = [];
+
+    for (let i = 0; i < coordinates.length; i += 2) {
+      out.push({ x: coordinates[i]!, y: coordinates[i + 1]! });
+    }
+
+    return out;
+  };
+
+  /** Three 100px edges from (-150, 0) to (150, 0); solid from above. */
+  const flatFloor = (): ChainShape => new ChainShape(points(-150, 0, -50, 0, 50, 0, 150, 0));
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('outlines a segment as its two endpoints', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new SegmentShape(-10, 0, 10, 0), { x: 0, y: 0 });
+
+    const lines = strokes();
+
+    renderWith(new PhysicsDebugDraw(fakeApp, world));
+
+    expect(lines).toHaveBeenCalledTimes(1);
+  });
+
+  it('outlines a capsule as two sides and two arcs', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new CapsuleShape(-10, 0, 10, 0, 4), { x: 0, y: 0 });
+
+    const lines = strokes();
+
+    renderWith(new PhysicsDebugDraw(fakeApp, world));
+
+    // One side, one cap arc, the other side's return leg and the second arc.
+    expect(lines).toHaveBeenCalledTimes(25);
+  });
+
+  it('outlines a chain edge by edge', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, flatFloor(), { x: 0, y: 0 });
+
+    const lines = strokes();
+
+    renderWith(new PhysicsDebugDraw(fakeApp, world));
+
+    expect(lines).toHaveBeenCalledTimes(3);
+  });
+
+  it('draws the broad phase leaves a chain actually holds, not its union box', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, flatFloor(), { x: 0, y: 0 });
+
+    const lines = strokes();
+
+    renderWith(new PhysicsDebugDraw(fakeApp, world, { drawAabb: true, drawShapes: false }));
+
+    // Four lines per edge proxy; the authored collider's union box is not a leaf.
+    expect(lines).toHaveBeenCalledTimes(12);
+  });
+
+  it('links a chain per overlapping edge in the broad-phase overlay', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, flatFloor(), { x: 0, y: 0 });
+    // Spans x ∈ [-70, -30]: overlaps the first two edges, not the third.
+    colliderAt(world, new BoxShape(40, 20), { x: -50, y: 0 });
+
+    const lines = strokes();
+
+    renderWith(new PhysicsDebugDraw(fakeApp, world, { drawBroadphase: true, drawShapes: false }));
+
+    expect(lines).toHaveBeenCalledTimes(2);
+  });
+
+  it('draws the contacts a chain produces, one manifold per touched edge', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, flatFloor(), { x: 0, y: 0 });
+    // Overlaps the floor line by 1px across the seam at x = -50.
+    colliderAt(world, new BoxShape(40, 20), { x: -50, y: -9 });
+
+    const lines = strokes();
+
+    renderWith(new PhysicsDebugDraw(fakeApp, world, { drawShapes: false, drawNormals: true }));
+
+    expect(lines.mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it('never draws a contact between two colliders of the same body', () => {
+    const world = new PhysicsWorld();
+
+    world.add(
+      new PhysicsBody({
+        type: 'static',
+        position: { x: 0, y: 0 },
+        colliders: [{ shape: new BoxShape(20, 20) }, { shape: new BoxShape(20, 20), offset: { x: 5, y: 0 } }],
+      }),
+    );
+
+    const lines = strokes();
+
+    renderWith(new PhysicsDebugDraw(fakeApp, world, { drawShapes: false, drawContacts: true, drawNormals: true }));
+
+    expect(lines).not.toHaveBeenCalled();
   });
 });

--- a/packages/exojs-physics/test/queries-shapes.test.ts
+++ b/packages/exojs-physics/test/queries-shapes.test.ts
@@ -1,0 +1,196 @@
+import type { PointLike } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import { BoxShape, CapsuleShape, ChainShape, CircleShape, PhysicsWorld, SegmentShape } from '../src/index';
+import type { AnyShape } from '../src/shapes/AnyShape';
+import type { ShapeType } from '../src/shapes/Shape';
+import { colliderAt } from './support';
+
+/**
+ * Queries across the whole shape set: which shapes answer which question, and
+ * what a chain reports - always the authored collider, never an edge proxy.
+ */
+
+const kinds: readonly ShapeType[] = ['circle', 'polygon', 'capsule', 'segment', 'chain'];
+
+/** Half-height of each probe shape, so a pair can be placed at a known overlap. */
+const halfHeight: Readonly<Record<string, number>> = { circle: 10, polygon: 10, capsule: 5, segment: 0, chain: 0 };
+
+/** The shapes with an interior; the two boundary kinds answer no area question. */
+const solids: readonly ShapeType[] = ['circle', 'polygon', 'capsule'];
+const boundaries: readonly ShapeType[] = ['segment', 'chain'];
+
+const points = (...coordinates: number[]): PointLike[] => {
+  const out: PointLike[] = [];
+
+  for (let i = 0; i < coordinates.length; i += 2) {
+    out.push({ x: coordinates[i]!, y: coordinates[i + 1]! });
+  }
+
+  return out;
+};
+
+const probe = (kind: ShapeType): AnyShape => {
+  switch (kind) {
+    case 'circle':
+      return new CircleShape(10);
+    case 'polygon':
+      return new BoxShape(20, 20);
+    case 'capsule':
+      return new CapsuleShape(-5, 0, 5, 0, 5);
+    case 'segment':
+      return new SegmentShape(-5, 0, 5, 0);
+    case 'chain':
+      return new ChainShape(points(-5, 0, 5, 0));
+  }
+};
+
+describe('queryPoint across the shape set', () => {
+  it.each(solids)('reports %s for a point inside it', (kind) => {
+    const world = new PhysicsWorld();
+    const collider = colliderAt(world, probe(kind), { x: 0, y: 0 });
+
+    expect(world.queryPoint({ x: 0, y: 0 })).toEqual([collider]);
+    expect(world.queryPoint({ x: 0, y: halfHeight[kind]! + 1 })).toEqual([]);
+  });
+
+  it.each(boundaries)('never reports %s, however close the point is', (kind) => {
+    const world = new PhysicsWorld();
+    colliderAt(world, probe(kind), { x: 0, y: 0 });
+
+    for (const point of [{ x: 0, y: 0 }, { x: 0, y: 1e-9 }, { x: -5, y: 0 }]) {
+      expect(world.queryPoint(point)).toEqual([]);
+    }
+  });
+
+  it('tests a capsule against its spine, not its bounding box', () => {
+    const world = new PhysicsWorld();
+    const collider = colliderAt(world, new CapsuleShape(-20, 0, 20, 0, 5), { x: 0, y: 0 });
+
+    expect(world.queryPoint({ x: 24, y: 0 })).toEqual([collider]); // inside the end cap
+    expect(world.queryPoint({ x: 24, y: 4 })).toEqual([]); // inside the AABB corner, outside the cap
+  });
+});
+
+describe('queryAabb and forEachAabbHit across the shape set', () => {
+  it.each(kinds)('finds %s exactly once', (kind) => {
+    const world = new PhysicsWorld();
+    const collider = colliderAt(world, probe(kind), { x: 0, y: 0 });
+    const bounds = { minX: -50, minY: -50, maxX: 50, maxY: 50 };
+    const visited: unknown[] = [];
+
+    expect(world.queryAabb(bounds)).toEqual([collider]);
+
+    world.forEachAabbHit(bounds, undefined, (hit) => visited.push(hit));
+
+    expect(visited).toEqual([collider]);
+  });
+
+  it('reports a multi-edge chain once, not once per edge', () => {
+    const world = new PhysicsWorld();
+    const chain = colliderAt(world, new ChainShape(points(-150, 0, -50, 0, 50, 0, 150, 0)), { x: 0, y: 0 });
+    const bounds = { minX: -200, minY: -50, maxX: 200, maxY: 50 };
+    const visited: unknown[] = [];
+
+    expect(world.queryAabb(bounds)).toEqual([chain]);
+
+    world.forEachAabbHit(bounds, undefined, (hit) => visited.push(hit));
+
+    expect(visited).toEqual([chain]);
+  });
+});
+
+describe('rayCast across the shape set', () => {
+  it.each(kinds)('hits %s and reports a normal facing the ray', (kind) => {
+    const world = new PhysicsWorld();
+    const collider = colliderAt(world, probe(kind), { x: 0, y: 0 });
+    const hit = world.rayCast({ x: 0, y: -50 }, { x: 0, y: 1 });
+
+    expect(hit?.collider).toBe(collider);
+    expect(hit!.normal.y).toBeCloseTo(-1, 6);
+    expect(hit!.distance).toBeCloseTo(50 - halfHeight[kind]!, 6);
+  });
+
+  it('hits a capsule on the cap as well as on the side', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new CapsuleShape(-20, 0, 20, 0, 5), { x: 0, y: 0 });
+
+    const side = world.rayCast({ x: 0, y: -50 }, { x: 0, y: 1 });
+    const cap = world.rayCast({ x: -50, y: 0 }, { x: 1, y: 0 });
+
+    expect(side!.distance).toBeCloseTo(45, 6);
+    expect(side!.normal.y).toBeCloseTo(-1, 4);
+    expect(cap!.distance).toBeCloseTo(25, 4); // spine end at −20, plus the radius
+    expect(cap!.normal.x).toBeCloseTo(-1, 4);
+  });
+
+  it('hits a segment from either side and misses one it runs parallel to', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, new SegmentShape(-20, 0, 20, 0), { x: 0, y: 0 });
+
+    expect(world.rayCast({ x: 0, y: -50 }, { x: 0, y: 1 })!.normal.y).toBeCloseTo(-1, 6);
+    expect(world.rayCast({ x: 0, y: 50 }, { x: 0, y: -1 })!.normal.y).toBeCloseTo(1, 6);
+    expect(world.rayCast({ x: -50, y: 0 }, { x: 1, y: 0 })).toBeNull();
+    // Past the endpoint: the boundary is finite.
+    expect(world.rayCast({ x: 21, y: -50 }, { x: 0, y: 1 })).toBeNull();
+  });
+
+  it('reports the authored chain for every edge a ray crosses', () => {
+    const world = new PhysicsWorld();
+    // An inverted V: a horizontal ray at y = −25 crosses both edges.
+    const chain = colliderAt(world, new ChainShape(points(0, 0, 50, -50, 100, 0)), { x: 0, y: 0 });
+    const hits = world.rayCastAll({ x: -10, y: -25 }, { x: 1, y: 0 });
+
+    expect(hits).toHaveLength(2);
+    expect(hits.map((hit) => hit.collider)).toEqual([chain, chain]);
+    expect(hits[0]!.distance).toBeCloseTo(35, 6);
+    expect(hits[1]!.distance).toBeCloseTo(85, 6);
+    expect(world.rayCast({ x: -10, y: -25 }, { x: 1, y: 0 })!.distance).toBeCloseTo(35, 6);
+  });
+
+  it('reports a chain from either side: solidity is a contact rule, not a visibility rule', () => {
+    const world = new PhysicsWorld();
+    const chain = colliderAt(world, new ChainShape(points(-50, 0, 50, 0)), { x: 0, y: 0 });
+
+    expect(world.rayCast({ x: 0, y: 50 }, { x: 0, y: -1 })?.collider).toBe(chain);
+    expect(world.rayCast({ x: 0, y: -50 }, { x: 0, y: 1 })?.collider).toBe(chain);
+  });
+
+  it('reports no entry hit from inside a solid, whatever its kind', () => {
+    const world = new PhysicsWorld();
+    colliderAt(world, probe('capsule'), { x: 0, y: 0 });
+
+    expect(world.rayCast({ x: 0, y: 0 }, { x: 1, y: 0 })).toBeNull();
+  });
+});
+
+describe('overlapShape across the shape set', () => {
+  const cases = kinds.flatMap((collider) => kinds.map((query) => ({ collider, query })));
+
+  it.each(cases)('tests a $query probe against a $collider collider', ({ collider: colliderKind, query: queryKind }) => {
+    const world = new PhysicsWorld();
+    const collider = colliderAt(world, probe(colliderKind), { x: 0, y: 0 });
+    // 1px of overlap along y, and 1px of clearance in the second call.
+    const overlapping = halfHeight[colliderKind]! + halfHeight[queryKind]! - 1;
+    const bothBoundaries = boundaries.includes(colliderKind) && boundaries.includes(queryKind);
+
+    expect(world.overlapShape(probe(queryKind), { x: 0, y: overlapping })).toEqual(bothBoundaries ? [] : [collider]);
+    expect(world.overlapShape(probe(queryKind), { x: 0, y: overlapping + 2 })).toEqual([]);
+  });
+
+  it('reports a chain once for a probe covering several of its edges', () => {
+    const world = new PhysicsWorld();
+    const chain = colliderAt(world, new ChainShape(points(-150, 0, -50, 0, 50, 0, 150, 0)), { x: 0, y: 0 });
+
+    expect(world.overlapShape(new BoxShape(300, 20), { x: 0, y: 0 })).toEqual([chain]);
+  });
+
+  it('takes a rotated probe shape in its own frame', () => {
+    const world = new PhysicsWorld();
+    const collider = colliderAt(world, new BoxShape(20, 20), { x: 0, y: 0 });
+
+    // A 40px segment on the x axis, rotated upright: it reaches the box from 19px away.
+    expect(world.overlapShape(new SegmentShape(-20, 0, 20, 0), { x: 0, y: 29 }, undefined, Math.PI / 2)).toEqual([collider]);
+    expect(world.overlapShape(new SegmentShape(-20, 0, 20, 0), { x: 0, y: 31 }, undefined, Math.PI / 2)).toEqual([]);
+  });
+});

--- a/packages/exojs-physics/test/shape-matrix.test.ts
+++ b/packages/exojs-physics/test/shape-matrix.test.ts
@@ -1,0 +1,205 @@
+import type { PointLike } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import type { Collider } from '../src/Collider';
+import { Manifold } from '../src/collision/Manifold';
+import { collide, testOverlap } from '../src/collision/narrowphase';
+import { BoxShape, CapsuleShape, ChainShape, CircleShape, PhysicsWorld, PolygonShape, SegmentShape } from '../src/index';
+import type { AnyShape } from '../src/shapes/AnyShape';
+import type { ShapeType } from '../src/shapes/Shape';
+import { colliderAt } from './support';
+
+/**
+ * The narrow phase across every shape combination, in both operand orders.
+ *
+ * Per-shape suites cover the geometry; this one covers the dispatch: which pairs
+ * are solved at all, and whether swapping the operands only reverses the normal
+ * instead of changing the answer.
+ */
+
+const solverKinds: readonly ShapeType[] = ['circle', 'polygon', 'capsule', 'segment'];
+
+/** Half-height of each probe shape, so a pair can be placed at a known penetration. */
+const halfHeight: Readonly<Record<string, number>> = { circle: 10, polygon: 10, capsule: 5, segment: 0 };
+
+const probe = (kind: ShapeType): AnyShape => {
+  switch (kind) {
+    case 'circle':
+      return new CircleShape(10);
+    case 'polygon':
+      return new BoxShape(20, 20);
+    case 'capsule':
+      return new CapsuleShape(-5, 0, 5, 0, 5);
+    case 'segment':
+      return new SegmentShape(-5, 0, 5, 0);
+    case 'chain':
+      return new ChainShape([
+        { x: -5, y: 0 },
+        { x: 5, y: 0 },
+      ]);
+  }
+};
+
+const points = (...coordinates: number[]): PointLike[] => {
+  const out: PointLike[] = [];
+
+  for (let i = 0; i < coordinates.length; i += 2) {
+    out.push({ x: coordinates[i]!, y: coordinates[i + 1]! });
+  }
+
+  return out;
+};
+
+const manifoldA = new Manifold();
+const manifoldB = new Manifold();
+
+/** Deepest point of a manifold, which is the penetration the pair was built for. */
+const deepest = (manifold: Manifold): number => {
+  let deepestPoint = 0;
+
+  for (let i = 0; i < manifold.pointCount; i++) {
+    const point = i === 0 ? manifold.points[0] : manifold.points[1];
+
+    deepestPoint = Math.max(deepestPoint, point.penetration);
+  }
+
+  return deepestPoint;
+};
+
+/**
+ * Two colliders of the given kinds, stacked on the y axis with exactly 1px of
+ * overlap and aligned in x, so the shallowest axis - and therefore the contact
+ * normal - is `(0, ±1)` for every pair in the matrix.
+ */
+const overlappingPair = (first: ShapeType, second: ShapeType): { a: Collider; b: Collider } => {
+  const world = new PhysicsWorld();
+  const separation = halfHeight[first]! + halfHeight[second]! - 1;
+
+  return {
+    a: colliderAt(world, probe(first), { x: 0, y: 0 }),
+    b: colliderAt(world, probe(second), { x: 0, y: separation }),
+  };
+};
+
+const orderedPairs = solverKinds.flatMap((first) => solverKinds.map((second) => ({ first, second })));
+
+describe('cross-shape collision matrix', () => {
+  it.each(orderedPairs.filter(({ first, second }) => !(first === 'segment' && second === 'segment')))(
+    'solves $first against $second in both operand orders',
+    ({ first, second }) => {
+      const { a, b } = overlappingPair(first, second);
+
+      expect(collide(a, b, manifoldA)).toBe(true);
+      expect(collide(b, a, manifoldB)).toBe(true);
+
+      // The normal always points from the first operand toward the second, so
+      // swapping the operands must reverse it and change nothing else.
+      expect(manifoldA.normalY).toBeCloseTo(1, 6);
+      expect(manifoldA.normalX).toBeCloseTo(0, 6);
+      expect(manifoldB.normalY).toBeCloseTo(-1, 6);
+      expect(manifoldB.normalX).toBeCloseTo(0, 6);
+      expect(manifoldB.pointCount).toBe(manifoldA.pointCount);
+      expect(deepest(manifoldB)).toBeCloseTo(deepest(manifoldA), 6);
+      expect(deepest(manifoldA)).toBeCloseTo(1, 6);
+
+      expect(testOverlap(a, b)).toBe(true);
+      expect(testOverlap(b, a)).toBe(true);
+    },
+  );
+
+  it('leaves two boundaries unsolved: no overlap volume, no stable manifold', () => {
+    const { a, b } = overlappingPair('segment', 'segment');
+
+    expect(collide(a, b, manifoldA)).toBe(false);
+    expect(collide(b, a, manifoldB)).toBe(false);
+    expect(testOverlap(a, b)).toBe(false);
+    expect(testOverlap(b, a)).toBe(false);
+  });
+
+  it.each(solverKinds)('separates %s from a partner just out of reach', (kind) => {
+    const world = new PhysicsWorld();
+    const a = colliderAt(world, probe(kind), { x: 0, y: 0 });
+    // 1px of clearance instead of 1px of overlap.
+    const b = colliderAt(world, probe('circle'), { x: 0, y: halfHeight[kind]! + 11 });
+
+    expect(collide(a, b, manifoldA)).toBe(false);
+    expect(collide(b, a, manifoldB)).toBe(false);
+    expect(testOverlap(a, b)).toBe(false);
+  });
+
+  it('treats a box as the polygon it is, and a rotated one no differently', () => {
+    const world = new PhysicsWorld();
+    // A 90° rotated 40×20 box has the same 20px half-height as the probe box.
+    const rotated = colliderAt(world, new BoxShape(20, 40), { x: 0, y: 0 }, Math.PI / 2);
+    const capsule = colliderAt(world, probe('capsule'), { x: 0, y: 14 });
+
+    expect(collide(rotated, capsule, manifoldA)).toBe(true);
+    expect(manifoldA.normalY).toBeCloseTo(1, 6);
+    expect(deepest(manifoldA)).toBeCloseTo(1, 6);
+  });
+
+  it('solves a non-rectangular polygon against a rounded shape', () => {
+    const world = new PhysicsWorld();
+    const triangle = colliderAt(world, new PolygonShape(points(-10, -10, 10, -10, 0, 10)), { x: 0, y: 0 });
+    const capsule = colliderAt(world, probe('capsule'), { x: 0, y: 14 });
+
+    expect(collide(triangle, capsule, manifoldA)).toBe(true);
+    expect(collide(capsule, triangle, manifoldB)).toBe(true);
+    expect(manifoldB.normalX).toBeCloseTo(-manifoldA.normalX, 6);
+    expect(manifoldB.normalY).toBeCloseTo(-manifoldA.normalY, 6);
+  });
+});
+
+describe('a chain in the matrix', () => {
+  /** The engine-owned edge proxies of a one-edge chain placed at `y`. */
+  const chainEdgeAt = (world: PhysicsWorld, y: number): { chain: Collider; edge: Collider } => {
+    const chain = colliderAt(world, probe('chain'), { x: 0, y });
+
+    return { chain, edge: chain.chainEdges![0]! };
+  };
+
+  it.each(['circle', 'polygon', 'capsule'] as const)('solves a chain edge against %s', (kind) => {
+    const world = new PhysicsWorld();
+    const solid = colliderAt(world, probe(kind), { x: 0, y: 0 });
+    // Below the solid, so the chain's outward normal (up, for a left-to-right
+    // chain) faces it and the adjacency filter admits the contact.
+    const { edge } = chainEdgeAt(world, halfHeight[kind]! - 1);
+
+    expect(collide(solid, edge, manifoldA)).toBe(true);
+    expect(collide(edge, solid, manifoldB)).toBe(true);
+    expect(manifoldB.normalX).toBeCloseTo(-manifoldA.normalX, 6);
+    expect(manifoldB.normalY).toBeCloseTo(-manifoldA.normalY, 6);
+    expect(deepest(manifoldA)).toBeCloseTo(1, 6);
+  });
+
+  it('is never an operand itself - the authored collider carries no world geometry', () => {
+    const world = new PhysicsWorld();
+    const box = colliderAt(world, probe('polygon'), { x: 0, y: 0 });
+    const { chain } = chainEdgeAt(world, 9);
+
+    expect(collide(chain, box, manifoldA)).toBe(false);
+    expect(testOverlap(chain, box)).toBe(false);
+  });
+
+  it('never reports a contact against another boundary', () => {
+    const world = new PhysicsWorld();
+    const { edge } = chainEdgeAt(world, 0);
+    const other = chainEdgeAt(world, 0.5);
+    const segment = colliderAt(world, probe('segment'), { x: 0, y: 0.5 });
+
+    expect(collide(edge, other.edge, manifoldA)).toBe(false);
+    expect(collide(edge, segment, manifoldA)).toBe(false);
+    expect(collide(segment, edge, manifoldA)).toBe(false);
+    expect(testOverlap(edge, segment)).toBe(false);
+  });
+
+  it('admits a contact only from its solid side', () => {
+    const world = new PhysicsWorld();
+    const above = colliderAt(world, new CircleShape(10), { x: 0, y: -9 });
+    const below = colliderAt(world, new CircleShape(10), { x: 0, y: 9 });
+    const { edge } = chainEdgeAt(world, 0);
+
+    expect(collide(above, edge, manifoldA)).toBe(true);
+    expect(collide(below, edge, manifoldB)).toBe(false);
+  });
+});

--- a/site/src/content/guide/physics/joints-and-dynamics.mdx
+++ b/site/src/content/guide/physics/joints-and-dynamics.mdx
@@ -252,8 +252,17 @@ along the surface (keeping its tangential velocity), while a bouncy one (`restit
 `1`) rebounds elastically. The swept test runs against static, kinematic **and** dynamic
 bodies; sensors never block.
 
-<Callout type="warning" title="CCD sweeps only the body's centre point">
-This is ideal for small, point-like projectiles (bullets, pellets), but a **large** fast body can still clip a corner because only its centre is swept. For those, raise [`subStepCount`](/ExoJS/en/api/physics-world/) (or the step rate) so each step covers less distance, or thicken the geometry it must not pass. A full swept-shape time-of-impact for large bodies is a future enhancement.
+The whole shape is swept, not just its centre, so a large body cannot clip a corner its
+centre line happened to miss. The cast is exact for a translation and covers every solid
+shape against every shape kind:
+
+| Moving shape | Swept against |
+|---|---|
+| `CircleShape`, `CapsuleShape`, `PolygonShape`/`BoxShape` | circle, capsule, polygon/box, segment, chain |
+| `SegmentShape`, `ChainShape` | not swept as the moving shape |
+
+<Callout type="warning" title="Boundary geometry is a target, never a bullet">
+A segment or a chain is level structure: it is what a bullet is swept *against*, and it is never swept itself. A fast **kinematic** boundary can still cross a body within one step — give anything that moves that fast a solid collider instead. The rotation of a bullet is applied before the cast, not swept through it, so a fast *spin* is still resolved by the discrete solver.
 </Callout>
 
 ## Contact modifier

--- a/site/src/content/guide/physics/physics-basics.mdx
+++ b/site/src/content/guide/physics/physics-basics.mdx
@@ -87,9 +87,12 @@ its position or drive it later. Collider material is set per collider:
 - `friction` (default `0.2`) — Coulomb friction coefficient.
 - `restitution` (default `0`) — bounciness in `[0, 1]`.
 
-The two built-in shapes are [`BoxShape(width, height)`](/ExoJS/en/api/box-shape/) and
-[`CircleShape(radius)`](/ExoJS/en/api/circle-shape/) (there is also a general
-`PolygonShape` for convex outlines):
+Four shapes enclose an area and therefore carry mass:
+[`BoxShape(width, height)`](/ExoJS/en/api/box-shape/),
+[`CircleShape(radius)`](/ExoJS/en/api/circle-shape/),
+[`CapsuleShape(x0, y0, x1, y1, radius)`](/ExoJS/en/api/capsule-shape/) — the exact
+geometry, never a polygon approximation — and
+[`PolygonShape(points)`](/ExoJS/en/api/polygon-shape/) for a convex outline:
 
 ```ts
 import { CircleShape, PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
@@ -104,6 +107,49 @@ const ball = world.add(
   }),
 );
 ```
+
+### Boundary shapes for level geometry
+
+[`SegmentShape(x0, y0, x1, y1)`](/ExoJS/en/api/segment-shape/) is a single edge and
+[`ChainShape(points)`](/ExoJS/en/api/chain-shape/) a connected run of them. Both are
+**boundaries**: they have no interior, so they contribute collision only, and a
+`dynamic` body carrying nothing but boundary geometry is rejected — give it a solid
+collider too.
+
+Reach for a chain rather than a list of segments whenever the geometry is one
+connected surface. The engine owns the shared vertices, so a body sliding along it
+never snags on a seam, and the whole chain stays **one** collider: one entry in
+`world.colliders`, one `collisionStart`, one query result, however many of its edges
+are touched.
+
+```ts
+import { CapsuleShape, ChainShape, PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
+
+const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+
+// A hillside. Drawn left to right, so it is solid from above.
+world.add(
+  new PhysicsBody({
+    type: 'static',
+    position: { x: 0, y: 0 },
+    colliders: [{ shape: new ChainShape([{ x: -400, y: 0 }, { x: 0, y: 40 }, { x: 400, y: 0 }]) }],
+  }),
+);
+
+world.add(
+  new PhysicsBody({
+    type: 'dynamic',
+    position: { x: -200, y: -100 },
+    colliders: [{ shape: new CapsuleShape(0, -12, 0, 12, 8), density: 1 }],
+  }),
+);
+```
+
+A chain is **one-sided**: the vertex order decides which side is solid, and a body
+may pass through it from behind — which is what makes it the right shape for ground
+you only ever land on. A single `SegmentShape` has no such order and blocks from both
+sides; one-way behaviour there is a contact rule, not geometry, and belongs in the
+[contact modifier](/ExoJS/en/guide/physics/joints-and-dynamics/).
 
 ## Stepping the world
 
@@ -362,7 +408,8 @@ dense clusters that would degrade a sort-and-sweep broad phase.
   and shows how to stop fast projectiles from tunnelling.
 - **API reference:** [`PhysicsWorld`](/ExoJS/en/api/physics-world/),
   [`PhysicsBody`](/ExoJS/en/api/physics-body/), [`Collider`](/ExoJS/en/api/collider/),
-  [`BoxShape`](/ExoJS/en/api/box-shape/), [`CircleShape`](/ExoJS/en/api/circle-shape/) and
-  [`PhysicsBinding`](/ExoJS/en/api/physics-binding/).
+  [`BoxShape`](/ExoJS/en/api/box-shape/), [`CircleShape`](/ExoJS/en/api/circle-shape/),
+  [`CapsuleShape`](/ExoJS/en/api/capsule-shape/), [`SegmentShape`](/ExoJS/en/api/segment-shape/),
+  [`ChainShape`](/ExoJS/en/api/chain-shape/) and [`PhysicsBinding`](/ExoJS/en/api/physics-binding/).
 - **The frame loop:** [Scenes & lifecycle](/ExoJS/en/guide/runtime/scenes-and-lifecycle/)
   covers `fixedUpdate`, `update` and `draw` and the order they run in.


### PR DESCRIPTION
Closes the HI-19 shape completion: continuous collision, the debug overlay and a
cross-shape regression pass over the capsule/segment/chain work from #587, #588
and #589.

## Continuous collision

The sweep only covered circle and polygon, so a bullet crossed a capsule, a
segment or a chain within one step exactly as if `isBullet` had never been set -
the shapes most likely to be the thin wall a projectile must not pass. All
twelve ordered pairs are filled now:

| Moving shape | Swept against |
|---|---|
| `CircleShape`, `CapsuleShape`, `PolygonShape`/`BoxShape` | circle, capsule, polygon/box, segment, chain |
| `SegmentShape`, `ChainShape` | not swept as the moving operand |

A pair carrying a radius builds one configuration-space ring - the Minkowski sum
of the target's core and the negated start-pose core of the mover - and casts
the origin against it inflated by both radii. That is exact where a
radius-inflated SAT squares off the rounded corner: a capsule meets a boundary
endpoint on its cap arc at `t = 0.46`, not a full radius short at `t = 0.45`.
Radius-free pairs keep the existing swept SAT.

A chain is swept through its edge proxies and blocks under the same one-sided
adjacency rule the discrete narrow phase applies (moved to
`collision/chainAdjacency.ts`, now shared by both), so a bullet arriving from the
hollow side passes through exactly as a slow body does, and the blocking collider
handed back is always the authored chain. Boundary geometry as the *moving*
operand stays deliberately unswept, with a development warning per shape kind.

## Debug overlay

Its AABB, broad-phase and contact passes all scanned `world.colliders`, which is
the authored set: a chain contributed one union box that no phase ever tests, and
its contacts could not be drawn at all, because an authored chain collider is not
a narrow-phase operand. All three now read the solver-side geometry
(`PhysicsWorld.detectionGeometry`, `@internal`), so the boxes are the real leaves,
a chain links per overlapping edge, and contacts against a chain appear.
`world.colliders`, `body.colliders` and every query result are unchanged. The same
pass stops drawing contacts between two colliders of one body.

## What is pinned

- `shape-matrix.test.ts` - narrow phase and overlap for every pair in **both**
  operand orders, at a known 1px penetration, plus the deliberately unsupported
  boundary/boundary pairs.
- `ccd-shapes.test.ts` - the sweep matrix, an exact time of impact per pair, the
  cap-arc case, start-overlap/near-miss/earliest-hit invariants, chain
  one-sidedness, and a steady-state allocation check (7.6 KB/step capsule vs
  segment against 7.1 KB/step circle vs box).
- `queries-shapes.test.ts` - the 5x5 query matrix: `queryPoint` never hits a
  boundary, `rayCastAll` returns one hit per crossed chain edge and always the
  authored collider, `overlapShape` covers every probe/collider combination.
- `chain-seam.test.ts` - seam stability as a full transient trace (no vertical
  spike, no friction spike, no angular kick, no sleep chatter) for box, circle and
  capsule, plus convex/concave joints, a free end and a closed chain's wrap-around
  seam.

Physics suite 508 tests, `pnpm test` 10 804, `verify:quick` 16/16. API docs
regenerate unchanged. README and the physics guide claimed "no dynamics solver"
and "CCD sweeps only the body's centre point" respectively; both are corrected.

`NEU-W1` (sleeping with unresolved penetration) is untouched and stays its own
slice.

https://claude.ai/code/session_01R4RHfm7nhMPXAuxFrpgrqj