### PR TITLE
Stop dropping the promises the example catalog returns

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1038,12 +1038,15 @@ export default defineConfig([
     },
   },
 
-  // Two files in the tree are outside `tsconfig.examples.json` on purpose - the
-  // Monaco-only shim, and the worker source the generator inlines - so a named
-  // project cannot parse them. They keep the service-free setup, which means
-  // giving up the catalog's one type-aware rule for these two files.
+  // Three files in the tree are unreachable through `tsconfig.examples.json`, so
+  // a named project cannot parse them: the Monaco-only shim and the worker
+  // source the generator inlines are outside the program on purpose, and
+  // `runtime.d.ts` is inside the include glob but never lands in the program -
+  // TypeScript resolves that module through the `runtime.ts` it is generated
+  // from and drops the declaration twin. They keep the service-free setup, which
+  // means giving up the catalog's one type-aware rule for these three files.
   {
-    files: ['examples/**/*.worker.ts', 'examples/shared/editor-support.d.ts'],
+    files: ['examples/**/*.worker.ts', 'examples/shared/editor-support.d.ts', 'examples/shared/runtime.d.ts'],
     languageOptions: {
       parserOptions: { projectService: false, project: null },
     },

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -980,8 +980,15 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
+      // Named project rather than the project service: the service resolves the
+      // nearest `tsconfig.json`, which is the engine's own program over `src/**`
+      // and does not contain these files. The catalog's type-aware rules are off
+      // (above), but `no-floating-promises` below is not, and it cannot run
+      // without a program.
       parserOptions: {
-        project: null,
+        projectService: false,
+        project: './tsconfig.examples.json',
+        tsconfigRootDir: import.meta.dirname,
       },
       globals: {
         ...globals.browser,
@@ -1022,26 +1029,40 @@ export default defineConfig([
       'object-shorthand': 'error',
       'prefer-template': 'error',
       'unicorn/prefer-node-protocol': 'error',
+      // The one type-aware rule the catalog keeps. A dropped promise in an
+      // example is not a style question: the rejection is swallowed, the reader
+      // copies the shape, and the failure surfaces somewhere else entirely.
+      // Everything the rule flags here is either a missing `await` or a
+      // deliberate fire-and-forget that should say so with `void`.
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
+
+  // Two files in the tree are outside `tsconfig.examples.json` on purpose - the
+  // Monaco-only shim, and the worker source the generator inlines - so a named
+  // project cannot parse them. They keep the service-free setup, which means
+  // giving up the catalog's one type-aware rule for these two files.
+  {
+    files: ['examples/**/*.worker.ts', 'examples/shared/editor-support.d.ts'],
+    languageOptions: {
+      parserOptions: { projectService: false, project: null },
+    },
+    rules: {
+      '@typescript-eslint/no-floating-promises': 'off',
     },
   },
 
   // Guide sources (examples/guides/**) - the running programs the guide
   // chapters embed regions of. They are authored in TypeScript and never
   // transpiled to a `.js` twin, so unlike the rest of the example catalog the
-  // `.ts` file is what gets linted. Type-aware rules are off for the same
-  // reason they are off for example `.js`: the file belongs to
-  // `tsconfig.examples.json`, which is not the project the service resolves
-  // for it, and `typecheck:examples` already checks it with the right one.
-  {
-    files: ['examples/guides/**/*.ts'],
-    ...tseslint.configs.disableTypeChecked,
-  },
+  // `.ts` file is what gets linted. They inherit the catalog's policy above,
+  // including its program and its one type-aware rule, and add the two
+  // relaxations a listing needs.
   {
     files: ['examples/guides/**/*.ts'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
-      parserOptions: { projectService: false, project: null },
       globals: {
         ...globals.browser,
         ...globals.es2024,

--- a/examples/application-scenes/camera-and-view.js
+++ b/examples/application-scenes/camera-and-view.js
@@ -81,4 +81,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(CameraViewScene);
+await app.start(CameraViewScene);

--- a/examples/application-scenes/camera-and-view.ts
+++ b/examples/application-scenes/camera-and-view.ts
@@ -92,4 +92,4 @@ const app = new Application({
   },
 });
 
-app.start(CameraViewScene);
+await app.start(CameraViewScene);

--- a/examples/application-scenes/camera-basic.js
+++ b/examples/application-scenes/camera-basic.js
@@ -61,4 +61,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(CameraBasicScene);
+await app.start(CameraBasicScene);

--- a/examples/application-scenes/camera-basic.ts
+++ b/examples/application-scenes/camera-basic.ts
@@ -75,4 +75,4 @@ const app = new Application({
   },
 });
 
-app.start(CameraBasicScene);
+await app.start(CameraBasicScene);

--- a/examples/application-scenes/loading-screen.js
+++ b/examples/application-scenes/loading-screen.js
@@ -142,4 +142,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(BootScene);
+await app.start(BootScene);

--- a/examples/application-scenes/loading-screen.ts
+++ b/examples/application-scenes/loading-screen.ts
@@ -183,4 +183,4 @@ const app = new Application({
   },
 });
 
-app.start(BootScene);
+await app.start(BootScene);

--- a/examples/application-scenes/multi-view-split-screen.js
+++ b/examples/application-scenes/multi-view-split-screen.js
@@ -111,4 +111,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(SplitScreenScene);
+await app.start(SplitScreenScene);

--- a/examples/application-scenes/multi-view-split-screen.ts
+++ b/examples/application-scenes/multi-view-split-screen.ts
@@ -134,4 +134,4 @@ const app = new Application({
   },
 });
 
-app.start(SplitScreenScene);
+await app.start(SplitScreenScene);

--- a/examples/application-scenes/multiple-scenes.js
+++ b/examples/application-scenes/multiple-scenes.js
@@ -59,4 +59,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(MenuScene);
+await app.start(MenuScene);

--- a/examples/application-scenes/multiple-scenes.ts
+++ b/examples/application-scenes/multiple-scenes.ts
@@ -74,4 +74,4 @@ const app = new Application({
   },
 });
 
-app.start(MenuScene);
+await app.start(MenuScene);

--- a/examples/application-scenes/pause-and-resume.js
+++ b/examples/application-scenes/pause-and-resume.js
@@ -49,4 +49,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(PauseResumeScene);
+await app.start(PauseResumeScene);

--- a/examples/application-scenes/pause-and-resume.ts
+++ b/examples/application-scenes/pause-and-resume.ts
@@ -60,4 +60,4 @@ const app = new Application({
   },
 });
 
-app.start(PauseResumeScene);
+await app.start(PauseResumeScene);

--- a/examples/application-scenes/picture-in-picture.js
+++ b/examples/application-scenes/picture-in-picture.js
@@ -48,4 +48,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(PictureInPictureScene);
+await app.start(PictureInPictureScene);

--- a/examples/application-scenes/picture-in-picture.ts
+++ b/examples/application-scenes/picture-in-picture.ts
@@ -59,4 +59,4 @@ const app = new Application({
   },
 });
 
-app.start(PictureInPictureScene);
+await app.start(PictureInPictureScene);

--- a/examples/application-scenes/scene-less-app.js
+++ b/examples/application-scenes/scene-less-app.js
@@ -29,4 +29,4 @@ app.systems.add({
     context.render(square);
   },
 });
-app.start();
+await app.start();

--- a/examples/application-scenes/scene-less-app.ts
+++ b/examples/application-scenes/scene-less-app.ts
@@ -34,4 +34,4 @@ app.systems.add({
   },
 });
 
-app.start();
+await app.start();

--- a/examples/application-scenes/scene-lifecycle.js
+++ b/examples/application-scenes/scene-lifecycle.js
@@ -73,4 +73,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(LifecycleScene);
+await app.start(LifecycleScene);

--- a/examples/application-scenes/scene-lifecycle.ts
+++ b/examples/application-scenes/scene-lifecycle.ts
@@ -85,4 +85,4 @@ const app = new Application({
   },
 });
 
-app.start(LifecycleScene);
+await app.start(LifecycleScene);

--- a/examples/application-scenes/world-vs-screen-coords.js
+++ b/examples/application-scenes/world-vs-screen-coords.js
@@ -60,4 +60,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(WorldScreenScene);
+await app.start(WorldScreenScene);

--- a/examples/application-scenes/world-vs-screen-coords.ts
+++ b/examples/application-scenes/world-vs-screen-coords.ts
@@ -73,4 +73,4 @@ const app = new Application({
   },
 });
 
-app.start(WorldScreenScene);
+await app.start(WorldScreenScene);

--- a/examples/audio-basics/audio-buses.js
+++ b/examples/audio-basics/audio-buses.js
@@ -127,4 +127,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(AudioBusesScene);
+await app.start(AudioBusesScene);

--- a/examples/audio-basics/audio-buses.ts
+++ b/examples/audio-basics/audio-buses.ts
@@ -147,4 +147,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(AudioBusesScene);
+await app.start(AudioBusesScene);

--- a/examples/audio-basics/crossfade-tracks.js
+++ b/examples/audio-basics/crossfade-tracks.js
@@ -130,4 +130,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(CrossfadeTracksScene);
+await app.start(CrossfadeTracksScene);

--- a/examples/audio-basics/crossfade-tracks.ts
+++ b/examples/audio-basics/crossfade-tracks.ts
@@ -165,4 +165,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(CrossfadeTracksScene);
+await app.start(CrossfadeTracksScene);

--- a/examples/audio-basics/music-loop.js
+++ b/examples/audio-basics/music-loop.js
@@ -115,4 +115,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(MusicLoopScene);
+await app.start(MusicLoopScene);

--- a/examples/audio-basics/music-loop.ts
+++ b/examples/audio-basics/music-loop.ts
@@ -148,4 +148,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(MusicLoopScene);
+await app.start(MusicLoopScene);

--- a/examples/audio-basics/play-sound.js
+++ b/examples/audio-basics/play-sound.js
@@ -40,4 +40,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(PlaySoundScene);
+await app.start(PlaySoundScene);

--- a/examples/audio-basics/play-sound.ts
+++ b/examples/audio-basics/play-sound.ts
@@ -47,4 +47,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(PlaySoundScene);
+await app.start(PlaySoundScene);

