### PR TITLE
Emit the shared runtime's declarations from its source

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,8 +5,9 @@ coverage
 # Vendored third-party asset data and its notices - copied in, not authored here.
 examples/assets/**
 
-# Generated Monaco type shim; its exact shape is pinned by a drift test.
+# Generated Monaco type shims; their exact shape is pinned by a drift test.
 examples/shared/assets-global.d.ts
+examples/shared/runtime.d.ts
 
 # Astro's generated cache, and the vendored bundles plus copied example catalog
 # the site serves - none of it authored here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,12 +134,17 @@ and that gate is the only thing that should hold an opinion about it. Never edit
 one by hand — a committed `.js` also shadows its `.ts` for anyone searching the
 tree.
 
-Two files are not that. `examples/shared/runtime.js` is authored, with a
-hand-written `runtime.d.ts` beside it and no `.ts` source. And
-`examples/tilemap/worker-streamed-terrain.js` is the one example whose generation
-is not a plain transpile: its `?worker` import is inlined at generation time, so
-the emitted file carries code its source does not, and it stays in
-`tsconfig.examples.json` for that reason.
+One file is not quite that: `examples/tilemap/worker-streamed-terrain.js` is the
+only example whose generation is not a plain transpile. Its `?worker` import is
+inlined at generation time, so the emitted file carries code its source does not,
+and it stays in `tsconfig.examples.json` for that reason.
+
+`examples/shared/` holds one more generated artifact of a different kind.
+`runtime.d.ts` is emitted from `runtime.ts` during the same sync, because the
+Playground editor resolves `@examples/runtime` through a declaration file it
+fetches from the served snapshot rather than through the implementation. Like
+`assets-global.d.ts` it is Prettier-ignored and pinned by a drift test rather
+than by `examples:sync:check`.
 
 ### Guide sources
 

--- a/examples/shared/runtime.d.ts
+++ b/examples/shared/runtime.d.ts
@@ -12,94 +12,114 @@
  * subsystem-specific. Declare `webgpu` if the example explicitly needs
  * the WebGPU backend (custom shaders, compute, GPU stress).
  */
-export type Capability =
-  | 'webgl2'
-  | 'webgpu'
-  | 'pointer'
-  | 'keyboard'
-  | 'gamepad'
-  | 'touch'
-  | 'audio'
-  | 'fullscreen'
-  | 'vibration'
-  | 'offscreenCanvas'
-  | 'webWorkers';
-
+export type Capability = 'webgl2' | 'webgpu' | 'pointer' | 'keyboard' | 'gamepad' | 'touch' | 'audio' | 'fullscreen' | 'vibration' | 'offscreenCanvas' | 'webWorkers';
 export interface ExampleRuntimeMeta {
-  slug?: string;
-  path?: string;
-  title?: string;
-  description?: string;
-  backend?: 'core' | 'webgl2' | 'webgpu' | 'advanced' | string;
-  /**
-   * Hard runtime requirements. The runner verifies each entry against
-   * the resolved engine `Capabilities` instance before mounting the
-   * example, and replaces the canvas with an unmet-capabilities overlay
-   * if any entry is `false`.
-   */
-  capabilities?: Capability[];
-  notes?: string[];
-  unsupportedNote?: string;
-  tags?: string[];
-  section?: string;
-  order?: number;
-  status?: string;
+    slug?: string;
+    path?: string;
+    title?: string;
+    description?: string;
+    backend?: 'core' | 'webgl2' | 'webgpu' | 'advanced' | string;
+    /**
+     * Hard runtime requirements. The runner verifies each entry against
+     * the resolved engine `Capabilities` instance before mounting the
+     * example, and replaces the canvas with an unmet-capabilities overlay
+     * if any entry is `false`.
+     */
+    capabilities?: Capability[];
+    notes?: string[];
+    unsupportedNote?: string;
+    tags?: string[];
+    section?: string;
+    order?: number;
+    status?: string;
 }
-
 export interface ExampleRuntime {
-  assets: Record<string, unknown>;
-  assetUrl?: (path: string) => string;
+    assets: Record<string, unknown>;
+    assetUrl?: (path: string) => string;
 }
-
 declare global {
-  interface Window {
-    __EXAMPLE_META__?: ExampleRuntimeMeta | null;
-    __EXAMPLE_PREVIEW_AUTOPLAY__?: (() => void | Promise<void>) | null;
-    // `assets` is declared (typed) in assets-global.d.ts.
-  }
+    interface Window {
+        __EXAMPLE_META__?: ExampleRuntimeMeta | null;
+        __EXAMPLE_PREVIEW_AUTOPLAY__?: (() => void | Promise<void>) | null;
+    }
+    var __EXAMPLE_META__: ExampleRuntimeMeta | null | undefined;
 }
