### PR TITLE
fix(physics): keep a body awake while its contact is still penetrating

### DIFF
--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -7,6 +7,7 @@ import type { PhysicsBackend } from './backend/PhysicsBackend';
 import { BindingRegistry } from './binding/BindingRegistry';
 import type { PhysicsBinding } from './binding/PhysicsBinding';
 import { authoredCollider, Collider } from './Collider';
+import type { Manifold } from './collision/Manifold';
 import type { SweepHit } from './collision/sweep';
 import { canSweep, sweepProxies } from './collision/sweep';
 import type { ContactModifier } from './ContactModifier';
@@ -17,6 +18,7 @@ import { PhysicsBody } from './PhysicsBody';
 import type { QueryFilter, RayHit } from './query/QueryEngine';
 import { QueryEngine } from './query/QueryEngine';
 import type { AnyShape } from './shapes/AnyShape';
+import { maxRestingPenetration } from './solver/tolerances';
 import { TimeStepper } from './TimeStepper';
 import type { BodyType, CollisionFilter } from './types';
 import { shouldCollide } from './types';
@@ -120,6 +122,23 @@ const warnUnsweptBulletShape = (collider: Collider): void => {
  */
 const isMovingBoundary = (body: PhysicsBody): boolean =>
   body._teleported || body.linearVelocityX !== 0 || body.linearVelocityY !== 0 || body.angularVelocity !== 0;
+
+/**
+ * `true` while a contact still carries more overlap than the solver leaves
+ * behind at rest. Read from the manifold detection just produced, which is the
+ * same separation the solver's push-out bias is about to act on - the sleep gate
+ * and the constraint it gates therefore agree by construction.
+ */
+const isUnresolved = (manifold: Manifold): boolean => {
+  for (let i = 0; i < manifold.pointCount; i++) {
+    // i in 0..pointCount-1 and pointCount ≤ 2, so the manifold point exists.
+    if ((i === 0 ? manifold.points[0] : manifold.points[1]).penetration > maxRestingPenetration) {
+      return true;
+    }
+  }
+
+  return false;
+};
 
 /**
  * {@link PhysicsWorld.attach}'s default `position`: `node`'s current WORLD
@@ -937,8 +956,11 @@ export class PhysicsWorld implements BodyOwner {
    * any member does (e.g. an awake body merges into it via a new contact).
    * A boundary that is itself moving resets the sleep timer of every dynamic
    * body it touches, so a platform keeps its passengers awake however slowly it
-   * travels. Deterministic: union-find roots break ties by lower index and the
-   * contact set is id-sorted.
+   * travels; so does a contact still carrying more penetration than the solver
+   * leaves at rest, because the push-out that resolves it is slower than the
+   * sleep velocity threshold and a body would otherwise be frozen embedded.
+   * Deterministic: union-find roots break ties by lower index and the contact
+   * set is id-sorted.
    */
   private _updateSleeping(dt: number): void {
     const bodies = this._bodies;
@@ -1007,11 +1029,17 @@ export class PhysicsWorld implements BodyOwner {
    * are island boundaries, not members, so nothing else would keep the passenger
    * of a slow-moving platform awake - and the solver skips a contact whose
    * dynamic side is asleep, letting the platform drive straight through it.
+   *
+   * The same traversal resets the sleep timer of both sides of a contact whose
+   * penetration the solver has not worked off yet, so the island it belongs to
+   * stays awake until the overlap is within the tolerance the solver itself
+   * converges to.
    */
   private _unionContactIslands(): void {
     for (const contact of this._backend.contactGraph.solidContacts) {
       // A contact the modifier disabled carries no load this step, so it neither
-      // forms an island nor keeps a passenger of a moving platform awake.
+      // forms an island, nor keeps a passenger of a moving platform awake, nor
+      // has an overlap anything is going to resolve.
       if (!contact.enabled) {
         continue;
       }
@@ -1027,6 +1055,16 @@ export class PhysicsWorld implements BodyOwner {
         bodyA._sleepTime = 0;
       } else if (dynamicB && isMovingBoundary(bodyA)) {
         bodyB._sleepTime = 0;
+      }
+
+      if (isUnresolved(contact.manifold)) {
+        if (dynamicA) {
+          bodyA._sleepTime = 0;
+        }
+
+        if (dynamicB) {
+          bodyB._sleepTime = 0;
+        }
       }
     }
   }

--- a/packages/exojs-physics/src/PhysicsWorld.ts
+++ b/packages/exojs-physics/src/PhysicsWorld.ts
@@ -18,7 +18,7 @@ import { PhysicsBody } from './PhysicsBody';
 import type { QueryFilter, RayHit } from './query/QueryEngine';
 import { QueryEngine } from './query/QueryEngine';
 import type { AnyShape } from './shapes/AnyShape';
-import { maxRestingPenetration } from './solver/tolerances';
+import { sleepPenetrationTolerance } from './solver/tolerances';
 import { TimeStepper } from './TimeStepper';
 import type { BodyType, CollisionFilter } from './types';
 import { shouldCollide } from './types';
@@ -132,7 +132,7 @@ const isMovingBoundary = (body: PhysicsBody): boolean =>
 const isUnresolved = (manifold: Manifold): boolean => {
   for (let i = 0; i < manifold.pointCount; i++) {
     // i in 0..pointCount-1 and pointCount ≤ 2, so the manifold point exists.
-    if ((i === 0 ? manifold.points[0] : manifold.points[1]).penetration > maxRestingPenetration) {
+    if ((i === 0 ? manifold.points[0] : manifold.points[1]).penetration > sleepPenetrationTolerance) {
       return true;
     }
   }
@@ -1057,7 +1057,10 @@ export class PhysicsWorld implements BodyOwner {
         bodyB._sleepTime = 0;
       }
 
-      if (isUnresolved(contact.manifold)) {
+      // Unresolved overlap only matters where there is a dynamic body to hold
+      // awake; a static↔static pair reaches the contact set but has no sleep
+      // decision to gate.
+      if ((dynamicA || dynamicB) && isUnresolved(contact.manifold)) {
         if (dynamicA) {
           bodyA._sleepTime = 0;
         }

--- a/packages/exojs-physics/src/solver/ContactSolver.ts
+++ b/packages/exojs-physics/src/solver/ContactSolver.ts
@@ -1,16 +1,9 @@
 import type { ContactRecord } from '../ContactGraph';
 import type { PhysicsBody } from '../PhysicsBody';
+import { contactSlop } from './tolerances';
 
 /** Relative normal speed (px/s) below which a contact is treated as resting (no restitution). */
 const restitutionThreshold = 1;
-/**
- * Penetration allowance (px) the soft bias leaves uncorrected. The narrow phase
- * only produces a manifold while the colliders overlap, so pushing penetration
- * fully to zero lets a resting contact wink out for a frame (free-fall, then
- * re-detect) - a periodic energy spike. Leaving a small slop keeps the contact
- * persistently overlapping and the warm-start cache alive.
- */
-const slop = 0.25;
 /**
  * Cap on the soft-constraint push-out velocity (px/s). Bounds how fast the bias
  * resolves deep penetration so a large overlap cannot fling bodies apart; the
@@ -348,7 +341,7 @@ export class ContactSolver {
     for (let i = 0; i < constraint.pointCount; i++) {
       // Push out only the penetration beyond the slop, capped - leaving the slop
       // keeps the contact overlapping so the narrow phase does not drop it.
-      const excess = -currentSeparation(constraint, i) - slop;
+      const excess = -currentSeparation(constraint, i) - contactSlop;
 
       constraint.velocityBias[i] = useBias && excess > 0 ? Math.min(constraint.biasRate * excess, maxBiasVelocity) : 0;
     }

--- a/packages/exojs-physics/src/solver/tolerances.ts
+++ b/packages/exojs-physics/src/solver/tolerances.ts
@@ -1,0 +1,27 @@
+/**
+ * Penetration allowance (px) the soft bias leaves uncorrected. The narrow phase
+ * only produces a manifold while the colliders overlap, so pushing penetration
+ * fully to zero lets a resting contact wink out for a frame (free-fall, then
+ * re-detect) - a periodic energy spike. Leaving a small slop keeps the contact
+ * persistently overlapping and the warm-start cache alive.
+ * @internal
+ */
+export const contactSlop = 0.25;
+
+/**
+ * Penetration (px) above which a contact still counts as unresolved for the
+ * sleep decision, so neither of its bodies may bank sleep time.
+ *
+ * The solver drives every resting contact down to {@link contactSlop}, but only
+ * at a capped push-out speed that is below the sleep velocity threshold: a body
+ * that landed hard therefore looks motionless long before its overlap is worked
+ * off, and sleeping it would freeze it visibly embedded. Both sides must read
+ * the same tolerance, or the sleep gate and the constraint it is gating drift
+ * apart.
+ *
+ * Three slops of headroom: the converged fixed point is one slop for a
+ * face contact and a little above it for a single-point one, while the failure
+ * case is several px deep.
+ * @internal
+ */
+export const maxRestingPenetration = 3 * contactSlop;

--- a/packages/exojs-physics/src/solver/tolerances.ts
+++ b/packages/exojs-physics/src/solver/tolerances.ts
@@ -19,9 +19,14 @@ export const contactSlop = 0.25;
  * the same tolerance, or the sleep gate and the constraint it is gating drift
  * apart.
  *
- * Three slops of headroom: the converged fixed point is one slop for a
- * face contact and a little above it for a single-point one, while the failure
- * case is several px deep.
+ * The value is empirical, not derived: a face contact converges to exactly one
+ * slop at any gravity, but a single-point contact settles a little deeper, and
+ * that offset grows with gravity (0.28 px at 1 000 px/s², 0.53 px at 10 000,
+ * 0.67 px at 15 000). Three slops clears that envelope for the gravity range
+ * the engine is tuned for while staying far below the failure it gates, which
+ * starts at several px. Past roughly 15 000 px/s² the two converge and sleep is
+ * delayed; well before that the solver itself stops resolving single-point
+ * contacts at all, which is a separate limitation.
  * @internal
  */
-export const maxRestingPenetration = 3 * contactSlop;
+export const sleepPenetrationTolerance = 3 * contactSlop;

--- a/packages/exojs-physics/test/sleep-penetration.test.ts
+++ b/packages/exojs-physics/test/sleep-penetration.test.ts
@@ -1,0 +1,261 @@
+import type { PointLike } from '@codexo/exojs';
+import { describe, expect, it } from 'vitest';
+
+import {
+  BoxShape,
+  CapsuleShape,
+  ChainShape,
+  CircleShape,
+  type ContactModifierContext,
+  DistanceJoint,
+  PhysicsBody,
+  PhysicsWorld,
+  SegmentShape,
+} from '../src/index';
+import type { AnyShape } from '../src/shapes/AnyShape';
+
+/**
+ * Sleeping must not freeze a body while its contact still carries penetration
+ * the solver has not worked off. The solver converges every resting contact to
+ * its own slop, so a body that comes to rest visibly embedded in the floor is a
+ * sleep decision taken too early - not a solver limit. Default solver config,
+ * +Y down.
+ */
+
+const GRAVITY = 1000; // px/s²
+const FRAME = 1 / 60;
+const FLOOR_TOP = 300;
+/**
+ * Penetration a settled contact may keep, in px. Three times the solver's
+ * contact slop: the converged fixed point sits at (or just above) one slop for
+ * every shape pair, while a body that fell asleep mid-correction is off by
+ * several px.
+ */
+const MAX_RESTING_SINK = 0.75;
+
+const advance = (world: PhysicsWorld, seconds: number): void => {
+  const frames = Math.round(seconds / FRAME);
+
+  for (let frame = 0; frame < frames; frame++) {
+    world.step(FRAME);
+  }
+};
+
+/** Step until `body` sleeps, returning the frame index (or -1 within `seconds`). */
+const framesUntilAsleep = (world: PhysicsWorld, body: PhysicsBody, seconds: number): number => {
+  const frames = Math.round(seconds / FRAME);
+
+  for (let frame = 0; frame < frames; frame++) {
+    world.step(FRAME);
+
+    if (body.isSleeping) {
+      return frame;
+    }
+  }
+
+  return -1;
+};
+
+const points = (...coords: number[]): Readonly<PointLike>[] => {
+  const result: Readonly<PointLike>[] = [];
+
+  for (let i = 0; i < coords.length; i += 2) {
+    result.push({ x: coords[i]!, y: coords[i + 1]! });
+  }
+
+  return result;
+};
+
+/** A wide static floor whose top surface sits at {@link FLOOR_TOP}. */
+const addBoxFloor = (world: PhysicsWorld): PhysicsBody =>
+  world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: FLOOR_TOP + 20 }, colliders: [{ shape: new BoxShape(1200, 40) }] }));
+
+const addDynamic = (world: PhysicsWorld, shape: AnyShape, y: number, x = 0): PhysicsBody =>
+  world.add(new PhysicsBody({ type: 'dynamic', position: { x, y }, colliders: [{ shape, friction: 0.5 }] }));
+
+/** How far the body's lowest point sits below the floor surface. */
+const sink = (body: PhysicsBody, halfHeight: number): number => body.y + halfHeight - FLOOR_TOP;
+
+describe('sleeping with unresolved contact penetration', () => {
+  it('a body dropped from a height does not fall asleep embedded in the floor', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+
+    addBoxFloor(world);
+
+    // One fixed step at impact speed bridges ~10px, far more than the contact
+    // slop, so detection first sees the contact deeply penetrating.
+    const body = addDynamic(world, new CircleShape(8), 100);
+    const sleptAt = framesUntilAsleep(world, body, 6);
+
+    expect(sleptAt).toBeGreaterThan(0);
+    expect(sink(body, 8)).toBeLessThanOrEqual(MAX_RESTING_SINK);
+  });
+
+  it.each([
+    ['circle', (): AnyShape => new CircleShape(8), 8],
+    ['box', (): AnyShape => new BoxShape(32, 32), 16],
+    ['capsule', (): AnyShape => new CapsuleShape(0, -10, 0, 10, 8), 18],
+  ] as const)('a falling %s comes to rest on the floor surface before sleeping', (_name, makeShape, halfHeight) => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+
+    addBoxFloor(world);
+
+    const body = addDynamic(world, makeShape(), 100);
+
+    advance(world, 6);
+
+    expect(body.isSleeping).toBe(true);
+    expect(sink(body, halfHeight)).toBeLessThanOrEqual(MAX_RESTING_SINK);
+  });
+
+  it.each([
+    ['segment', (): AnyShape => new SegmentShape(-600, 0, 600, 0)],
+    ['chain', (): AnyShape => new ChainShape(points(-600, 0, -200, 0, 200, 0, 600, 0))],
+  ] as const)('a falling body comes to rest on a %s boundary before sleeping', (_name, makeBoundary) => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: FLOOR_TOP }, colliders: [{ shape: makeBoundary() }] }));
+
+    const body = addDynamic(world, new BoxShape(32, 32), 100);
+
+    advance(world, 6);
+
+    expect(body.isSleeping).toBe(true);
+    expect(sink(body, 16)).toBeLessThanOrEqual(MAX_RESTING_SINK);
+  });
+
+  it('a body that is already resting still falls asleep at the usual time', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+
+    addBoxFloor(world);
+
+    // 2px above its resting height: it settles within a few frames, so the
+    // penetration check must not delay the sleep decision at all.
+    const body = addDynamic(world, new BoxShape(32, 32), FLOOR_TOP - 16 - 2);
+    const sleptAt = framesUntilAsleep(world, body, 2);
+
+    // timeToSleep is 0.5s (30 frames) plus the few frames of settling.
+    expect(sleptAt).toBeGreaterThan(0);
+    expect(sleptAt).toBeLessThan(45);
+  });
+
+  it('a body spawned inside the floor stays awake until it has worked its way out', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+
+    addBoxFloor(world);
+
+    const body = addDynamic(world, new CircleShape(8), FLOOR_TOP + 5); // 13px deep
+
+    // Well past timeToSleep, but the push-out is speed-capped, so it is still
+    // climbing out and must not be frozen where it is.
+    advance(world, 1);
+    expect(body.isSleeping).toBe(false);
+    expect(sink(body, 8)).toBeGreaterThan(MAX_RESTING_SINK);
+
+    advance(world, 6);
+    expect(body.isSleeping).toBe(true);
+    expect(sink(body, 8)).toBeLessThanOrEqual(MAX_RESTING_SINK);
+  });
+
+  it('one embedded body keeps its whole contact island awake', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+
+    addBoxFloor(world);
+
+    // The bottom box starts 6px inside the floor; the two above it rest on it
+    // and are at rest almost immediately.
+    const bottom = addDynamic(world, new BoxShape(32, 32), FLOOR_TOP - 16 + 6);
+    const middle = addDynamic(world, new BoxShape(32, 32), FLOOR_TOP - 48 + 6);
+    const top = addDynamic(world, new BoxShape(32, 32), FLOOR_TOP - 80 + 6);
+
+    advance(world, 1);
+
+    expect(bottom.isSleeping).toBe(false);
+    expect(middle.isSleeping).toBe(false);
+    expect(top.isSleeping).toBe(false);
+
+    advance(world, 6);
+
+    expect(bottom.isSleeping).toBe(true);
+    expect(middle.isSleeping).toBe(true);
+    expect(top.isSleeping).toBe(true);
+    expect(sink(bottom, 16)).toBeLessThanOrEqual(MAX_RESTING_SINK);
+  });
+
+  it('a joint carries the block to a body that has no contact of its own', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+
+    addBoxFloor(world);
+
+    const embedded = addDynamic(world, new BoxShape(32, 32), FLOOR_TOP - 16 + 6);
+    // Hangs from the embedded body on a rigid joint, far away from the floor,
+    // so nothing but the island coupling can keep it awake.
+    const hanging = addDynamic(world, new BoxShape(16, 16), FLOOR_TOP - 116, 200);
+
+    world.addJoint(new DistanceJoint({ bodyA: embedded, bodyB: hanging, length: 100 }));
+
+    advance(world, 1);
+
+    expect(embedded.isSleeping).toBe(false);
+    expect(hanging.isSleeping).toBe(false);
+
+    advance(world, 8);
+
+    expect(embedded.isSleeping).toBe(true);
+    expect(hanging.isSleeping).toBe(true);
+  });
+
+  it('a deeply overlapping sensor does not block sleep', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+
+    addBoxFloor(world);
+
+    // A trigger volume the resting body sits well inside of.
+    world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: FLOOR_TOP - 16 }, colliders: [{ shape: new BoxShape(200, 200), isSensor: true }] }));
+
+    const body = addDynamic(world, new BoxShape(32, 32), FLOOR_TOP - 16 - 2);
+    const sleptAt = framesUntilAsleep(world, body, 2);
+
+    expect(sleptAt).toBeGreaterThan(0);
+    expect(sleptAt).toBeLessThan(45);
+  });
+
+  it('a contact the modifier disabled does not block sleep', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+
+    addBoxFloor(world);
+
+    // A pass-through platform the resting body overlaps by 10px. Disabled, it
+    // applies no impulse, so its penetration is never going to be resolved -
+    // and must not keep the body awake forever.
+    const platform = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: FLOOR_TOP - 26 }, colliders: [{ shape: new BoxShape(200, 20) }] }));
+
+    world.contactModifier = (contact: ContactModifierContext): void => {
+      if (contact.bodyA === platform || contact.bodyB === platform) {
+        contact.enabled = false;
+      }
+    };
+
+    const body = addDynamic(world, new BoxShape(32, 32), FLOOR_TOP - 16 - 2);
+    const sleptAt = framesUntilAsleep(world, body, 2);
+
+    expect(sleptAt).toBeGreaterThan(0);
+    expect(sleptAt).toBeLessThan(45);
+  });
+
+  it('a bullet stopped by CCD sleeps at the surface it hit', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
+
+    world.add(new PhysicsBody({ type: 'static', position: { x: 300, y: 0 }, colliders: [{ shape: new BoxShape(40, 400) }] }));
+
+    const bullet = addDynamic(world, new CircleShape(4), 0, -200);
+
+    bullet.isBullet = true;
+    bullet.linearVelocityX = 4000;
+
+    advance(world, 3);
+
+    expect(bullet.isSleeping).toBe(true);
+    expect(bullet.x + 4).toBeLessThanOrEqual(280 + MAX_RESTING_SINK);
+  });
+});

