### PR TITLE
Warn when the playground editor sees a dropped promise

### DIFF
--- a/site/src/components/EditorCode.tsx
+++ b/site/src/components/EditorCode.tsx
@@ -6,6 +6,7 @@ import EditorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import TsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
 import { type ChangeEvent, type Ref, type RefObject, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 
+import { findFootgunCandidates, footgunMessage, type QuickInfoResponse, returnsPromise } from '../lib/footgun-diagnostics';
 import { buildPublicUrl } from '../lib/url-builder';
 import { CURRENT_VERSION_ID } from '../lib/versions';
 import styles from './EditorCode.module.scss';
@@ -125,6 +126,7 @@ export const EditorCode = ({
   const modelRef = useRef<monaco.editor.ITextModel | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const autoRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const footgunTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const autoRefreshRef = useRef(autoRefresh);
   const typingsAppliedVersionRef = useRef<string | null>(null);
   const disposablesRef = useRef<monaco.IDisposable[]>([]);
@@ -174,6 +176,10 @@ export const EditorCode = ({
       if (autoRefreshTimerRef.current !== null) {
         clearTimeout(autoRefreshTimerRef.current);
         autoRefreshTimerRef.current = null;
+      }
+      if (footgunTimerRef.current !== null) {
+        clearTimeout(footgunTimerRef.current);
+        footgunTimerRef.current = null;
       }
       for (const disposable of disposablesRef.current) disposable.dispose();
       disposablesRef.current = [];
@@ -246,6 +252,16 @@ export const EditorCode = ({
       editor.onDidChangeModelContent(() => {
         const dirty = editor.getValue() !== sourceCodeRef.current;
         onDirty(dirty);
+
+        // Scheduled from the content change rather than from
+        // `onDidChangeMarkers`: this handler writes markers itself, and reacting
+        // to marker changes would have it retrigger on its own output.
+        if (footgunTimerRef.current !== null) clearTimeout(footgunTimerRef.current);
+        footgunTimerRef.current = setTimeout(() => {
+          footgunTimerRef.current = null;
+          void updateFootgunMarkers(editor.getModel());
+        }, FOOTGUN_DEBOUNCE_MS);
+
         if (autoRefreshRef.current && dirty) {
           if (autoRefreshTimerRef.current !== null) clearTimeout(autoRefreshTimerRef.current);
           autoRefreshTimerRef.current = setTimeout(() => {
@@ -270,6 +286,7 @@ export const EditorCode = ({
 
     onCursorChange({ lineNumber: 1, column: 1, selectionLength: 0 });
     updateDiagnostics(editor.getModel(), selectedVersionRef.current, typingsAppliedVersionRef.current, onDiagnostic);
+    void updateFootgunMarkers(editor.getModel());
     requestAnimationFrame(() => editor.layout());
   };
 
@@ -472,6 +489,74 @@ const updateDiagnostics = (
     endColumn: marker.endColumn,
   }));
   onDiagnostic(diagnostics);
+};
+
+/**
+ * Marker owner for the dropped-promise hints. Kept separate from the language
+ * service's own owner so setting these never disturbs Monaco's markers - and so
+ * `onDidChangeMarkers` can tell the two apart.
+ */
+const FOOTGUN_OWNER = 'exo-footguns';
+
+/** How long the buffer has to sit still before the hints are recomputed. */
+const FOOTGUN_DEBOUNCE_MS = 500;
+
+type QuickInfoClient = {
+  getQuickInfoAtPosition(uri: string, position: number): Promise<QuickInfoResponse | undefined>;
+};
+
+/**
+ * Asks the language service about each candidate call and marks the ones whose
+ * signature returns a promise.
+ *
+ * Silent on any failure: these are hints layered over a working editor, and a
+ * warming-up worker or a buffer that changed mid-scan is not worth a message.
+ * The next keystroke schedules another pass.
+ */
+const updateFootgunMarkers = async (model: monaco.editor.ITextModel | null): Promise<void> => {
+  if (!model) return;
+
+  const versionAtStart = model.getVersionId();
+  const candidates = findFootgunCandidates(model.getValue());
+
+  if (candidates.length === 0) {
+    monaco.editor.setModelMarkers(model, FOOTGUN_OWNER, []);
+    return;
+  }
+
+  try {
+    const monacoTs = (monaco.languages as unknown as { typescript: { getTypeScriptWorker(): Promise<(...uris: monaco.Uri[]) => Promise<QuickInfoClient>> } })
+      .typescript;
+    const workerFactory = await monacoTs.getTypeScriptWorker();
+    const client = await workerFactory(model.uri);
+    const uri = model.uri.toString();
+
+    const markers: monaco.editor.IMarkerData[] = [];
+
+    for (const candidate of candidates) {
+      const info = await client.getQuickInfoAtPosition(uri, candidate.calleeOffset);
+      if (!returnsPromise(info)) continue;
+
+      markers.push({
+        severity: monaco.MarkerSeverity.Warning,
+        message: footgunMessage(candidate.callee),
+        startLineNumber: candidate.lineNumber,
+        startColumn: candidate.column,
+        endLineNumber: candidate.lineNumber,
+        endColumn: candidate.endColumn,
+        source: FOOTGUN_OWNER,
+      });
+    }
+
+    // The buffer moved while the worker was answering, so these positions
+    // describe text that no longer exists. Drop them; the edit scheduled a
+    // fresh pass of its own.
+    if (model.isDisposed() || model.getVersionId() !== versionAtStart) return;
+
+    monaco.editor.setModelMarkers(model, FOOTGUN_OWNER, markers);
+  } catch {
+    // See the note above: hints never interrupt editing.
+  }
 };
 
 // Emits JS for the editor's current TypeScript buffer via Monaco's TS worker.

--- a/site/src/lib/footgun-diagnostics.ts
+++ b/site/src/lib/footgun-diagnostics.ts
@@ -1,0 +1,162 @@
+/**
+ * Playground editor: dropped-promise hints.
+ *
+ * The editor runs no linter - only Monaco's TypeScript language service - and
+ * TypeScript has no floating-promise check of its own, which is why the rule
+ * lives in ESLint. So an expression statement whose value is a promise reads as
+ * perfectly fine in the editor while its rejection goes nowhere: the failure
+ * surfaces later, somewhere unrelated, or not at all.
+ *
+ * That class is worth a squiggle for someone writing their own code in the
+ * playground. It is not worth a second TypeScript program in the browser: the
+ * committed catalog is already held to `@typescript-eslint/no-floating-promises`
+ * by the repository's lint gate, so this layer only has to be useful, not
+ * exhaustive.
+ *
+ * The approach is therefore deliberately partial. Candidate statements are found
+ * by reading lines; each candidate's callee is then handed to the language
+ * service, which answers with the real resolved signature. So the decision "is
+ * this a promise" is exact - the compiler makes it - while the decision "is this
+ * a statement worth asking about" is a heuristic.
+ *
+ * What it does not see:
+ *
+ * - a call spread across lines before its own argument list opens;
+ * - a promise reached through anything but a plain identifier chain
+ *   (`getThing().save();`, `handlers[key]();`);
+ * - a promise produced without a call at all (`const p = fetch(...); p;`).
+ *
+ * Each of those is a miss, never a false alarm: the scan only proposes
+ * candidates, and a candidate that is not a promise is dropped.
+ */
+
+/** One `displayPart` of a quick-info response, as the TypeScript worker returns them. */
+export interface QuickInfoDisplayPart {
+  readonly text: string;
+  readonly kind: string;
+}
+
+/** The subset of the worker's quick-info response this module reads. */
+export interface QuickInfoResponse {
+  readonly displayParts?: readonly QuickInfoDisplayPart[];
+}
+
+/** A statement the line scan proposes, and the offset of the callee to ask about. */
+export interface FootgunCandidate {
+  /** 1-based line the statement starts on. */
+  readonly lineNumber: number;
+  /** 1-based column of the first character of the statement. */
+  readonly column: number;
+  /** 1-based column just past the callee's closing parenthesis position on this line. */
+  readonly endColumn: number;
+  /** 0-based offset of the callee's final identifier, which is what quick info is asked about. */
+  readonly calleeOffset: number;
+  /** The callee chain as written, e.g. `this.app.scenes.change`. */
+  readonly callee: string;
+}
+
+/**
+ * A statement that begins with an identifier chain followed by `(`. The chain
+ * may start with `this`, and the line may open a multi-line argument list.
+ */
+const STATEMENT_CALL = /^((?:this\.)?[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*)\s*\(/;
+
+/**
+ * Prefixes that already say what happens to the value. `void` and `await` are
+ * the two answers this hint asks for, so a statement carrying one is finished.
+ */
+const HANDLED_PREFIX = /^(?:await|void|return|yield|new|delete|typeof)\b/;
+
+/** A line that continues an argument list rather than starting a statement. */
+const CONTINUES_ARGUMENTS = /[(,[{]$/;
+
+const lineIsCandidate = (line: string, previous: string | undefined): boolean => {
+  const trimmed = line.trim();
+
+  if (trimmed === '' || trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')) return false;
+  if (HANDLED_PREFIX.test(trimmed)) return false;
+
+  // `.then`/`.catch` on the same line means the caller already answered for the
+  // rejection, whatever it did with the value.
+  if (trimmed.includes('.then(') || trimmed.includes('.catch(')) return false;
+
+  // An argument, not a statement: `foo(\n  bar.baz(x),\n)`.
+  if (trimmed.endsWith(',')) return false;
+  if (previous !== undefined && CONTINUES_ARGUMENTS.test(previous.trim())) return false;
+
+  return STATEMENT_CALL.test(trimmed);
+};
+
+/**
+ * Reads `text` and returns the call statements worth asking the language service
+ * about, in source order.
+ */
+export const findFootgunCandidates = (text: string): FootgunCandidate[] => {
+  const lines = text.split('\n');
+  const candidates: FootgunCandidate[] = [];
+  let offset = 0;
+
+  for (const [index, line] of lines.entries()) {
+    const lineStart = offset;
+    offset += line.length + 1;
+
+    if (!lineIsCandidate(line, index > 0 ? lines[index - 1] : undefined)) continue;
+
+    const trimmed = line.trim();
+    const match = STATEMENT_CALL.exec(trimmed);
+    if (!match) continue;
+
+    const callee = match[1];
+    const indent = line.length - line.trimStart().length;
+    // Quick info is asked at the final identifier of the chain, where the
+    // language service reports the resolved signature rather than the receiver.
+    const lastDot = callee.lastIndexOf('.');
+    const calleeStart = indent + (lastDot === -1 ? 0 : lastDot + 1);
+
+    candidates.push({
+      lineNumber: index + 1,
+      column: indent + 1,
+      endColumn: indent + trimmed.length + 1,
+      calleeOffset: lineStart + calleeStart,
+      callee,
+    });
+  }
+
+  return candidates;
+};
+
+/**
+ * True when quick info describes something whose call signature returns a
+ * promise.
+ *
+ * Reads the structured `displayParts` rather than the joined string: a parameter
+ * or a receiver may well be named `Promise`, and only the part after the
+ * signature's `):` decides. A generic `Promise<T>` and a bare `Promise` both
+ * count, as does a union that contains one.
+ */
+export const returnsPromise = (info: QuickInfoResponse | undefined | null): boolean => {
+  const parts = info?.displayParts;
+  if (!parts || parts.length === 0) return false;
+
+  let depth = 0;
+  let seenReturn = false;
+
+  for (const part of parts) {
+    if (part.kind === 'punctuation') {
+      if (part.text === '(') depth += 1;
+      else if (part.text === ')') depth -= 1;
+      // The return type of the outermost signature starts at its `:` - a `:`
+      // inside the parameter list belongs to a parameter.
+      else if (part.text === ':' && depth === 0) seenReturn = true;
+    }
+
+    if (seenReturn && part.text === 'Promise') return true;
+  }
+
+  return false;
+};
+
+/** The message a dropped-promise marker carries. */
+export const footgunMessage = (callee: string): string =>
+  `\`${callee}(...)\` returns a promise that nothing here waits for, so a failure inside it is discarded rather than reported. ` +
+  `Write \`await\` to wait for it, \`.catch(...)\` to handle a failure, or \`void\` to say the result is deliberately ignored.`;

--- a/test/site/footgun-diagnostics.test.ts
+++ b/test/site/footgun-diagnostics.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import { findFootgunCandidates, footgunMessage, returnsPromise } from '../../site/src/lib/footgun-diagnostics.ts';
+
+const calleesIn = (source: string): string[] => findFootgunCandidates(source).map(candidate => candidate.callee);
+
+describe('findFootgunCandidates', () => {
+  it('proposes a plain call statement', () => {
+    expect(calleesIn('app.start(GameScene);\n')).toEqual(['app.start']);
+  });
+
+  it('follows an identifier chain through this', () => {
+    expect(calleesIn('  this.app.scenes.change(GameScene);\n')).toEqual(['this.app.scenes.change']);
+  });
+
+  it('skips statements that already say what happens to the value', () => {
+    const source = ['await app.start(A);', 'void app.destroy();', 'return loader.load(B);', 'const p = fetch(url);'].join('\n');
+
+    expect(calleesIn(source)).toEqual([]);
+  });
+
+  it('skips a statement that already handles the rejection', () => {
+    expect(calleesIn('app.start(A).catch(reportFailure);\n')).toEqual([]);
+    expect(calleesIn('app.start(A).then(onReady);\n')).toEqual([]);
+  });
+
+  it('skips a nested call that is an argument, and keeps the statement around it', () => {
+    const source = ['register(', '  loader.load(asset),', ');'].join('\n');
+
+    expect(calleesIn(source)).toEqual(['register']);
+  });
+
+  it('proposes a statement whose argument list opens on the same line', () => {
+    const source = ['pad.vibrate({', '  duration: 200,', '});'].join('\n');
+
+    expect(calleesIn(source)).toEqual(['pad.vibrate']);
+  });
+
+  it('skips comments', () => {
+    expect(calleesIn('// app.start(GameScene);\n')).toEqual([]);
+    expect(calleesIn(' * app.start(GameScene);\n')).toEqual([]);
+  });
+
+  it('points at the final identifier of the chain, not the receiver', () => {
+    const source = 'this.app.scenes.change(GameScene);';
+    const [candidate] = findFootgunCandidates(source);
+
+    expect(source.slice(candidate.calleeOffset, candidate.calleeOffset + 'change'.length)).toBe('change');
+  });
+
+  it('reports positions relative to the whole document', () => {
+    const source = ['const app = new Application();', '', 'app.start(GameScene);'].join('\n');
+    const [candidate] = findFootgunCandidates(source);
+
+    expect(candidate.lineNumber).toBe(3);
+    expect(candidate.column).toBe(1);
+    expect(source.slice(candidate.calleeOffset, candidate.calleeOffset + 'start'.length)).toBe('start');
+  });
+});
+
+describe('returnsPromise', () => {
+  const parts = (spec: ReadonlyArray<[string, string]>): { displayParts: Array<{ text: string; kind: string }> } => ({
+    displayParts: spec.map(([text, kind]) => ({ text, kind })),
+  });
+
+  it('accepts a signature returning a promise', () => {
+    // (method) Application.start(target: K): Promise<this>
+    const info = parts([
+      ['start', 'methodName'],
+      ['(', 'punctuation'],
+      ['target', 'parameterName'],
+      [':', 'punctuation'],
+      ['K', 'typeParameterName'],
+      [')', 'punctuation'],
+      [':', 'punctuation'],
+      ['Promise', 'className'],
+      ['<', 'punctuation'],
+      ['this', 'keyword'],
+      ['>', 'punctuation'],
+    ]);
+
+    expect(returnsPromise(info)).toBe(true);
+  });
+
+  it('rejects a signature that only takes a promise', () => {
+    // (method) Runner.observe(promise: Promise<void>): void
+    const info = parts([
+      ['observe', 'methodName'],
+      ['(', 'punctuation'],
+      ['promise', 'parameterName'],
+      [':', 'punctuation'],
+      ['Promise', 'className'],
+      ['<', 'punctuation'],
+      ['void', 'keyword'],
+      ['>', 'punctuation'],
+      [')', 'punctuation'],
+      [':', 'punctuation'],
+      ['void', 'keyword'],
+    ]);
+
+    expect(returnsPromise(info)).toBe(false);
+  });
+
+  it('rejects a synchronous signature', () => {
+    const info = parts([
+      ['render', 'methodName'],
+      ['(', 'punctuation'],
+      [')', 'punctuation'],
+      [':', 'punctuation'],
+      ['void', 'keyword'],
+    ]);
+
+    expect(returnsPromise(info)).toBe(false);
+  });
+
+  it('is false for a missing or empty response', () => {
+    expect(returnsPromise(undefined)).toBe(false);
+    expect(returnsPromise(null)).toBe(false);
+    expect(returnsPromise({ displayParts: [] })).toBe(false);
+  });
+});
+
+describe('footgunMessage', () => {
+  it('names the call and the three ways out', () => {
+    const message = footgunMessage('app.start');
+
+    expect(message).toContain('app.start(...)');
+    expect(message).toContain('await');
+    expect(message).toContain('.catch(...)');
+    expect(message).toContain('void');
+  });
+});


### PR DESCRIPTION
The playground editor runs no linter — only Monaco's TypeScript language service — and TypeScript has no floating-promise check of its own, which is why that rule lives in ESLint. So an expression statement whose value is a promise reads as perfectly fine in the editor while its rejection goes nowhere.

#621 supplied the evidence for why that matters: an example had been throwing during startup and showing a black canvas, and nothing reported it.

## Why this is small

The committed catalog is now held to `@typescript-eslint/no-floating-promises` by the lint gate. This layer therefore does not have to be a second gate — it has to be useful to someone writing their own code in the playground. That is a lower bar, and it buys a much smaller design: no second TypeScript program in the browser, no custom Monaco worker reaching into unversioned internals.

Monaco's `customWorkerPath` was ruled out on its own terms, not on taste: it requires `importScripts`, and the site loads its workers as ESM through Vite's `?worker`.

## The two decisions are split

**Is this a statement worth asking about** — a line scan. Its three known gaps are documented in the module header, and each is a miss rather than a false alarm: the scan only proposes candidates, and a candidate that turns out not to be a promise is dropped.

**Is the value a promise** — the compiler's answer. Each candidate's callee goes to the language service via the worker proxy the editor already uses for `getEmitOutput`, and the reply is read through its structured `displayParts` rather than as text. A parameter may well be named `Promise`; only the outermost signature's return type decides.

## Wiring details that are easy to get wrong

- Markers carry their own owner (`exo-footguns`), so setting them never disturbs the language service's own.
- The scan is scheduled from the content change, **not** from `onDidChangeMarkers` — this handler writes markers, so reacting to marker changes would have it retrigger on its own output.
- A scan whose worker reply arrives after the buffer moved is discarded rather than written at positions that no longer describe the text.
- Severity is `Warning`, not `Error`: the editor should flag the footgun without turning red on someone mid-edit.

## Validation

14 unit tests over the pure logic (`test/site/footgun-diagnostics.test.ts`), covering chains through `this`, statements that already say what happens to the value, `.then`/`.catch` on the line, arguments inside multi-line lists, comments, and both directions of the `displayParts` check — including a signature that *takes* a promise and returns `void`, which must not fire.

Behaviour confirmed in a real browser against the built site (throwaway Playwright probe, not committed):

| Buffer | Markers |
|---|---|
| `app.start(DemoScene);` | 1, Warning, line 7 |
| `await app.start(DemoScene);` | 0 |
| `void app.start(DemoScene);` | 0 |
| `app.resize(800, 600);` | 0 |

`pnpm gates lint` and `pnpm gates site` green.