### PR TITLE
Compile the guide fragments the tooling had been excusing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,12 @@ checked against the same program state, so prefer one file per chapter.
 These sources are part of the example catalog for tooling — `typecheck:examples`,
 ESLint and Prettier cover them — but not for the playground: they get no
 generated `.js` sibling, no `examples.json` entry, and are left out of the
-served example snapshot. A listing that is a fragment (a method body shown
+served example snapshot. The one exception is the React chapter: its
+listings live in `packages/exojs-react/examples/guides/*.tsx`, because React
+resolves through that package's own `node_modules` and the root package
+deliberately carries no `react` dependency. The package's `typecheck` script
+and its ESLint config cover them; `<SourceSnippet source>` is repo-root
+relative either way. A listing that is a fragment (a method body shown
 without its class, a value only the reader owns) stays a fenced block in the
 MDX; `pnpm typecheck:guides` checks those.
 

--- a/examples/guides/cinematics/cinematic-scene.ts
+++ b/examples/guides/cinematics/cinematic-scene.ts
@@ -81,3 +81,5 @@ class CinematicScene extends Scene {
   }
 }
 // #endregion guide:cinematic-scene
+
+export { CinematicScene };

--- a/examples/guides/cinematics/cutscene-flow.ts
+++ b/examples/guides/cinematics/cutscene-flow.ts
@@ -1,0 +1,62 @@
+import { FadeSceneTransition, GamepadButton, Keyboard, Scene, Sprite, type Voice } from '@codexo/exojs';
+
+import { CinematicScene } from './cinematic-scene';
+
+class GameScene extends Scene {
+  private startCutscene(): void {
+    // #region guide:enter-cinematic
+    // From the game scene - switch to the cinematic:
+    this.app.scenes.change(CinematicScene);
+    // #endregion guide:enter-cinematic
+  }
+}
+
+class CutsceneFlowScene extends Scene {
+  private barSize = { v: 70 };
+  private musicVoice!: Voice;
+  private boss!: Sprite;
+
+  private closeOut(): void {
+    // #region guide:return-to-game
+    // At the end of the sequence - chain a tween to transition back to the game:
+    this.app.tweens
+      .create(this.barSize)
+      .to({ v: 70 }, 0.6)
+      .delay(3.5) // start closing bars after the sequence plays
+      .onComplete(() => {
+        this.app.scenes.change(GameScene, { transition: new FadeSceneTransition() });
+      })
+      .start();
+    // #endregion guide:return-to-game
+  }
+
+  // #region guide:skip-input
+  override init(): void {
+    // ... cinematic setup ...
+
+    this.inputs.onTrigger(Keyboard.Space, () => {
+      this.app.scenes.change(GameScene);
+    });
+
+    const pad = this.app.input.getGamepad(0);
+    pad.onTrigger(GamepadButton.Start, () => {
+      this.app.scenes.change(GameScene);
+    });
+  }
+  // #endregion guide:skip-input
+
+  private skipSmoothly(): void {
+    // #region guide:skip-fast-forward
+    this.inputs.onTrigger(Keyboard.Space, () => {
+      // Jump all tweens to their end state
+      this.app.tweens.clear(); // stops all active tweens
+      this.musicVoice.volume = 0.85;
+      this.boss.setScale(2.1, 2.1);
+      // ... snap other properties ...
+      this.app.scenes.change(GameScene);
+    });
+    // #endregion guide:skip-fast-forward
+  }
+}
+
+export { CutsceneFlowScene, GameScene };

--- a/examples/guides/gameplay-collision/quadtree.ts
+++ b/examples/guides/gameplay-collision/quadtree.ts
@@ -1,0 +1,33 @@
+import { Quadtree, Rectangle, Scene, Sprite } from '@codexo/exojs';
+
+// The game's own hit reaction: the guide shows which pairs reach it, not what
+// it does with them.
+declare const resolveCollision: (a: Sprite, b: Sprite) => void;
+
+class QuadtreeScene extends Scene {
+  private enemies: Sprite[] = [];
+  private player!: Sprite;
+
+  private resolveHits(): void {
+    const { player } = this;
+
+    // #region guide:quadtree
+    const tree = new Quadtree<Sprite>(new Rectangle(0, 0, 800, 600), 8, 5);
+
+    // Insert objects each frame
+    for (const enemy of this.enemies) {
+      tree.insert({ bounds: enemy.getBounds(), payload: enemy });
+    }
+
+    // Query nearby objects
+    const nearby = tree.queryRect(player.getBounds());
+    for (const item of nearby) {
+      if (player.intersectsWith(item.payload)) {
+        resolveCollision(player, item.payload);
+      }
+    }
+    // #endregion guide:quadtree
+  }
+}
+
+export { QuadtreeScene };

--- a/examples/guides/immediate-mode/draw-call-readout.ts
+++ b/examples/guides/immediate-mode/draw-call-readout.ts
@@ -1,0 +1,15 @@
+import { type RenderingContext, Scene } from '@codexo/exojs';
+
+// The application's own overlay: the counter is the engine's, the widget is not.
+declare const hud: { setStatus: (text: string) => void };
+
+class ReadoutScene extends Scene {
+  public override draw(context: RenderingContext): void {
+    // #region guide:draw-call-readout
+    const drawCalls = context.stats.drawCalls;
+    hud.setStatus(`sparks via RenderBatch - drawCalls: ${drawCalls}`);
+    // #endregion guide:draw-call-readout
+  }
+}
+
+export { ReadoutScene };

--- a/examples/guides/immediate-mode/dynamic-geometry.ts
+++ b/examples/guides/immediate-mode/dynamic-geometry.ts
@@ -1,0 +1,29 @@
+import { Geometry, RenderBatch, type RenderingContext, Scene } from '@codexo/exojs';
+
+// The application's own vertex writer: what it draws is its business, that the
+// buffer is republished with invalidate() is the guide's.
+declare const writeWaveVertices: (target: ArrayBuffer, elapsed: number) => void;
+
+class RibbonScene extends Scene {
+  private elapsed = 0;
+  private ribbon = new Geometry({
+    attributes: [{ name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 }],
+    vertexData: new Float32Array(256),
+    stride: 8,
+    usage: 'dynamic',
+  });
+
+  private batch = new RenderBatch(this.ribbon);
+
+  public override draw(context: RenderingContext): void {
+    // #region guide:dynamic-geometry
+    // Rewrite the vertex data in place, then publish the change.
+    writeWaveVertices(this.ribbon.vertexData as ArrayBuffer, this.elapsed);
+    this.ribbon.invalidate();
+
+    context.drawBatch(this.batch);
+    // #endregion guide:dynamic-geometry
+  }
+}
+
+export { RibbonScene };