--- a/packages/exojs-physics/test/sleep-penetration.test.ts
+++ b/packages/exojs-physics/test/sleep-penetration.test.ts
@@ -16,22 +16,29 @@ import type { AnyShape } from '../src/shapes/AnyShape';
 
 /**
  * Sleeping must not freeze a body while its contact still carries penetration
- * the solver has not worked off. The solver converges every resting contact to
- * its own slop, so a body that comes to rest visibly embedded in the floor is a
- * sleep decision taken too early - not a solver limit. Default solver config,
- * +Y down.
+ * the solver has not worked off. Left running, the solver settles a resting
+ * contact within a fraction of a px of its slop, so a body that comes to rest
+ * visibly embedded in the floor is a sleep decision taken too early - not a
+ * solver limit. Default solver config unless stated, +Y down.
  */
 
 const GRAVITY = 1000; // px/s²
 const FRAME = 1 / 60;
 const FLOOR_TOP = 300;
 /**
- * Penetration a settled contact may keep, in px. Three times the solver's
- * contact slop: the converged fixed point sits at (or just above) one slop for
- * every shape pair, while a body that fell asleep mid-correction is off by
- * several px.
+ * Penetration a body may still carry once it is asleep, in px. Deliberately a
+ * literal rather than the engine constant: these tests pin the observable
+ * resting behaviour, so lowering the engine's tolerance towards the contact slop
+ * (bodies stop sleeping) and raising it (bodies sleep embedded again) both turn
+ * them red.
  */
