### PR TITLE
build(gates): type-check the repository's own tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "typecheck:guides:no-check": "tsx scripts/check-guide-no-check-reasons.ts",
     "typecheck:guides:no-check:update-baseline": "tsx scripts/check-guide-no-check-reasons.ts --update-baseline",
     "typecheck:packages": "pnpm --filter \"@codexo/exojs-build\" --filter \"@codexo/exojs-particles\" --filter \"@codexo/exojs-tilemap\" --filter \"@codexo/exojs-tiled\" --filter \"@codexo/exojs-physics\" --filter \"@codexo/exojs-tilemap-physics\" --filter \"@codexo/exojs-audio-fx\" --filter \"@codexo/exojs-aseprite\" --filter \"@codexo/exojs-ldtk\" --filter \"@codexo/exojs-react\" typecheck",
+    "typecheck:scripts": "tsc --noEmit -p tsconfig.scripts.json",
     "typecheck:site": "pnpm --filter @codexo/exojs-examples check-ts",
     "typecheck:test": "tsx scripts/typecheck-tests.ts",
     "typecheck:test:update-baseline": "tsx scripts/typecheck-tests.ts --update-baseline",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -24,7 +24,7 @@ import { fileURLToPath } from 'node:url';
 import { codecovRollupPlugin } from '@codecov/rollup-plugin';
 import { createShaderPlugin, createWorkletPlugin } from '@codexo/exojs-build';
 import { createBuildDefinesFromRepo } from '@codexo/exojs-config/build-defines';
-import { rolldown, watch, type OutputOptions, type Plugin, type RolldownOptions } from 'rolldown';
+import { rolldown, watch, type OutputOptions, type Plugin, type PreRenderedChunk, type RolldownOptions } from 'rolldown';
 
 const rootDir = resolvePath(dirname(fileURLToPath(import.meta.url)), '..');
 const watchMode = process.argv.includes('--watch');