--- a/examples/guides/immediate-mode/instance-attributes.ts
+++ b/examples/guides/immediate-mode/instance-attributes.ts
@@ -1,0 +1,60 @@
+import { Color, Geometry, INSTANCE_TRANSFORM_GLSL, Matrix, MeshMaterial, RenderBatch, Scene, ShaderSource } from '@codexo/exojs';
+
+interface Spark {
+  driftX: number;
+  driftY: number;
+  phase: number;
+  scale: number;
+  tint: Color;
+  x: number;
+  y: number;
+}
+
+const sparkGeometry = new Geometry({
+  attributes: [{ name: 'a_position', size: 2, type: 'f32', normalized: false, offset: 0 }],
+  vertexData: new Float32Array([0, 0, 8, 0, 4, 8]),
+  stride: 8,
+  usage: 'static',
+});
+
+const sparkMaterial = new MeshMaterial({
+  shader: new ShaderSource({
+    glsl: {
+      vertex: `#version 300 es\n${INSTANCE_TRANSFORM_GLSL}`,
+      fragment: '#version 300 es\nprecision mediump float;\nout vec4 fragColor;\nvoid main() { fragColor = vec4(1.0); }',
+    },
+  }),
+});
+
+// #region guide:instance-attributes
+const batch = new RenderBatch(sparkGeometry, sparkMaterial, {
+  instanceAttributes: [
+    { name: 'a_offset', format: 'float32x2' },
+    { name: 'a_phase', format: 'float32' },
+  ],
+});
+// #endregion guide:instance-attributes
+
+class SparkFieldScene extends Scene {
+  private batch = batch;
+  private scratch = new Matrix();
+  private sparks: Spark[] = [];
+
+  private submit(): void {
+    // #region guide:instance-data
+    const data = { a_offset: [0, 0], a_phase: 0 };
+
+    this.batch.clear();
+    for (const spark of this.sparks) {
+      data.a_offset[0] = spark.driftX;
+      data.a_offset[1] = spark.driftY;
+      data.a_phase = spark.phase;
+
+      this.scratch.set(spark.scale, 0, spark.x, 0, spark.scale, spark.y);
+      this.batch.add(this.scratch, spark.tint, data);
+    }
+    // #endregion guide:instance-data
+  }
+}
+
+export { SparkFieldScene };

--- a/examples/guides/joints-and-dynamics/joint-lifecycle.ts
+++ b/examples/guides/joints-and-dynamics/joint-lifecycle.ts
@@ -1,0 +1,12 @@
+import { BoxShape, PhysicsBody, PhysicsWorld, RevoluteJoint } from '@codexo/exojs-physics';
+
+const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+const bodyA = world.add(new PhysicsBody({ type: 'static', position: { x: 0, y: 0 } }));
+const bodyB = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 70, y: 0 }, colliders: [{ shape: new BoxShape(100, 10) }] }));
+const anchor = { x: 0, y: 0 };
+
+// #region guide:joint-lifecycle
+const joint = world.addJoint(new RevoluteJoint({ bodyA, bodyB, anchor }));
+// ...later...
+world.removeJoint(joint);
+// #endregion guide:joint-lifecycle

--- a/examples/guides/loading-and-resources/compose-diamond.ts
+++ b/examples/guides/loading-and-resources/compose-diamond.ts
@@ -1,0 +1,14 @@
+import { Assets } from '@codexo/exojs';
+
+const SharedAssets = Assets.from({
+  logo: 'image/logo.png',
+  click: 'audio/click.wav',
+  atlas: 'image/atlas.png',
+});
+
+// #region guide:compose-diamond
+const Left = Assets.compose(SharedAssets, Assets.from({ tree: 'image/tree.png' }));
+const Right = Assets.compose(SharedAssets, Assets.from({ rock: 'image/rock.png' }));
+
+Assets.compose(Left, Right); // { logo, click, atlas, tree, rock } - shared keys counted once
+// #endregion guide:compose-diamond

--- a/examples/guides/loading-and-resources/height-field-load.ts
+++ b/examples/guides/loading-and-resources/height-field-load.ts
@@ -1,0 +1,17 @@
+import { Assets, Scene } from '@codexo/exojs';
+
+import { heightFieldType } from './height-field-type';
+
+class HeightFieldScene extends Scene {
+  public override async load(): Promise<void> {
+    // #region guide:height-field-load
+    // The type itself gives you a fully typed, loadable descriptor
+    const field = await this.loader.load(heightFieldType.asset('maps/level-1.hf'));
+
+    // Or grouped in a catalog
+    const World = Assets.from({ level1: heightFieldType.asset('maps/level-1.hf') });
+    // #endregion guide:height-field-load
+  }
+}
+
+export { HeightFieldScene };

--- a/examples/guides/offline/cache-miss.ts
+++ b/examples/guides/offline/cache-miss.ts
@@ -1,0 +1,25 @@
+import { AssetCacheMissError, Assets, Scene } from '@codexo/exojs';
+
+const assets = Assets.from({ world: 'data/world.json' });
+
+// The application's own recovery UI: what it shows is the application's
+// business, that this branch is reached is the guide's.
+declare const showNotDownloadedYet: () => void;
+
+class WorldScene extends Scene {
+  public override async load(): Promise<void> {
+    // #region guide:cache-miss
+    try {
+      const world = await this.loader.load(assets.world);
+    } catch (error) {
+      if (error instanceof AssetCacheMissError) {
+        // Not "loading failed" - "this was never cached". A different message,
+        // and often a different recovery.
+        showNotDownloadedYet();
+      }
+    }
+    // #endregion guide:cache-miss
+  }
+}
+
+export { WorldScene };

--- a/examples/guides/offline/connectivity-ui.ts
+++ b/examples/guides/offline/connectivity-ui.ts
@@ -1,0 +1,18 @@
+import { Application } from '@codexo/exojs';
+
+const app = new Application();
+
+// The application's own widgets. Connectivity drives them; it does not know
+// what they are.
+declare const offlineBanner: { visible: boolean };
+declare const downloadButton: { enabled: boolean };
+
+// #region guide:connectivity-ui
+app.connectivity.onStateChange.add(state => {
+  offlineBanner.visible = state === 'offline';
+});
+
+app.connectivity.onModeChange.add(mode => {
+  downloadButton.enabled = mode !== 'offline';
+});
+// #endregion guide:connectivity-ui

--- a/examples/guides/offline/offline-load.ts
+++ b/examples/guides/offline/offline-load.ts
@@ -1,0 +1,15 @@
+import { Asset, Scene } from '@codexo/exojs';
+
+class OfflineScene extends Scene {
+  public override async load(): Promise<void> {
+    // #region guide:load-media
+    // Online: the browser streams it from the URL.
+    // Offline: the same call reads the warmed blob, or misses.
+    const theme = await this.loader.load(Asset.type('music', 'theme.mp3'));
+    // #endregion guide:load-media
+
+    this.app.audio.play(theme);
+  }
+}
+
+export { OfflineScene };

--- a/examples/guides/offline/warm-sources.ts
+++ b/examples/guides/offline/warm-sources.ts
@@ -1,0 +1,12 @@
+import { Application, Asset } from '@codexo/exojs';
+
+const app = new Application();
+
+// #region guide:warm-sources
+await app.loader.cacheSource(Asset.type('json', 'levels/01.json'));
+await app.loader.cacheSource(Asset.type('json', 'text/dialogue.json'));
+// #endregion guide:warm-sources
+
+// #region guide:warm-media
+await app.loader.cacheSource(Asset.type('music', 'theme.mp3'));
+// #endregion guide:warm-media

--- a/examples/guides/particles/spawn-on-death.ts
+++ b/examples/guides/particles/spawn-on-death.ts
@@ -1,0 +1,15 @@
+import { type ParticleSystem, SpawnModule, SpawnOnDeath } from '@codexo/exojs-particles';
+
+declare const system: ParticleSystem;
+declare const childSystem: ParticleSystem;
+declare const childBurst: SpawnModule;
+
+// #region guide:spawn-on-death
+system.addDeathModule(
+  new SpawnOnDeath(
+    childSystem, // target ParticleSystem
+    childBurst, // SpawnModule that spawns into childSystem
+    3, // spawn childBurst.apply(...) this many times
+  ),
+);
+// #endregion guide:spawn-on-death

