### PR TITLE
build(gates): type-check the shared config package and its consumers

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -145,7 +145,6 @@ export default defineConfig([
       ],
       '@typescript-eslint/explicit-member-accessibility': 'error',
       '@typescript-eslint/no-confusing-void-expression': ['error', { ignoreArrowShorthand: true }],
-      '@typescript-eslint/no-deprecated': 'error',
       '@typescript-eslint/no-empty-function': [
         'warn',
         {
@@ -195,8 +194,6 @@ export default defineConfig([
       '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/non-nullable-type-assertion-style': 'error',
       '@typescript-eslint/prefer-for-of': 'off',
-      '@typescript-eslint/prefer-nullish-coalescing': 'error',
-      '@typescript-eslint/prefer-optional-chain': 'error',
       '@typescript-eslint/prefer-readonly': 'off',
       '@typescript-eslint/prefer-reduce-type-parameter': 'error',
       '@typescript-eslint/prefer-regexp-exec': 'error',
@@ -213,7 +210,6 @@ export default defineConfig([
       ],
       '@typescript-eslint/return-await': ['error', 'in-try-catch'],
       '@typescript-eslint/strict-boolean-expressions': 'error',
-      '@typescript-eslint/switch-exhaustiveness-check': 'error',
       '@typescript-eslint/unbound-method': 'error',
       '@typescript-eslint/unified-signatures': 'error',
 

--- a/packages/exojs-config/build-defines/index.js
+++ b/packages/exojs-config/build-defines/index.js
@@ -23,7 +23,9 @@ import { resolve } from 'node:path';
  */
 
 /**
- * @param {{ cwd?: string, runner?: MiniRunner }} opts
+ * @param {string} cmd
+ * @param {string[]} args
+ * @param {{ cwd?: string, runner?: MiniRunner }} [opts]
  * @returns {{ code: number; stdout: string; stderr: string }}
  */
 const run = (cmd, args, { cwd, runner } = {}) => {
@@ -31,7 +33,8 @@ const run = (cmd, args, { cwd, runner } = {}) => {
   try {
     const stdout = execSync(`${cmd} ${args.join(' ')}`, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
     return { code: 0, stdout, stderr: '' };
-  } catch (e) {
+  } catch (error) {
+    const e = /** @type {{ status?: number, stdout?: string, stderr?: string }} */ (error);
     return { code: e.status ?? 1, stdout: e.stdout?.trim() ?? '', stderr: e.stderr?.trim() ?? '' };
   }
 };
@@ -83,8 +86,8 @@ const ciShaEnv = () => {
 };
 
 /**
- * @param {{ cwd?: string, runner?: MiniRunner }} opts
- * @returns {string}
+ * @param {{ cwd?: string, runner?: MiniRunner }} [opts]
+ * @returns {string | undefined}
  */
 const gitRevParse = ({ cwd, runner } = {}) => {
   const result = run('git', ['rev-parse', 'HEAD'], { cwd, runner });
@@ -100,7 +103,7 @@ const gitRevParse = ({ cwd, runner } = {}) => {
  *
  * Returns the FULL SHA so downstream code can abbreviate it as needed.
  *
- * @param {{ cwd?: string, runner?: MiniRunner }} opts
+ * @param {{ cwd?: string, runner?: MiniRunner }} [opts]
  * @returns {string}
  */
 export const resolveRevision = (opts = {}) => {
@@ -119,7 +122,7 @@ export const resolveRevision = (opts = {}) => {
 // ---- dirty-tree detection --------------------------------------------------
 
 /**
- * @param {{ cwd?: string, runner?: MiniRunner }} opts
+ * @param {{ cwd?: string, runner?: MiniRunner }} [opts]
  * @returns {boolean}
  */
 export const isTreeDirty = ({ cwd, runner } = {}) => {

--- a/packages/exojs-config/eslint/extension.js
+++ b/packages/exojs-config/eslint/extension.js
@@ -137,7 +137,6 @@ export function extensionSourceConfig({ files, tsconfigRootDir }) {
         ],
         '@typescript-eslint/explicit-member-accessibility': 'error',
         '@typescript-eslint/no-confusing-void-expression': ['error', { ignoreArrowShorthand: true }],
-        '@typescript-eslint/no-deprecated': 'error',
         '@typescript-eslint/no-empty-function': [
           'warn',
           {
@@ -186,8 +185,6 @@ export function extensionSourceConfig({ files, tsconfigRootDir }) {
         '@typescript-eslint/no-unused-vars': 'off',
         '@typescript-eslint/non-nullable-type-assertion-style': 'error',
         '@typescript-eslint/prefer-for-of': 'off',
-        '@typescript-eslint/prefer-nullish-coalescing': 'error',
-        '@typescript-eslint/prefer-optional-chain': 'error',
         '@typescript-eslint/prefer-readonly': 'off',
         '@typescript-eslint/prefer-reduce-type-parameter': 'error',
         '@typescript-eslint/prefer-regexp-exec': 'error',
@@ -204,7 +201,6 @@ export function extensionSourceConfig({ files, tsconfigRootDir }) {
         ],
         '@typescript-eslint/return-await': ['error', 'in-try-catch'],
         '@typescript-eslint/strict-boolean-expressions': 'error',
-        '@typescript-eslint/switch-exhaustiveness-check': 'error',
         '@typescript-eslint/unbound-method': 'error',
         '@typescript-eslint/unified-signatures': 'error',
 

--- a/packages/exojs-config/package-policy/index.js
+++ b/packages/exojs-config/package-policy/index.js
@@ -5,10 +5,12 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-/** @typedef {{ ok: boolean, checks: { name: string, ok: boolean, detail?: string }[] }} PolicyResult */
+/** @typedef {{ name: string, ok: boolean, detail?: string }} PolicyCheck */
+/** @typedef {{ ok: boolean, checks: PolicyCheck[] }} PolicyResult */
 
 const SOURCE_CONDITION_RE = /-source$/;
 
+/** @param {string} dir */
 function read(dir) {
   return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
 }
@@ -21,7 +23,9 @@ function read(dir) {
  */
 export function verifyRuntimePackage(dir, opts) {
   const pkg = read(dir);
+  /** @type {PolicyCheck[]} */
   const checks = [];
+  /** @type {(name: string, cond: unknown, detail?: string) => number} */
   const ok = (name, cond, detail) => checks.push({ name, ok: Boolean(cond), detail });
 
   ok('name matches', pkg.name === opts.name, `${pkg.name} vs ${opts.name}`);
@@ -34,7 +38,7 @@ export function verifyRuntimePackage(dir, opts) {
   ok('files allowlist', Array.isArray(pkg.files) && pkg.files.length > 0);
   ok(
     'files ship dist/esm',
-    (pkg.files ?? []).some(f => f.includes('dist/esm')),
+    /** @type {string[]} */ (pkg.files ?? []).some(f => f.includes('dist/esm')),
   );
   ok('ships LICENSE', (pkg.files ?? []).includes('LICENSE'));
   ok('publishConfig public', pkg.publishConfig?.access === 'public');
@@ -90,7 +94,9 @@ export function verifyRuntimePackage(dir, opts) {
  */
 export function verifyToolingPackage(dir, opts) {
   const pkg = read(dir);
+  /** @type {PolicyCheck[]} */
   const checks = [];
+  /** @type {(name: string, cond: unknown, detail?: string) => number} */
   const ok = (name, cond, detail) => checks.push({ name, ok: Boolean(cond), detail });
 
   ok('name matches', pkg.name === opts.name, `${pkg.name} vs ${opts.name}`);
@@ -103,7 +109,7 @@ export function verifyToolingPackage(dir, opts) {
   ok('files allowlist', Array.isArray(pkg.files) && pkg.files.length > 0);
   ok(
     'files ship dist/esm',
-    (pkg.files ?? []).some(f => f.includes('dist/esm')),
+    /** @type {string[]} */ (pkg.files ?? []).some(f => f.includes('dist/esm')),
   );
   ok('ships LICENSE', (pkg.files ?? []).includes('LICENSE'));
   ok('publishConfig public', pkg.publishConfig?.access === 'public');
@@ -131,7 +137,9 @@ export function verifyToolingPackage(dir, opts) {
  */
 export function verifyConfigPackage(dir) {
   const pkg = read(dir);
+  /** @type {PolicyCheck[]} */
   const checks = [];
+  /** @type {(name: string, cond: unknown, detail?: string) => number} */
   const ok = (name, cond, detail) => checks.push({ name, ok: Boolean(cond), detail });
   ok('name @codexo/exojs-config', pkg.name === '@codexo/exojs-config');
   ok('private: true', pkg.private === true);

--- a/packages/exojs-config/rolldown/index.js
+++ b/packages/exojs-config/rolldown/index.js
@@ -20,6 +20,10 @@ import { createBuildDefinesFromRepo } from '../build-defines/index.js';
 // has always contained. Rebuilding the path from `facadeModuleId` restores
 // that for the shader files; every other module keeps the default `[name]`.
 const SHADER_EXTENSION = /\.(?:vert|frag|wgsl)$/;
+/**
+ * @param {string} sourceRoot
+ * @returns {import('rolldown').ChunkFileNamesFunction}
+ */
 function preservedModuleNaming(sourceRoot) {
   return info => {
     const id = info.facadeModuleId;
@@ -43,6 +47,7 @@ export function createExtensionBuildOptions(opts) {
     packageDir: root,
   });
 
+  /** @param {string} id */
   const isExternal = id => id.startsWith('@codexo/exojs') || external.some(name => id === name || id.startsWith(`${name}/`));
 
   const packageName = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8')).name ?? 'extension';

--- a/packages/exojs-config/vitest/index.js
+++ b/packages/exojs-config/vitest/index.js
@@ -41,7 +41,7 @@ export const workerTransformPlugin = createWorkerPlugin();
  * the function; it does not otherwise change how V8 collects. Note this is a
  * top-level test option in Vitest 4 - under `poolOptions.forks` it is silently
  * ignored.
- * @param {{ name: string, include: string[], exclude?: string[], setupFiles?: string[], alias?: unknown }} opts
+ * @param {{ name: string, include: string[], exclude?: string[], setupFiles?: string[], alias?: NonNullable<import('vitest/config').ViteUserConfig['resolve']>['alias'] }} opts
  */
 export function createJsdomTestProject(opts) {
   const { name, include, exclude, setupFiles = ['./test/setup-env.vitest.ts'], alias } = opts;

--- a/scripts/untyped-config-modules.d.ts
+++ b/scripts/untyped-config-modules.d.ts
@@ -1,26 +1,14 @@
-// Declaration bridge for the plain-JavaScript modules the tooling imports.
+// Declaration bridge for the one dependency the tooling imports that ships no
+// types of its own.
 //
-// `@codexo/exojs-config` ships ESM `.js` with no declarations: it is consumed
-// by ESLint, Prettier and Vitest, which read its exports as data rather than
-// through a typed API. `scripts/ci/select-lanes.mjs` is the same shape, and
-// `eslint-plugin-security` publishes no types of its own.
+// `eslint-plugin-security` publishes plain JavaScript with no declarations, so
+// without this the ESLint config would not resolve it at all. This is a
+// shorthand ambient declaration, so everything imported from it is `any` -
+// stating that keeps `noImplicitAny` on for everything else in
+// `tsconfig.scripts.json`, where a genuinely missing annotation is an error
+// rather than silent.
 //
-// These are shorthand ambient declarations, so everything imported from them is
-// `any`. That is what crosses the boundary today either way - the difference is
-// that stating it keeps `noImplicitAny` on for everything else in
-// `tsconfig.scripts.json`, so a genuinely missing annotation in the
-// repository's own tooling is still an error rather than silent.
-//
-// Typing `@codexo/exojs-config` for real would remove this file.
+// `@codexo/exojs-config` used to be listed here as well. It is now part of the
+// program (`allowJs` + `checkJs`), so its JSDoc types reach every consumer.
 
-declare module '@codexo/exojs-config/build-defines';
-declare module '@codexo/exojs-config/eslint';
-declare module '@codexo/exojs-config/eslint/base';
-declare module '@codexo/exojs-config/eslint/correctness';
-declare module '@codexo/exojs-config/eslint/extension';
-declare module '@codexo/exojs-config/eslint/package-test';
-declare module '@codexo/exojs-config/eslint/vitest';
-declare module '@codexo/exojs-config/package-policy';
-declare module '@codexo/exojs-config/prettier';
-declare module '@codexo/exojs-config/vitest';
 declare module 'eslint-plugin-security';

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -15,12 +15,21 @@
   // `allowImportingTsExtensions` with `noEmit`. `verbatimModuleSyntax` from the
   // shared base stays on: the scripts are ESM and the distinction between a
   // type and a value import is the same contract here as in the engine.
+  //
+  // `@codexo/exojs-config` is plain ESM `.js` annotated with JSDoc, and it is
+  // in this program rather than behind an ambient `declare module`: with
+  // `allowJs`/`checkJs` its annotations are the real types, so a consumer that
+  // passes the wrong shape to a shared ESLint/Vitest/Rolldown factory fails
+  // here. Converting it to TypeScript is not required for that and would cost
+  // more than it buys - ESLint and Prettier load it directly at runtime.
   "extends": "@codexo/exojs-config/typescript/base.json",
   "compilerOptions": {
     "lib": ["es2023"],
     "types": ["node"],
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "allowJs": true,
+    "checkJs": true,
     "noEmit": true,
     "noUncheckedIndexedAccess": false,
     "exactOptionalPropertyTypes": false
@@ -28,6 +37,6 @@
   // `exo-full.entry.ts` is a bundler entry, not a Node program: it re-exports
   // every extension package and is type-checked by `tsconfig.examples.json`
   // against their sources.
-  "include": ["scripts/**/*.ts", "*.config.ts"],
+  "include": ["scripts/**/*.ts", "*.config.ts", "packages/exojs-config/**/*.js"],
   "exclude": ["scripts/exo-full.entry.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -58,7 +58,7 @@ const browserBase = {
   // sources in a genuine Worker, so both need functioning code, not a stub.
   plugins: [realShaderPlugin, workletTransformPlugin, workerTransformPlugin],
   define: { __DEV__: JSON.stringify(true), __VERSION__: JSON.stringify('0.0.0'), __REVISION__: JSON.stringify('test') },
-} as const;
+};
 
 // Per-project browser headedness:
 //  - WebGL2 Chromium: new headless. EXOJS_BROWSER_HEADED=1 only for local headed debug.
@@ -552,8 +552,8 @@ export default defineConfig({
           browser: {
             enabled: true,
             headless: false,
-            provider: playwright(),
-            instances: [{ browser: 'firefox', contextOptions: { colorScheme: 'dark' } }],
+            provider: playwright({ contextOptions: { colorScheme: 'dark' } }),
+            instances: [{ browser: 'firefox' }],
           },
         },
       },


### PR DESCRIPTION
`packages/exojs-config` ships plain ESM `.js` annotated with JSDoc, and was hidden from every type-checked program behind shorthand ambient `declare module` entries - so every import of a shared ESLint, Vitest or Rolldown factory arrived as `any`. It is now part of `tsconfig.scripts.json` (`allowJs` + `checkJs`, plus the package's `**/*.js` in `include`), and the declaration bridge is reduced to `eslint-plugin-security`, the one dependency that genuinely ships no types.

Converting the package to TypeScript was the alternative and costs more than it buys: 176 errors inside the package against 28 in its consumers, and ESLint and Prettier load these modules directly at runtime.

## What the change exposed

- **Eight rules were set twice in one `rules` object** and silently overwritten by the `typeAwareCorrectnessRules` spread that follows them: `no-deprecated`, `prefer-nullish-coalescing`, `prefer-optional-chain`, `switch-exhaustiveness-check` - in `eslint.config.ts` *and* in `eslint/extension.js`. The spread's variants are the documented ones (`ignoreIfStatements`, `considerDefaultExhaustiveForUnions`), so the duplicates go and the effective configuration is unchanged.
- **`createJsdomTestProject` declared `alias?: unknown`**, which made all thirteen project entries built from it unassignable to `TestProjectConfiguration`.
- **`browserBase` was `as const`**, so its plugin tuple was `readonly` and no browser project matched `UserWorkspaceConfig` either.
- **`browser-webgpu-firefox-dark` passed `contextOptions` on a browser instance**, where the option does not exist - it belongs to the Playwright provider (`PlaywrightProviderOptions`). The project has no npm script and no CI lane, which is why a dark-scheme run that was never dark went unnoticed.
- **`gitRevParse` documented `@returns {string}`** but returns `undefined` when git fails; `run` documented a parameter it does not take, and its catch bound an untyped error.

## Validation

`pnpm gates typecheck`, `pnpm lint:all`, `npx prettier --check .`, `git diff --check` - all clean. `tsc -p tsconfig.scripts.json` goes from 28 errors to 0. Pre-push ran `verify:quick` plus every lane (a `vitest.config.ts` change selects all of them).

## Known gap, not addressed here

`lint:all` still does not cover `packages/exojs-config/**/*.js`. Type-checking and linting that tree are separate changes; this one is the type side.