-
 /** Corner anchor for example overlays. */
 export type OverlayCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
-
 /** A single controls-legend entry: which key(s) trigger which action. */
 export interface ControlHint {
-  keys?: string | string[];
-  action?: string;
+    keys?: string | string[];
+    action?: string;
 }
-
 /** Handle returned by {@link mountControls}. */
 export interface ControlsHandle {
-  element: HTMLElement;
-  setStatus(text: string): void;
-  setControls(list: ControlHint[]): void;
-  setHint(text: string): void;
-  dispose(): void;
+    element: HTMLElement;
+    setStatus(text: string): void;
+    setControls(list: ControlHint[]): void;
+    setHint(text: string): void;
+    dispose(): void;
 }
-
 /** A single mounted control (slider/toggle/cycle) with a programmatic setter. */
 export interface ControlBinding<T = number> {
-  set(value: T): void;
+    set(value: T): void;
 }
-
 /** Handle returned by {@link mountControlPanel}. */
 export interface ControlPanelHandle {
-  element: HTMLElement;
-  addSlider(options: { label: string; min?: number; max?: number; step?: number; value?: number; onChange?: (value: number) => void }): ControlBinding<number>;
-  addToggle(options: { label: string; value?: boolean; onChange?: (value: boolean) => void }): ControlBinding<boolean>;
-  addCycle(options: { label: string; options: string[]; index?: number; onChange?: (index: number, value: string) => void }): ControlBinding<number>;
-  addButton(options: { label: string; onClick?: () => void }): { element: HTMLButtonElement };
-  dispose(): void;
+    element: HTMLElement;
+    addSlider(options: {
+        label: string;
+        min?: number;
+        max?: number;
+        step?: number;
+        value?: number;
+        onChange?: (value: number) => void;
+    }): ControlBinding<number>;
+    addToggle(options: {
+        label: string;
+        value?: boolean;
+        onChange?: (value: boolean) => void;
+    }): ControlBinding<boolean>;
+    addCycle(options: {
+        label: string;
+        options: string[];
+        index?: number;
+        onChange?: (index: number, value: string) => void;
+    }): ControlBinding<number>;
+    addButton(options: {
+        label: string;
+        onClick?: () => void;
+    }): {
+        element: HTMLButtonElement;
+    };
+    dispose(): void;
 }
-
-export function getExampleMeta(): ExampleRuntimeMeta;
-export function supportsWebGpu(): boolean;
-export function createInfoElement(maxWidth?: string): HTMLElement;
-export function showInfo(element: HTMLElement, title: string, detail: string, isError?: boolean): void;
-export function formatErrorMessage(error: unknown): string;
-
-/** Mount a non-blocking title + controls-legend + status overlay. */
-export function mountControls(options?: { title?: string; controls?: ControlHint[]; status?: string; hint?: string; corner?: OverlayCorner }): ControlsHandle;
-
-/** Mount a predictable DOM control panel (sliders/toggles/cycles/buttons). */
-export function mountControlPanel(options?: { title?: string; corner?: OverlayCorner }): ControlPanelHandle;
+/** Options for {@link mountControls}. */
+export interface MountControlsOptions {
+    title?: string;
+    controls?: ControlHint[];
+    status?: string;
+    hint?: string;
+    corner?: OverlayCorner;
+}
+/** Options for {@link mountControlPanel}. */
+export interface MountControlPanelOptions {
+    title?: string;
+    corner?: OverlayCorner;
+}
+export declare function getExampleMeta(): ExampleRuntimeMeta;
+export declare function supportsWebGpu(): boolean;
+export declare function createInfoElement(maxWidth?: string): HTMLElement;
+export declare function showInfo(element: HTMLElement, title: string, detail: string, isError?: boolean): void;
+export declare function formatErrorMessage(error: unknown): string;
+/**
+ * Mount a non-blocking on-screen panel with a title, a controls legend, an
+ * optional live status line, and an optional hint. Returns a handle to update
+ * the status/controls and to remove the panel.
+ */
+export declare function mountControls(options?: MountControlsOptions): ControlsHandle;
+/**
+ * Mount a predictable DOM control panel over the canvas - sliders, toggles,
+ * cycles, and buttons - so interactive examples expose their parameters in a
+ * consistent, discoverable way instead of hand-rolling canvas hit-tests.
+ */
+export declare function mountControlPanel(options?: MountControlPanelOptions): ControlPanelHandle;