-const MAX_RESTING_SINK = 0.75;
+const MAX_SLEEPING_PENETRATION = 0.75;
+/**
+ * The solver's own penetration allowance. A resting single-point contact settles
+ * measurably deeper than this, which is why the sleep tolerance above cannot be
+ * the slop itself.
+ */
+const CONTACT_SLOP = 0.25;
 
 const advance = (world: PhysicsWorld, seconds: number): void => {
   const frames = Math.round(seconds / FRAME);
@@ -88,7 +95,7 @@ describe('sleeping with unresolved contact penetration', () => {
     const sleptAt = framesUntilAsleep(world, body, 6);
 
     expect(sleptAt).toBeGreaterThan(0);
-    expect(sink(body, 8)).toBeLessThanOrEqual(MAX_RESTING_SINK);
+    expect(sink(body, 8)).toBeLessThanOrEqual(MAX_SLEEPING_PENETRATION);
   });
 
   it.each([
@@ -105,7 +112,7 @@ describe('sleeping with unresolved contact penetration', () => {
     advance(world, 6);
 
     expect(body.isSleeping).toBe(true);
-    expect(sink(body, halfHeight)).toBeLessThanOrEqual(MAX_RESTING_SINK);
+    expect(sink(body, halfHeight)).toBeLessThanOrEqual(MAX_SLEEPING_PENETRATION);
   });
 
   it.each([
@@ -121,7 +128,7 @@ describe('sleeping with unresolved contact penetration', () => {
     advance(world, 6);
 
     expect(body.isSleeping).toBe(true);
-    expect(sink(body, 16)).toBeLessThanOrEqual(MAX_RESTING_SINK);
+    expect(sink(body, 16)).toBeLessThanOrEqual(MAX_SLEEPING_PENETRATION);
   });
 
   it('a body that is already resting still falls asleep at the usual time', () => {
@@ -150,11 +157,11 @@ describe('sleeping with unresolved contact penetration', () => {
     // climbing out and must not be frozen where it is.
     advance(world, 1);
     expect(body.isSleeping).toBe(false);
-    expect(sink(body, 8)).toBeGreaterThan(MAX_RESTING_SINK);
+    expect(sink(body, 8)).toBeGreaterThan(MAX_SLEEPING_PENETRATION);
 
     advance(world, 6);
     expect(body.isSleeping).toBe(true);
-    expect(sink(body, 8)).toBeLessThanOrEqual(MAX_RESTING_SINK);
+    expect(sink(body, 8)).toBeLessThanOrEqual(MAX_SLEEPING_PENETRATION);
   });
 
   it('one embedded body keeps its whole contact island awake', () => {
@@ -179,7 +186,7 @@ describe('sleeping with unresolved contact penetration', () => {
     expect(bottom.isSleeping).toBe(true);
     expect(middle.isSleeping).toBe(true);
     expect(top.isSleeping).toBe(true);
-    expect(sink(bottom, 16)).toBeLessThanOrEqual(MAX_RESTING_SINK);
+    expect(sink(bottom, 16)).toBeLessThanOrEqual(MAX_SLEEPING_PENETRATION);
   });
 
   it('a joint carries the block to a body that has no contact of its own', () => {
@@ -243,6 +250,65 @@ describe('sleeping with unresolved contact penetration', () => {
     expect(sleptAt).toBeLessThan(45);
   });
 
+  it('a sleeping body woken by new overlapping geometry pushes out and settles again', () => {
+    const world = new PhysicsWorld({ gravity: { x: 0, y: GRAVITY } });
+
+    addBoxFloor(world);
+
+    const body = addDynamic(world, new BoxShape(32, 32), FLOOR_TOP - 16 - 2);
+
+    advance(world, 2);
+    expect(body.isSleeping).toBe(true);
+
+    // A wall appears overlapping the sleeping body by 8px. Its sleep timer is
+    // frozen past timeToSleep, so only the penetration itself can re-open the
+    // decision - and a body left asleep here would stay visibly inside the wall.
+    world.add(new PhysicsBody({ type: 'static', position: { x: 28, y: FLOOR_TOP - 16 }, colliders: [{ shape: new BoxShape(40, 40) }] }));
+
+    const overlapBefore = body.x + 16 - 8;
+
+    expect(overlapBefore).toBeGreaterThan(MAX_SLEEPING_PENETRATION);
+
+    world.step(FRAME);
+    expect(body.isSleeping).toBe(false);
+
+    advance(world, 0.5);
+    expect(body.x + 16 - 8).toBeLessThan(overlapBefore); // pushing out
+
+    const sleptAt = framesUntilAsleep(world, body, 8);
+
+    expect(sleptAt).toBeGreaterThan(0);
+    expect(body.x + 16 - 8).toBeLessThanOrEqual(MAX_SLEEPING_PENETRATION);
+
+    // And it stays asleep: a body parked just inside the tolerance must not
+    // oscillate between waking and sleeping every few frames.
+    const restingX = body.x;
+
+    for (let frame = 0; frame < 600; frame++) {
+      world.step(FRAME);
+      expect(body.isSleeping).toBe(true);
+    }
+
+    expect(body.x).toBe(restingX);
+  });
+
+  it('a single-point contact at high gravity settles above the slop and still sleeps', () => {
+    // The converged resting depth of a one-point contact grows with gravity: at
+    // 10,000 px/s² it is roughly twice the solver's slop. The sleep tolerance
+    // has to clear that, so this pins the envelope from both sides - a tolerance
+    // pulled down towards the slop stops this body sleeping at all.
+    const world = new PhysicsWorld({ gravity: { x: 0, y: 10000 } });
+
+    addBoxFloor(world);
+
+    const body = addDynamic(world, new CircleShape(8), FLOOR_TOP - 8 - 0.5);
+    const sleptAt = framesUntilAsleep(world, body, 8);
+
+    expect(sleptAt).toBeGreaterThan(0);
+    expect(sink(body, 8)).toBeGreaterThan(CONTACT_SLOP);
+    expect(sink(body, 8)).toBeLessThanOrEqual(MAX_SLEEPING_PENETRATION);
+  });
+
   it('a bullet stopped by CCD sleeps at the surface it hit', () => {
     const world = new PhysicsWorld({ gravity: { x: 0, y: 0 } });
 
@@ -256,6 +322,6 @@ describe('sleeping with unresolved contact penetration', () => {
     advance(world, 3);
 
     expect(bullet.isSleeping).toBe(true);
-    expect(bullet.x + 4).toBeLessThanOrEqual(280 + MAX_RESTING_SINK);
+    expect(bullet.x + 4).toBeLessThanOrEqual(280 + MAX_SLEEPING_PENETRATION);
   });
 });

--- a/site/src/content/guide/physics/joints-and-dynamics.mdx
+++ b/site/src/content/guide/physics/joints-and-dynamics.mdx
@@ -200,6 +200,14 @@ island) sleep and wake as a unit, so a tower never half-sleeps. A body wakes the
 is touched by an awake body, hit by an `applyImpulse`/`applyForce`, or moved with
 `setTransform`.
 
+Low velocity alone is not enough. A body that landed hard is overlapping the ground by more
+than one step of push-out, and the solver corrects that overlap at a speed below the sleep
+threshold — so an island also stays awake while any of its solid contacts still carries
+more penetration than a resting contact keeps. A body therefore always comes to rest on the
+surface rather than embedded in it, at the cost of a fraction of a second of extra
+simulation after a fast impact. Sensor overlaps and contacts a `contactModifier` disabled
+are not solved and never delay sleep.
+
 It is on by default; tune it through `PhysicsWorld` options:
 
 ```ts


### PR DESCRIPTION
Closes the `NEU-W1` correctness point: a dynamic body could fall asleep with a contact still deeply penetrating, freezing it visibly embedded in the ground it landed on.

## Root cause

`_stepOnce` takes the sleep decision between `detect` and `prepareSolve`, and `_accumulateSleepTime` looks at velocity only. The soft solver's push-out is capped at `maxBiasVelocity = 4` px/s while `sleepLinearVelocity` is `5` px/s, so a body doing nothing but climbing out of an overlap looks at rest for the whole correction - and sleeping it ends the correction for good.

Measured on a fall from y = 100 onto a floor at y = 300, gravity 1000 px/s²: circle rests at 8.20 px penetration (asleep from frame 69), capsule 7.75 px, box 5.36 px, a body spawned overlapping 11.24 px.

The counter-measurement is what makes it a correctness bug rather than a solver limit. With `enableSleeping: false`, separate probes showed face contacts converging to exactly one contact slop (0.250 px) across gravity 1,000-100,000; body count (1-10), sub-step count (1-8) and contact hertz (10-60) were varied independently rather than as a Cartesian product. Single-point contacts settle deeper, and the offset grows with gravity (0.28 px at 1,000, 0.53 px at 10,000). Every resting position above that is a sleep decision taken too early.

## Change

The island pass now reads the penetration detection has just produced - the same separation the push-out bias is about to act on - and resets the sleep timer of the dynamic sides of any contact deeper than the empirically chosen sleep-penetration tolerance derived from the shared contact slop. The existing per-island minimum then carries that across contacts *and* joints, so a whole island stays awake until the overlap is worked off.

- New internal `solver/tolerances.ts` holds `contactSlop` (moved out of `ContactSolver`, which now imports it) and `sleepPenetrationTolerance = 3 × contactSlop`, so the sleep gate and the constraint it gates cannot drift apart. The factor is empirical, not derived, and the doc comment records the measured envelope and where it stops holding.
- The check rides the traversal that already builds the islands: no second narrow phase, no second traversal, no per-step allocation, and it only runs where a dynamic body exists to hold awake.
- Sensors never reach the solid contact set and contacts a `ContactModifier` disabled are skipped before the check, so neither delays sleep.
- No public API change. Guide section on sleeping updated.

Alternative considered and rejected: committing the sleep decision *after* the solver. `ContactSolver` exposes no trustworthy residual error afterwards - `currentSeparation` is module-private and only meaningful relative to the frame-start anchor - so it would have cost new solver surface plus a second sleep phase in the step, for a statement that is already exact before the solve.

## Tests

`test/sleep-penetration.test.ts`, 15 cases: fall height across circle/box/capsule, segment and chain boundaries, a body spawned inside the floor, a three-body contact island, a joint island with no contact of its own, a deeply overlapping sensor, a `ContactModifier`-disabled platform, a CCD bullet, a timing guard that an ordinary resting body still sleeps within 45 frames, a sleeping body woken by newly appearing overlapping geometry that pushes out, settles and then does not oscillate over 600 frames, and a single-point contact at gravity 10 000 that rests measurably deeper than the slop and still sleeps.

Three mutations confirm the tests bite in both directions: removing the gate turns 10 red (the four control cases stay green); collapsing the tolerance onto the slop turns 13 red; raising it well past the failure turns 10 red. The tests pin observable resting behaviour and deliberately do not import the engine constant.

Physics suite 523/523, repeated three times. Allocation gate (< 600 KB/step) and the 5 000-body sleeping gate (>= 4 500 asleep, >= 2x faster than awake) unchanged.

## Known, deliberately out of scope

A body wedged between opposing static geometry now never sleeps, because its contact error is genuinely unresolved - CPU spent instead of a frozen wrong pose. Separately, past roughly 20 000 px/s² the solver stops resolving single-point contacts at all; that is a pre-existing limitation and is not folded into this change.

