### PR TITLE
Compile the four listings that named the reader's own members

### DIFF
--- a/examples/guides/audio-basics/cross-fade.ts
+++ b/examples/guides/audio-basics/cross-fade.ts
@@ -1,0 +1,18 @@
+import { type AudioStream, crossFade, Scene } from '@codexo/exojs';
+
+class CrossFadeScene extends Scene {
+  private trackA!: AudioStream;
+  private trackB!: AudioStream;
+
+  private async swapTracks(): Promise<void> {
+    // #region guide:cross-fade
+    const current = this.app.audio.play(this.trackA, { volume: 0.7 });
+    const next = this.app.audio.play(this.trackB, { volume: 0 });
+
+    await crossFade(current, next, 2000);
+    // next is at full volume; current has faded out and stopped (stopAfter defaults to true)
+    // #endregion guide:cross-fade
+  }
+}
+
+export { CrossFadeScene };

--- a/examples/guides/filters/wave-filter.ts
+++ b/examples/guides/filters/wave-filter.ts
@@ -1,0 +1,53 @@
+import { Scene, type Seconds, ShaderFilter, Sprite, Texture } from '@codexo/exojs';
+
+class WaveFilterScene extends Scene {
+  private time = 0;
+  private sprite = new Sprite(Texture.empty);
+
+  // #region guide:wave-filter
+  private waveFilter = new ShaderFilter({
+    glsl: {
+      fragment: `
+        #version 300 es
+        precision mediump float;
+        uniform sampler2D uTexture;
+        uniform float uTime;
+        in vec2 vUv;
+        out vec4 fragColor;
+
+        void main() {
+            vec2 uv = vUv;
+            uv.y += sin(uv.x * 12.0 + uTime * 3.0) * 0.03;
+            fragColor = texture(uTexture, uv);
+        }
+      `,
+    },
+    wgsl: `
+      struct Uniforms { uTime: f32 };
+
+      @group(0) @binding(1) var uTexture: texture_2d<f32>;
+      @group(0) @binding(2) var uSampler: sampler;
+      @group(1) @binding(0) var<uniform> uniforms: Uniforms;
+
+      @fragment
+      fn fragmentMain(@location(0) vUv: vec2<f32>) -> @location(0) vec4<f32> {
+          var uv = vUv;
+          uv.y += sin(uv.x * 12.0 + uniforms.uTime * 3.0) * 0.03;
+          return textureSample(uTexture, uSampler, uv);
+      }
+    `,
+    uniforms: { uTime: 0 },
+  });
+
+  override init(): void {
+    this.sprite.filters = [this.waveFilter];
+  }
+
+  override update(delta: Seconds): void {
+    this.time += delta;
+    this.waveFilter.setUniform('uTime', this.time);
+  }
+  // #endregion guide:wave-filter
+}
+
+export { WaveFilterScene };

--- a/examples/guides/keyboard-and-actions/trigger-threshold.ts
+++ b/examples/guides/keyboard-and-actions/trigger-threshold.ts
@@ -1,0 +1,26 @@
+import { Keyboard, Scene } from '@codexo/exojs';
+
+// The scene's own player and pause handling: the guide's subject is which
+// binding fires, not what it does.
+declare const player: { jump: () => void };
+declare const togglePause: () => void;
+
+class GameScene extends Scene {
+  // #region guide:trigger-threshold
+  override init(): void {
+    this.inputs.onTrigger(Keyboard.Space, () => {
+      player.jump();
+    });
+
+    this.inputs.onTrigger(
+      Keyboard.Escape,
+      () => {
+        togglePause();
+      },
+      { threshold: 200 },
+    );
+  }
+  // #endregion guide:trigger-threshold
+}
+
+export { GameScene };