--- a/examples/audio-basics/random-pitch-pool.js
+++ b/examples/audio-basics/random-pitch-pool.js
@@ -102,4 +102,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(RandomPitchPoolScene);
+await app.start(RandomPitchPoolScene);

--- a/examples/audio-basics/random-pitch-pool.ts
+++ b/examples/audio-basics/random-pitch-pool.ts
@@ -121,4 +121,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(RandomPitchPoolScene);
+await app.start(RandomPitchPoolScene);

--- a/examples/audio-basics/sound-pool.js
+++ b/examples/audio-basics/sound-pool.js
@@ -124,4 +124,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(SoundPoolScene);
+await app.start(SoundPoolScene);

--- a/examples/audio-basics/sound-pool.ts
+++ b/examples/audio-basics/sound-pool.ts
@@ -147,4 +147,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(SoundPoolScene);
+await app.start(SoundPoolScene);

--- a/examples/audio-fx/compressor.js
+++ b/examples/audio-fx/compressor.js
@@ -123,4 +123,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(CompressorScene);
+await app.start(CompressorScene);

--- a/examples/audio-fx/compressor.ts
+++ b/examples/audio-fx/compressor.ts
@@ -149,4 +149,4 @@ const app = new Application({
   },
 });
 
-app.start(CompressorScene);
+await app.start(CompressorScene);

--- a/examples/audio-fx/ducking.js
+++ b/examples/audio-fx/ducking.js
@@ -113,4 +113,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(DuckingScene);
+await app.start(DuckingScene);

--- a/examples/audio-fx/ducking.ts
+++ b/examples/audio-fx/ducking.ts
@@ -142,4 +142,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(DuckingScene);
+await app.start(DuckingScene);

--- a/examples/audio-fx/reverb-and-delay.js
+++ b/examples/audio-fx/reverb-and-delay.js
@@ -139,4 +139,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(ReverbAndDelayScene);
+await app.start(ReverbAndDelayScene);

--- a/examples/audio-fx/reverb-and-delay.ts
+++ b/examples/audio-fx/reverb-and-delay.ts
@@ -156,4 +156,4 @@ const app = new Application({
   },
 });
 
-app.start(ReverbAndDelayScene);
+await app.start(ReverbAndDelayScene);

--- a/examples/audio-fx/vocoder.js
+++ b/examples/audio-fx/vocoder.js
@@ -93,4 +93,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(VocoderScene);
+await app.start(VocoderScene);

--- a/examples/audio-fx/vocoder.ts
+++ b/examples/audio-fx/vocoder.ts
@@ -111,4 +111,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(VocoderScene);
+await app.start(VocoderScene);

--- a/examples/beat-detection/beat-sync-pulse.js
+++ b/examples/beat-detection/beat-sync-pulse.js
@@ -91,4 +91,4 @@ const app = new Application({
   },
   extensions: [particlesExtension],
 });
-app.start(BeatSyncPulseScene);
+await app.start(BeatSyncPulseScene);

--- a/examples/beat-detection/beat-sync-pulse.ts
+++ b/examples/beat-detection/beat-sync-pulse.ts
@@ -116,4 +116,4 @@ const app = new Application({
   extensions: [particlesExtension],
 });
 
-app.start(BeatSyncPulseScene);
+await app.start(BeatSyncPulseScene);

--- a/examples/beat-detection/frequency-bands.js
+++ b/examples/beat-detection/frequency-bands.js
@@ -122,4 +122,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(FrequencyBandsScene);
+await app.start(FrequencyBandsScene);

--- a/examples/beat-detection/frequency-bands.ts
+++ b/examples/beat-detection/frequency-bands.ts
@@ -147,4 +147,4 @@ const app = new Application({
   },
 });
 
-app.start(FrequencyBandsScene);
+await app.start(FrequencyBandsScene);

--- a/examples/beat-detection/tempo-tracking.js
+++ b/examples/beat-detection/tempo-tracking.js
@@ -99,4 +99,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(TempoTrackingScene);
+await app.start(TempoTrackingScene);

--- a/examples/beat-detection/tempo-tracking.ts
+++ b/examples/beat-detection/tempo-tracking.ts
@@ -121,4 +121,4 @@ const app = new Application({
   },
 });
 
-app.start(TempoTrackingScene);
+await app.start(TempoTrackingScene);

--- a/examples/custom-renderers/custom-render-pass.js
+++ b/examples/custom-renderers/custom-render-pass.js
@@ -56,4 +56,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(CustomRenderPassScene);
+await app.start(CustomRenderPassScene);

--- a/examples/custom-renderers/custom-render-pass.ts
+++ b/examples/custom-renderers/custom-render-pass.ts
@@ -75,4 +75,4 @@ const app = new Application({
   },
 });
 
-app.start(CustomRenderPassScene);
+await app.start(CustomRenderPassScene);

--- a/examples/custom-renderers/custom-triangle-renderer.js
+++ b/examples/custom-renderers/custom-triangle-renderer.js
@@ -145,5 +145,5 @@ const app = new Application({
 });
 app.start(CustomTriangleRendererScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });

--- a/examples/custom-renderers/custom-triangle-renderer.ts
+++ b/examples/custom-renderers/custom-triangle-renderer.ts
@@ -166,5 +166,5 @@ const app = new Application({
 
 app.start(CustomTriangleRendererScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });

--- a/examples/debug-layer/asset-browser.js
+++ b/examples/debug-layer/asset-browser.js
@@ -972,4 +972,4 @@ const app = new Application({
   canvas: { width: W, height: H, mount: document.body, sizing: new FixedResolutionCanvasSizing() },
   clearColor: C.bg,
 });
-app.start(AssetBrowserScene);
+await app.start(AssetBrowserScene);

--- a/examples/debug-layer/asset-browser.ts
+++ b/examples/debug-layer/asset-browser.ts
@@ -1147,4 +1147,4 @@ const app = new Application({
   clearColor: C.bg,
 });
 
-app.start(AssetBrowserScene);
+await app.start(AssetBrowserScene);

--- a/examples/debug-layer/bounding-boxes.js
+++ b/examples/debug-layer/bounding-boxes.js
@@ -48,4 +48,4 @@ const app = new Application({
 });
 const debug = new DebugOverlay(app);
 debug.layers.boundingBoxes.visible = true;
-app.start(BoundingBoxesScene);
+await app.start(BoundingBoxesScene);

--- a/examples/debug-layer/bounding-boxes.ts
+++ b/examples/debug-layer/bounding-boxes.ts
@@ -56,4 +56,4 @@ const app = new Application({
 const debug = new DebugOverlay(app);
 debug.layers.boundingBoxes.visible = true;
 
-app.start(BoundingBoxesScene);
+await app.start(BoundingBoxesScene);

--- a/examples/debug-layer/performance-overlay.js
+++ b/examples/debug-layer/performance-overlay.js
@@ -54,4 +54,4 @@ const app = new Application({
 });
 const debug = new DebugOverlay(app);
 debug.layers.performance.visible = true;
-app.start(PerformanceOverlayScene);
+await app.start(PerformanceOverlayScene);

--- a/examples/debug-layer/performance-overlay.ts
+++ b/examples/debug-layer/performance-overlay.ts
@@ -62,4 +62,4 @@ const app = new Application({
 const debug = new DebugOverlay(app);
 debug.layers.performance.visible = true;
 
-app.start(PerformanceOverlayScene);
+await app.start(PerformanceOverlayScene);

--- a/examples/debug-layer/pointer-and-hittest.js
+++ b/examples/debug-layer/pointer-and-hittest.js
@@ -42,4 +42,4 @@ const app = new Application({
 const debug = new DebugOverlay(app);
 debug.layers.hitTest.visible = true;
 debug.layers.pointerStack.visible = true;
-app.start(PointerAndHittestScene);
+await app.start(PointerAndHittestScene);

--- a/examples/debug-layer/pointer-and-hittest.ts
+++ b/examples/debug-layer/pointer-and-hittest.ts
@@ -48,4 +48,4 @@ const debug = new DebugOverlay(app);
 debug.layers.hitTest.visible = true;
 debug.layers.pointerStack.visible = true;
 
-app.start(PointerAndHittestScene);
+await app.start(PointerAndHittestScene);

--- a/examples/debug-layer/signal-bus-inspector.js
+++ b/examples/debug-layer/signal-bus-inspector.js
@@ -54,4 +54,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(SignalBusInspectorScene);
+await app.start(SignalBusInspectorScene);

--- a/examples/debug-layer/signal-bus-inspector.ts
+++ b/examples/debug-layer/signal-bus-inspector.ts
@@ -59,4 +59,4 @@ const app = new Application({
   },
 });
 
-app.start(SignalBusInspectorScene);
+await app.start(SignalBusInspectorScene);

--- a/examples/filters/blur-filter.js
+++ b/examples/filters/blur-filter.js
@@ -74,4 +74,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(BlurFilterScene);
+await app.start(BlurFilterScene);

--- a/examples/filters/blur-filter.ts
+++ b/examples/filters/blur-filter.ts
@@ -86,4 +86,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(BlurFilterScene);
+await app.start(BlurFilterScene);

--- a/examples/filters/chromatic-aberration.js
+++ b/examples/filters/chromatic-aberration.js
@@ -81,4 +81,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(ChromaticAberrationScene);
+await app.start(ChromaticAberrationScene);

--- a/examples/filters/chromatic-aberration.ts
+++ b/examples/filters/chromatic-aberration.ts
@@ -95,4 +95,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(ChromaticAberrationScene);
+await app.start(ChromaticAberrationScene);

--- a/examples/filters/color-matrix-filter.js
+++ b/examples/filters/color-matrix-filter.js
@@ -68,4 +68,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(ColorMatrixFilterScene);
+await app.start(ColorMatrixFilterScene);

--- a/examples/filters/color-matrix-filter.ts
+++ b/examples/filters/color-matrix-filter.ts
@@ -80,4 +80,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(ColorMatrixFilterScene);
+await app.start(ColorMatrixFilterScene);

--- a/examples/filters/crt-scanlines.js
+++ b/examples/filters/crt-scanlines.js
@@ -57,4 +57,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(CrtScanlinesScene);
+await app.start(CrtScanlinesScene);

--- a/examples/filters/crt-scanlines.ts
+++ b/examples/filters/crt-scanlines.ts
@@ -67,4 +67,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(CrtScanlinesScene);
+await app.start(CrtScanlinesScene);

--- a/examples/filters/custom-fragment-shader.js
+++ b/examples/filters/custom-fragment-shader.js
@@ -57,4 +57,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(CustomFragmentShaderScene);
+await app.start(CustomFragmentShaderScene);

--- a/examples/filters/custom-fragment-shader.ts
+++ b/examples/filters/custom-fragment-shader.ts
@@ -66,4 +66,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(CustomFragmentShaderScene);
+await app.start(CustomFragmentShaderScene);

--- a/examples/filters/filter-stack.js
+++ b/examples/filters/filter-stack.js
@@ -84,4 +84,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(FilterStackScene);
+await app.start(FilterStackScene);

--- a/examples/filters/filter-stack.ts
+++ b/examples/filters/filter-stack.ts
@@ -108,4 +108,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(FilterStackScene);
+await app.start(FilterStackScene);

--- a/examples/filters/metaballs.js
+++ b/examples/filters/metaballs.js
@@ -63,4 +63,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(MetaballsScene);
+await app.start(MetaballsScene);

--- a/examples/filters/metaballs.ts
+++ b/examples/filters/metaballs.ts
@@ -75,4 +75,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(MetaballsScene);
+await app.start(MetaballsScene);

--- a/examples/filters/noise-vignette.js
+++ b/examples/filters/noise-vignette.js
@@ -78,4 +78,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(NoiseVignetteScene);
+await app.start(NoiseVignetteScene);

--- a/examples/filters/noise-vignette.ts
+++ b/examples/filters/noise-vignette.ts
@@ -91,4 +91,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(NoiseVignetteScene);
+await app.start(NoiseVignetteScene);

--- a/examples/filters/palette-cycling.js
+++ b/examples/filters/palette-cycling.js
@@ -64,4 +64,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(ColourRampCyclingScene);
+await app.start(ColourRampCyclingScene);

--- a/examples/filters/palette-cycling.ts
+++ b/examples/filters/palette-cycling.ts
@@ -75,4 +75,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(ColourRampCyclingScene);
+await app.start(ColourRampCyclingScene);

--- a/examples/geometry-graphics/gradient.js
+++ b/examples/geometry-graphics/gradient.js
@@ -64,5 +64,5 @@ const app = new Application({
 });
 app.start(GradientScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });

--- a/examples/geometry-graphics/gradient.ts
+++ b/examples/geometry-graphics/gradient.ts
@@ -82,5 +82,5 @@ const app = new Application({
 
 app.start(GradientScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });

--- a/examples/geometry-graphics/graphics-gradient.js
+++ b/examples/geometry-graphics/graphics-gradient.js
@@ -77,5 +77,5 @@ const app = new Application({
 });
 app.start(GraphicsGradientScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });

--- a/examples/geometry-graphics/graphics-gradient.ts
+++ b/examples/geometry-graphics/graphics-gradient.ts
@@ -100,5 +100,5 @@ const app = new Application({
 
 app.start(GraphicsGradientScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });

--- a/examples/geometry-graphics/graphics-primitives.js
+++ b/examples/geometry-graphics/graphics-primitives.js
@@ -51,5 +51,5 @@ const app = new Application({
 });
 app.start(GraphicsPrimitivesScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });

--- a/examples/geometry-graphics/graphics-primitives.ts
+++ b/examples/geometry-graphics/graphics-primitives.ts
@@ -63,5 +63,5 @@ const app = new Application({
 
 app.start(GraphicsPrimitivesScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });

--- a/examples/geometry-graphics/immediate-mode-rendering.js
+++ b/examples/geometry-graphics/immediate-mode-rendering.js
@@ -190,4 +190,4 @@ const app = new Application({
   },
   clearColor: new Color(6, 9, 18, 1),
 });
-app.start(ImmediateModeScene);
+await app.start(ImmediateModeScene);

--- a/examples/geometry-graphics/immediate-mode-rendering.ts
+++ b/examples/geometry-graphics/immediate-mode-rendering.ts
@@ -242,4 +242,4 @@ const app = new Application({
   clearColor: new Color(6, 9, 18, 1),
 });
 
-app.start(ImmediateModeScene);
+await app.start(ImmediateModeScene);

--- a/examples/geometry-graphics/infinite-grid.js
+++ b/examples/geometry-graphics/infinite-grid.js
@@ -115,4 +115,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(InfiniteGridScene);
+await app.start(InfiniteGridScene);

--- a/examples/geometry-graphics/infinite-grid.ts
+++ b/examples/geometry-graphics/infinite-grid.ts
@@ -134,4 +134,4 @@ const app = new Application({
   },
 });
 
-app.start(InfiniteGridScene);
+await app.start(InfiniteGridScene);

--- a/examples/geometry-graphics/mesh-deformed-grid.js
+++ b/examples/geometry-graphics/mesh-deformed-grid.js
@@ -82,4 +82,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(MeshDeformedGridScene);
+await app.start(MeshDeformedGridScene);

--- a/examples/geometry-graphics/mesh-deformed-grid.ts
+++ b/examples/geometry-graphics/mesh-deformed-grid.ts
@@ -96,4 +96,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(MeshDeformedGridScene);
+await app.start(MeshDeformedGridScene);

--- a/examples/geometry-graphics/mesh-textured-quad.js
+++ b/examples/geometry-graphics/mesh-textured-quad.js
@@ -32,4 +32,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(MeshTexturedQuadScene);
+await app.start(MeshTexturedQuadScene);

--- a/examples/geometry-graphics/mesh-textured-quad.ts
+++ b/examples/geometry-graphics/mesh-textured-quad.ts
@@ -40,4 +40,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(MeshTexturedQuadScene);
+await app.start(MeshTexturedQuadScene);

--- a/examples/geometry-graphics/mesh-triangle.js
+++ b/examples/geometry-graphics/mesh-triangle.js
@@ -28,4 +28,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(MeshTriangleScene);
+await app.start(MeshTriangleScene);

--- a/examples/geometry-graphics/mesh-triangle.ts
+++ b/examples/geometry-graphics/mesh-triangle.ts
@@ -35,4 +35,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(MeshTriangleScene);
+await app.start(MeshTriangleScene);

--- a/examples/getting-started/game-loop.js
+++ b/examples/getting-started/game-loop.js
@@ -29,4 +29,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(GameLoopScene);
+await app.start(GameLoopScene);

--- a/examples/getting-started/game-loop.ts
+++ b/examples/getting-started/game-loop.ts
@@ -35,4 +35,4 @@ const app = new Application({
   },
 });
 
-app.start(GameLoopScene);
+await app.start(GameLoopScene);

--- a/examples/getting-started/hello-world.js
+++ b/examples/getting-started/hello-world.js
@@ -28,4 +28,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(HelloWorldScene);
+await app.start(HelloWorldScene);

--- a/examples/getting-started/hello-world.ts
+++ b/examples/getting-started/hello-world.ts
@@ -33,4 +33,4 @@ const app = new Application({
   },
 });
 
-app.start(HelloWorldScene);
+await app.start(HelloWorldScene);

--- a/examples/getting-started/resize-and-dpr.js
+++ b/examples/getting-started/resize-and-dpr.js
@@ -54,4 +54,4 @@ window.addEventListener('resize', () => {
 });
 app.resize(window.innerWidth, window.innerHeight);
 // #endregion guide:resize
-app.start(ResizeScene);
+await app.start(ResizeScene);

--- a/examples/getting-started/resize-and-dpr.ts
+++ b/examples/getting-started/resize-and-dpr.ts
@@ -67,4 +67,4 @@ window.addEventListener('resize', () => {
 app.resize(window.innerWidth, window.innerHeight);
 // #endregion guide:resize
 
-app.start(ResizeScene);
+await app.start(ResizeScene);

--- a/examples/guides/application/start-loop.ts
+++ b/examples/guides/application/start-loop.ts
@@ -8,7 +8,7 @@ class HelloScene extends Scene {
 }
 
 const app = new Application({ scenes: { HelloScene } });
-app.start(HelloScene);
+await app.start(HelloScene);
 // #endregion guide:start-loop
 
 export { HelloScene };

--- a/examples/guides/audio-reactive-visualization/full-visualizer.ts
+++ b/examples/guides/audio-reactive-visualization/full-visualizer.ts
@@ -56,5 +56,5 @@ class AudioReactiveScene extends Scene {
 
 const app = new Application({ scenes: { AudioReactiveScene }, canvas: { width: 800, height: 600, mount: document.body } });
 
-app.start(AudioReactiveScene);
+await app.start(AudioReactiveScene);
 // #endregion guide:full-visualizer

--- a/examples/guides/cinematics/cutscene-flow.ts
+++ b/examples/guides/cinematics/cutscene-flow.ts
@@ -6,7 +6,7 @@ class GameScene extends Scene {
   private startCutscene(): void {
     // #region guide:enter-cinematic
     // From the game scene - switch to the cinematic:
-    this.app.scenes.change(CinematicScene);
+    void this.app.scenes.change(CinematicScene);
     // #endregion guide:enter-cinematic
   }
 }
@@ -24,7 +24,7 @@ class CutsceneFlowScene extends Scene {
       .to({ v: 70 }, 0.6)
       .delay(3.5) // start closing bars after the sequence plays
       .onComplete(() => {
-        this.app.scenes.change(GameScene, { transition: new FadeSceneTransition() });
+        void this.app.scenes.change(GameScene, { transition: new FadeSceneTransition() });
       })
       .start();
     // #endregion guide:return-to-game
@@ -35,12 +35,12 @@ class CutsceneFlowScene extends Scene {
     // ... cinematic setup ...
 
     this.inputs.onTrigger(Keyboard.Space, () => {
-      this.app.scenes.change(GameScene);
+      void this.app.scenes.change(GameScene);
     });
 
     const pad = this.app.input.getGamepad(0);
     pad.onTrigger(GamepadButton.Start, () => {
-      this.app.scenes.change(GameScene);
+      void this.app.scenes.change(GameScene);
     });
   }
   // #endregion guide:skip-input
@@ -53,7 +53,7 @@ class CutsceneFlowScene extends Scene {
       this.musicVoice.volume = 0.85;
       this.boss.setScale(2.1, 2.1);
       // ... snap other properties ...
-      this.app.scenes.change(GameScene);
+      void this.app.scenes.change(GameScene);
     });
     // #endregion guide:skip-fast-forward
   }

--- a/examples/guides/gamepad/capability-probe.ts
+++ b/examples/guides/gamepad/capability-probe.ts
@@ -35,7 +35,7 @@ class VibrationScene extends Scene {
   override init(): void {
     const pad = this.app.input.getGamepad(0);
     if (pad.canVibrate) {
-      pad.vibrate({
+      void pad.vibrate({
         duration: 200, // ms
         weakMagnitude: 0.5, // low-frequency rumble 0..1
         strongMagnitude: 0.8, // high-frequency rumble 0..1

--- a/examples/guides/scenes-and-lifecycle/title-scene.ts
+++ b/examples/guides/scenes-and-lifecycle/title-scene.ts
@@ -19,7 +19,7 @@ class TitleScene extends Scene {
 
 // #region guide:run-a-scene
 const app = new Application({ scenes: { TitleScene } });
-app.start(TitleScene);
+await app.start(TitleScene);
 // #endregion guide:run-a-scene
 
 export { TitleScene };

--- a/examples/guides/what-is-exojs/minimal-app.ts
+++ b/examples/guides/what-is-exojs/minimal-app.ts
@@ -8,7 +8,7 @@ class MyScene extends Scene {
 }
 
 const app = new Application({ scenes: { MyScene } });
-app.start(MyScene);
+await app.start(MyScene);
 // #endregion guide:minimal-app
 
 export { MyScene };

--- a/examples/guides/your-first-scene/minimal-scene.ts
+++ b/examples/guides/your-first-scene/minimal-scene.ts
@@ -8,7 +8,7 @@ class HelloScene extends Scene {
 }
 
 const app = new Application({ scenes: { HelloScene }, canvas: { width: 800, height: 600 } });
-app.start(HelloScene);
+await app.start(HelloScene);
 // #endregion guide:minimal-scene
 
 export { HelloScene };

--- a/examples/input/action-mapping.js
+++ b/examples/input/action-mapping.js
@@ -84,4 +84,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(ActionMappingScene);
+await app.start(ActionMappingScene);

--- a/examples/input/action-mapping.ts
+++ b/examples/input/action-mapping.ts
@@ -111,4 +111,4 @@ const app = new Application({
   },
 });
 
-app.start(ActionMappingScene);
+await app.start(ActionMappingScene);

--- a/examples/input/gamepad.js
+++ b/examples/input/gamepad.js
@@ -232,4 +232,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(GamepadScene);
+await app.start(GamepadScene);

--- a/examples/input/gamepad.ts
+++ b/examples/input/gamepad.ts
@@ -312,4 +312,4 @@ const app = new Application({
   },
 });
 
-app.start(GamepadScene);
+await app.start(GamepadScene);

--- a/examples/input/key-rebinding.js
+++ b/examples/input/key-rebinding.js
@@ -129,4 +129,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(KeyRebindingScene);
+await app.start(KeyRebindingScene);

--- a/examples/input/key-rebinding.js
+++ b/examples/input/key-rebinding.js
@@ -35,7 +35,9 @@ class KeyRebindingScene extends Scene {
   graphics;
   controls = new ActionMap({
     jump: new ButtonAction(Keyboard.Space),
-    rebind: new ButtonAction(Keyboard.J),
+    // Not `rebind`: an action name has to clear ActionMap's own surface, and
+    // `rebind()` is the method this example calls three lines down.
+    startRebind: new ButtonAction(Keyboard.J),
   });
   profile = loadProfile();
   rebindRequested = false;
@@ -88,7 +90,7 @@ class KeyRebindingScene extends Scene {
   update(delta) {
     // Arm on the RELEASE of J, so the J keydown itself is not captured as
     // the new binding in the same frame.
-    if (this.controls.rebind.released && !this.rebindRequested) {
+    if (this.controls.startRebind.released && !this.rebindRequested) {
       this.rebindRequested = true;
       this.refreshHud();
     }

--- a/examples/input/key-rebinding.ts
+++ b/examples/input/key-rebinding.ts
@@ -171,4 +171,4 @@ const app = new Application({
   },
 });
 
-app.start(KeyRebindingScene);
+await app.start(KeyRebindingScene);

--- a/examples/input/key-rebinding.ts
+++ b/examples/input/key-rebinding.ts
@@ -55,7 +55,9 @@ class KeyRebindingScene extends Scene {
   private graphics!: Graphics;
   private controls = new ActionMap({
     jump: new ButtonAction(Keyboard.Space),
-    rebind: new ButtonAction(Keyboard.J),
+    // Not `rebind`: an action name has to clear ActionMap's own surface, and
+    // `rebind()` is the method this example calls three lines down.
+    startRebind: new ButtonAction(Keyboard.J),
   });
 
   private profile = loadProfile();
@@ -120,7 +122,7 @@ class KeyRebindingScene extends Scene {
   override update(delta: Seconds): void {
     // Arm on the RELEASE of J, so the J keydown itself is not captured as
     // the new binding in the same frame.
-    if (this.controls.rebind.released && !this.rebindRequested) {
+    if (this.controls.startRebind.released && !this.rebindRequested) {
       this.rebindRequested = true;
       this.refreshHud();
     }

--- a/examples/input/keyboard.js
+++ b/examples/input/keyboard.js
@@ -78,4 +78,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(KeyboardScene);
+await app.start(KeyboardScene);

--- a/examples/input/keyboard.ts
+++ b/examples/input/keyboard.ts
@@ -100,4 +100,4 @@ const app = new Application({
   },
 });
 
-app.start(KeyboardScene);
+await app.start(KeyboardScene);

--- a/examples/input/mouse-and-pointer.js
+++ b/examples/input/mouse-and-pointer.js
@@ -87,4 +87,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(MouseAndPointerScene);
+await app.start(MouseAndPointerScene);

--- a/examples/input/mouse-and-pointer.ts
+++ b/examples/input/mouse-and-pointer.ts
@@ -100,4 +100,4 @@ const app = new Application({
   },
 });
 
-app.start(MouseAndPointerScene);
+await app.start(MouseAndPointerScene);

--- a/examples/input/multi-gamepad.js
+++ b/examples/input/multi-gamepad.js
@@ -84,4 +84,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(MultiGamepadScene);
+await app.start(MultiGamepadScene);

--- a/examples/input/multi-gamepad.ts
+++ b/examples/input/multi-gamepad.ts
@@ -118,4 +118,4 @@ const app = new Application({
   },
 });
 
-app.start(MultiGamepadScene);
+await app.start(MultiGamepadScene);

--- a/examples/input/multitouch.js
+++ b/examples/input/multitouch.js
@@ -91,4 +91,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(MultitouchScene);
+await app.start(MultitouchScene);

--- a/examples/input/multitouch.ts
+++ b/examples/input/multitouch.ts
@@ -117,4 +117,4 @@ const app = new Application({
   },
 });
 
-app.start(MultitouchScene);
+await app.start(MultitouchScene);

--- a/examples/input/pointer-to-world.js
+++ b/examples/input/pointer-to-world.js
@@ -105,4 +105,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(PointerToWorldScene);
+await app.start(PointerToWorldScene);

--- a/examples/input/pointer-to-world.ts
+++ b/examples/input/pointer-to-world.ts
@@ -129,4 +129,4 @@ const app = new Application({
   },
 });
 
-app.start(PointerToWorldScene);
+await app.start(PointerToWorldScene);

--- a/examples/particles/bonfire.js
+++ b/examples/particles/bonfire.js
@@ -74,4 +74,4 @@ const app = new Application({
   clearColor: Color.black,
   extensions: [particlesExtension],
 });
-app.start(BonfireScene);
+await app.start(BonfireScene);

--- a/examples/particles/bonfire.ts
+++ b/examples/particles/bonfire.ts
@@ -84,4 +84,4 @@ const app = new Application({
   extensions: [particlesExtension],
 });
 
-app.start(BonfireScene);
+await app.start(BonfireScene);

--- a/examples/particles/cursor-attractor-particles.js
+++ b/examples/particles/cursor-attractor-particles.js
@@ -102,4 +102,4 @@ const app = new Application({
   clearColor: Color.black,
   extensions: [particlesExtension],
 });
-app.start(CursorAttractorParticlesScene);
+await app.start(CursorAttractorParticlesScene);

--- a/examples/particles/cursor-attractor-particles.ts
+++ b/examples/particles/cursor-attractor-particles.ts
@@ -120,4 +120,4 @@ const app = new Application({
   extensions: [particlesExtension],
 });
 
-app.start(CursorAttractorParticlesScene);
+await app.start(CursorAttractorParticlesScene);

--- a/examples/particles/custom-wgsl-module.js
+++ b/examples/particles/custom-wgsl-module.js
@@ -91,4 +91,4 @@ const app = new Application({
   clearColor: Color.black,
   extensions: [particlesExtension],
 });
-app.start(CustomWgslModuleScene);
+await app.start(CustomWgslModuleScene);

--- a/examples/particles/custom-wgsl-module.ts
+++ b/examples/particles/custom-wgsl-module.ts
@@ -104,4 +104,4 @@ const app = new Application({
   extensions: [particlesExtension],
 });
 
-app.start(CustomWgslModuleScene);
+await app.start(CustomWgslModuleScene);

--- a/examples/particles/emitter-basics.js
+++ b/examples/particles/emitter-basics.js
@@ -80,4 +80,4 @@ const app = new Application({
   clearColor: Color.black,
   extensions: [particlesExtension],
 });
-app.start(EmitterBasicsScene);
+await app.start(EmitterBasicsScene);

--- a/examples/particles/emitter-basics.ts
+++ b/examples/particles/emitter-basics.ts
@@ -90,4 +90,4 @@ const app = new Application({
   extensions: [particlesExtension],
 });
 
-app.start(EmitterBasicsScene);
+await app.start(EmitterBasicsScene);

--- a/examples/particles/fireworks.js
+++ b/examples/particles/fireworks.js
@@ -145,4 +145,4 @@ const app = new Application({
   clearColor: Color.black,
   extensions: [particlesExtension],
 });
-app.start(FireworksScene);
+await app.start(FireworksScene);

--- a/examples/particles/fireworks.ts
+++ b/examples/particles/fireworks.ts
@@ -194,4 +194,4 @@ const app = new Application({
   extensions: [particlesExtension],
 });
 
-app.start(FireworksScene);
+await app.start(FireworksScene);

--- a/examples/particles/gpu-particles.js
+++ b/examples/particles/gpu-particles.js
@@ -57,4 +57,4 @@ const app = new Application({
 const isWebGpu = app.backend.backendType === RenderBackendType.WebGpu;
 const CAPACITY = isWebGpu ? 320_000 : 20_000;
 const RATE = isWebGpu ? 75_000 : 3_000;
-app.start(GpuParticlesScene);
+await app.start(GpuParticlesScene);

--- a/examples/particles/gpu-particles.ts
+++ b/examples/particles/gpu-particles.ts
@@ -66,4 +66,4 @@ const isWebGpu = app.backend.backendType === RenderBackendType.WebGpu;
 const CAPACITY = isWebGpu ? 320_000 : 20_000;
 const RATE = isWebGpu ? 75_000 : 3_000;
 
-app.start(GpuParticlesScene);
+await app.start(GpuParticlesScene);

--- a/examples/performance/backend-comparison.js
+++ b/examples/performance/backend-comparison.js
@@ -56,7 +56,7 @@ const boot = type => {
     overlay = null;
   }
   if (app !== null) {
-    app.destroy();
+    void app.destroy();
     app.element?.remove();
     app = null;
   }

--- a/examples/performance/backend-comparison.ts
+++ b/examples/performance/backend-comparison.ts
@@ -63,7 +63,7 @@ const boot = (type: 'webgl2' | 'webgpu'): void => {
     overlay = null;
   }
   if (app !== null) {
-    app.destroy();
+    void app.destroy();
     app.element?.remove();
     app = null;
   }

--- a/examples/performance/multi-texture-stress.js
+++ b/examples/performance/multi-texture-stress.js
@@ -77,7 +77,7 @@ const app = new Application({
 });
 app.start(MultiTextureStressScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });
 function createTextureInfos() {
   return [

--- a/examples/performance/multi-texture-stress.ts
+++ b/examples/performance/multi-texture-stress.ts
@@ -119,7 +119,7 @@ const app = new Application({
 
 app.start(MultiTextureStressScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });
 
 function createTextureInfos(): TextureInfo[] {

--- a/examples/performance/particle-stress.js
+++ b/examples/performance/particle-stress.js
@@ -171,7 +171,7 @@ const app = new Application({
 });
 app.start(ParticleStressScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });
 function createParticleTexture() {
   const canvas = document.createElement('canvas');

--- a/examples/performance/particle-stress.ts
+++ b/examples/performance/particle-stress.ts
@@ -213,7 +213,7 @@ const app = new Application({
 
 app.start(ParticleStressScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });
 
 function createParticleTexture(): Texture {

--- a/examples/performance/sprite-stress.js
+++ b/examples/performance/sprite-stress.js
@@ -76,7 +76,7 @@ const app = new Application({
 });
 app.start(SpriteStressScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });
 function createAtlasTexture() {
   const atlasCanvas = document.createElement('canvas');

--- a/examples/performance/sprite-stress.ts
+++ b/examples/performance/sprite-stress.ts
@@ -113,7 +113,7 @@ const app = new Application({
 
 app.start(SpriteStressScene).catch(() => {
   app.element?.remove();
-  app.destroy();
+  void app.destroy();
 });
 
 function createAtlasTexture(): Texture {

--- a/examples/physics/sprite-follows-body.js
+++ b/examples/physics/sprite-follows-body.js
@@ -100,4 +100,4 @@ const app = new Application({
   },
   clearColor: new Color(18, 22, 33),
 });
-app.start(SpriteFollowsBodyScene);
+await app.start(SpriteFollowsBodyScene);

--- a/examples/physics/sprite-follows-body.ts
+++ b/examples/physics/sprite-follows-body.ts
@@ -133,4 +133,4 @@ const app = new Application({
   clearColor: new Color(18, 22, 33),
 });
 
-app.start(SpriteFollowsBodyScene);
+await app.start(SpriteFollowsBodyScene);

--- a/examples/physics/tiled-map-physics-actor.js
+++ b/examples/physics/tiled-map-physics-actor.js
@@ -172,4 +172,4 @@ const app = new Application({
   // TileMapNode can draw. Physics is a plain library - no extension needed.
   extensions: [tilemapExtension],
 });
-app.start(TiledMapPhysicsActorScene);
+await app.start(TiledMapPhysicsActorScene);

--- a/examples/physics/tiled-map-physics-actor.ts
+++ b/examples/physics/tiled-map-physics-actor.ts
@@ -220,4 +220,4 @@ const app = new Application({
   extensions: [tilemapExtension],
 });
 
-app.start(TiledMapPhysicsActorScene);
+await app.start(TiledMapPhysicsActorScene);

--- a/examples/render-targets/bloom-lite.js
+++ b/examples/render-targets/bloom-lite.js
@@ -89,4 +89,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(BloomLiteScene);
+await app.start(BloomLiteScene);

--- a/examples/render-targets/bloom-lite.ts
+++ b/examples/render-targets/bloom-lite.ts
@@ -99,4 +99,4 @@ const app = new Application({
   },
 });
 
-app.start(BloomLiteScene);
+await app.start(BloomLiteScene);

--- a/examples/render-targets/mini-map.js
+++ b/examples/render-targets/mini-map.js
@@ -102,4 +102,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(MiniMapScene);
+await app.start(MiniMapScene);

--- a/examples/render-targets/mini-map.ts
+++ b/examples/render-targets/mini-map.ts
@@ -118,4 +118,4 @@ const app = new Application({
   },
 });
 
-app.start(MiniMapScene);
+await app.start(MiniMapScene);

--- a/examples/render-targets/post-processing-chain.js
+++ b/examples/render-targets/post-processing-chain.js
@@ -77,4 +77,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(PostProcessingChainScene);
+await app.start(PostProcessingChainScene);

--- a/examples/render-targets/post-processing-chain.ts
+++ b/examples/render-targets/post-processing-chain.ts
@@ -87,4 +87,4 @@ const app = new Application({
   },
 });
 
-app.start(PostProcessingChainScene);
+await app.start(PostProcessingChainScene);

--- a/examples/render-targets/render-pipeline.js
+++ b/examples/render-targets/render-pipeline.js
@@ -105,4 +105,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(RenderPipelineScene);
+await app.start(RenderPipelineScene);

--- a/examples/render-targets/render-pipeline.ts
+++ b/examples/render-targets/render-pipeline.ts
@@ -123,4 +123,4 @@ const app = new Application({
   },
 });
 
-app.start(RenderPipelineScene);
+await app.start(RenderPipelineScene);

--- a/examples/render-targets/render-to-texture.js
+++ b/examples/render-targets/render-to-texture.js
@@ -50,4 +50,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(RenderToTextureScene);
+await app.start(RenderToTextureScene);

--- a/examples/render-targets/render-to-texture.ts
+++ b/examples/render-targets/render-to-texture.ts
@@ -67,4 +67,4 @@ const app = new Application({
   },
 });
 
-app.start(RenderToTextureScene);
+await app.start(RenderToTextureScene);

--- a/examples/render-targets/trail-feedback.js
+++ b/examples/render-targets/trail-feedback.js
@@ -91,4 +91,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(TrailFeedbackScene);
+await app.start(TrailFeedbackScene);

--- a/examples/render-targets/trail-feedback.ts
+++ b/examples/render-targets/trail-feedback.ts
@@ -103,4 +103,4 @@ const app = new Application({
   },
 });
 
-app.start(TrailFeedbackScene);
+await app.start(TrailFeedbackScene);

--- a/examples/render-targets/water-mirror.js
+++ b/examples/render-targets/water-mirror.js
@@ -90,4 +90,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(WaterMirrorScene);
+await app.start(WaterMirrorScene);

--- a/examples/render-targets/water-mirror.ts
+++ b/examples/render-targets/water-mirror.ts
@@ -101,4 +101,4 @@ const app = new Application({
   },
 });
 
-app.start(WaterMirrorScene);
+await app.start(WaterMirrorScene);

--- a/examples/scene-graph/containers.js
+++ b/examples/scene-graph/containers.js
@@ -44,4 +44,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(ContainersScene);
+await app.start(ContainersScene);

--- a/examples/scene-graph/containers.ts
+++ b/examples/scene-graph/containers.ts
@@ -56,4 +56,4 @@ const app = new Application({
   },
 });
 
-app.start(ContainersScene);
+await app.start(ContainersScene);

--- a/examples/scene-graph/local-vs-global-transform.js
+++ b/examples/scene-graph/local-vs-global-transform.js
@@ -50,4 +50,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(LocalVsGlobalTransformScene);
+await app.start(LocalVsGlobalTransformScene);

--- a/examples/scene-graph/local-vs-global-transform.ts
+++ b/examples/scene-graph/local-vs-global-transform.ts
@@ -57,4 +57,4 @@ const app = new Application({
   },
 });
 
-app.start(LocalVsGlobalTransformScene);
+await app.start(LocalVsGlobalTransformScene);

--- a/examples/scene-graph/masks.js
+++ b/examples/scene-graph/masks.js
@@ -48,4 +48,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(MasksScene);
+await app.start(MasksScene);

--- a/examples/scene-graph/masks.ts
+++ b/examples/scene-graph/masks.ts
@@ -58,4 +58,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(MasksScene);
+await app.start(MasksScene);

--- a/examples/scene-graph/nested-transforms.js
+++ b/examples/scene-graph/nested-transforms.js
@@ -49,4 +49,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(NestedTransformsScene);
+await app.start(NestedTransformsScene);

--- a/examples/scene-graph/nested-transforms.ts
+++ b/examples/scene-graph/nested-transforms.ts
@@ -58,4 +58,4 @@ const app = new Application({
   },
 });
 
-app.start(NestedTransformsScene);
+await app.start(NestedTransformsScene);

--- a/examples/scene-graph/parallax-starfield.js
+++ b/examples/scene-graph/parallax-starfield.js
@@ -50,4 +50,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(ParallaxStarfieldScene);
+await app.start(ParallaxStarfieldScene);

--- a/examples/scene-graph/parallax-starfield.ts
+++ b/examples/scene-graph/parallax-starfield.ts
@@ -58,4 +58,4 @@ const app = new Application({
   },
 });
 
-app.start(ParallaxStarfieldScene);
+await app.start(ParallaxStarfieldScene);

--- a/examples/scene-graph/pivot-and-anchor.js
+++ b/examples/scene-graph/pivot-and-anchor.js
@@ -58,4 +58,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(PivotAndAnchorScene);
+await app.start(PivotAndAnchorScene);

--- a/examples/scene-graph/pivot-and-anchor.ts
+++ b/examples/scene-graph/pivot-and-anchor.ts
@@ -66,4 +66,4 @@ const app = new Application({
   },
 });
 
-app.start(PivotAndAnchorScene);
+await app.start(PivotAndAnchorScene);

--- a/examples/scene-graph/retained-container.js
+++ b/examples/scene-graph/retained-container.js
@@ -119,7 +119,7 @@ const app = new Application({
   },
   clearColor: new Color(6, 9, 18, 1),
 });
-app.start(RetainedContainerScene);
+await app.start(RetainedContainerScene);
 /** Draw a small 2x2 sprite atlas procedurally so the example needs no asset load. */
 function createAtlasTexture() {
   const canvas = document.createElement('canvas');

--- a/examples/scene-graph/retained-container.ts
+++ b/examples/scene-graph/retained-container.ts
@@ -152,7 +152,7 @@ const app = new Application({
   clearColor: new Color(6, 9, 18, 1),
 });
 
-app.start(RetainedContainerScene);
+await app.start(RetainedContainerScene);
 
 /** Draw a small 2x2 sprite atlas procedurally so the example needs no asset load. */
 function createAtlasTexture(): Texture {

--- a/examples/scene-graph/z-ordering.js
+++ b/examples/scene-graph/z-ordering.js
@@ -52,4 +52,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(ZOrderingScene);
+await app.start(ZOrderingScene);

--- a/examples/scene-graph/z-ordering.ts
+++ b/examples/scene-graph/z-ordering.ts
@@ -60,4 +60,4 @@ const app = new Application({
   },
 });
 
-app.start(ZOrderingScene);
+await app.start(ZOrderingScene);

--- a/examples/showcase/audio-reactive-particles.js
+++ b/examples/showcase/audio-reactive-particles.js
@@ -98,4 +98,4 @@ const app = new Application({
   clearColor: Color.black,
   extensions: [particlesExtension],
 });
-app.start(AudioReactiveParticlesScene);
+await app.start(AudioReactiveParticlesScene);

--- a/examples/showcase/audio-reactive-particles.ts
+++ b/examples/showcase/audio-reactive-particles.ts
@@ -128,4 +128,4 @@ const app = new Application({
   extensions: [particlesExtension],
 });
 
-app.start(AudioReactiveParticlesScene);
+await app.start(AudioReactiveParticlesScene);

--- a/examples/showcase/audio-visualisation.js
+++ b/examples/showcase/audio-visualisation.js
@@ -131,4 +131,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(AudioVisualisationScene);
+await app.start(AudioVisualisationScene);

--- a/examples/showcase/audio-visualisation.ts
+++ b/examples/showcase/audio-visualisation.ts
@@ -172,4 +172,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(AudioVisualisationScene);
+await app.start(AudioVisualisationScene);

--- a/examples/showcase/boss-intro-cinematic.js
+++ b/examples/showcase/boss-intro-cinematic.js
@@ -141,4 +141,4 @@ const app = new Application({
   },
   clearColor: new Color(16, 16, 24),
 });
-app.start(BossIntroCinematicScene);
+await app.start(BossIntroCinematicScene);

--- a/examples/showcase/boss-intro-cinematic.ts
+++ b/examples/showcase/boss-intro-cinematic.ts
@@ -176,4 +176,4 @@ const app = new Application({
   clearColor: new Color(16, 16, 24),
 });
 
-app.start(BossIntroCinematicScene);
+await app.start(BossIntroCinematicScene);

--- a/examples/showcase/color-grading.js
+++ b/examples/showcase/color-grading.js
@@ -115,4 +115,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(ColorGradingScene);
+await app.start(ColorGradingScene);

--- a/examples/showcase/color-grading.ts
+++ b/examples/showcase/color-grading.ts
@@ -133,4 +133,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(ColorGradingScene);
+await app.start(ColorGradingScene);

--- a/examples/showcase/damage-flash.js
+++ b/examples/showcase/damage-flash.js
@@ -55,4 +55,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(DamageFlashScene);
+await app.start(DamageFlashScene);

--- a/examples/showcase/damage-flash.ts
+++ b/examples/showcase/damage-flash.ts
@@ -63,4 +63,4 @@ const app = new Application({
   },
 });
 
-app.start(DamageFlashScene);
+await app.start(DamageFlashScene);

--- a/examples/showcase/dialog-system.js
+++ b/examples/showcase/dialog-system.js
@@ -125,4 +125,4 @@ const app = new Application({
   },
   clearColor: new Color(20, 24, 34),
 });
-app.start(DialogSystemScene);
+await app.start(DialogSystemScene);

--- a/examples/showcase/dialog-system.ts
+++ b/examples/showcase/dialog-system.ts
@@ -153,4 +153,4 @@ const app = new Application({
   clearColor: new Color(20, 24, 34),
 });
 
-app.start(DialogSystemScene);
+await app.start(DialogSystemScene);

--- a/examples/showcase/gamepad-spaceship.js
+++ b/examples/showcase/gamepad-spaceship.js
@@ -184,4 +184,4 @@ const app = new Application({
   clearColor: new Color(8, 10, 18),
   extensions: [particlesExtension],
 });
-app.start(GamepadSpaceshipScene);
+await app.start(GamepadSpaceshipScene);

--- a/examples/showcase/gamepad-spaceship.ts
+++ b/examples/showcase/gamepad-spaceship.ts
@@ -237,4 +237,4 @@ const app = new Application({
   extensions: [particlesExtension],
 });
 
-app.start(GamepadSpaceshipScene);
+await app.start(GamepadSpaceshipScene);

--- a/examples/showcase/loading-progress-with-shader.js
+++ b/examples/showcase/loading-progress-with-shader.js
@@ -57,4 +57,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(LoadingProgressWithShaderScene);
+await app.start(LoadingProgressWithShaderScene);

--- a/examples/showcase/loading-progress-with-shader.ts
+++ b/examples/showcase/loading-progress-with-shader.ts
@@ -65,4 +65,4 @@ const app = new Application({
   },
 });
 
-app.start(LoadingProgressWithShaderScene);
+await app.start(LoadingProgressWithShaderScene);

--- a/examples/showcase/low-band-camera-shake.js
+++ b/examples/showcase/low-band-camera-shake.js
@@ -70,4 +70,4 @@ const app = new Application({
   },
   clearColor: new Color(22, 24, 34),
 });
-app.start(LowBandCameraShakeScene);
+await app.start(LowBandCameraShakeScene);

--- a/examples/showcase/low-band-camera-shake.ts
+++ b/examples/showcase/low-band-camera-shake.ts
@@ -96,4 +96,4 @@ const app = new Application({
   clearColor: new Color(22, 24, 34),
 });
 
-app.start(LowBandCameraShakeScene);
+await app.start(LowBandCameraShakeScene);

--- a/examples/showcase/minimap-with-mask.js
+++ b/examples/showcase/minimap-with-mask.js
@@ -106,4 +106,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(MinimapWithMaskScene);
+await app.start(MinimapWithMaskScene);

--- a/examples/showcase/minimap-with-mask.ts
+++ b/examples/showcase/minimap-with-mask.ts
@@ -119,4 +119,4 @@ const app = new Application({
   },
 });
 
-app.start(MinimapWithMaskScene);
+await app.start(MinimapWithMaskScene);

--- a/examples/showcase/mouse-parallax.js
+++ b/examples/showcase/mouse-parallax.js
@@ -59,4 +59,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(MouseParallaxScene);
+await app.start(MouseParallaxScene);

--- a/examples/showcase/mouse-parallax.ts
+++ b/examples/showcase/mouse-parallax.ts
@@ -69,4 +69,4 @@ const app = new Application({
   },
 });
 
-app.start(MouseParallaxScene);
+await app.start(MouseParallaxScene);

--- a/examples/showcase/orb-dodge.js
+++ b/examples/showcase/orb-dodge.js
@@ -258,4 +258,4 @@ const app = new Application({
   clearColor: new Color(10, 14, 26),
 });
 // #endregion guide:application-setup
-app.start(PlayScene);
+await app.start(PlayScene);

--- a/examples/showcase/orb-dodge.ts
+++ b/examples/showcase/orb-dodge.ts
@@ -319,4 +319,4 @@ const app = new Application({
 });
 // #endregion guide:application-setup
 
-app.start(PlayScene);
+await app.start(PlayScene);

--- a/examples/showcase/rectangles-collision.js
+++ b/examples/showcase/rectangles-collision.js
@@ -80,4 +80,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(RectanglesCollisionScene);
+await app.start(RectanglesCollisionScene);

--- a/examples/showcase/rectangles-collision.ts
+++ b/examples/showcase/rectangles-collision.ts
@@ -96,4 +96,4 @@ const app = new Application({
   },
 });
 
-app.start(RectanglesCollisionScene);
+await app.start(RectanglesCollisionScene);

--- a/examples/showcase/screen-shake-on-explosion.js
+++ b/examples/showcase/screen-shake-on-explosion.js
@@ -49,4 +49,4 @@ const app = new Application({
   },
   extensions: [particlesExtension],
 });
