### PR TITLE
build(size): make the IIFE budget an architecture limit and report it per PR

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -40,10 +40,22 @@ ignore:
   - 'site/**'
 
 comment:
-  layout: 'reach,diff,flags,components,files'
+  layout: 'reach,diff,flags,components,files,bundle_analysis'
   behavior: default
   require_changes: true # only comment when coverage actually changes
   after_n_builds: 2 # same reason as `codecov.notify` — never comment on half the data
+
+# Bundle analysis. `scripts/build.ts` uploads per-bundle module stats for every
+# artefact it builds when CODECOV_TOKEN is present, which is what lets Codecov
+# report a base-vs-PR size delta in the PR comment above.
+#
+# Informational on purpose: the hard budget is the `pnpm size` gate in the
+# Package Build + Verify job, whose limits live in package.json#size-limit and
+# whose absolute numbers the same job writes to the run summary. A percentage
+# threshold here would be a second, differently-shaped budget nobody set.
+bundle_analysis:
+  status: informational
+  warning_threshold: '5%'
 
 # Upload flags — one per CI lane that uploads (see _ci-checks.yml).
 flags:

--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -916,6 +916,12 @@ jobs:
       - name: Check bundle sizes
         run: pnpm size
 
+      # Reports, never judges: the step above is the gate. `always()` so a
+      # breached budget still says by how much instead of only that it failed.
+      - name: Report bundle budgets
+        if: always()
+        run: pnpm size:summary
+
       - name: Verify core package exports
         run: pnpm verify:exports
 

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "perf:profile": "tsx test/perf/profile-benchmark.ts",
     "perf:profile:gc": "node --expose-gc --import tsx/esm test/perf/profile-benchmark.ts",
     "size": "size-limit",
+    "size:summary": "node scripts/ci/bundle-size-summary.mjs",
     "prepare": "husky",
     "perf:renderers:instance-cost": "node --expose-gc --max-old-space-size=8192 --conditions=@codexo/exojs-source --import ./scripts/glsl-register.mjs --import tsx/esm test/perf/rendering/run-instance-cost.ts",
     "perf:webgpu:alloc": "tsx test/perf/webgpu/run-webgpu-allocation.ts",
@@ -202,7 +203,7 @@
     },
     {
       "path": "dist/exo.iife.min.js",
-      "limit": "275 KB",
+      "limit": "300 KB",
       "gzip": true
     },
     {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -174,7 +174,7 @@ function iife(minify: boolean): RolldownOptions {
   return {
     ...shared,
     input: 'src/index.ts',
-    plugins: shaderAndWorkletPlugins(minify),
+    plugins: [...shaderAndWorkletPlugins(minify), ...codecovBundlePlugin(minify ? 'exo-iife-min' : 'exo-iife')],
     output: { file: minify ? 'dist/exo.iife.min.js' : 'dist/exo.iife.js', format: 'iife', name: 'Exo', sourcemap: true, minify },
   };
 }
@@ -185,7 +185,7 @@ function fullBundle(minify: boolean): RolldownOptions {
     input: 'scripts/exo-full.entry.ts',
     transform: { define: defines },
     resolve: { conditionNames: fullSourceConditions, mainFields: ['browser', 'module', 'main'] },
-    plugins: [extensionSourcePlugin, ...shaderAndWorkletPlugins(minify), ...codecovBundlePlugin('exo-full-iife')],
+    plugins: [extensionSourcePlugin, ...shaderAndWorkletPlugins(minify), ...codecovBundlePlugin(minify ? 'exo-full-iife-min' : 'exo-full-iife')],
     output: { file: minify ? 'dist/exo.full.iife.min.js' : 'dist/exo.full.iife.js', format: 'iife', name: 'Exo', sourcemap: true, minify },
   };
 }