@@ -76,7 +76,7 @@ const sourcemapPathTransform = (relativeSourcePath: string, sourcemapPath: strin
 // `facadeModuleId` restores that for the shader files; every other module
 // keeps the default `[name]`.
 const SHADER_EXTENSION = /\.(?:vert|frag|wgsl)$/;
-const preservedModuleNaming = (info: { facadeModuleId: string | null }): string => {
+const preservedModuleNaming = (info: PreRenderedChunk): string => {
   const id = info.facadeModuleId;
   if (id && SHADER_EXTENSION.test(id)) {
     return `${relativePath(resolvePath(rootDir, 'src'), id).replaceAll('\\', '/')}.js`;
@@ -88,8 +88,11 @@ const preservedModuleNaming = (info: { facadeModuleId: string | null }): string 
 // present (CI passes CODECOV_TOKEN via secrets: inherit). A plain local
 // `pnpm build` has no token and stays fully offline.
 const codecovBundlePlugin = (bundleName: string): Plugin[] => {
+  // `codecovRollupPlugin` returns a Rollup plugin array. Rolldown accepts them
+  // at runtime, but the two `Plugin` types are nominally distinct, so the shape
+  // has to be restated rather than narrowed.
   return process.env.CODECOV_TOKEN
-    ? [codecovRollupPlugin({ enableBundleAnalysis: true, bundleName, uploadToken: process.env.CODECOV_TOKEN, telemetry: false }) as Plugin]
+    ? (codecovRollupPlugin({ enableBundleAnalysis: true, bundleName, uploadToken: process.env.CODECOV_TOKEN, telemetry: false }) as unknown as Plugin[])
     : [];
 };
 

--- a/scripts/check-guide-no-check-reasons.ts
+++ b/scripts/check-guide-no-check-reasons.ts
@@ -72,7 +72,11 @@ const CHECKED_LANGS = new Set(['ts', 'tsx', 'typescript', 'js', 'javascript']);
 // and ```ts no-check: pseudo-code``` both count; a bare ```ts no-check``` does not.
 const NO_CHECK_REASON_RE = /\bno-check\b\s*(?:--|:|—)?\s*(.*)$/;
 
-const fail = (message: string): never => {
+// A `never` return only ends control flow for the caller when the callee is a
+// function declaration or a constant with an explicit type annotation.
+type Abort = (message: string) => never;
+
+const fail: Abort = message => {
   console.error(message);
   process.exit(1);
 };

--- a/scripts/check-skipped-tests.ts
+++ b/scripts/check-skipped-tests.ts
@@ -50,7 +50,11 @@ interface Baseline {
   files: Record<string, number>;
 }
 
-const fail = (message: string): never => {
+// A `never` return only ends control flow for the caller when the callee is a
+// function declaration or a constant with an explicit type annotation.
+type Abort = (message: string) => never;
+
+const fail: Abort = message => {
   console.error(message);
   process.exit(1);
 };

--- a/scripts/check-source-hygiene.ts
+++ b/scripts/check-source-hygiene.ts
@@ -219,7 +219,11 @@ const commentKind = (text: string): CommentKind => {
   return text.startsWith('/*') ? 'block-comment' : 'line-comment';
 };
 
-const fail = (message: string): never => {
+// A `never` return only ends control flow for the caller when the callee is a
+// function declaration or a constant with an explicit type annotation.
+type Abort = (message: string) => never;
+
+const fail: Abort = message => {
   console.error(message);
   process.exit(1);
 };

--- a/scripts/ci/gate-groups.ts
+++ b/scripts/ci/gate-groups.ts
@@ -9,7 +9,16 @@
 
 /** Package.json script names per owning CI job. Order within a group is the run order. */
 export const GATE_GROUPS = {
-  typecheck: ['typecheck', 'typecheck:guides', 'typecheck:examples', 'typecheck:workers', 'typecheck:type-tests', 'typecheck:packages', 'typecheck:test'],
+  typecheck: [
+    'typecheck',
+    'typecheck:guides',
+    'typecheck:examples',
+    'typecheck:workers',
+    'typecheck:type-tests',
+    'typecheck:packages',
+    'typecheck:test',
+    'typecheck:scripts',
+  ],
   lint: ['lint:all', 'lint:source-hygiene', 'lint:inline-source', 'lint:shaders', 'format:check'],
   sync: ['docs:api:check', 'examples:sync:check'],
   // `full-bundle:exports:check` reads every bundled package's built ESM barrel,

--- a/scripts/ci/select-lanes.d.mts
+++ b/scripts/ci/select-lanes.d.mts
@@ -1,0 +1,31 @@
+// Declarations for `select-lanes.mjs`, which is plain JavaScript so that the CI
+// workflow can run it through Node without a loader. Its JSDoc already carries
+// these shapes; this file is what makes them visible to the TypeScript callers
+// in `scripts/`.
+
+export interface LaneAreas {
+  engine: boolean;
+  site: boolean;
+  audioFx: boolean;
+  tilemapWorker: boolean;
+}
+
+export interface EffectiveLanes {
+  typecheck: boolean;
+  lint: boolean;
+  unit: boolean;
+  coverage: boolean;
+  browserWebgl2: boolean;
+  browserWebgpu: boolean;
+  browserFirefox: boolean;
+  browserAudio: boolean;
+  browserTilemapWorker: boolean;
+  packageVerify: boolean;
+  siteBuild: boolean;
+}
+
+/** Classify a list of changed files into the effective validation areas. */
+export function selectAreas(changedFiles: readonly string[]): LaneAreas;
+
+/** Expand the areas into the lanes a change actually requires. */
+export function effectiveLanes(areas: LaneAreas): EffectiveLanes;

--- a/scripts/create-package.ts
+++ b/scripts/create-package.ts
@@ -48,7 +48,11 @@ const USAGE = `Usage: pnpm create:package <name> [--dep <pkg>]... [--description
   --description "..."  package.json description
   --no-offline-smoke   exclude from the offline external-consumer smoke (react is the precedent)`;
 
-const fail = (message: string): never => {
+// A `never` return only ends control flow for the caller when the callee is a
+// function declaration or a constant with an explicit type annotation.
+type Abort = (message: string) => never;
+
+const fail: Abort = message => {
   process.stderr.write(`create:package: ${message}\n\n${USAGE}\n`);
   process.exit(1);
 };

--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -9,6 +9,11 @@ interface ChangelogEntry {
   version: string;
 }
 
+/** A changelog entry after validation: the release date is known to be present. */
+interface DatedChangelogEntry extends ChangelogEntry {
+  releaseDate: string;
+}
+
 interface ChangelogEntryWithBounds extends ChangelogEntry {
   bodyStart: number;
   headingStart: number;
@@ -58,7 +63,11 @@ const placeholderPattern = /\$\{([A-Z_]+)}/g;
 const semverTagPattern = /^v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:[-+].+)?$/;
 const repoSlugPattern = /^(?<owner>[A-Za-z0-9_.-]+)\/(?<repo>[A-Za-z0-9_.-]+)$/;
 
-const fail = (message: string): never => {
+// A `never` return only ends control flow for the caller when the callee is a
+// function declaration or a constant with an explicit type annotation.
+type Abort = (message: string) => never;
+
+const fail: Abort = message => {
   throw new Error(message);
 };
 
@@ -136,22 +145,24 @@ const parseChangelogEntries = (changelog: string): ChangelogEntry[] => {
   });
 };
 
-const getMatchingChangelogEntry = (changelog: string, version: string): ChangelogEntry => {
+const getMatchingChangelogEntry = (changelog: string, version: string): DatedChangelogEntry => {
   const entries = parseChangelogEntries(changelog);
   const matchingEntry = entries.find(entry => entry.version === version);
   if (!matchingEntry) {
     fail(`Missing changelog section for version ${version}. Expected heading: "## [${version}] - YYYY-MM-DD".`);
   }
 
-  if (!matchingEntry.releaseDate) {
+  const { releaseDate } = matchingEntry;
+
+  if (!releaseDate) {
     fail(`Release date is missing for changelog section [${version}]. Expected heading: "## [${version}] - YYYY-MM-DD".`);
   }
 
   if (!matchingEntry.sectionBody) {
-    fail(`Changelog section [${version}] is empty. Add release notes content under "## [${version}] - ${matchingEntry.releaseDate}".`);
+    fail(`Changelog section [${version}] is empty. Add release notes content under "## [${version}] - ${releaseDate}".`);
   }
 
-  return matchingEntry;
+  return { ...matchingEntry, releaseDate };
 };
 
 const resolveRepoUrl = (repo: string): string => {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -48,7 +48,11 @@ const out = (command: string): string => {
   return execSync(command, { cwd: rootDir, encoding: 'utf8' }).trim();
 };
 
-const fail = (message: string): never => {
+// A `never` return only ends control flow for the caller when the callee is a
+// function declaration or a constant with an explicit type annotation.
+type Abort = (message: string) => never;
+
+const fail: Abort = message => {
   process.stderr.write(`\n  ✗ ${message}\n\n`);
   process.exit(1);
 };

--- a/scripts/release/cut.ts
+++ b/scripts/release/cut.ts
@@ -46,10 +46,19 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 const LOCKSTEP_DIRS: { name: string; dir: string }[] = LOCKSTEP_PACKAGES.map(p => ({ name: p.name, dir: p.dir }));
 
-const EXTENSION_NAMES = new Set(LOCKSTEP_PACKAGES.filter(p => p.isExtension).map(p => p.name));
+// `LOCKSTEP_PACKAGES` is `as const`, so mapping its names yields a literal
+// union and `Set.has` would accept only those literals - but the caller tests
+// names read back from a package manifest, which are plain strings.
+const EXTENSION_NAMES: ReadonlySet<string> = new Set(LOCKSTEP_PACKAGES.filter(p => p.isExtension).map(p => p.name));
 
-const log = (msg: string): void => process.stdout.write(`${msg}\n`);
-const die = (msg: string): never => {
+const log = (msg: string): void => {
+  process.stdout.write(`${msg}\n`);
+};
+// A `never` return only ends control flow for the caller when the callee is a
+// function declaration or a constant with an explicit type annotation.
+type Abort = (msg: string) => never;
+
+const die: Abort = msg => {
   process.stderr.write(`\n✗ ${msg}\n`);
   process.exit(1);
 };

--- a/scripts/release/publish.ts
+++ b/scripts/release/publish.ts
@@ -63,7 +63,7 @@ const isAlreadyPublished = (runner: CommandRunner, pkg: TarballRecord): boolean 
   return result.code === 0 && result.stdout.trim() === pkg.version;
 };
 
-const publishTarball = (runner: CommandRunner, pkg: TarballRecord, absoluteTarball: string, options: PublishOptions): CommandResult => {
+const publishTarball = (runner: CommandRunner, _pkg: TarballRecord, absoluteTarball: string, options: PublishOptions): CommandResult => {
   const args = ['publish', absoluteTarball, '--tag', options.distTag, '--access', 'public'];
   if (options.provenance) args.push('--provenance');
   if (options.dryRun) args.push('--dry-run');

--- a/scripts/release/run.ts
+++ b/scripts/release/run.ts
@@ -19,7 +19,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { resolveRevision } from '../../packages/exojs-config/build-defines/index.js';
+import { resolveRevision } from '@codexo/exojs-config/build-defines';
 import { checkAllTarballTypes } from './attw.ts';
 import { createExecRunner } from './command-runner.ts';
 import { verifyExternalConsumers } from './external-consumers.ts';
@@ -39,8 +39,14 @@ const runner = createExecRunner({ echo: true });
 const argv = process.argv.slice(2);
 const has = (flag: string): boolean => argv.includes(flag);
 
-const log = (message: string): void => process.stdout.write(`${message}\n`);
-const die = (message: string): never => {
+const log = (message: string): void => {
+  process.stdout.write(`${message}\n`);
+};
+// A `never` return only ends control flow for the caller when the callee is a
+// function declaration or a constant with an explicit type annotation.
+type Abort = (message: string) => never;
+
+const die: Abort = message => {
   process.stderr.write(`\n✗ ${message}\n`);
   process.exit(1);
 };
@@ -119,7 +125,8 @@ const doPrepare = (): void => {
     // Offline-smoke subset only: `@codexo/exojs-react` is excluded because its
     // `react`/`react-dom` peers cannot be resolved in an offline throwaway
     // project. attw still type-checks every packed tarball (react included).
-    const smokeNames = new Set(LOCKSTEP_PACKAGES.filter(p => p.inOfflineSmoke).map(p => p.name));
+    // Literal union from `as const` again - the manifest supplies plain strings.
+    const smokeNames: ReadonlySet<string> = new Set(LOCKSTEP_PACKAGES.filter(p => p.inOfflineSmoke).map(p => p.name));
     const smokeTarballs = manifest.packages.filter(p => smokeNames.has(p.name)).map(p => resolve(stagingDir, p.file));
     const consumers = verifyExternalConsumers(smokeTarballs);
     for (const c of consumers.checks) log(`  ${c.ok ? '✓' : '✗'} ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);

--- a/scripts/typecheck-guides.ts
+++ b/scripts/typecheck-guides.ts
@@ -34,7 +34,11 @@ const FORMAT_HOST: ts.FormatDiagnosticsHost = {
   getNewLine: () => ts.sys.newLine,
 };
 
-const fail = (message: string): never => {
+// A `never` return only ends control flow for the caller when the callee is a
+// function declaration or a constant with an explicit type annotation.
+type Abort = (message: string) => never;
+
+const fail: Abort = message => {
   console.error(message);
   process.exit(1);
 };

--- a/scripts/typecheck-tests.ts
+++ b/scripts/typecheck-tests.ts
@@ -50,7 +50,11 @@ const FORMAT_HOST: ts.FormatDiagnosticsHost = {
   getNewLine: () => ts.sys.newLine,
 };
 
-const fail = (message: string): never => {
+// A `never` return only ends control flow for the caller when the callee is a
+// function declaration or a constant with an explicit type annotation.
+type Abort = (message: string) => never;
+
+const fail: Abort = message => {
   console.error(message);
   process.exit(1);
 };

--- a/scripts/untyped-config-modules.d.ts
+++ b/scripts/untyped-config-modules.d.ts
@@ -1,0 +1,26 @@
+// Declaration bridge for the plain-JavaScript modules the tooling imports.
+//
+// `@codexo/exojs-config` ships ESM `.js` with no declarations: it is consumed
+// by ESLint, Prettier and Vitest, which read its exports as data rather than
+// through a typed API. `scripts/ci/select-lanes.mjs` is the same shape, and
+// `eslint-plugin-security` publishes no types of its own.
+//
+// These are shorthand ambient declarations, so everything imported from them is
+// `any`. That is what crosses the boundary today either way - the difference is
+// that stating it keeps `noImplicitAny` on for everything else in
+// `tsconfig.scripts.json`, so a genuinely missing annotation in the
+// repository's own tooling is still an error rather than silent.
+//
+// Typing `@codexo/exojs-config` for real would remove this file.
+
+declare module '@codexo/exojs-config/build-defines';
+declare module '@codexo/exojs-config/eslint';
+declare module '@codexo/exojs-config/eslint/base';
+declare module '@codexo/exojs-config/eslint/correctness';
+declare module '@codexo/exojs-config/eslint/extension';
+declare module '@codexo/exojs-config/eslint/package-test';
+declare module '@codexo/exojs-config/eslint/vitest';
+declare module '@codexo/exojs-config/package-policy';
+declare module '@codexo/exojs-config/prettier';
+declare module '@codexo/exojs-config/vitest';
+declare module 'eslint-plugin-security';

--- a/scripts/verify-package-policy.ts
+++ b/scripts/verify-package-policy.ts
@@ -7,6 +7,19 @@ import { verifyConfigPackage, verifyRuntimePackage, verifyToolingPackage } from 
 
 import { INDEPENDENT_PACKAGES, LOCKSTEP_PACKAGES } from './release/lockstep-packages.ts';
 
+// The verifier is plain JavaScript (see `scripts/untyped-config-modules.d.ts`),
+// so its result shape is named here - this script reads nothing else from it.
+interface PolicyCheck {
+  readonly ok: boolean;
+  readonly name: string;
+  readonly detail?: string;
+}
+
+interface PolicyResult {
+  readonly ok: boolean;
+  readonly checks: readonly PolicyCheck[];
+}
+
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 const targets = LOCKSTEP_PACKAGES.map(p => ({
@@ -18,7 +31,7 @@ const targets = LOCKSTEP_PACKAGES.map(p => ({
 let failed = 0;
 
 for (const t of targets) {
-  const { ok, checks } = verifyRuntimePackage(t.dir, { name: t.name, isExtension: t.isExtension });
+  const { ok, checks }: PolicyResult = verifyRuntimePackage(t.dir, { name: t.name, isExtension: t.isExtension });
   const bad = checks.filter(c => !c.ok);
   console.log(`${ok ? '✓' : '✗'} ${t.name} (${checks.length} checks${bad.length ? `, ${bad.length} failed` : ''})`);
   for (const c of bad) console.log(`    ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
@@ -34,13 +47,13 @@ if (tooling === undefined) {
   process.exit(1);
 }
 
-const build = verifyToolingPackage(resolve(root, tooling.dir), { name: tooling.name });
+const build: PolicyResult = verifyToolingPackage(resolve(root, tooling.dir), { name: tooling.name });
 const buildBad = build.checks.filter(c => !c.ok);
 console.log(`${build.ok ? '✓' : '✗'} ${tooling.name} (${build.checks.length} checks${buildBad.length ? `, ${buildBad.length} failed` : ''})`);
 for (const c of buildBad) console.log(`    ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
 if (!build.ok) failed++;
 
-const cfg = verifyConfigPackage(resolve(root, 'packages/exojs-config'));
+const cfg: PolicyResult = verifyConfigPackage(resolve(root, 'packages/exojs-config'));
 const cfgBad = cfg.checks.filter(c => !c.ok);
 console.log(`${cfg.ok ? '✓' : '✗'} @codexo/exojs-config (${cfg.checks.length} checks${cfgBad.length ? `, ${cfgBad.length} failed` : ''})`);
 for (const c of cfgBad) console.log(`    ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);

--- a/test/perf/webgpu/heapSamplingCommands.ts
+++ b/test/perf/webgpu/heapSamplingCommands.ts
@@ -35,13 +35,16 @@ export interface SamplingProfileNode {
 
 /**
  * The playwright provider augments `BrowserCommandContext` with `page` and
- * `context`; the augmentation is only visible where the provider's types are
- * imported, so the two fields are narrowed locally instead.
+ * `context`. That augmentation is visible in some programs and not others, so
+ * the two fields are stated here as the minimum this file uses. An
+ * intersection rather than `extends`: where the augmentation *is* visible,
+ * `page` is Playwright's full `Page`, and re-declaring it as a narrower type
+ * through inheritance is an error.
  */
-interface PlaywrightCommandContext extends BrowserCommandContext {
+type PlaywrightCommandContext = BrowserCommandContext & {
   readonly page: object;
   readonly context: { newCDPSession(page: object): Promise<CdpSession> };
-}
+};
 
 interface CdpSession {
   send(method: string, params?: Record<string, unknown>): Promise<unknown>;

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,33 @@
+{
+  // Type-check for the repository's own tooling: the gate runners, the release
+  // cut, the build driver, the measurement harnesses, and the root config
+  // files.
+  //
+  // `tsconfig.json` covers `src/**` only, so until this config existed nothing
+  // type-checked `scripts/**` - a rename or a changed signature surfaced when
+  // the script next ran, which for the release cut means during a release.
+  // ESLint runs over the tree but with `disableTypeChecked`, since these files
+  // sit outside any typed program; that catches unused symbols and import
+  // order, not types.
+  //
+  // These are Node programs executed through `tsx`, so they import each other
+  // by their real `.ts` paths rather than extensionless specifiers - hence
+  // `allowImportingTsExtensions` with `noEmit`. `verbatimModuleSyntax` from the
+  // shared base stays on: the scripts are ESM and the distinction between a
+  // type and a value import is the same contract here as in the engine.
+  "extends": "@codexo/exojs-config/typescript/base.json",
+  "compilerOptions": {
+    "lib": ["es2023"],
+    "types": ["node"],
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": false,
+    "exactOptionalPropertyTypes": false
+  },
+  // `exo-full.entry.ts` is a bundler entry, not a Node program: it re-exports
+  // every extension package and is type-checked by `tsconfig.examples.json`
+  // against their sources.
+  "include": ["scripts/**/*.ts", "*.config.ts"],
+  "exclude": ["scripts/exo-full.entry.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -649,8 +649,13 @@ export default defineConfig({
         },
       },
     ],
-  },
-  benchmark: {
-    include: ['test/bench/**/*.bench.ts'],
+    // Nested under `test`, which is where Vitest reads it. As a sibling of
+    // `test` the key has no effect and the run falls back to the default
+    // include, which matches any `*.bench.ts` anywhere below the root -
+    // including a nested checkout or worktree holding its own copy of these
+    // same files.
+    benchmark: {
+      include: ['test/bench/**/*.bench.ts'],
+    },
   },
 });


### PR DESCRIPTION
`tsconfig.json` covers `src/**` only, so nothing type-checked `scripts/**` - 45 files including the build driver, the gate runners and the release cut. A rename or a changed signature surfaced when the script next ran, which for the release cut means during a release. ESLint runs over the tree but with `disableTypeChecked`, since these files sit outside any typed program.

`tsconfig.scripts.json` gives them one, and `pnpm typecheck:scripts` joins the typecheck gate group.

### The profile

The shared base minus `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`. Both exist to protect the engine's hot paths; holding internal tooling to them produced 59 findings that were about index access rather than about the tooling. The same argument `tsconfig.examples.json` already makes for example code.

### What the first run found

All of it pre-existing, none of it introduced here.

- **Ten `fail`/`die` helpers** returned `never` from an unannotated constant, so the compiler never treated a call as terminating. Every validation guard after one was dead weight: `parseTag` read `match.groups` after a `fail` on no-match, and `resolvePreviousTag` was typed `string` while falling off its end. Named signatures restore the narrowing.
- **`getMatchingChangelogEntry`** checks that a release date is present, then returned a type that still called it optional - the guarantee was lost at every call site. It returns `DatedChangelogEntry` now.
- **`preservedModuleNaming`** declared `facadeModuleId` as `string | null`; Rolldown's `PreRenderedChunk` declares it optional, so the shader-path naming callback did not match the option it was passed to.
- **`vitest.config.ts`** carried `benchmark` as a sibling of `test` rather than inside it. The key had no effect, and the default include it fell back to matches `*.bench.ts` anywhere below the root - including a nested checkout holding its own copy.
- **`release/run.ts`** imported the config package by a relative path into `packages/`, where every other caller uses the package specifier.

### The remaining untyped boundary

`untyped-config-modules.d.ts` declares the plain-JavaScript modules ESLint, Prettier and Vitest consume from `@codexo/exojs-config`; `select-lanes.d.mts` states the shapes that script's JSDoc already describes. Typing `@codexo/exojs-config` for real would remove the first.

Verified with `pnpm gates typecheck` (all 8 gates), `lint:all`, repo-wide Prettier, and a deliberate error injected into `scripts/lanes.ts` to confirm the new gate reports it.
