### PR TITLE
Run the example catalog smoke on the changes that can break it

### DIFF
--- a/.github/workflows/_ci-checks.yml
+++ b/.github/workflows/_ci-checks.yml
@@ -43,6 +43,7 @@ jobs:
       site: ${{ steps.decide.outputs.site }}
       audioFx: ${{ steps.decide.outputs.audioFx }}
       tilemapWorker: ${{ steps.decide.outputs.tilemapWorker }}
+      exampleCatalog: ${{ steps.decide.outputs.exampleCatalog }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -1102,6 +1103,75 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # Boots every entry in the example catalog in headless Chromium. Nothing else
+  # in CI executes an example: `typecheck:examples` compiles the sources,
+  # `examples:sync:check` compares the generated `.js` twins against them, and
+  # the site build only has to render the pages that link them - an example
+  # whose scene throws on start passes all three and still ships a black canvas.
+  #
+  # Consumes the `site-build` job's artifact rather than building the site a
+  # second time: `smoke-examples.ts` serves `site/dist` over a throwaway static
+  # server, so the bytes it smokes are the bytes that job validated.
+  example-smoke:
+    name: Example Smoke
+    needs: [changes, site-build]
+    if: ${{ !cancelled() && needs.changes.outputs.exampleCatalog == 'true' && needs['site-build'].result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: ${{ inputs.pnpm-version }}
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+          check-latest: true
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm bootstrap
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Download site artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: site-dist-${{ github.sha }}
+          path: site/dist
+
+      - name: Smoke the example catalog
+        run: pnpm test:examples:smoke
+
+      # The harness writes a per-example table; keep it when the lane is red so
+      # the failing entry is readable without re-running anything.
+      - name: Upload the smoke report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-smoke-report
+          path: .workspace/reports/example-smoke.md
+          retention-days: 7
+          if-no-files-found: ignore
+
   required-ci:
     name: Required CI
     if: ${{ always() }}
@@ -1122,6 +1192,7 @@ jobs:
         build,
         package-verify,
         site-build,
+        example-smoke,
       ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1132,6 +1203,7 @@ jobs:
           SITE: ${{ needs.changes.outputs.site }}
           AUDIOFX: ${{ needs.changes.outputs.audioFx }}
           TILEMAPWORKER: ${{ needs.changes.outputs.tilemapWorker }}
+          EXAMPLECATALOG: ${{ needs.changes.outputs.exampleCatalog }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           TYPECHECK_RESULT: ${{ needs.typecheck.result }}
           LINT_RESULT: ${{ needs.lint.result }}
@@ -1147,8 +1219,9 @@ jobs:
           BUILD_RESULT: ${{ needs.build.result }}
           PACKAGE_VERIFY_RESULT: ${{ needs['package-verify'].result }}
           SITE_BUILD_RESULT: ${{ needs['site-build'].result }}
+          EXAMPLE_SMOKE_RESULT: ${{ needs['example-smoke'].result }}
         run: |
-          echo "areas: engine=$ENGINE site=$SITE audioFx=$AUDIOFX tilemapWorker=$TILEMAPWORKER"
+          echo "areas: engine=$ENGINE site=$SITE audioFx=$AUDIOFX tilemapWorker=$TILEMAPWORKER exampleCatalog=$EXAMPLECATALOG"
           echo "changes: $CHANGES_RESULT"
           echo "typecheck: $TYPECHECK_RESULT"
           echo "lint: $LINT_RESULT"
@@ -1164,6 +1237,7 @@ jobs:
           echo "build: $BUILD_RESULT"
           echo "package-verify: $PACKAGE_VERIFY_RESULT"
           echo "site-build: $SITE_BUILD_RESULT"
+          echo "example-smoke: $EXAMPLE_SMOKE_RESULT"
 
           failed=0
 
@@ -1193,7 +1267,8 @@ jobs:
             "skip-budget=$SKIP_BUDGET_RESULT" \
             "build=$BUILD_RESULT" \
             "package-verify=$PACKAGE_VERIFY_RESULT" \
-            "site-build=$SITE_BUILD_RESULT"; do
+            "site-build=$SITE_BUILD_RESULT" \
+            "example-smoke=$EXAMPLE_SMOKE_RESULT"; do
             name="${entry%%=*}"
             result="${entry#*=}"
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
@@ -1248,6 +1323,16 @@ jobs:
           if [ "$SITE" = "true" ] && [ "$PACKAGE_VERIFY_RESULT" != "failure" ]; then
             if [ "$SITE_BUILD_RESULT" = "skipped" ]; then
               echo "::error::Site change detected but 'site-build' was skipped (path-filter regression)."
+              failed=1
+            fi
+          fi
+
+          # An example-catalog change must smoke the catalog - unless the site
+          # build it consumes failed first, in which case example-smoke is
+          # intentionally skipped and the site-build failure is already counted.
+          if [ "$EXAMPLECATALOG" = "true" ] && [ "$SITE_BUILD_RESULT" != "failure" ] && [ "$BUILD_RESULT" != "failure" ]; then
+            if [ "$EXAMPLE_SMOKE_RESULT" = "skipped" ]; then
+              echo "::error::Example-catalog change detected but 'example-smoke' was skipped (path-filter regression)."
               failed=1
             fi
           fi

--- a/scripts/ci/select-lanes.d.mts
+++ b/scripts/ci/select-lanes.d.mts
@@ -8,6 +8,7 @@ export interface LaneAreas {
   site: boolean;
   audioFx: boolean;
   tilemapWorker: boolean;
+  exampleCatalog: boolean;
 }
 
 export interface EffectiveLanes {
@@ -22,6 +23,7 @@ export interface EffectiveLanes {
   browserTilemapWorker: boolean;
   packageVerify: boolean;
   siteBuild: boolean;
+  exampleSmoke: boolean;
 }
 
 /** Classify a list of changed files into the effective validation areas. */

--- a/scripts/ci/select-lanes.ts
+++ b/scripts/ci/select-lanes.ts
@@ -32,6 +32,7 @@ export interface LaneAreas {
   site: boolean;
   audioFx: boolean;
   tilemapWorker: boolean;
+  exampleCatalog: boolean;
 }
 
 /** The concrete CI lanes those areas enable. */
@@ -47,6 +48,7 @@ export interface EffectiveLanes {
   browserTilemapWorker: boolean;
   packageVerify: boolean;
   siteBuild: boolean;
+  exampleSmoke: boolean;
 }
 
 /**
@@ -148,6 +150,37 @@ const isTilemapWorkerPath = (file: string): boolean => {
 };
 
 /**
+ * Example-catalog area: the playground catalog itself and the machinery that
+ * puts it in front of a browser. Gates the example-smoke lane, which boots
+ * every catalog entry in headless Chromium.
+ *
+ * Nothing else in CI executes an example. `typecheck:examples` compiles the
+ * sources, `examples:sync:check` compares the generated `.js` twins against
+ * them, and the site build only has to render the pages that link them - an
+ * example whose scene throws on start passes all three and still ships a black
+ * canvas.
+ *
+ * Narrow on purpose, and narrower than `site`: the lane drives a real browser
+ * over the whole catalog, so an unrelated site page or a package README must
+ * not pull it in. Engine paths are deliberately NOT in this set either - they
+ * run the browser rendering lanes, which cover the same runtime on a suite
+ * built for it.
+ */
+const isExampleCatalogPath = (file: string): boolean => {
+  if (file.startsWith('.github/workflows/')) return true;
+  if (file === 'package.json' || file === 'pnpm-lock.yaml' || file === 'pnpm-workspace.yaml') return true;
+  // The catalog sources, their generated `.js` twins, the example assets, and
+  // `examples.json` - the manifest the harness iterates.
+  if (file.startsWith('examples/')) return true;
+  // The harness, the page it loads every example through, and the generator
+  // that copies the catalog into the site the harness serves.
+  if (file === 'site/scripts/smoke-examples.ts') return true;
+  if (file === 'site/scripts/sync-examples-static.ts') return true;
+  if (file === 'site/public/preview.html') return true;
+  return false;
+};
+
+/**
  * Site area: anything that can change the generated examples site / API docs.
  * Gates the site-build lane. Mirrors (and intentionally keeps) the prior `site`
  * filter: every `packages/**` change - docs included - can affect generated docs
@@ -171,6 +204,7 @@ export const selectAreas = (changedFiles: readonly string[]): LaneAreas => {
   let site = false;
   let audioFx = false;
   let tilemapWorker = false;
+  let exampleCatalog = false;
   for (const raw of changedFiles) {
     // Normalise Windows separators and trim stray whitespace/blank entries.
     const file = String(raw).replace(/\\/g, '/').trim();
@@ -179,9 +213,10 @@ export const selectAreas = (changedFiles: readonly string[]): LaneAreas => {
     if (!site && isSitePath(file)) site = true;
     if (!audioFx && isAudioFxPath(file)) audioFx = true;
     if (!tilemapWorker && isTilemapWorkerPath(file)) tilemapWorker = true;
-    if (engine && site && audioFx && tilemapWorker) break;
+    if (!exampleCatalog && isExampleCatalogPath(file)) exampleCatalog = true;
+    if (engine && site && audioFx && tilemapWorker && exampleCatalog) break;
   }
-  return { engine, site, audioFx, tilemapWorker };
+  return { engine, site, audioFx, tilemapWorker, exampleCatalog };
 };
 
 /**
@@ -192,10 +227,13 @@ export const selectAreas = (changedFiles: readonly string[]): LaneAreas => {
  *     (the WebGPU + Firefox browser lanes still run when engine is true; they are
  *     merely `continue-on-error`, i.e. non-blocking, in the workflow);
  *   - site-build gates on `site`;
- *   - the browser-audio lane gates on `audioFx` (a narrow subset of engine).
+ *   - the browser-audio lane gates on `audioFx` (a narrow subset of engine);
+ *   - example-smoke gates on `exampleCatalog` (a narrow subset of site) and
+ *     additionally waits for site-build, because it smokes that job's artifact
+ *     rather than building the site a second time.
  */
 export const effectiveLanes = (areas: LaneAreas): EffectiveLanes => {
-  const { engine, site, audioFx, tilemapWorker } = areas;
+  const { engine, site, audioFx, tilemapWorker, exampleCatalog } = areas;
   return {
     typecheck: true,
     lint: true,
@@ -208,6 +246,7 @@ export const effectiveLanes = (areas: LaneAreas): EffectiveLanes => {
     browserTilemapWorker: tilemapWorker,
     packageVerify: engine,
     siteBuild: site,
+    exampleSmoke: exampleCatalog,
   };
 };
 
@@ -245,13 +284,15 @@ const main = (): void => {
   const areas =
     eventName === 'pull_request'
       ? selectAreas(parseChangedFiles(process.env['CHANGED_FILES']))
-      : { engine: true, site: true, audioFx: true, tilemapWorker: true };
+      : { engine: true, site: true, audioFx: true, tilemapWorker: true, exampleCatalog: true };
 
   // Human-readable trace to the job log (stderr keeps it out of $GITHUB_OUTPUT).
   process.stderr.write(
-    `select-lanes: event=${eventName || 'unknown'} engine=${areas.engine} site=${areas.site} audioFx=${areas.audioFx} tilemapWorker=${areas.tilemapWorker}\n`,
+    `select-lanes: event=${eventName || 'unknown'} engine=${areas.engine} site=${areas.site} audioFx=${areas.audioFx} tilemapWorker=${areas.tilemapWorker} exampleCatalog=${areas.exampleCatalog}\n`,
   );
-  process.stdout.write(`engine=${areas.engine}\nsite=${areas.site}\naudioFx=${areas.audioFx}\ntilemapWorker=${areas.tilemapWorker}\n`);
+  process.stdout.write(
+    `engine=${areas.engine}\nsite=${areas.site}\naudioFx=${areas.audioFx}\ntilemapWorker=${areas.tilemapWorker}\nexampleCatalog=${areas.exampleCatalog}\n`,
+  );
 };
 
 // Only run the CLI when executed directly (`node scripts/ci/select-lanes.ts`),

--- a/scripts/lanes.ts
+++ b/scripts/lanes.ts
@@ -73,6 +73,15 @@ export const LOCAL_LANES: readonly Lane[] = [
   { key: 'browserAudio', name: 'browser: audio worklets', command: ['pnpm', 'test:browser:audio'], browser: true },
   { key: 'browserTilemapWorker', name: 'browser: tilemap worker', command: ['pnpm', 'test:browser:tilemap'], browser: true },
   { key: 'siteBuild', name: 'site gates', command: ['pnpm', 'gates', 'site'], gate: true },
+  // The harness serves `site/dist`, so locally the build is part of the lane -
+  // smoking a stale dist is the false green this lane exists to prevent. CI
+  // gets the build for free by reusing the site-build job's artifact.
+  {
+    key: 'exampleSmoke',
+    name: 'example catalog smoke',
+    command: ['pnpm', 'site:build', '&&', 'pnpm', 'test:examples:smoke'],
+    browser: true,
+  },
 ];
 
 const git = (...args: string[]): string => {
@@ -123,7 +132,7 @@ const main = (): void => {
   const base = readFlag(argv, '--base') ?? 'origin/main';
 
   const files = all ? [] : changedFiles(base);
-  const areas = all ? { engine: true, site: true, audioFx: true, tilemapWorker: true } : selectAreas(files);
+  const areas = all ? { engine: true, site: true, audioFx: true, tilemapWorker: true, exampleCatalog: true } : selectAreas(files);
   const effective = effectiveLanes(areas);
 
   const selected = LOCAL_LANES.filter(lane => lane.key === 'always' || effective[lane.key])
@@ -133,7 +142,9 @@ const main = (): void => {
   const scope = all ? 'every lane' : `${files.length} changed file(s) since ${base}`;
 
   process.stdout.write(`lanes: ${scope}\n`);
-  process.stdout.write(`lanes: engine=${areas.engine} site=${areas.site} audioFx=${areas.audioFx} tilemapWorker=${areas.tilemapWorker}\n\n`);
+  process.stdout.write(
+    `lanes: engine=${areas.engine} site=${areas.site} audioFx=${areas.audioFx} tilemapWorker=${areas.tilemapWorker} exampleCatalog=${areas.exampleCatalog}\n\n`,
+  );
 
   for (const lane of selected) {
     process.stdout.write(`  ${lane.command.join(' ')}${lane.browser ? '   (browser)' : ''}\n`);

--- a/test/ci/lane-commands.test.ts
+++ b/test/ci/lane-commands.test.ts
@@ -25,7 +25,14 @@ const repoRoot = resolve(import.meta.dirname!, '../..');
  */
 const INTENTIONALLY_LOCAL_ONLY_IN_CI = new Set(['coverage', 'browserFirefox', 'packageVerify']);
 
-const allLaneKeys = Object.keys(effectiveLanes({ engine: true, site: true, audioFx: true, tilemapWorker: true }));
+const allLaneKeys = Object.keys(effectiveLanes({ engine: true, site: true, audioFx: true, tilemapWorker: true, exampleCatalog: true }));
+
+/**
+ * The package scripts a lane runs. A lane may chain steps with `&&` - the
+ * example smoke serves the site build's output, so locally the build is part
+ * of the lane - and every step named in it has to exist.
+ */
+const laneScripts = (command: readonly string[]): string[] => command.filter((part, index) => command[index - 1] === 'pnpm');
 
 const packageScripts = (): Record<string, string> => {
   const manifest = JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8')) as { scripts: Record<string, string> };
@@ -61,16 +68,24 @@ describe('local lane commands', () => {
     const scripts = packageScripts();
 
     for (const lane of LOCAL_LANES) {
-      const [runner, script] = lane.command;
+      expect(lane.command[0]).toBe('pnpm');
 
-      expect(runner).toBe('pnpm');
-      expect(Object.keys(scripts)).toContain(script);
+      const named = laneScripts(lane.command);
+
+      expect(named.length).toBeGreaterThan(0);
+
+      for (const script of named) {
+        expect(Object.keys(scripts)).toContain(script);
+      }
     }
   });
 
   it('marks every browser-driven lane so --quick can skip it', () => {
     for (const lane of LOCAL_LANES) {
-      const drivesBrowser = lane.command.some(part => part.startsWith('test:browser'));
+      // `test:examples:smoke` drives a real Chromium too - it boots the whole
+      // example catalog - so the flag has to follow what a lane actually does,
+      // not just the `test:browser*` naming the vitest projects happen to use.
+      const drivesBrowser = laneScripts(lane.command).some(script => script.startsWith('test:browser') || script === 'test:examples:smoke');
 
       expect(lane.browser ?? false).toBe(drivesBrowser);
     }

--- a/test/ci/select-lanes.test.ts
+++ b/test/ci/select-lanes.test.ts
@@ -282,3 +282,53 @@ describe('CI lane selection — browser-tilemap-worker lane', () => {
     expect(decide('.github/workflows/ci.yml').lanes.browserTilemapWorker).toBe(true);
   });
 });
+
+describe('CI lane selection - example-smoke lane', () => {
+  it('example SOURCE change runs the example-smoke lane', () => {
+    const { areas, lanes } = decide('examples/input/key-rebinding.ts');
+    expect(areas.exampleCatalog).toBe(true);
+    expect(lanes.exampleSmoke).toBe(true);
+    // The lane consumes the site-build artifact, so that lane has to run too.
+    expect(areas.site).toBe(true);
+    expect(lanes.siteBuild).toBe(true);
+    // The catalog is not engine code.
+    expect(areas.engine).toBe(false);
+    expect(lanes.unit).toBe(false);
+    expect(lanes.browserWebgl2).toBe(false);
+  });
+
+  it('the generated `.js` twin and the catalog manifest run the lane too', () => {
+    expect(decide('examples/input/key-rebinding.js').lanes.exampleSmoke).toBe(true);
+    expect(decide('examples/examples.json').lanes.exampleSmoke).toBe(true);
+    expect(decide('examples/assets/catalog.js').lanes.exampleSmoke).toBe(true);
+  });
+
+  it('the harness, the preview page and the catalog sync script run the lane', () => {
+    expect(decide('site/scripts/smoke-examples.ts').lanes.exampleSmoke).toBe(true);
+    expect(decide('site/public/preview.html').lanes.exampleSmoke).toBe(true);
+    expect(decide('site/scripts/sync-examples-static.ts').lanes.exampleSmoke).toBe(true);
+  });
+
+  it('an unrelated site change does NOT run the lane, but still builds the site', () => {
+    const { areas, lanes } = decide('site/src/pages/index.astro');
+    expect(areas.exampleCatalog).toBe(false);
+    expect(lanes.exampleSmoke).toBe(false);
+    expect(lanes.siteBuild).toBe(true);
+  });
+
+  it('engine and package changes do NOT run the lane (the browser lanes cover that runtime)', () => {
+    expect(decide('src/rendering/Drawable.ts').lanes.exampleSmoke).toBe(false);
+    expect(decide('packages/exojs-tilemap/src/TileMap.ts').lanes.exampleSmoke).toBe(false);
+    expect(decide('packages/exojs-tiled/README.md').lanes.exampleSmoke).toBe(false);
+  });
+
+  it('workflow / lockfile / workspace changes run the lane', () => {
+    expect(decide('.github/workflows/_ci-checks.yml').lanes.exampleSmoke).toBe(true);
+    expect(decide('pnpm-lock.yaml').lanes.exampleSmoke).toBe(true);
+    expect(decide('pnpm-workspace.yaml').lanes.exampleSmoke).toBe(true);
+  });
+
+  it('negative: a root docs-only change selects no example-smoke lane', () => {
+    expect(decide('README.md').lanes.exampleSmoke).toBe(false);
+  });
+});


### PR DESCRIPTION
Nothing in CI executed an example. `typecheck:examples` compiles the sources,
`examples:sync:check` compares the generated `.js` twins against them, and the
site build only has to render the pages that link them — an example whose scene
throws on start passes all three and still ships a black canvas. That is exactly
how `examples/input/key-rebinding` stayed dead in the catalog.

## What this adds

- An `exampleCatalog` area in `scripts/ci/select-lanes.ts`, gating a new
  `exampleSmoke` lane. Deliberately narrower than `site` — the lane drives a real
  browser over the whole catalog, so an unrelated site page or a package README
  must not pull it in — and it excludes engine paths, which run the browser
  rendering lanes instead.
- An `example-smoke` job that consumes the `site-build` job's artifact rather
  than rebuilding the site, so the bytes it smokes are the bytes that job
  validated. The per-example report is uploaded on failure.
- The matching Required CI contract check: an example-catalog change whose smoke
  lane was skipped is a path-filter regression, not a green run.
- A local lane in `scripts/lanes.ts`. It chains `site:build` because the harness
  serves `site/dist`, and smoking a stale build is the false green this lane
  exists to prevent.

## Verification

- `test/ci/select-lanes.test.ts`: 7 new cases. Removing the `examples/` predicate
  turns 2 of them red.
- `test/ci/lane-commands.test.ts`: its "script exists" check only validated
  `command[1]`, and its browser-detection heuristic keyed on `test:browser*`,
  which `test:examples:smoke` does not match — the lane would have survived
  `--quick`. Both now follow every step a lane names. Dropping `browser: true`
  turns the second red.
- The Required CI shell block was exercised directly against fabricated job
  results: all-green passes, a skipped smoke on a catalog change fails, a skipped
  smoke on an unrelated change passes, and a skipped smoke behind a failed
  site-build does not double-report.
- The lane ran for real on this push: 135 passed, 0 failed. On the pre-rebase
  commit it reported `FAILED input/key-rebinding.js — ActionMap: "rebind"
  collides with ActionMap's own API`, which is the defect #621 fixed.

https://claude.ai/code/session_0164QPPaBfzxFjPvTQZJsiZC