--- a/scripts/ci/bundle-size-summary.mjs
+++ b/scripts/ci/bundle-size-summary.mjs
@@ -1,0 +1,70 @@
+/**
+ * Writes the current bundle sizes, their budgets and the headroom left to the
+ * GitHub run summary (stdout when run outside Actions).
+ *
+ * This reports; it never judges. The budget is enforced by `pnpm size` itself,
+ * which this deliberately runs a second time rather than sharing a process
+ * with: a reporter that can turn a green gate red is a second gate.
+ *
+ * Base-vs-PR deltas come from Codecov's bundle analysis (see `.codecov.yml`),
+ * which has the base commit's numbers; a single CI run does not.
+ */
+import { spawnSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+
+// `size-limit` does not export its bin from `exports`, and the `.bin` shim is a
+// `.cmd` on Windows - spawning either needs a shell. Reading the bin entry out
+// of the manifest keeps this a plain `node <file>` spawn everywhere.
+const require = createRequire(import.meta.url);
+const manifestPath = require.resolve('size-limit/package.json');
+const sizeLimitBin = resolve(dirname(manifestPath), require(manifestPath).bin);
+
+/** size-limit exits non-zero when a budget is exceeded, and still prints the report. */
+function readSizeLimitReport() {
+  const result = spawnSync(process.execPath, [sizeLimitBin, '--json'], { encoding: 'utf8' });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  const json = /\[[\s\S]*\]/.exec(result.stdout ?? '');
+
+  if (!json) {
+    throw new Error(`size-limit produced no JSON report (exit ${result.status}).\n${result.stderr ?? ''}`);
+  }
+
+  return JSON.parse(json[0]);
+}
+
+const KB = 1000;
+
+function kb(bytes) {
+  return `${(bytes / KB).toFixed(2)} kB`;
+}
+
+function row({ name, size, sizeLimit, passed }) {
+  const headroom = sizeLimit - size;
+  const used = ((size / sizeLimit) * 100).toFixed(1);
+
+  return `| \`${name}\` | ${kb(size)} | ${kb(sizeLimit)} | ${used}% | ${headroom < 0 ? `-${kb(-headroom)}` : kb(headroom)} | ${passed ? 'ok' : 'over budget'} |`;
+}
+
+const report = readSizeLimitReport();
+const summary = [
+  '## Bundle budgets',
+  '',
+  'Sizes are gzipped. Base-vs-PR deltas are reported by Codecov bundle analysis on the pull request.',
+  '',
+  '| Artifact | Size | Budget | Used | Headroom | |',
+  '| --- | ---: | ---: | ---: | ---: | --- |',
+  ...report.map(row),
+  '',
+].join('\n');
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`);
+} else {
+  process.stdout.write(`${summary}\n`);
+}


### PR DESCRIPTION
The 275 kB gzip limit sat 1.96 kB above the build it was measuring, so it had
stopped being a budget and become a tripwire: the next feature-sized commit
breaches it whatever that commit is, and the only available answer is to raise
the number again. 300 kB is a limit the architecture is meant to stay under,
with room to say something when it does not.

A budget nobody watches approaching is still only a tripwire, though, so the
same job now reports the numbers. `pnpm size:summary` writes size, budget,
percentage used and headroom for every measured artefact to the run summary,
and runs on `always()` so a breach reports by how much rather than only that it
happened. It reruns size-limit rather than sharing a process with the gate:
a reporter that can turn a green gate red is a second gate.

The delta against the base commit needs numbers a single CI run does not have,
and Codecov already stores them per bundle - except for the two artefacts that
matter most here, which had no bundle-analysis plugin at all. The minified IIFE
is the one the gate measures and it was uploading nothing. Both IIFE builds now
upload, under names that distinguish minified from readable: the full bundle
previously reported its minified and unminified builds under one name, so two
different artefacts were overwriting each other's history.

Bundle analysis is informational. The hard budget stays the `pnpm size` gate,
and a percentage threshold on top of it would be a second budget nobody set.