--- a/examples/guides/physics-basics/manual-sync.ts
+++ b/examples/guides/physics-basics/manual-sync.ts
@@ -1,0 +1,11 @@
+import { MathUtils, Sprite, Texture } from '@codexo/exojs';
+import { BoxShape, PhysicsBody, PhysicsWorld } from '@codexo/exojs-physics';
+
+const world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+const body = world.add(new PhysicsBody({ type: 'dynamic', position: { x: 100, y: 0 }, colliders: [{ shape: new BoxShape(32, 32) }] }));
+const sprite = new Sprite(Texture.empty);
+
+// #region guide:manual-sync
+sprite.setPosition(body.x, body.y);
+sprite.setRotation(MathUtils.radiansToDegrees(body.angle));
+// #endregion guide:manual-sync

--- a/examples/guides/physics-basics/variable-step.ts
+++ b/examples/guides/physics-basics/variable-step.ts
@@ -1,0 +1,17 @@
+import { Scene, type Seconds } from '@codexo/exojs';
+import { PhysicsWorld } from '@codexo/exojs-physics';
+
+class VariableStepScene extends Scene {
+  private readonly world = new PhysicsWorld({ gravity: { x: 0, y: 1000 } });
+
+  // #region guide:variable-step
+  public override update(delta: Seconds): void {
+    // Also valid: world.step owns its own accumulator, so a raw variable delta
+    // from requestAnimationFrame still yields deterministic, frame-rate
+    // independent physics - you don't have to build your own accumulator.
+    this.world.step(delta);
+  }
+  // #endregion guide:variable-step
+}
+
+export { VariableStepScene };

--- a/examples/guides/tiled-maps/wang-sets.ts
+++ b/examples/guides/tiled-maps/wang-sets.ts
@@ -1,0 +1,34 @@
+import { Asset, Scene } from '@codexo/exojs';
+import { tiledWangSetToWangSet } from '@codexo/exojs-tiled';
+import { autoTile, refreshCell } from '@codexo/exojs-tilemap';
+
+class WangSetScene extends Scene {
+  public override async load(): Promise<void> {
+    const map = await this.loader.load(Asset.type('tiledSource', 'levels/forest.tmj'));
+    const tx = 0;
+    const ty = 0;
+
+    // #region guide:wang-sets
+    const tileMap = map.toTileMap();
+    const [ground] = tileMap.layers;
+
+    // wangSets live on the parsed TiledTileset, keyed by the runtime tileset's
+    // index within `layer.tilesets` (0 here - the layer's only tileset).
+    const [wangSetData] = map.tilesets[0].wangSets;
+    const wangSet = tiledWangSetToWangSet(wangSetData, 0);
+
+    // A 'mixed' wangset has no single-mask equivalent and converts to null.
+    if (wangSet) {
+      // Re-derive every autotiled variant across the whole layer, e.g. after
+      // generating terrain procedurally:
+      autoTile(ground, wangSet);
+
+      // Or, after painting a single cell, refresh just that cell and its eight
+      // neighbours instead of re-running autoTile over the whole layer:
+      refreshCell(ground, tx, ty, wangSet);
+    }
+    // #endregion guide:wang-sets
+  }
+}
+
+export { WangSetScene };

--- a/packages/exojs-react/eslint.config.ts
+++ b/packages/exojs-react/eslint.config.ts
@@ -17,6 +17,7 @@ import { defineConfig } from 'eslint/config';
 import prettier from 'eslint-config-prettier';
 
 const SOURCE = ['src/**/*.{ts,tsx}'];