--- a/examples/guides/spatial-audio/distance-model.ts
+++ b/examples/guides/spatial-audio/distance-model.ts
@@ -1,0 +1,23 @@
+import { Scene, Sound } from '@codexo/exojs';
+
+// The decoded buffer is the caller's: how it was obtained does not change how
+// the voice is positioned.
+declare const audioBuffer: AudioBuffer;
+
+class AmbientScene extends Scene {
+  private configure(): void {
+    // #region guide:distance-model
+    const ambient = new Sound(audioBuffer);
+    const voice = this.app.audio.play(ambient, {
+      loop: true,
+      position: { x: 0, y: 0 },
+      distanceModel: 'exponential',
+      refDistance: 100, // pixels - full volume within this radius
+      maxDistance: 800, // pixels - silence beyond this (linear only)
+      rolloffFactor: 1.5, // steepness multiplier (all models)
+    });
+    // #endregion guide:distance-model
+  }
+}
+
+export { AmbientScene };

--- a/site/src/content/guide/audio/audio-basics.mdx
+++ b/site/src/content/guide/audio/audio-basics.mdx
@@ -162,15 +162,12 @@ voice.fade(0.7, 500);
 
 The `crossFade` utility fades one playing voice down while fading another up, in parallel:
 
-```ts no-check -- scene-method fragment shown at top level; both tracks belong to the scene above
-import { crossFade } from '@codexo/exojs';
-
-const current = this.app.audio.play(this.trackA, { volume: 0.7 });
-const next = this.app.audio.play(this.trackB, { volume: 0 });
-
-await crossFade(current, next, 2000);
-// next is at full volume; current has faded out and stopped (stopAfter defaults to true)
-```
+<SourceSnippet
+  source="examples/guides/audio-basics/cross-fade.ts"
+  region="cross-fade"
+  language="ts"
+  title="examples/guides/audio-basics/cross-fade.ts"
+/>
 
 Pass `{ toVolume }` to fade the incoming voice to something other than full, and `{ stopAfter: false }` to keep the outgoing voice alive at volume 0 — the right choice when you crossfade back and forth between two looping tracks.
 

--- a/site/src/content/guide/audio/spatial-audio.mdx
+++ b/site/src/content/guide/audio/spatial-audio.mdx
@@ -90,19 +90,12 @@ Three attenuation curves control how volume drops with distance:
 
 Configure per-voice via `PlayOptions` at play time, or live on the returned `Voice`:
 
-```ts no-check -- scene-method fragment shown at top level; audioBuffer is the caller's own decoded buffer
-import { Sound } from '@codexo/exojs';
-
-const ambient = new Sound(audioBuffer);
-const voice = this.app.audio.play(ambient, {
-    loop: true,
-    position: { x: 0, y: 0 },
-    distanceModel: 'exponential',
-    refDistance: 100,      // pixels — full volume within this radius
-    maxDistance: 800,      // pixels — silence beyond this (linear only)
-    rolloffFactor: 1.5,    // steepness multiplier (all models)
-});
-```
+<SourceSnippet
+  source="examples/guides/spatial-audio/distance-model.ts"
+  region="distance-model"
+  language="ts"
+  title="examples/guides/spatial-audio/distance-model.ts"
+/>
 
 `refDistance` (default 50) is the radius around the listener where the sound plays at full volume. `maxDistance` (default 1000) only applies to the linear model. `rolloffFactor` (default 1) scales the steepness — higher values make the sound drop off faster.
 

--- a/site/src/content/guide/effects/filters.mdx
+++ b/site/src/content/guide/effects/filters.mdx
@@ -114,51 +114,12 @@ filter.setLut(differentLutTexture);
 
 `ShaderFilter` takes a fragment shader source per language and an optional uniforms map. It renders a fullscreen quad and executes the shader against the filter input texture, picking the source the active backend speaks:
 