-app.start(ScreenShakeOnExplosionScene);
+await app.start(ScreenShakeOnExplosionScene);

--- a/examples/showcase/screen-shake-on-explosion.ts
+++ b/examples/showcase/screen-shake-on-explosion.ts
@@ -54,4 +54,4 @@ const app = new Application({
   extensions: [particlesExtension],
 });
 
-app.start(ScreenShakeOnExplosionScene);
+await app.start(ScreenShakeOnExplosionScene);

--- a/examples/showcase/typewriter-text.js
+++ b/examples/showcase/typewriter-text.js
@@ -51,4 +51,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(TypewriterTextScene);
+await app.start(TypewriterTextScene);

--- a/examples/showcase/typewriter-text.ts
+++ b/examples/showcase/typewriter-text.ts
@@ -59,4 +59,4 @@ const app = new Application({
   },
 });
 
-app.start(TypewriterTextScene);
+await app.start(TypewriterTextScene);

--- a/examples/showcase/vinyl-record.js
+++ b/examples/showcase/vinyl-record.js
@@ -98,4 +98,4 @@ const app = new Application({
   },
   clearColor: new Color(16, 18, 26),
 });
-app.start(VinylRecordScene);
+await app.start(VinylRecordScene);

--- a/examples/showcase/vinyl-record.ts
+++ b/examples/showcase/vinyl-record.ts
@@ -124,4 +124,4 @@ const app = new Application({
   clearColor: new Color(16, 18, 26),
 });
 