+const EXAMPLES = ['examples/**/*.{ts,tsx}'];
 const TESTS = ['test/**/*.{ts,tsx}'];
 
 export default defineConfig([
@@ -60,6 +61,30 @@ export default defineConfig([
     files: ['src/Scenes.tsx'],
     rules: {
       '@eslint-react/no-unused-props': 'off',
+    },
+  },
+
+  // Guide sources (examples/guides/**) - the listings the React chapter embeds
+  // regions of. They are React code, so the React policy governs them.
+  ...reactConfig({ files: EXAMPLES, tsconfigRootDir: import.meta.dirname }),
+  {
+    files: EXAMPLES,
+    languageOptions: {
+      // Named project rather than the project service: the service resolves the
+      // nearest `tsconfig.json`, which is the package's own program over
+      // `src/**` and does not contain these files. The React rules that need
+      // type information - `no-implicit-key` among them - fail to load without
+      // a program, so pointing at the right one is what keeps them on.
+      parserOptions: { projectService: false, project: './tsconfig.examples.json', tsconfigRootDir: import.meta.dirname },
+    },
+    rules: {
+      // A listing names what it demonstrates and stops there: the headless-hook
+      // listing destructures both `app` and `canvasRef` because the chapter's
+      // point is that the hook returns both. Renaming to `_app` would put the
+      // workaround in the documentation. A stale IMPORT is still an error -
+      // that one is drift, not narration.
+      '@typescript-eslint/no-unused-vars': 'off',
+      'unused-imports/no-unused-vars': 'off',
     },
   },
 

--- a/packages/exojs-react/examples/guides/active-scene-hud.tsx
+++ b/packages/exojs-react/examples/guides/active-scene-hud.tsx
@@ -1,0 +1,13 @@
+// #region guide:active-scene-hud
+import { useActiveScene } from '@codexo/exojs-react';
+
+import type { GameScene } from './scenes';
+
+function Hud() {
+  const scene = useActiveScene<GameScene>();
+  if (scene === null) return null;
+  return <div style={{ position: 'absolute', top: 8, left: 8 }}>Score: {scene.score}</div>;
+}
+// #endregion guide:active-scene-hud
+
+export { Hud };

--- a/packages/exojs-react/examples/guides/end-to-end.tsx
+++ b/packages/exojs-react/examples/guides/end-to-end.tsx
@@ -1,0 +1,31 @@
+// #region guide:end-to-end
+import { FadeSceneTransition } from '@codexo/exojs';
+import { ExoCanvas, Scene, Scenes, useActiveScene } from '@codexo/exojs-react';
+import { useState } from 'react';
+
+import { GameScene, TitleScene } from './scenes';
+
+function Hud() {
+  const scene = useActiveScene();
+  return <div style={{ position: 'absolute', top: 8, left: 8, color: 'white' }}>{scene?.constructor.name}</div>;
+}
+
+export function App() {
+  const [screen, setScreen] = useState<'title' | 'game'>('title');
+
+  return (
+    <ExoCanvas options={{ canvas: { width: 1280, height: 720 } }} style={{ width: 1280, height: 720 }}>
+      <Scenes active={screen} transition={new FadeSceneTransition({ duration: 300 })}>
+        <Scene name="title" component={TitleScene}>
+          <button style={{ position: 'absolute', inset: 0 }} onClick={() => setScreen('game')}>
+            Start
+          </button>
+        </Scene>
+        <Scene name="game" component={GameScene}>
+          <Hud />
+        </Scene>
+      </Scenes>
+    </ExoCanvas>
+  );
+}
+// #endregion guide:end-to-end

--- a/packages/exojs-react/examples/guides/exo-canvas.tsx
+++ b/packages/exojs-react/examples/guides/exo-canvas.tsx
@@ -1,0 +1,13 @@
+// #region guide:exo-canvas
+import { ExoCanvas } from '@codexo/exojs-react';
+
+function Game() {
+  return (
+    <ExoCanvas options={{ canvas: { width: 1280, height: 720 } }} style={{ width: 1280, height: 720 }}>
+      <div style={{ position: 'absolute', top: 8, left: 8 }}>HUD overlay</div>
+    </ExoCanvas>
+  );
+}
+// #endregion guide:exo-canvas
+
+export { Game };

--- a/packages/exojs-react/examples/guides/frame-counter.tsx
+++ b/packages/exojs-react/examples/guides/frame-counter.tsx
@@ -1,0 +1,11 @@
+// #region guide:frame-counter
+import { useExoApp, useSignal } from '@codexo/exojs-react';
+
+function FrameCounter() {
+  const app = useExoApp(); // throws if rendered outside <ExoCanvas>
+  const frameCount = useSignal(app.onFrame, () => app.frameCount);
+  return <span>Frame: {frameCount}</span>;
+}
+// #endregion guide:frame-counter
+
+export { FrameCounter };

--- a/packages/exojs-react/examples/guides/headless-hook.tsx
+++ b/packages/exojs-react/examples/guides/headless-hook.tsx
@@ -1,0 +1,11 @@
+// #region guide:headless-hook
+import { useExoApplication } from '@codexo/exojs-react';
+
+function Game() {
+  const { app, canvasRef } = useExoApplication({ canvas: { width: 800, height: 600 } });
+  // `app` is null until the canvas is mounted; render it however you like.
+  return <canvas ref={canvasRef} className="game-surface" />;
+}
+// #endregion guide:headless-hook
+
+export { Game };

--- a/packages/exojs-react/examples/guides/scene-switching.tsx
+++ b/packages/exojs-react/examples/guides/scene-switching.tsx
@@ -1,0 +1,22 @@
+import { FadeSceneTransition } from '@codexo/exojs';
+import { ExoCanvas, Scene, Scenes } from '@codexo/exojs-react';
+
+import { Hud } from './active-scene-hud';
+import { GameScene, TitleScene } from './scenes';
+
+// #region guide:scene-switching
+function Game({ screen }: { screen: 'title' | 'game' }) {
+  return (
+    <ExoCanvas options={{ canvas: { width: 1280, height: 720 } }} style={{ width: 1280, height: 720 }}>
+      <Scenes active={screen} transition={new FadeSceneTransition({ duration: 300 })}>
+        <Scene name="title" component={TitleScene} />
+        <Scene name="game" component={GameScene}>
+          <Hud />
+        </Scene>
+      </Scenes>
+    </ExoCanvas>
+  );
+}
+// #endregion guide:scene-switching
+
+export { Game };

--- a/packages/exojs-react/examples/guides/scenes.ts
+++ b/packages/exojs-react/examples/guides/scenes.ts
@@ -2,5 +2,7 @@ import { Scene } from '@codexo/exojs';
 
 // #region guide:scene-registry
 export class TitleScene extends Scene {}
-export class GameScene extends Scene {}
+export class GameScene extends Scene {
+  public score = 0;
+}
 // #endregion guide:scene-registry

--- a/packages/exojs-react/package.json
+++ b/packages/exojs-react/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "build": "tsx ../../scripts/build-extension.ts",
     "build:dev": "tsx ../../scripts/build-extension.ts --dev",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && tsc --noEmit -p tsconfig.examples.json",
     "lint": "eslint --max-warnings=0 ."
   },
   "peerDependencies": {

--- a/packages/exojs-react/tsconfig.examples.json
+++ b/packages/exojs-react/tsconfig.examples.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "_comment": "Type-checks the guide listings under examples/guides/**. They live in this package rather than in the repository's own example catalog because React resolves through this package's node_modules - the root package carries no react dependency, and adding one for six documentation listings would put React in every consumer-facing program. `paths` is redeclared in full (extends replaces the key rather than merging it) so a listing can import `@codexo/exojs-react` by name, exactly as a reader's application does.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // A listing names what it demonstrates. `useExoApplication` returns both
+    // `app` and `canvasRef`, and the chapter's point is that both exist - a
+    // listing that destructured only the half it goes on to use would document
+    // the hook worse. The same relaxation the repository's guide sources carry.
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "paths": {
+      "@codexo/exojs": ["../../src/index.ts"],
+      "@codexo/exojs-react": ["./src/index.ts"]
+    }
+  },
+  "include": ["examples/**/*", "../../src/typings.d.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/site/src/content/guide/assets/loading-and-resources.mdx
+++ b/site/src/content/guide/assets/loading-and-resources.mdx
@@ -179,12 +179,12 @@ Assets.compose(LevelLocalAssets, Assets.from({ ship: 'image/other-ship.png' }));
 
 The same catalog arriving twice along different paths — a diamond — is not a conflict and deduplicates:
 
-```ts no-check -- continues the catalog above; SharedAssets comes from it
-const Left = Assets.compose(SharedAssets, Assets.from({ tree: 'image/tree.png' }));
-const Right = Assets.compose(SharedAssets, Assets.from({ rock: 'image/rock.png' }));
-
-Assets.compose(Left, Right); // { logo, click, atlas, tree, rock } — shared keys counted once
-```
+<SourceSnippet
+  source="examples/guides/loading-and-resources/compose-diamond.ts"
+  region="compose-diamond"
+  language="ts"
+  title="examples/guides/loading-and-resources/compose-diamond.ts"
+/>
 
 To re-declare a key on purpose, derive with `Assets.extend(base, entries)`. New keys are added, existing keys are deliberately overridden, and the base catalog is never mutated:
 
@@ -609,13 +609,12 @@ makes it loadable, and it makes it loadable on that application alone - two
 applications in one process can map the same suffix to different types without
 seeing each other. Once installed, the type works everywhere the built-ins do:
 
-```ts no-check -- continues the asset type above; this belongs to a scene the block does not show
-// The type itself gives you a fully typed, loadable descriptor
-const field = await this.loader.load(heightFieldType.asset('maps/level-1.hf'));
-
-// Or grouped in a catalog
-const World = Assets.from({ level1: heightFieldType.asset('maps/level-1.hf') });
-```
+<SourceSnippet
+  source="examples/guides/loading-and-resources/height-field-load.ts"
+  region="height-field-load"
+  language="ts"
+  title="examples/guides/loading-and-resources/height-field-load.ts"
+/>
 
 <Callout type="hint" title="Bare-path inference is built-in only">
 `heightFieldType.asset(...)` always works, and so does

--- a/site/src/content/guide/assets/offline.mdx
+++ b/site/src/content/guide/assets/offline.mdx
@@ -4,6 +4,7 @@ description: 'Warm a persistent cache ahead of time, and keep the application wo
 ---
 
 import Callout from '../../../components/Callout.astro';
+import SourceSnippet from '../../../components/SourceSnippet.astro';
 
 # Offline-capable asset loading
 
@@ -35,10 +36,12 @@ That is what makes one `AssetCache` safe to share between two applications - eac
 
 `loader.cacheSource(asset)` acquires an asset's **source** and lets the cache keep it - without building the asset:
 
-```ts no-check -- continues the configuration above; Asset and the app come from it
-await app.loader.cacheSource(Asset.type('json', 'levels/01.json'));
-await app.loader.cacheSource(Asset.type('json', 'text/dialogue.json'));
-```
+<SourceSnippet
+  source="examples/guides/offline/warm-sources.ts"
+  region="warm-sources"
+  language="ts"
+  title="examples/guides/offline/warm-sources.ts"
+/>
 
 Nothing is constructed, nothing is claimed, and nothing stays in memory. What remains is a cache record, which a later `load()` of the same asset finds because both derive the same source identity from the same descriptor.
 
@@ -47,9 +50,12 @@ Run it where a delay is acceptable and a connection is likely: a title screen, a
 <Callout type="hint" title="Media is warmed the same way">
 Music and video are streamed by the browser while the network is available: the element owns the transfer and never holds more than it is playing, so an ordinary `load()` acquires nothing and caches nothing. `cacheSource` is you asking for the acquisition by name, so it applies to media too, from the very same descriptor:
 
-```ts no-check -- continues the configuration above; Asset and the app come from it
-await app.loader.cacheSource(Asset.type('music', 'theme.mp3'));
-```
+<SourceSnippet
+  source="examples/guides/offline/warm-sources.ts"
+  region="warm-media"
+  language="ts"
+  title="examples/guides/offline/warm-sources.ts"
+/>
 
 Warming a source does not take streaming away. While the network is there, `load()` still streams that URL; the record is for when it is not.
 
@@ -68,29 +74,23 @@ From the next acquisition on, the resolver picks a cache-only policy. That has t
 
 Streamed media follows the same rule, without the caller doing anything:
 
-```ts no-check -- continues the configuration above; Asset and the app come from it
-// Online: the browser streams it from the URL.
-// Offline: the same call reads the warmed blob, or misses.
-const theme = await this.loader.load(Asset.type('music', 'theme.mp3'));
-```
+<SourceSnippet
+  source="examples/guides/offline/offline-load.ts"
+  region="load-media"
+  language="ts"
+  title="examples/guides/offline/offline-load.ts"
+/>
 
 One descriptor covers all of it: `cacheSource` warms it, `load` streams or reads it back, and nothing in the descriptor names a transport.
 
 Streaming reaches the network directly, past the cache and therefore past every policy. So when the network is forbidden, a normally-streamed request stops streaming and takes the acquisition path instead - which is the only way `mode = 'offline'` can mean what it says. No network-backed source is ever installed on the element.
 
-```ts no-check -- the recovery branch calls into an application's own UI, which the guide cannot define
-import { AssetCacheMissError } from '@codexo/exojs';
-
-try {
-  const world = await this.loader.load(assets.world);
-} catch (error) {
-  if (error instanceof AssetCacheMissError) {
-    // Not "loading failed" - "this was never cached". A different message,
-    // and often a different recovery.
-    showNotDownloadedYet();
-  }
-}
-```
+<SourceSnippet
+  source="examples/guides/offline/cache-miss.ts"
+  region="cache-miss"
+  language="ts"
+  title="examples/guides/offline/cache-miss.ts"
+/>
 
 Set `mode` back to `'auto'` to follow the environment again, or to `'online'` to keep using the network whatever the host reports.
 
@@ -116,15 +116,12 @@ Set `mode` back to `'auto'` to follow the environment again, or to `'online'` to
 
 The same object drives an offline banner. It is an ordinary runtime service - nothing about it is cache-specific:
 
-```ts no-check -- both listeners drive an application's own UI objects, which the guide cannot define
-app.connectivity.onStateChange.add(state => {
-  offlineBanner.visible = state === 'offline';
-});
-
-app.connectivity.onModeChange.add(mode => {
-  downloadButton.enabled = mode !== 'offline';
-});
-```
+<SourceSnippet
+  source="examples/guides/offline/connectivity-ui.ts"
+  region="connectivity-ui"
+  language="ts"
+  title="examples/guides/offline/connectivity-ui.ts"
+/>
 
 ## Where media data lives
 

--- a/site/src/content/guide/assets/tiled-maps.mdx
+++ b/site/src/content/guide/assets/tiled-maps.mdx
@@ -4,6 +4,7 @@ description: 'Load Tiled (.tmj) tilemaps as assets through the official @codexo/
 ---
 
 import Callout from '../../../components/Callout.astro';
+import SourceSnippet from '../../../components/SourceSnippet.astro';
 
 # Tiled maps
 
@@ -313,26 +314,12 @@ Wang sets — Tiled's terrain/auto-tile definitions — parse onto `TiledTileset
 it to a layer with `autoTile` (a full-layer pass) or `refreshCell` (an incremental, single-cell
 update) from `@codexo/exojs-tilemap`:
 
-```ts no-check -- continues the load above; map and the painted cell coordinates come from it
-import { tiledWangSetToWangSet } from '@codexo/exojs-tiled';
-import { autoTile, refreshCell } from '@codexo/exojs-tilemap';
-
-const tileMap = map.toTileMap();
-const [ground] = tileMap.layers;
-
-// wangSets live on the parsed TiledTileset, keyed by the runtime tileset's
-// index within `layer.tilesets` (0 here — the layer's only tileset).
-const [wangSetData] = map.tilesets[0].wangSets;
-const wangSet = tiledWangSetToWangSet(wangSetData, 0);
-
-// Re-derive every autotiled variant across the whole layer, e.g. after
-// generating terrain procedurally:
-autoTile(ground, wangSet);
-
-// Or, after painting a single cell, refresh just that cell and its eight
-// neighbours instead of re-running autoTile over the whole layer:
-refreshCell(ground, tx, ty, wangSet);
-```
+<SourceSnippet
+  source="examples/guides/tiled-maps/wang-sets.ts"
+  region="wang-sets"
+  language="ts"
+  title="examples/guides/tiled-maps/wang-sets.ts"
+/>
 
 `tiledWangSetToWangSet` handles Tiled's `'corner'` (blob-style, 8-neighbour) and `'edge'`
 (4-neighbour) wangset types; `'mixed'` wangsets interleave both semantics in a way that can't be

--- a/site/src/content/guide/effects/particles.mdx
+++ b/site/src/content/guide/effects/particles.mdx
@@ -181,15 +181,12 @@ Other available update modules: `RotateOverLifetime`, `VelocityOverLifetime`, `A
 
 A death module fires once per particle when its lifetime expires. The only built-in death module is `SpawnOnDeath`:
 
-```ts no-check -- continues the system above; system, childSystem and childBurst come from it
-import { SpawnOnDeath } from '@codexo/exojs-particles';
-
-system.addDeathModule(new SpawnOnDeath(
-    childSystem,     // target ParticleSystem
-    childBurst,       // SpawnModule that spawns into childSystem
-    3                 // spawn childBurst.apply(...) this many times
-));
-```
+<SourceSnippet
+  source="examples/guides/particles/spawn-on-death.ts"
+  region="spawn-on-death"
+  language="ts"
+  title="examples/guides/particles/spawn-on-death.ts"
+/>
 
 `SpawnOnDeath` forwards the dying particle's position to the child system's spawn, so each child burst appears at the parent's death location.
 

--- a/site/src/content/guide/integrations/react.mdx
+++ b/site/src/content/guide/integrations/react.mdx
@@ -45,15 +45,12 @@ both.
 
 `useExoApplication(options?, onReady?)` returns the app and a ref to attach to your own canvas:
 
-```tsx no-check -- JSX; the snippet extractor writes .ts files and the guide program carries no JSX or React types
-import { useExoApplication } from '@codexo/exojs-react';
-
-function Game() {
-  const { app, canvasRef } = useExoApplication({ canvas: { width: 800, height: 600 } });
-  // `app` is null until the canvas is mounted; render it however you like.
-  return <canvas ref={canvasRef} className="game-surface" />;
-}
-```
+<SourceSnippet
+  source="packages/exojs-react/examples/guides/headless-hook.tsx"
+  region="headless-hook"
+  language="tsx"
+  title="packages/exojs-react/examples/guides/headless-hook.tsx"
+/>
 
 The hook returns `{ app, canvasRef }`: `app` is the `Application` (or `null` until the canvas
 mounts and the app is created), and `canvasRef` is a stable ref you attach to the `<canvas>` the
@@ -93,20 +90,12 @@ With no `canvas.sizing` the engine only ever writes the base resolution onto the
 the app via context so descendants (HUD, the scene API) can reach it. Because the wrapper is
 positioned, absolutely-positioned children sit over the canvas with no extra setup.
 
-```tsx no-check -- JSX; the snippet extractor writes .ts files and the guide program carries no JSX or React types
-import { ExoCanvas } from '@codexo/exojs-react';
-
-function Game() {
-  return (
-    <ExoCanvas
-      options={{ canvas: { width: 1280, height: 720 } }}
-      style={{ width: 1280, height: 720 }}
-    >
-      <div style={{ position: 'absolute', top: 8, left: 8 }}>HUD overlay</div>
-    </ExoCanvas>
-  );
-}
-```
+<SourceSnippet
+  source="packages/exojs-react/examples/guides/exo-canvas.tsx"
+  region="exo-canvas"
+  language="tsx"
+  title="packages/exojs-react/examples/guides/exo-canvas.tsx"
+/>
 
 Props:
 
@@ -135,30 +124,18 @@ The scene classes you reference are ordinary ExoJS scenes — the React layer on
 one is active:
 
 <SourceSnippet
-  source="examples/guides/react/scene-registry.ts"
+  source="packages/exojs-react/examples/guides/scenes.ts"
   region="scene-registry"
   language="ts"
-  title="examples/guides/react/scene-registry.ts"
+  title="packages/exojs-react/examples/guides/scenes.ts"
 />
 
-```tsx no-check -- JSX; the snippet extractor writes .ts files and the guide program carries no JSX or React types
-import { FadeSceneTransition } from '@codexo/exojs';
-import { ExoCanvas, Scenes, Scene } from '@codexo/exojs-react';
-import { TitleScene, GameScene } from './scenes';
-
-function Game({ screen }: { screen: 'title' | 'game' }) {
-  return (
-    <ExoCanvas options={{ canvas: { width: 1280, height: 720 } }} style={{ width: 1280, height: 720 }}>
-      <Scenes active={screen} transition={new FadeSceneTransition({ duration: 300 })}>
-        <Scene name="title" component={TitleScene} />
-        <Scene name="game" component={GameScene}>
-          <Hud />
-        </Scene>
-      </Scenes>
-    </ExoCanvas>
-  );
-}
-```
+<SourceSnippet
+  source="packages/exojs-react/examples/guides/scene-switching.tsx"
+  region="scene-switching"
+  language="tsx"
+  title="packages/exojs-react/examples/guides/scene-switching.tsx"
+/>
 
 Each `<Scene>` takes a unique `name`, the scene `component` class to instantiate, and optional
 `children` that render as the active scene's overlay. The `transition` (a `SceneTransition`
@@ -174,16 +151,12 @@ name="...">` declarations if you see the warning.
 `useActiveScene()` reads the live scene instance from the nearest `<Scenes>`, so an overlay can
 react to scene state:
 
-```tsx no-check -- JSX; the snippet extractor writes .ts files and the guide program carries no JSX or React types
-import { useActiveScene } from '@codexo/exojs-react';
-import type { GameScene } from './scenes';
-
-function Hud() {
-  const scene = useActiveScene<GameScene>();
-  if (scene === null) return null;
-  return <div style={{ position: 'absolute', top: 8, left: 8 }}>Score: {scene.score}</div>;
-}
-```
+<SourceSnippet
+  source="packages/exojs-react/examples/guides/active-scene-hud.tsx"
+  region="active-scene-hud"
+  language="tsx"
+  title="packages/exojs-react/examples/guides/active-scene-hud.tsx"
+/>
 
 For the simplest case — a single scene with no switching — use `useScene(SceneClass, deps?)`
 instead. It instantiates and activates one scene, returning the instance once it is live (or
@@ -203,58 +176,24 @@ Any component rendered inside `<ExoCanvas>` can read the running app:
 alone does not make a component re-render. Pair `useExoApp()` with `useSignal()` to subscribe
 to `app.onFrame` and re-render on every dispatch:
 
-```tsx no-check -- JSX; the snippet extractor writes .ts files and the guide program carries no JSX or React types
-import { useExoApp, useSignal } from '@codexo/exojs-react';
-
-function FrameCounter() {
-  const app = useExoApp(); // throws if rendered outside <ExoCanvas>
-  const frameCount = useSignal(app.onFrame, () => app.frameCount);
-  return <span>Frame: {frameCount}</span>;
-}
-```
+<SourceSnippet
+  source="packages/exojs-react/examples/guides/frame-counter.tsx"
+  region="frame-counter"
+  language="tsx"
+  title="packages/exojs-react/examples/guides/frame-counter.tsx"
+/>
 
 ## End-to-end
 
 A small app that hosts the canvas, switches between two scenes with a fade, and overlays React
 HUD on the active scene:
 
-```tsx no-check -- JSX; the snippet extractor writes .ts files and the guide program carries no JSX or React types
-import { useState } from 'react';
-import { FadeSceneTransition } from '@codexo/exojs';
-import { ExoCanvas, Scenes, Scene, useActiveScene } from '@codexo/exojs-react';
-import { TitleScene, GameScene } from './scenes';
-
-function Hud() {
-  const scene = useActiveScene();
-  return (
-    <div style={{ position: 'absolute', top: 8, left: 8, color: 'white' }}>
-      {scene?.constructor.name}
-    </div>
-  );
-}
-
-export function App() {
-  const [screen, setScreen] = useState<'title' | 'game'>('title');
-
-  return (
-    <ExoCanvas
-      options={{ canvas: { width: 1280, height: 720 } }}
-      style={{ width: 1280, height: 720 }}
-    >
-      <Scenes active={screen} transition={new FadeSceneTransition({ duration: 300 })}>
-        <Scene name="title" component={TitleScene}>
-          <button style={{ position: 'absolute', inset: 0 }} onClick={() => setScreen('game')}>
-            Start
-          </button>
-        </Scene>
-        <Scene name="game" component={GameScene}>
-          <Hud />
-        </Scene>
-      </Scenes>
-    </ExoCanvas>
-  );
-}
-```
+<SourceSnippet
+  source="packages/exojs-react/examples/guides/end-to-end.tsx"
+  region="end-to-end"
+  language="tsx"
+  title="packages/exojs-react/examples/guides/end-to-end.tsx"
+/>
 
 React owns the screen state and the HUD; ExoJS owns the canvas, the renderer, and the per-frame
 loop. The two stay cleanly separated.

--- a/site/src/content/guide/physics/joints-and-dynamics.mdx
+++ b/site/src/content/guide/physics/joints-and-dynamics.mdx
@@ -20,11 +20,12 @@ contacts in the sub-step loop. The pattern is always the same: construct the joi
 then register it with `world.addJoint(...)`. Remove it with `world.removeJoint(joint)`,
 which wakes both bodies so they respond to the lost constraint.
 
-```ts no-check -- continues the world setup above; bodyA, bodyB and anchor come from it
-const joint = world.addJoint(new RevoluteJoint({ bodyA, bodyB, anchor }));
-// ...later...
-world.removeJoint(joint);
-```
+<SourceSnippet
+  source="examples/guides/joints-and-dynamics/joint-lifecycle.ts"
+  region="joint-lifecycle"
+  language="ts"
+  title="examples/guides/joints-and-dynamics/joint-lifecycle.ts"
+/>
 
 Many joints take a `hertz` (and `dampingRatio`) pair: leaving `hertz` at `0` makes the
 constraint **rigid**, while `hertz > 0` turns it into a **damped spring** at that

--- a/site/src/content/guide/physics/physics-basics.mdx
+++ b/site/src/content/guide/physics/physics-basics.mdx
@@ -164,14 +164,12 @@ fraction into the next call. That means both of these are correct:
   pattern — ExoJS's physics package implements the accumulator half of it for
   you; you only need to feed it a delta, fixed or not.
 
-```ts no-check -- class-method fragment shown with its modifiers but without its class
-public override update(delta: Seconds): void {
-  // Also valid: world.step owns its own accumulator, so a raw variable delta
-  // from requestAnimationFrame still yields deterministic, frame-rate
-  // independent physics — you don't have to build your own accumulator.
-  this.world.step(delta);
-}
-```
+<SourceSnippet
+  source="examples/guides/physics-basics/variable-step.ts"
+  region="variable-step"
+  language="ts"
+  title="examples/guides/physics-basics/variable-step.ts"
+/>
 
 One visible consequence: because bound sprites are written once per
 `world.step` call (once per rendered frame), a display refresh rate *above*
@@ -211,10 +209,12 @@ If you'd rather position things yourself, skip the binding and read the body's
 transform after each step — `body.x`, `body.y` (world position) and `body.angle`
 (radians):
 
-```ts no-check -- two-line sync fragment; sprite, body and MathUtils all come from the example above
-sprite.setPosition(body.x, body.y);
-sprite.setRotation(MathUtils.radiansToDegrees(body.angle));
-```
+<SourceSnippet
+  source="examples/guides/physics-basics/manual-sync.ts"
+  region="manual-sync"
+  language="ts"
+  title="examples/guides/physics-basics/manual-sync.ts"
+/>
 
 ## Smoothing motion between fixed steps
 

--- a/site/src/content/guide/recipes/cinematics.mdx
+++ b/site/src/content/guide/recipes/cinematics.mdx
@@ -41,23 +41,21 @@ Each tween operates independently — they don't need to know about each other. 
 
 Navigate to the cinematic scene from the game to fully replace the active scene while the cutscene plays:
 
-```ts no-check -- app.scenes.change needs a real Scene subclass; the scenes this page names exist only in prose
-// From the game scene — switch to the cinematic:
-this.app.scenes.change(CinematicScene);
-```
+<SourceSnippet
+  source="examples/guides/cinematics/cutscene-flow.ts"
+  region="enter-cinematic"
+  language="ts"
+  title="examples/guides/cinematics/cutscene-flow.ts"
+/>
 
 Because the cinematic is now the only active scene, the game scene neither renders nor updates for the duration. When the cinematic ends, switch back:
 
-```ts no-check -- app.scenes.change needs a real Scene subclass; the scenes this page names exist only in prose
-// At the end of the sequence — chain a tween to transition back to the game:
-this.app.tweens.create(this.barSize)
-    .to({ v: 70 }, 0.6)
-    .delay(3.5) // start closing bars after the sequence plays
-    .onComplete(() => {
-        this.app.scenes.change(GameScene, { transition: new FadeSceneTransition() });
-    })
-    .start();
-```
+<SourceSnippet
+  source="examples/guides/cinematics/cutscene-flow.ts"
+  region="return-to-game"
+  language="ts"
+  title="examples/guides/cinematics/cutscene-flow.ts"
+/>
 
 The closing shutter bars animate over the scene, then `change(...)` transitions back to the game with a fade.
 
@@ -82,33 +80,21 @@ Add a skip mechanism — press any confirm key (Space, Enter, gamepad Start) to 
 Staggering tweens with `Tween.delay()` is what turns independent animations into a timeline — no sequencer needed. To skip the whole cutscene, `app.tweens.clear()` stops every active tween at once so you can snap straight to the end state.
 </Callout>
 
-```ts no-check -- app.scenes.change needs a real Scene subclass; the scenes this page names exist only in prose
-init() {
-    // ... cinematic setup ...
-
-    this.inputs.onTrigger(Keyboard.Space, () => {
-        this.app.scenes.change(GameScene);
-    });
-
-    const pad = this.app.input.getGamepad(0);
-    pad.onTrigger(GamepadButton.Start, () => {
-        this.app.scenes.change(GameScene);
-    });
-}
-```
+<SourceSnippet
+  source="examples/guides/cinematics/cutscene-flow.ts"
+  region="skip-input"
+  language="ts"
+  title="examples/guides/cinematics/cutscene-flow.ts"
+/>
 
 For a smoother skip, fast-forward remaining tweens to completion rather than cutting hard:
 
-```ts no-check -- app.scenes.change needs a real Scene subclass; the scenes this page names exist only in prose
-this.inputs.onTrigger(Keyboard.Space, () => {
-    // Jump all tweens to their end state
-    this.app.tweens.clear(); // stops all active tweens
-    this.musicVoice.volume = 0.85;
-    this.boss.setScale(2.1, 2.1);
-    // ... snap other properties ...
-    this.app.scenes.change(GameScene);
-});
-```
+<SourceSnippet
+  source="examples/guides/cinematics/cutscene-flow.ts"
+  region="skip-fast-forward"
+  language="ts"
+  title="examples/guides/cinematics/cutscene-flow.ts"
+/>
 
 ## When not to build a cinematic system
 

--- a/site/src/content/guide/recipes/gameplay-collision.mdx
+++ b/site/src/content/guide/recipes/gameplay-collision.mdx
@@ -153,24 +153,12 @@ if (hero.intersectsWith(box)) {
 
 For scenes with many objects, pair-wise collision checks against every other object are O(n²). A [`Quadtree`](/ExoJS/en/api/quadtree/) reduces the search space:
 
-```ts no-check -- continues the collision example; Rectangle, player and the enemy list come from it
-import { Quadtree } from '@codexo/exojs';
-
-const tree = new Quadtree(new Rectangle(0, 0, 800, 600), 8, 5);
-
-// Insert objects each frame
-for (const enemy of this.enemies) {
-    tree.insert({ bounds: enemy.getBounds(), payload: enemy });
-}
-
-// Query nearby objects
-const nearby = tree.queryRect(player.getBounds());
-for (const item of nearby) {
-    if (player.intersectsWith(item.payload)) {
-        resolveCollision(player, item.payload);
-    }
-}
-```
+<SourceSnippet
+  source="examples/guides/gameplay-collision/quadtree.ts"
+  region="quadtree"
+  language="ts"
+  title="examples/guides/gameplay-collision/quadtree.ts"
+/>
 
 `Quadtree.insert(item)` auto-subdivides when a quadrant exceeds `maxItems` (default 8). `queryRect(rect)` returns all items whose bounds overlap the query rectangle. `queryPoint(x, y)` returns items containing the point. The `maxDepth` parameter (default 5) limits subdivision depth.
 

--- a/site/src/content/guide/rendering/immediate-mode.mdx
+++ b/site/src/content/guide/rendering/immediate-mode.mdx
@@ -112,13 +112,12 @@ Two things worth knowing:
 - An empty batch (`count === 0`) is a no-op.
 - Geometry of any `usage` works. `'static'` is uploaded once and cached by identity, which is what you want for a shape that never changes. `'dynamic'` or `'stream'` geometry is re-packed and re-uploaded whenever you call [`invalidate`](/ExoJS/en/api/geometry/) on it, so a mesh you rewrite per frame reaches the GPU without rebuilding the batch:
 
-```ts no-check -- call statement shown without its method; the extractor reads a leading call as a method declaration
-// Rewrite the vertex data in place, then publish the change.
-writeWaveVertices(this.ribbon.vertexData as ArrayBuffer, this.elapsed);
-this.ribbon.invalidate();
-
-context.drawBatch(this.batch);
-```
+<SourceSnippet
+  source="examples/guides/immediate-mode/dynamic-geometry.ts"
+  region="dynamic-geometry"
+  language="ts"
+  title="examples/guides/immediate-mode/dynamic-geometry.ts"
+/>
 
 Call `batch.destroy()` in `Scene.unload`/`destroy` to release the pooled storage. The geometry and any material are owned by you and are not destroyed with the batch.
 
@@ -128,30 +127,21 @@ By default a batch renders through the default mesh material, so the only thing 
 
 Declare those values as `instanceAttributes` when constructing the batch. The engine interleaves them into one buffer and hands each instance its own slice:
 
-```ts no-check -- batch options literal; the geometry and material come from the example above
-const batch = new RenderBatch(sparkGeometry, sparkMaterial, {
-    instanceAttributes: [
-        { name: 'a_offset', format: 'float32x2' },
-        { name: 'a_phase', format: 'float32' },
-    ],
-});
-```
+<SourceSnippet
+  source="examples/guides/immediate-mode/instance-attributes.ts"
+  region="instance-attributes"
+  language="ts"
+  title="examples/guides/immediate-mode/instance-attributes.ts"
+/>
 
 `add` takes the values as its third argument, keyed by attribute name, and **copies** them — exactly like it copies the `Matrix` and `Color`. So hoist one scratch object out of the loop rather than allocating a literal per instance, or the batch stops being allocation-free:
 
-```ts no-check -- update-loop fragment; the batch and the spark list belong to the scene above
-const data = { a_offset: [0, 0], a_phase: 0 };
-
-this.batch.clear();
-for (const spark of this.sparks) {
-    data.a_offset[0] = spark.driftX;
-    data.a_offset[1] = spark.driftY;
-    data.a_phase = spark.phase;
-
-    this.scratch.set(spark.scale, 0, spark.x, 0, spark.scale, spark.y);
-    this.batch.add(this.scratch, spark.tint, data);
-}
-```
+<SourceSnippet
+  source="examples/guides/immediate-mode/instance-attributes.ts"
+  region="instance-data"
+  language="ts"
+  title="examples/guides/immediate-mode/instance-attributes.ts"
+/>
 
 ### The shader contract
 
@@ -219,10 +209,12 @@ struct VertexInput {
 
 The payoff is visible in the per-frame counters. `context.stats.drawCalls` reports the number of GPU draw calls issued this frame. A batched field of 2,400 sparks adds exactly **one** to that count; drawing the same 2,400 sparks with one `drawGeometry` each adds 2,400. Read it at the end of `draw` to surface it in a HUD or the debug overlay:
 
-```ts no-check -- HUD fragment; context and hud come from the example above
-const drawCalls = context.stats.drawCalls;
-hud.setStatus(`sparks via RenderBatch · drawCalls: ${drawCalls}`);
-```
+<SourceSnippet
+  source="examples/guides/immediate-mode/draw-call-readout.ts"
+  region="draw-call-readout"
+  language="ts"
+  title="examples/guides/immediate-mode/draw-call-readout.ts"
+/>
 
 ## Worked example
 

--- a/site/src/lib/source-snippets.ts
+++ b/site/src/lib/source-snippets.ts
@@ -17,6 +17,7 @@
  *
  * Typecheck coverage:
  *   - examples/* → typecheck:examples
+ *   - packages/exojs-react/examples/* → the package's own typecheck script
  *   - packages/create-exo-app/templates/* → verify:create-exo-app
  *   - site/src/snippets/* → typecheck:guides (included via tsconfig.guides.json)
  */


### PR DESCRIPTION
Takes the guide `no-check` budget from 53 to 26 by converting the blocks whose reason was a tooling limit rather than a property of the listing.

## What moved

- **13 continuation fragments** — `offline`, `loading-and-resources`, `immediate-mode`, `tiled-maps`, `particles`, `joints-and-dynamics`, `physics-basics`, `gameplay-collision`. Each said "continues the X above"; each now has a source and a region.
- **4 `cinematics` blocks** whose reason was that `app.scenes.change` needs a real `Scene` subclass. The chapter gets a `GameScene` and a flow scene.
- **2 extractor-heuristic cases** — a call statement the extractor read as a method declaration, and a method fragment shown with its modifiers but without its class.
- **6 React listings** — see below.

## Reader-owned seams

A block that showed engine calls *and* a widget the reader owns was going entirely unchecked. Declaring the widget outside the region leaves the listing identical and puts the engine half back under the compiler. That recovered `AssetCacheMissError`, `Connectivity.onStateChange`/`onModeChange`, `RenderingContext.stats` and `Geometry.invalidate`.

## Drift the compiler found

The wangset listing in `tiled-maps` passed `tiledWangSetToWangSet(...)` straight into `autoTile`, two paragraphs above prose stating that a `'mixed'` wangset converts to `null`. It now guards. The same listing named an asset type `'tiled-map'` that does not exist — the descriptor is `Asset.type('tiledSource', ...)`, as the chapter itself shows earlier.

## React lives in its own package

The six JSX blocks are now `packages/exojs-react/examples/guides/*.tsx`, not `examples/guides/`. React resolves through that package's own `node_modules`; the root package deliberately carries no `react` dependency, and adding one for six documentation listings would put React into every consumer-facing program. The package's `tsconfig.examples.json` and `typecheck` script check them, and its ESLint config lints them under the same React policy as its source — with a named project rather than the project service, since the service resolves the `src`-only program and the React rules that need type information would fail to load.

`examples/guides/react/scene-registry.ts` moves along as `scenes.ts`, the module the listings import.

## What stays fenced (26)

Two blocks that are deliberately not valid programs (the error `Assets.compose` reports; the removed 0.8.x API), six that belong to a different program (a Vite config, `?url`, `stripShaderSource` against the published package, an `AudioWorkletGlobalScope`, a worker against `lib: webworker`), four property tours, and sketches typed against values only the reader owns.

## Validation

`pnpm gates typecheck`, `pnpm gates lint`, `pnpm gates site`, `pnpm typecheck:examples`, `pnpm typecheck:guides`, `git diff --check` — all green.

Probed rather than assumed: renaming a `<SourceSnippet region>` fails the full `typecheck:guides` chain with exit 1, including for a source outside `examples/`. Note that the chain is three steps — running `scripts/typecheck-guides.ts` alone checks previously extracted snippets and reports green on stale input.