-```ts no-check -- the shader sources are inline text and the update hook belongs to a scene the block does not show
-import { ShaderFilter } from '@codexo/exojs';
-
-const waveFilter = new ShaderFilter({
-    glsl: {
-        fragment: `
-            #version 300 es
-            precision mediump float;
-            uniform sampler2D uTexture;
-            uniform float uTime;
-            in vec2 vUv;
-            out vec4 fragColor;
-
-            void main() {
-                vec2 uv = vUv;
-                uv.y += sin(uv.x * 12.0 + uTime * 3.0) * 0.03;
-                fragColor = texture(uTexture, uv);
-            }
-        `,
-    },
-    wgsl: `
-        struct Uniforms { uTime: f32 };
-
-        @group(0) @binding(1) var uTexture: texture_2d<f32>;
-        @group(0) @binding(2) var uSampler: sampler;
-        @group(1) @binding(0) var<uniform> uniforms: Uniforms;
-
-        @fragment
-        fn fragmentMain(@location(0) vUv: vec2<f32>) -> @location(0) vec4<f32> {
-            var uv = vUv;
-            uv.y += sin(uv.x * 12.0 + uniforms.uTime * 3.0) * 0.03;
-            return textureSample(uTexture, uSampler, uv);
-        }
-    `,
-    uniforms: { uTime: 0 },
-});
-
-sprite.filters = [waveFilter];
-
-// Update uniforms per frame
-update(delta) {
-    this._time += delta;
-    waveFilter.setUniform('uTime', this._time);
-}
-```
+<SourceSnippet
+  source="examples/guides/filters/wave-filter.ts"
+  region="wave-filter"
+  language="ts"
+  title="examples/guides/filters/wave-filter.ts"
+/>
 
 Both sources are optional on their own, but a filter is only portable when it carries both: `backend: 'auto'` decides which backend an application ends up on, and a filter missing that backend's language throws `ShaderFilterBackendError` the moment it is attached — before it compiles anything. Ask `filter.supports(backendType)` if you want to check first.
 

--- a/site/src/content/guide/input/keyboard-and-actions.mdx
+++ b/site/src/content/guide/input/keyboard-and-actions.mdx
@@ -25,21 +25,12 @@ The scene's `this.inputs` registry creates bindings that are automatically dispo
 
 Each returns an `InputBinding` you can call `.unbind()` on to detach early. The `threshold` option (in ms) overrides the 300 ms default for `onTrigger`:
 
-```ts no-check -- sketch of the reader's own scene; player and togglePause are its members, not the guide's
-import { Keyboard, Scene } from '@codexo/exojs';
-
-class GameScene extends Scene {
-    init() {
-        this.inputs.onTrigger(Keyboard.Space, () => {
-            this.player.jump();
-        });
-
-        this.inputs.onTrigger(Keyboard.Escape, () => {
-            this.togglePause();
-        }, { threshold: 200 });
-    }
-}
-```
+<SourceSnippet
+  source="examples/guides/keyboard-and-actions/trigger-threshold.ts"
+  region="trigger-threshold"
+  language="ts"
+  title="examples/guides/keyboard-and-actions/trigger-threshold.ts"
+/>
 
 For held-key patterns — movement, continuous actions — use `onActive`/`onStop` to track a boolean flag, then consume it in `update`:
 


### PR DESCRIPTION
Takes the guide `no-check` count from 26 to 22.

Each of these four blocks was a real listing of engine API wrapped around one or two symbols belonging to the reader. The recorded reason was accurate; the consequence was not. To protect a `player`, a `togglePause`, a decoded `AudioBuffer` and two music tracks — none of which the guide ever claimed to define — the listings also gave up checking `crossFade`, the spatial `PlayOptions`, the `threshold` overload of `onTrigger`, and the `ShaderFilter` constructor.

Declaring those symbols outside the region leaves each listing reading as it did and puts the engine calls back under the compiler. Same pattern the offline and immediate-mode chapters already use.

| Chapter | Was |
|---|---|
| `audio/audio-basics` | `crossFade` between two tracks the scene owns |
| `audio/spatial-audio` | distance model and rolloff on a caller-supplied buffer |
| `input/keyboard-and-actions` | the `onTrigger` threshold overload |
| `effects/filters` | the `ShaderFilter` GLSL/WGSL pair and its per-frame uniform |

The filter block needed more than a wrapper: it ended with a bare `update(delta) { ... }` following a top-level `sprite.filters = [waveFilter]`. It now has an actual scene, so the update hook sits in the class it belongs to.

## What is left at 22

Two blocks that are deliberately not valid programs, six belonging to a different program (a Vite config, `?url`, the published-package check, an `AudioWorkletGlobalScope`, a worker against `lib: webworker`), four property tours, and the remaining sketches that construct nothing checkable.

## Validation

`pnpm typecheck:guides`, `pnpm gates lint`, `pnpm gates site`, `pnpm examples:sync:check`, `git diff --check` — all green.