--- a/examples/shared/runtime.ts
+++ b/examples/shared/runtime.ts
@@ -1,13 +1,131 @@
-// Auto-generated from runtime.ts - edit the .ts source, not this file.
-export function getExampleMeta() {
+/**
+ * Boolean fields of the engine `Capabilities` object that an example may
+ * declare as a hard runtime requirement. Each value here maps 1:1 to a
+ * field of `Capabilities` (see `src/core/capabilities.ts`). When any
+ * declared capability resolves to `false` at runtime, the playground/guide
+ * shows an overlay listing required capabilities and which are missing,
+ * and skips mounting the example.
+ *
+ * Implicit default: every example is assumed to need a working `webgl2`
+ * context (the default render backend). Declare `webgl2` only if the
+ * example also runs on a WebGPU-only path or the requirement is
+ * subsystem-specific. Declare `webgpu` if the example explicitly needs
+ * the WebGPU backend (custom shaders, compute, GPU stress).
+ */
+export type Capability =
+  | 'webgl2'
+  | 'webgpu'
+  | 'pointer'
+  | 'keyboard'
+  | 'gamepad'
+  | 'touch'
+  | 'audio'
+  | 'fullscreen'
+  | 'vibration'
+  | 'offscreenCanvas'
+  | 'webWorkers';
+
+export interface ExampleRuntimeMeta {
+  slug?: string;
+  path?: string;
+  title?: string;
+  description?: string;
+  backend?: 'core' | 'webgl2' | 'webgpu' | 'advanced' | string;
+  /**
+   * Hard runtime requirements. The runner verifies each entry against
+   * the resolved engine `Capabilities` instance before mounting the
+   * example, and replaces the canvas with an unmet-capabilities overlay
+   * if any entry is `false`.
+   */
+  capabilities?: Capability[];
+  notes?: string[];
+  unsupportedNote?: string;
+  tags?: string[];
+  section?: string;
+  order?: number;
+  status?: string;
+}
+
+export interface ExampleRuntime {
+  assets: Record<string, unknown>;
+  assetUrl?: (path: string) => string;
+}
+
+declare global {
+  interface Window {
+    __EXAMPLE_META__?: ExampleRuntimeMeta | null;
+    __EXAMPLE_PREVIEW_AUTOPLAY__?: (() => void | Promise<void>) | null;
+    // `assets` is declared (typed) in assets-global.d.ts.
+  }
+
+  // Declared on the global scope as well as on `Window`: the runner injects the
+  // meta before the example module evaluates, and `getExampleMeta` reads it
+  // through `globalThis` so the helper also works where `window` is not the
+  // global object.
+  var __EXAMPLE_META__: ExampleRuntimeMeta | null | undefined;
+}
+
+/** Corner anchor for example overlays. */
+export type OverlayCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+/** A single controls-legend entry: which key(s) trigger which action. */
+export interface ControlHint {
+  keys?: string | string[];
+  action?: string;
+}
+
+/** Handle returned by {@link mountControls}. */
+export interface ControlsHandle {
+  element: HTMLElement;
+  setStatus(text: string): void;
+  setControls(list: ControlHint[]): void;
+  setHint(text: string): void;
+  dispose(): void;
+}
+
+/** A single mounted control (slider/toggle/cycle) with a programmatic setter. */
+export interface ControlBinding<T = number> {
+  set(value: T): void;
+}
+
+/** Handle returned by {@link mountControlPanel}. */
+export interface ControlPanelHandle {
+  element: HTMLElement;
+  addSlider(options: { label: string; min?: number; max?: number; step?: number; value?: number; onChange?: (value: number) => void }): ControlBinding<number>;
+  addToggle(options: { label: string; value?: boolean; onChange?: (value: boolean) => void }): ControlBinding<boolean>;
+  addCycle(options: { label: string; options: string[]; index?: number; onChange?: (index: number, value: string) => void }): ControlBinding<number>;
+  addButton(options: { label: string; onClick?: () => void }): { element: HTMLButtonElement };
+  dispose(): void;
+}
+
+/** Options for {@link mountControls}. */
+export interface MountControlsOptions {
+  title?: string;
+  controls?: ControlHint[];
+  status?: string;
+  hint?: string;
+  corner?: OverlayCorner;
+}
+
+/** Options for {@link mountControlPanel}. */
+export interface MountControlPanelOptions {
+  title?: string;
+  corner?: OverlayCorner;
+}
+
+export function getExampleMeta(): ExampleRuntimeMeta {
   const meta = globalThis.__EXAMPLE_META__;
+
   return meta && typeof meta === 'object' ? meta : {};
 }
-export function supportsWebGpu() {
+
+export function supportsWebGpu(): boolean {
   return typeof navigator !== 'undefined' && 'gpu' in navigator;
 }
-export function createInfoElement(maxWidth = '430px') {
+
+export function createInfoElement(maxWidth = '430px'): HTMLElement {
   const element = document.createElement('aside');
+
   Object.assign(element.style, {
     position: 'fixed',
     top: '16px',
@@ -26,27 +144,35 @@ export function createInfoElement(maxWidth = '430px') {
     pointerEvents: 'none',
     whiteSpace: 'normal',
   });
+
   return element;
 }
-export function showInfo(element, title, detail, isError = false) {
+
+export function showInfo(element: HTMLElement, title: string, detail: string, isError = false): void {
   if (!element.isConnected) {
     document.body.append(element);
   }
+
   const titleElement = document.createElement('strong');
   const detailElement = document.createElement('span');
+
   titleElement.textContent = title;
   detailElement.textContent = detail;
+
   Object.assign(titleElement.style, {
     display: 'block',
     marginBottom: '6px',
     fontSize: '14px',
     color: isError ? '#ffb4b4' : '#ffffff',
   });
+
   element.replaceChildren(titleElement, detailElement);
 }
-export function formatErrorMessage(error) {
+
+export function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
 // ---------------------------------------------------------------------------
 // Example helper kit
 //
@@ -57,15 +183,19 @@ export function formatErrorMessage(error) {
 // All overlays are fixed-position DOM elements layered over the WebGL canvas, so
 // they never interfere with the rendered scene and stay crisp at any DPR.
 // ---------------------------------------------------------------------------
+
 const FONT_STACK = '"Segoe UI", system-ui, sans-serif';
-const CORNER_STYLES = {
+
+const CORNER_STYLES: Record<OverlayCorner, Partial<CSSStyleDeclaration>> = {
   'top-left': { top: '16px', left: '16px' },
   'top-right': { top: '16px', right: '16px' },
   'bottom-left': { bottom: '16px', left: '16px' },
   'bottom-right': { bottom: '16px', right: '16px' },
 };
-function createPanel(corner = 'top-left') {
+
+function createPanel(corner: OverlayCorner = 'top-left'): HTMLElement {
   const panel = document.createElement('aside');
+
   Object.assign(panel.style, {
     position: 'fixed',
     padding: '12px 14px',
@@ -81,11 +211,15 @@ function createPanel(corner = 'top-left') {
     maxWidth: '300px',
     ...(CORNER_STYLES[corner] ?? CORNER_STYLES['top-left']),
   });
+
   return panel;
 }
-function createKeyChip(label) {
+
+function createKeyChip(label: string): HTMLElement {
   const chip = document.createElement('kbd');
+
   chip.textContent = label;
+
   Object.assign(chip.style, {
     display: 'inline-block',
     padding: '1px 7px',
@@ -97,55 +231,72 @@ function createKeyChip(label) {
     color: '#dce8ff',
     whiteSpace: 'nowrap',
   });
+
   return chip;
 }
-function createControlRow(control) {
+
+function createControlRow(control: ControlHint): HTMLElement {
   const row = document.createElement('div');
+
   Object.assign(row.style, { display: 'flex', alignItems: 'baseline', gap: '4px', margin: '4px 0' });
+
   const rawKeys = control.keys ?? [];
   const keys = Array.isArray(rawKeys) ? rawKeys : [rawKeys];
   const keysWrap = document.createElement('span');
+
   for (const key of keys) {
     keysWrap.append(createKeyChip(String(key)));
   }
+
   const action = document.createElement('span');
+
   action.textContent = control.action ?? '';
   action.style.color = '#c4d2ec';
+
   row.append(keysWrap, action);
+
   return row;
 }
+
 /**
  * Mount a non-blocking on-screen panel with a title, a controls legend, an
  * optional live status line, and an optional hint. Returns a handle to update
  * the status/controls and to remove the panel.
  */
-export function mountControls(options = {}) {
+export function mountControls(options: MountControlsOptions = {}): ControlsHandle {
   const { title = '', controls = [], status = '', hint = '', corner = 'top-left' } = options;
+
   const panel = createPanel(corner);
   panel.style.pointerEvents = 'none';
+
   const titleEl = document.createElement('strong');
   const controlsEl = document.createElement('div');
   const statusEl = document.createElement('div');
   const hintEl = document.createElement('div');
+
   Object.assign(titleEl.style, { display: 'block', marginBottom: '6px', fontSize: '14px', color: '#ffffff' });
   Object.assign(statusEl.style, { marginTop: '6px', font: `600 13px ${FONT_STACK}`, color: '#9fd0ff' });
   Object.assign(hintEl.style, { marginTop: '6px', fontSize: '12px', color: '#8aa0c4' });
-  const renderControls = list => controlsEl.replaceChildren(...list.map(createControlRow));
+
+  const renderControls = (list: ControlHint[]) => controlsEl.replaceChildren(...list.map(createControlRow));
+
   titleEl.textContent = title;
   renderControls(controls);
   statusEl.textContent = status;
   hintEl.textContent = hint;
+
   panel.append(titleEl, controlsEl, statusEl, hintEl);
   document.body.append(panel);
+
   return {
     element: panel,
-    setStatus(text) {
+    setStatus(text: string) {
       statusEl.textContent = text ?? '';
     },
-    setControls(list) {
+    setControls(list: ControlHint[]) {
       renderControls(list ?? []);
     },
-    setHint(text) {
+    setHint(text: string) {
       hintEl.textContent = text ?? '';
     },
     dispose() {
@@ -153,71 +304,98 @@ export function mountControls(options = {}) {
     },
   };
 }
-function createControlRowContainer() {
+
+function createControlRowContainer(): HTMLElement {
   const row = document.createElement('div');
+
   Object.assign(row.style, { display: 'flex', alignItems: 'center', gap: '10px', margin: '6px 0' });
+
   return row;
 }
-function createControlLabel(text) {
+
+function createControlLabel(text: string): HTMLElement {
   const label = document.createElement('span');
+
   label.textContent = text;
+
   Object.assign(label.style, { flex: '0 0 auto', minWidth: '92px', color: '#c4d2ec', fontSize: '12px' });
+
   return label;
 }
+
 /**
  * Mount a predictable DOM control panel over the canvas - sliders, toggles,
  * cycles, and buttons - so interactive examples expose their parameters in a
  * consistent, discoverable way instead of hand-rolling canvas hit-tests.
  */
-export function mountControlPanel(options = {}) {
+export function mountControlPanel(options: MountControlPanelOptions = {}): ControlPanelHandle {
   const { title = '', corner = 'bottom-left' } = options;
+
   const panel = createPanel(corner);
+
   panel.style.pointerEvents = 'auto';
   panel.style.minWidth = '230px';
+
   if (title) {
     const titleEl = document.createElement('strong');
+
     titleEl.textContent = title;
     Object.assign(titleEl.style, { display: 'block', marginBottom: '8px', fontSize: '14px', color: '#ffffff' });
     panel.append(titleEl);
   }
+
   document.body.append(panel);
-  const stop = event => event.stopPropagation();
+
+  const stop = (event: Event) => event.stopPropagation();
+
   panel.addEventListener('pointerdown', stop);
+
   return {
     element: panel,
+
     addSlider({ label, min = 0, max = 1, step = 0.01, value = min, onChange }) {
       const row = createControlRowContainer();
       const input = document.createElement('input');
       const readout = document.createElement('span');
+
       input.type = 'range';
       input.min = String(min);
       input.max = String(max);
       input.step = String(step);
       input.value = String(value);
       input.style.flex = '1 1 auto';
+
       Object.assign(readout.style, { flex: '0 0 auto', minWidth: '42px', textAlign: 'right', color: '#9fd0ff', font: `600 12px ${FONT_STACK}` });
-      const render = v => {
+
+      const render = (v: number) => {
         readout.textContent = Number(v).toFixed(2);
       };
+
       render(value);
       input.addEventListener('input', () => {
         const v = Number(input.value);
+
         render(v);
         onChange?.(v);
       });
+
       row.append(createControlLabel(label), input, readout);
       panel.append(row);
+
       return {
-        set(v) {
+        set(v: number) {
           input.value = String(v);
           render(v);
         },
       };
     },
+
     addToggle({ label, value = false, onChange }) {
       const row = createControlRowContainer();
       const button = document.createElement('button');
+
       let state = value;
+
       Object.assign(button.style, {
         flex: '1 1 auto',
         padding: '5px 10px',
@@ -228,31 +406,38 @@ export function mountControlPanel(options = {}) {
         font: `600 12px ${FONT_STACK}`,
         cursor: 'pointer',
       });
+
       const render = () => {
         button.textContent = state ? 'On' : 'Off';
         button.style.background = state ? 'rgba(120, 220, 160, 0.22)' : 'rgba(154, 193, 255, 0.12)';
       };
+
       render();
       button.addEventListener('click', () => {
         state = !state;
         render();
         onChange?.(state);
       });
+
       row.append(createControlLabel(label), button);
       panel.append(row);
+
       return {
-        set(v) {
+        set(v: boolean) {
           state = Boolean(v);
           render();
         },
       };
     },
+
     addCycle({ label, options: choices, index = 0, onChange }) {
       const row = createControlRowContainer();
       const prev = document.createElement('button');
       const next = document.createElement('button');
       const readout = document.createElement('span');
+
       let current = index;
+
       for (const button of [prev, next]) {
         Object.assign(button.style, {
           flex: '0 0 auto',
@@ -266,32 +451,42 @@ export function mountControlPanel(options = {}) {
           cursor: 'pointer',
         });
       }
+
       prev.textContent = '‹';
       next.textContent = '›';
+
       Object.assign(readout.style, { flex: '1 1 auto', textAlign: 'center', color: '#9fd0ff', font: `600 12px ${FONT_STACK}` });
+
       const render = () => {
         readout.textContent = String(choices[current]);
       };
-      const move = delta => {
+
+      const move = (delta: number) => {
         current = (current + delta + choices.length) % choices.length;
         render();
         onChange?.(current, choices[current]);
       };
+
       render();
       prev.addEventListener('click', () => move(-1));
       next.addEventListener('click', () => move(1));
+
       row.append(createControlLabel(label), prev, readout, next);
       panel.append(row);
+
       return {
-        set(i) {
+        set(i: number) {
           current = ((i % choices.length) + choices.length) % choices.length;
           render();
         },
       };
     },
+
     addButton({ label, onClick }) {
       const button = document.createElement('button');
+
       button.textContent = label;
+
       Object.assign(button.style, {
         display: 'block',
         width: '100%',
@@ -304,10 +499,13 @@ export function mountControlPanel(options = {}) {
         font: `600 12px ${FONT_STACK}`,
         cursor: 'pointer',
       });
+
       button.addEventListener('click', () => onClick?.());
       panel.append(button);
+
       return { element: button };
     },
+
     dispose() {
       panel.remove();
     },

--- a/scripts/generate-examples-runtime-dts.ts
+++ b/scripts/generate-examples-runtime-dts.ts
@@ -1,0 +1,60 @@
+/**
+ * Declaration emit for the shared example runtime.
+ *
+ * `examples/shared/runtime.ts` is the implementation the examples import. The
+ * Playground editor cannot read it: Monaco resolves `@examples/runtime` through
+ * a virtual `index.d.ts` it fetches over HTTP from the served snapshot (see
+ * `SHARED_LIB_FILES` in the site's editor component), so the module needs a
+ * declaration file next to it.
+ *
+ * That file used to be hand-written alongside a hand-written `runtime.js`, which
+ * left the editor's view of the helper kit free to drift from the helper kit.
+ * Emitting it from the implementation removes the second copy; a drift test
+ * pins the committed output the same way `assets-global.d.ts` is pinned.
+ */
+import path from 'node:path';
+
+import ts from 'typescript';
+
+/** Compiler options for the emit. Kept explicit so the output does not move with an unrelated tsconfig edit. */
+const EMIT_OPTIONS: ts.CompilerOptions = {
+  declaration: true,
+  emitDeclarationOnly: true,
+  strict: true,
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  moduleResolution: ts.ModuleResolutionKind.Bundler,
+  lib: ['lib.es2022.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts'],
+  skipLibCheck: true,
+};
+
+/**
+ * Emits the declaration file for `examples/shared/runtime.ts`.
+ *
+ * Throws when the emit produces no declaration output, which means the source
+ * failed to compile - a silent empty write would hand the editor an empty
+ * module and show up as "has no exported member" on every example.
+ */
+export const renderRuntimeDts = (repositoryRoot: string): string => {
+  const entry = path.resolve(repositoryRoot, 'examples', 'shared', 'runtime.ts');
+  const program = ts.createProgram([entry], EMIT_OPTIONS);
+
+  let output: string | null = null;
+
+  const result = program.emit(undefined, (fileName, text) => {
+    if (fileName.endsWith('runtime.d.ts')) output = text;
+  });
+
+  if (output === null) {
+    const diagnostics = ts.getPreEmitDiagnostics(program).concat(result.diagnostics);
+    const detail = ts.formatDiagnostics(diagnostics, {
+      getCanonicalFileName: fileName => fileName,
+      getCurrentDirectory: () => repositoryRoot,
+      getNewLine: () => '\n',
+    });
+
+    throw new Error(`Declaration emit for examples/shared/runtime.ts produced no output.\n${detail}`);
+  }
+
+  return output;
+};

--- a/site/scripts/sync-examples-static.ts
+++ b/site/scripts/sync-examples-static.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { renderAssetsGlobalDts } from '../../scripts/generate-examples-global-dts.ts';
+import { renderRuntimeDts } from '../../scripts/generate-examples-runtime-dts.ts';
 import { transpileTypescriptExamples } from '../../scripts/transpile-examples.ts';
 import { assets } from '../../examples/assets/assets.js';
 import { rawAssets } from '../../examples/assets/catalog.js';
@@ -74,6 +75,14 @@ const run = async (): Promise<void> => {
   const globalDtsPath = path.resolve(sourceExamplesDir, 'shared', 'assets-global.d.ts');
   fs.writeFileSync(globalDtsPath, renderAssetsGlobalDts(assets as unknown as Record<string, unknown>), 'utf8');
   console.log(`[examples:sync] Generated ${globalDtsPath}`);
+
+  // The Playground editor resolves `@examples/runtime` through a declaration
+  // file it fetches from the served snapshot, so the shared helper kit needs one
+  // beside its implementation. Emitted rather than hand-written: a second copy
+  // of the same signatures is free to drift from the code the examples run.
+  const runtimeDtsPath = path.resolve(sourceExamplesDir, 'shared', 'runtime.d.ts');
+  fs.writeFileSync(runtimeDtsPath, renderRuntimeDts(repositoryRoot), 'utf8');
+  console.log(`[examples:sync] Generated ${runtimeDtsPath}`);
 
   resetDir(targetExamplesDir);
   resetDir(targetAssetsDir);

--- a/test/site/runtime-dts.test.ts
+++ b/test/site/runtime-dts.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { renderRuntimeDts } from '../../scripts/generate-examples-runtime-dts.ts';
+
+const repositoryRoot = resolve(import.meta.dirname, '..', '..');
+const committedPath = resolve(repositoryRoot, 'examples', 'shared', 'runtime.d.ts');
+
+describe('examples/shared/runtime.d.ts', () => {
+  const committed = readFileSync(committedPath, 'utf8');
+
+  it('matches a fresh emit from runtime.ts', () => {
+    expect(committed).toBe(renderRuntimeDts(repositoryRoot));
+  });
+
+  it('declares the helper kit the examples import', () => {
+    expect(committed).toContain('export declare function mountControls(');
+    expect(committed).toContain('export declare function mountControlPanel(');
+    expect(committed).toContain('export declare function getExampleMeta(');
+  });
+
+  it('keeps the playground globals the runner injects', () => {
+    expect(committed).toContain('__EXAMPLE_META__');
+    expect(committed).toContain('__EXAMPLE_PREVIEW_AUTOPLAY__');
+  });
+});

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -6,7 +6,7 @@
   // The runtime example smoke (site/scripts/smoke-examples.ts) only catches
   // crashes and missing canvases - stale TextStyle keys like `fill`, `stroke`,
   // or `wordWrap` are silently ignored at runtime, so they slip through. This
-  // config type-checks the example `.js` sources against the engine's own source
+  // config type-checks the example sources against the engine's own source
   // types (no build required: `@codexo/exojs` maps to `src/index.ts`), so the
   // editor-visible "`fill` does not exist in TextStyleOptions" diagnostics also
   // fail `pnpm typecheck:examples`.
@@ -23,13 +23,14 @@
   // accessed before the scene is attached).
   //
   // Scope: the full example catalog plus `scripts/exo-full.entry.ts`. Every
-  // `.js` under `examples/` is type-checked against the engine source types, so
-  // stale TextStyle keys are caught catalog-wide. The full-bundle entry is the
+  // authored `.ts` under `examples/` is type-checked against the engine source
+  // types, so stale TextStyle keys are caught catalog-wide. The full-bundle entry is the
   // same kind of program - a named re-export surface resolved against every
   // extension package's source - and the production build only compiles it when
   // EXOJS_FULL_BUNDLE=1, so without it here a stale named export is visible only
-  // in the CI build lane. `examples/shared/runtime.d.ts` supplies the
-  // playground-only globals (`window.assets`, `__EXAMPLE_META__`).
+  // in the CI build lane. `examples/shared/runtime.ts` supplies the shared
+  // helper kit and the playground-only globals (`window.assets`,
+  // `__EXAMPLE_META__`).
   //
   // The generated `.js` siblings are NOT in this program. They are transpiled
   // from the `.ts` beside them by `examples:sync` and committed so a release
@@ -44,18 +45,11 @@
   // emitted file carries code the `.ts` does not, and dropping it would leave
   // that code unchecked.
   //
-  // `examples/shared/runtime.js` stays out for a different reason: it is
-  // authored rather than generated, but what every consumer resolves is its
-  // hand-written `runtime.d.ts`, and the file itself is not checked under the
-  // previous include either. Putting it in the program reports ~30 implicit
-  // `any`s that have always been there, which is its own change and not this
-  // one.
-  //
   // `examples/shared/editor-support.d.ts` is deliberately NOT included: it is a
   // Monaco-only extra-lib that re-declares `Json`/`TextAsset`/etc. inside
   // `declare module '@codexo/exojs'`, which collides with the real source
-  // exports here (duplicate-identifier). Its permissive Scene/Loader shims are
-  // unnecessary for `.js` sources - checked JS infers `this._x` fields directly.
+  // exports here (duplicate-identifier). Its permissive Scene/Loader shims exist
+  // for the editor's JavaScript view, which is not this program.
   //
   // The entire example catalog type-checks against the engine source types with
   // zero per-example excludes. The former stale-API clusters (two-argument
@@ -79,16 +73,10 @@
       "@codexo/exojs-physics/debug": ["./packages/exojs-physics/src/debug/index.ts"],
       "@codexo/exojs-tilemap-physics": ["./packages/exojs-tilemap-physics/src/index.ts"],
       "@codexo/exojs-audio-fx": ["./packages/exojs-audio-fx/src/index.ts"],
-      "@examples/runtime": ["./examples/shared/runtime.d.ts"],
+      "@examples/runtime": ["./examples/shared/runtime.ts"],
       "@examples/terrain-noise": ["./examples/shared/terrain-noise.ts"]
     }
   },
-  "include": [
-    "examples/**/*.ts",
-    "examples/tilemap/worker-streamed-terrain.js",
-    "examples/shared/runtime.d.ts",
-    "scripts/exo-full.entry.ts",
-    "src/typings.d.ts"
-  ],
+  "include": ["examples/**/*.ts", "examples/tilemap/worker-streamed-terrain.js", "scripts/exo-full.entry.ts", "src/typings.d.ts"],
   "exclude": ["examples/shared/editor-support.d.ts", "examples/**/*.worker.ts"]
 }


### PR DESCRIPTION
`examples/shared/runtime.js` was the last authored JavaScript under `examples/`, and it shipped with a hand-written `runtime.d.ts` restating the same signatures. Nothing checked one against the other, so the Playground editor's view of the shared helper kit was free to drift from the helper kit.

## Why the `.d.ts` cannot just be deleted

Monaco does not resolve `@examples/runtime` through the implementation. It fetches a declaration file over HTTP from the served snapshot and registers it as a virtual `node_modules/@examples/runtime/index.d.ts` (`SHARED_LIB_FILES` in `site/src/components/EditorCode.tsx`). Removing the file would surface as "has no exported member" on every example importing `mountControls`.

## What this does instead

`runtime.ts` becomes the source. Its `.js` is generated like every other example's, and the `.d.ts` is emitted from it in the same `examples:sync` run. Both stay committed: the `.js` is covered by `examples:sync:check`, the `.d.ts` by a drift test and a Prettier ignore — exactly how `examples/shared/assets-global.d.ts` is already handled.

`scripts/generate-examples-runtime-dts.ts` throws rather than writing an empty file when the source fails to compile. A silent empty write would reach the editor as the same "has no exported member", with nothing pointing at the cause.

## Side effect worth naming

`@examples/runtime` now resolves to the implementation, so `pnpm typecheck:examples` checks the helper kit for the first time. The two inline option bags gain names — `MountControlsOptions`, `MountControlPanelOptions` — because the JSDoc `@param` shapes they were written as do not survive declaration emit.

Two passages from #618 are corrected: `CONTRIBUTING.md` described `runtime.js` as authored, and `tsconfig.examples.json` still had three sentences about `.js` sources that stopped being true when the lint scope flipped.

## Validation

`pnpm gates lint`, `pnpm gates typecheck`, `pnpm gates sync`, `pnpm gates site`, `pnpm examples:sync:check`, `git diff --check` — all green. `test/site/runtime-dts.test.ts` 3/3.