-app.start(VinylRecordScene);
+await app.start(VinylRecordScene);

--- a/examples/spatial-audio/falloff-curves.js
+++ b/examples/spatial-audio/falloff-curves.js
@@ -137,4 +137,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(FalloffCurvesScene);
+await app.start(FalloffCurvesScene);

--- a/examples/spatial-audio/falloff-curves.ts
+++ b/examples/spatial-audio/falloff-curves.ts
@@ -171,4 +171,4 @@ const app = new Application({
   },
 });
 
-app.start(FalloffCurvesScene);
+await app.start(FalloffCurvesScene);

--- a/examples/spatial-audio/listener-and-source.js
+++ b/examples/spatial-audio/listener-and-source.js
@@ -128,4 +128,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(ListenerAndSourceScene);
+await app.start(ListenerAndSourceScene);

--- a/examples/spatial-audio/listener-and-source.ts
+++ b/examples/spatial-audio/listener-and-source.ts
@@ -148,4 +148,4 @@ const app = new Application({
   },
 });
 
-app.start(ListenerAndSourceScene);
+await app.start(ListenerAndSourceScene);

--- a/examples/spatial-audio/moving-source.js
+++ b/examples/spatial-audio/moving-source.js
@@ -116,4 +116,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(MovingSourceScene);
+await app.start(MovingSourceScene);

--- a/examples/spatial-audio/moving-source.ts
+++ b/examples/spatial-audio/moving-source.ts
@@ -136,4 +136,4 @@ const app = new Application({
   },
 });
 
-app.start(MovingSourceScene);
+await app.start(MovingSourceScene);

--- a/examples/sprites-textures/asset-catalogs.js
+++ b/examples/sprites-textures/asset-catalogs.js
@@ -171,4 +171,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(AssetCatalogsScene);
+await app.start(AssetCatalogsScene);

--- a/examples/sprites-textures/asset-catalogs.ts
+++ b/examples/sprites-textures/asset-catalogs.ts
@@ -216,4 +216,4 @@ const app = new Application({
   },
 });
 
-app.start(AssetCatalogsScene);
+await app.start(AssetCatalogsScene);

--- a/examples/sprites-textures/blendmodes.js
+++ b/examples/sprites-textures/blendmodes.js
@@ -113,4 +113,4 @@ const app = new Application({
   // visible instead of compositing into a black canvas.
   clearColor: new Color(48, 54, 68),
 });
-app.start(BlendmodesScene);
+await app.start(BlendmodesScene);

--- a/examples/sprites-textures/blendmodes.ts
+++ b/examples/sprites-textures/blendmodes.ts
@@ -144,4 +144,4 @@ const app = new Application({
   clearColor: new Color(48, 54, 68),
 });
 
-app.start(BlendmodesScene);
+await app.start(BlendmodesScene);

--- a/examples/sprites-textures/sprite-basics.js
+++ b/examples/sprites-textures/sprite-basics.js
@@ -56,4 +56,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(SpriteBasicsScene);
+await app.start(SpriteBasicsScene);

--- a/examples/sprites-textures/sprite-basics.ts
+++ b/examples/sprites-textures/sprite-basics.ts
@@ -69,4 +69,4 @@ const app = new Application({
   },
 });
 
-app.start(SpriteBasicsScene);
+await app.start(SpriteBasicsScene);

--- a/examples/sprites-textures/spritesheet-frames.js
+++ b/examples/sprites-textures/spritesheet-frames.js
@@ -78,4 +78,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(SpritesheetFramesScene);
+await app.start(SpritesheetFramesScene);

--- a/examples/sprites-textures/spritesheet-frames.ts
+++ b/examples/sprites-textures/spritesheet-frames.ts
@@ -105,4 +105,4 @@ const app = new Application({
   },
 });
 
-app.start(SpritesheetFramesScene);
+await app.start(SpritesheetFramesScene);

--- a/examples/sprites-textures/svg-drawable.js
+++ b/examples/sprites-textures/svg-drawable.js
@@ -41,4 +41,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(SvgDrawableScene);
+await app.start(SvgDrawableScene);

--- a/examples/sprites-textures/svg-drawable.ts
+++ b/examples/sprites-textures/svg-drawable.ts
@@ -47,4 +47,4 @@ const app = new Application({
   },
 });
 
-app.start(SvgDrawableScene);
+await app.start(SvgDrawableScene);

--- a/examples/sprites-textures/texture-loader.js
+++ b/examples/sprites-textures/texture-loader.js
@@ -62,4 +62,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(TextureLoaderScene);
+await app.start(TextureLoaderScene);

--- a/examples/sprites-textures/texture-loader.ts
+++ b/examples/sprites-textures/texture-loader.ts
@@ -72,4 +72,4 @@ const app = new Application({
   },
 });
 
-app.start(TextureLoaderScene);
+await app.start(TextureLoaderScene);

--- a/examples/sprites-textures/video-drawable.js
+++ b/examples/sprites-textures/video-drawable.js
@@ -106,4 +106,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(VideoDrawableScene);
+await app.start(VideoDrawableScene);

--- a/examples/sprites-textures/video-drawable.ts
+++ b/examples/sprites-textures/video-drawable.ts
@@ -123,4 +123,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(VideoDrawableScene);
+await app.start(VideoDrawableScene);

--- a/examples/text-fonts/basic-text.js
+++ b/examples/text-fonts/basic-text.js
@@ -40,4 +40,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(BasicTextScene);
+await app.start(BasicTextScene);

--- a/examples/text-fonts/basic-text.ts
+++ b/examples/text-fonts/basic-text.ts
@@ -48,4 +48,4 @@ const app = new Application({
   },
 });
 
-app.start(BasicTextScene);
+await app.start(BasicTextScene);

--- a/examples/text-fonts/bitmap-text-basic.js
+++ b/examples/text-fonts/bitmap-text-basic.js
@@ -47,4 +47,4 @@ const app = new Application({
   },
   clearColor: new Color(20, 24, 36),
 });
-app.start(BitmapTextBasicScene);
+await app.start(BitmapTextBasicScene);

--- a/examples/text-fonts/bitmap-text-basic.ts
+++ b/examples/text-fonts/bitmap-text-basic.ts
@@ -57,4 +57,4 @@ const app = new Application({
   clearColor: new Color(20, 24, 36),
 });
 
-app.start(BitmapTextBasicScene);
+await app.start(BitmapTextBasicScene);

--- a/examples/text-fonts/multiline-and-wrap.js
+++ b/examples/text-fonts/multiline-and-wrap.js
@@ -53,4 +53,4 @@ const app = new Application({
   },
   clearColor: Color.black,
 });
-app.start(MultilineAndWrapScene);
+await app.start(MultilineAndWrapScene);

--- a/examples/text-fonts/multiline-and-wrap.ts
+++ b/examples/text-fonts/multiline-and-wrap.ts
@@ -63,4 +63,4 @@ const app = new Application({
   clearColor: Color.black,
 });
 
-app.start(MultilineAndWrapScene);
+await app.start(MultilineAndWrapScene);

--- a/examples/text-fonts/stroke-and-shadow.js
+++ b/examples/text-fonts/stroke-and-shadow.js
@@ -36,4 +36,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(StrokeAndShadowScene);
+await app.start(StrokeAndShadowScene);

--- a/examples/text-fonts/stroke-and-shadow.ts
+++ b/examples/text-fonts/stroke-and-shadow.ts
@@ -41,4 +41,4 @@ const app = new Application({
   },
 });
 
-app.start(StrokeAndShadowScene);
+await app.start(StrokeAndShadowScene);

--- a/examples/text-fonts/text-glitch.js
+++ b/examples/text-fonts/text-glitch.js
@@ -58,4 +58,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(TextGlitchScene);
+await app.start(TextGlitchScene);

--- a/examples/text-fonts/text-glitch.ts
+++ b/examples/text-fonts/text-glitch.ts
@@ -66,4 +66,4 @@ const app = new Application({
   },
 });
 
-app.start(TextGlitchScene);
+await app.start(TextGlitchScene);

--- a/examples/text-fonts/web-fonts.js
+++ b/examples/text-fonts/web-fonts.js
@@ -32,4 +32,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(WebFontsScene);
+await app.start(WebFontsScene);

--- a/examples/text-fonts/web-fonts.ts
+++ b/examples/text-fonts/web-fonts.ts
@@ -38,4 +38,4 @@ const app = new Application({
   },
 });
 
-app.start(WebFontsScene);
+await app.start(WebFontsScene);

--- a/examples/tilemap/infinite-terrain.js
+++ b/examples/tilemap/infinite-terrain.js
@@ -183,4 +183,4 @@ const app = new Application({
   clearColor: new Color(38, 82, 128), // deep-water blue behind unloaded chunks
   extensions: [tilemapExtension],
 });
-app.start(InfiniteTerrainScene);
+await app.start(InfiniteTerrainScene);

--- a/examples/tilemap/infinite-terrain.ts
+++ b/examples/tilemap/infinite-terrain.ts
@@ -232,4 +232,4 @@ const app = new Application({
   extensions: [tilemapExtension],
 });
 
-app.start(InfiniteTerrainScene);
+await app.start(InfiniteTerrainScene);

--- a/examples/tilemap/ldtk-world-import.js
+++ b/examples/tilemap/ldtk-world-import.js
@@ -132,4 +132,4 @@ const app = new Application({
   // enough for both loading (.ldtk) and rendering (TileMapNode).
   extensions: [ldtkExtension],
 });
-app.start(LdtkWorldImportScene);
+await app.start(LdtkWorldImportScene);

--- a/examples/tilemap/ldtk-world-import.ts
+++ b/examples/tilemap/ldtk-world-import.ts
@@ -164,4 +164,4 @@ const app = new Application({
   extensions: [ldtkExtension],
 });
 
-app.start(LdtkWorldImportScene);
+await app.start(LdtkWorldImportScene);

--- a/examples/tilemap/tile-chunks-and-bands.js
+++ b/examples/tilemap/tile-chunks-and-bands.js
@@ -202,4 +202,4 @@ const app = new Application({
   // No loader.basePath here: every asset below comes from the shared
   // `assets` catalog, whose URLs are already fully resolved.
 });
-app.start(TileChunksAndBandsScene);
+await app.start(TileChunksAndBandsScene);

--- a/examples/tilemap/tile-chunks-and-bands.ts
+++ b/examples/tilemap/tile-chunks-and-bands.ts
@@ -231,4 +231,4 @@ const app = new Application({
   // `assets` catalog, whose URLs are already fully resolved.
 });
 
-app.start(TileChunksAndBandsScene);
+await app.start(TileChunksAndBandsScene);

--- a/examples/tilemap/tiled-infinite-map.js
+++ b/examples/tilemap/tiled-infinite-map.js
@@ -110,4 +110,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(TiledInfiniteMapScene);
+await app.start(TiledInfiniteMapScene);

--- a/examples/tilemap/tiled-infinite-map.ts
+++ b/examples/tilemap/tiled-infinite-map.ts
@@ -131,4 +131,4 @@ const app = new Application({
   },
 });
 
-app.start(TiledInfiniteMapScene);
+await app.start(TiledInfiniteMapScene);

--- a/examples/tilemap/tiled-map-import.js
+++ b/examples/tilemap/tiled-map-import.js
@@ -111,4 +111,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(TiledMapImportScene);
+await app.start(TiledMapImportScene);

--- a/examples/tilemap/tiled-map-import.ts
+++ b/examples/tilemap/tiled-map-import.ts
@@ -130,4 +130,4 @@ const app = new Application({
   },
 });
 
-app.start(TiledMapImportScene);
+await app.start(TiledMapImportScene);

--- a/examples/tilemap/worker-streamed-terrain.js
+++ b/examples/tilemap/worker-streamed-terrain.js
@@ -223,4 +223,4 @@ const app = new Application({
   clearColor: new Color(38, 82, 128), // deep-water blue behind unloaded chunks
   extensions: [tilemapExtension],
 });
-app.start(WorkerStreamedTerrainScene);
+await app.start(WorkerStreamedTerrainScene);

--- a/examples/tilemap/worker-streamed-terrain.ts
+++ b/examples/tilemap/worker-streamed-terrain.ts
@@ -267,4 +267,4 @@ const app = new Application({
   extensions: [tilemapExtension],
 });
 
-app.start(WorkerStreamedTerrainScene);
+await app.start(WorkerStreamedTerrainScene);

--- a/examples/tweens-animation/easing-curves.js
+++ b/examples/tweens-animation/easing-curves.js
@@ -131,4 +131,4 @@ const app = new Application({
   },
   clearColor: new Color(18, 21, 30),
 });
-app.start(EasingCurvesScene);
+await app.start(EasingCurvesScene);

--- a/examples/tweens-animation/easing-curves.ts
+++ b/examples/tweens-animation/easing-curves.ts
@@ -159,4 +159,4 @@ const app = new Application({
   clearColor: new Color(18, 21, 30),
 });
 
-app.start(EasingCurvesScene);
+await app.start(EasingCurvesScene);

--- a/examples/tweens-animation/frame-animation.js
+++ b/examples/tweens-animation/frame-animation.js
@@ -49,4 +49,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(FrameAnimationScene);
+await app.start(FrameAnimationScene);

--- a/examples/tweens-animation/frame-animation.ts
+++ b/examples/tweens-animation/frame-animation.ts
@@ -69,4 +69,4 @@ const app = new Application({
   },
 });
 
-app.start(FrameAnimationScene);
+await app.start(FrameAnimationScene);

--- a/examples/tweens-animation/interrupt-and-replace.js
+++ b/examples/tweens-animation/interrupt-and-replace.js
@@ -31,4 +31,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(InterruptAndReplaceScene);
+await app.start(InterruptAndReplaceScene);

--- a/examples/tweens-animation/interrupt-and-replace.ts
+++ b/examples/tweens-animation/interrupt-and-replace.ts
@@ -36,4 +36,4 @@ const app = new Application({
   },
 });
 
-app.start(InterruptAndReplaceScene);
+await app.start(InterruptAndReplaceScene);

--- a/examples/tweens-animation/tween-basics.js
+++ b/examples/tweens-animation/tween-basics.js
@@ -44,4 +44,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(TweenBasicsScene);
+await app.start(TweenBasicsScene);

--- a/examples/tweens-animation/tween-basics.ts
+++ b/examples/tweens-animation/tween-basics.ts
@@ -49,4 +49,4 @@ const app = new Application({
   },
 });
 
-app.start(TweenBasicsScene);
+await app.start(TweenBasicsScene);

--- a/examples/tweens-animation/tween-chains.js
+++ b/examples/tweens-animation/tween-chains.js
@@ -58,4 +58,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(TweenChainsScene);
+await app.start(TweenChainsScene);

--- a/examples/tweens-animation/tween-chains.ts
+++ b/examples/tweens-animation/tween-chains.ts
@@ -65,4 +65,4 @@ const app = new Application({
   },
 });
 
-app.start(TweenChainsScene);
+await app.start(TweenChainsScene);

--- a/examples/tweens-animation/tween-from-array.js
+++ b/examples/tweens-animation/tween-from-array.js
@@ -55,4 +55,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(TweenFromArrayScene);
+await app.start(TweenFromArrayScene);

--- a/examples/tweens-animation/tween-from-array.ts
+++ b/examples/tweens-animation/tween-from-array.ts
@@ -62,4 +62,4 @@ const app = new Application({
   },
 });
 
-app.start(TweenFromArrayScene);
+await app.start(TweenFromArrayScene);

--- a/examples/tweens-animation/tween-with-yoyo.js
+++ b/examples/tweens-animation/tween-with-yoyo.js
@@ -26,4 +26,4 @@ const app = new Application({
     basePath: 'assets/',
   },
 });
-app.start(TweenWithYoyoScene);
+await app.start(TweenWithYoyoScene);

--- a/examples/tweens-animation/tween-with-yoyo.ts
+++ b/examples/tweens-animation/tween-with-yoyo.ts
@@ -31,4 +31,4 @@ const app = new Application({
   },
 });
 
-app.start(TweenWithYoyoScene);
+await app.start(TweenWithYoyoScene);

--- a/site/src/content/guide/recipes/cinematics.mdx
+++ b/site/src/content/guide/recipes/cinematics.mdx
@@ -48,6 +48,8 @@ Navigate to the cinematic scene from the game to fully replace the active scene 
   title="examples/guides/cinematics/cutscene-flow.ts"
 />
 
+`scenes.change` is asynchronous — the incoming scene's `load()` has to run before it can activate — and the `void` says the caller is not waiting for it. Switching from an input handler or a tween callback, as here, is exactly that case: there is nothing to hand the promise to. Await it instead when the code around the switch depends on the new scene being live, and catch it if a failed switch needs to reach the player.
+
 Because the cinematic is now the only active scene, the game scene neither renders nor updates for the duration. When the cinematic ends, switch back:
 
 <SourceSnippet


### PR DESCRIPTION
Turns on `@typescript-eslint/no-floating-promises` for the example catalog — the one type-aware rule worth its noise on copy-paste material, since a dropped promise is not a style question. It found 141 sites across 139 files, which turn out to be three shapes rather than 141 decisions.

## The shapes

**127 are the last line of an example.** `Application.start()` is async, and its own doc says a failed startup returns the state to `Stopped` and propagates the error. Every example dropped that promise, so a backend that fails to initialise or an asset that fails to load produced a silent black canvas. They now `await` it at module top level — what a reader should write, and what the pause-menu guide source already showed. Verified that top-level await survives the transpile into the committed `.js`.

**Eight are `app.destroy()` inside an existing `.catch` fallback.** Teardown on the error path has nothing to await into, so they say `void`.

**Six are a scene change or a gamepad rumble from a synchronous callback.** Same case, same `void`. One of them appears in a published listing, so the cinematics chapter gains a paragraph on why the `void` is there and when to `await` or `.catch` instead — otherwise the listing contradicts prose two paragraphs above it.

Two files opt out instead of being fixed: `examples/shared/editor-support.d.ts` and the worker source the generator inlines are outside `tsconfig.examples.json` on purpose, so a named project cannot parse them and the rule has no program to ask.

The guide block no longer nulls out the project or re-disables the type-aware set; it inherits the catalog's policy and keeps only its two relaxations.

## What the rule found on its first run

`examples/input/key-rebinding.ts` declared an action named `rebind` — also the name of the `ActionMap` method it calls three lines later. `ActionMap` refuses that at construction, so the scene threw during startup and **the example had been a black canvas**.

Nothing reported it. The throw happened inside `start()`, whose promise the example dropped; the page raised no uncaught error and a canvas existed, so the smoke harness recorded a pass. Awaiting the promise is what surfaced it. Renamed to `startRebind`, with the reason at the declaration.

## Validation

`pnpm gates lint`, `pnpm gates typecheck`, `pnpm gates sync`, `pnpm typecheck:guides`, `pnpm examples:sync:check`, `git diff --check` — green.

`pnpm site:build` + `pnpm test:examples:smoke`: **135 passed, 0 warned, 0 skipped, 0 failed.**

## Follow-up, deliberately not in this PR

`scripts/ci/select-lanes.ts` does not select the example smoke for a change under `examples/**` — this PR rewrote the last line of all 140 executed examples and neither the pre-push hook nor CI would have run them. Adding that lane means defining a CI job and keeping `select-lanes.ts` in sync with `_ci-checks.yml` (its own comment says so), plus an `astro build` the site lane does not do today. That belongs in its own change.