### PR TITLE
Diagnostics policy, three error classes, sidecar sprites, an API rule and a parity oracle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,32 @@ release and includes intentional breaking changes; see **Changed** and
 
 ### Added
 
+- **Three error classes where callers were told to match on message text.** The
+  asset layer already reported cache and network failures as narrowable types,
+  and everything else in `audio`, `input`, `math` and the untyped remainder of
+  `assets` threw a bare `Error`. An error now gets its own class when a consumer
+  branches on it and acts differently, which is what these three do:
+
+  | Class                   | Raised for                                                                                                                | What the caller does                                               |
+  | ----------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+  | `AudioUnsupportedError` | No `AudioContext`, `OfflineAudioContext` or `getUserMedia` in this environment                                            | Disable audio outright - it will not work later either             |
+  | `InputBindingError`     | A saved binding profile whose shape, version, kind or tokens this build cannot read                                       | Discard the save, fall back to the declared defaults               |
+  | `AssetDecodeError`      | Bytes that arrived intact but cannot be decoded - a malformed container, rejected XML, undecodable audio, an empty buffer | Drop the asset; unlike a transport failure, retrying will not help |
+
+  `AudioInput.open()` still passes the browser's own `DOMException` through
+  unwrapped when `getUserMedia` exists but fails: its `name`
+  (`NotAllowedError`, `NotFoundError`) is the standard signal to branch on, and
+  hiding it behind an engine class would be a loss.
+
+  Programmer errors deliberately stay a plain `Error` - an action claimed by two
+  `ActionMap`s, a reserved action name, a malformed pattern written in source -
+  so a `catch` around a profile load does not swallow a bug.
+
+  Written down alongside them: a **failure-diagnostics policy** in
+  `CONTRIBUTING.md` covering when to reach for `assert`/`assertDefined`,
+  `invariant`, or a typed error class, and the argument-evaluation trap that
+  makes a formatted assert message allocate in production.
+
 - **A world runtime and a map object spawner — levels stream, authored objects become
   entities.** Both map adapters stopped at data. LDtk modelled a world as an array of converted
   levels: `__neighbours` was not parsed at all, world placement survived only as two numbers in
@@ -723,6 +749,29 @@ state, claims, inFlight, background }` — for diagnostics and support bundles.
   `unregister`, and no scene-level scope.
 
 ### Fixed
+
+- **A typed asset failure no longer loses its class on the way out of the
+  loader.** `AssetDecoder` wrapped every failure except a cancellation, a cache
+  miss and a store failure in a plain `Error` carrying the original as `cause`.
+  An `AssetNetworkError` - documented as narrowable and carrying `status` /
+  `statusText` - therefore never reached a caller as itself. It is now rethrown
+  unwrapped, and an `AssetDecodeError` is rebuilt rather than replaced, so it
+  keeps its type _and_ gains the "which asset, from where" envelope.
+
+- **Attaching the same audio effect twice built a feedback loop.**
+  `AudioBus.addEffect` and `Voice.addEffect` pushed the effect a second time and
+  rewired the chain, connecting the effect's output back into its own input. The
+  dev build now asserts; production ignores the second attach.
+
+- **A `GamepadMapping` with two controls on one channel silently dropped one of
+  them.** Every control writes into one channel slot per frame, so the pad
+  reported whichever ran last while the other looked dead. The constructor
+  asserts in the dev build.
+
+- **`triangulate()` and `buildPath()` accepted an odd-length coordinate list.**
+  The trailing value was dropped or read as half of a point that does not exist,
+  producing NaN vertices or a silently different polygon than the caller
+  described. Both now assert that the length is even.
 
 - **A single-point contact under very high acceleration sank without bound.** The two-point
   block solve reaches its push-out target exactly, so a face contact rests at the contact slop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -955,6 +955,20 @@ state, claims, inFlight, background }` — for diagnostics and support bundles.
 
 ### Changed
 
+- **BREAKING - three noun-only function exports are renamed.** A noun reads as a
+  value at the call site and hides that it has to be called:
+
+  | Before                    | After                        |
+  | ------------------------- | ---------------------------- |
+  | `tiledObjectAnchorOffset` | `getTiledObjectAnchorOffset` |
+  | `wgslFieldLayout`         | `getWgslFieldLayout`         |
+  | `wgslUniformByteSize`     | `getWgslUniformByteSize`     |
+
+  The package prefix stays: the full IIFE build is one flat `window.Exo` object
+  across every package, so it is the only marker of where a symbol came from.
+  This is the whole rename - the rule now written down in `CONTRIBUTING.md`
+  reshapes existing API only where a change touches it anyway.
+
 - **BREAKING — canvas sizing is a policy object, not a mode string.**
   `CanvasSizingMode` named five modes along three different technical axes at
   once, so `'fit'` and `'letterbox'` differed in ways the names never said, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,27 @@ release and includes intentional breaking changes; see **Changed** and
 
 ### Added
 
+- **Audio sprite tables can live in a sidecar file.** `sprites` on a `sound`
+  asset now also accepts a source string naming a JSON sidecar that holds the
+  same `{ name: { start, end, loop? } }` map, so a table a tool produced no
+  longer has to be pasted into code:
+
+  ```ts
+  Assets.from({ sfx: { type: 'sound', source: 'sfx.ogg', sprites: 'sfx.sprites.json' } });
+  ```
+
+  The sidecar is loaded through the sound's own dependency scope - it is claimed
+  and released with the sound, the way `LdtkProject` claims its atlases - so one
+  asset is configured, not two. Its source resolves against the loader's base
+  path like any other asset source, _not_ relative to the audio file. A
+  malformed sheet fails the load with an `AssetDecodeError` naming the sidecar,
+  including a window only the decoded buffer's duration can reject.
+
+  Deliberately **not** added: a converter for foreign atlas formats.
+  `audiosprite` and Howler store `[offsetMs, durationMs]` tuples in formats that
+  are not even a shared file layout; that conversion belongs in a build step,
+  once, not in the loader on every load.
+
 - **Three error classes where callers were told to match on message text.** The
   asset layer already reported cache and network failures as narrowable types,
   and everything else in `audio`, `input`, `math` and the untyped remainder of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -771,6 +771,29 @@ state, claims, inFlight, background }` — for diagnostics and support bundles.
 
 ### Fixed
 
+- **The rendering-parity matrix now proves correctness somewhere, not only
+  agreement.** `oracle` was the matrix's own strongest evidence class and
+  appeared zero times in the checked-in evidence: every property compared a
+  rendering against another rendering, so two backends computing a colour the
+  same wrong way agreed perfectly and a backend computing it wrongly every time
+  was perfectly deterministic.
+
+  A scene can now declare an oracle - expected pixels derived on the CPU from
+  its own inputs - and a new `oracle-agreement` property checks them per
+  backend. Four scenes carry one, covering exactly the class a traced pixel
+  cannot reach, where the output is computed rather than sampled: premultiplied
+  source-over, additive blending, a colour-matrix channel swap, and a linear
+  gradient ramp. Where a pixel already traces back to its source texel the gap
+  was never open - that is a renderer-independent expectation already - so no
+  blanket oracle mandate was added.
+
+- **Two empty frames no longer count as cross-backend parity.** An empty frame
+  is byte-identical to another empty frame, so a scene that drew nothing filled
+  its parity row with a `traced` claim about nothing. `renders-something`
+  reported the same fact in its own row, but the misleading row was the parity
+  one, so emptiness is now a precondition of the comparison rather than a
+  neighbouring property's business.
+
 - **A typed asset failure no longer loses its class on the way out of the
   loader.** `AssetDecoder` wrapped every failure except a cancellation, a cache
   miss and a store failure in a plain `Error` carrying the original as `cause`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,6 +267,41 @@ Prefer a plain string union over an enum when there is no need to reference the
 members as values — `CanvasSizingMode` is a union, not an enum, because callers
 only ever write the literal.
 
+## Free function or class member?
+
+A public symbol's shape is an API decision, so decide it from what the symbol
+_is_, not from where the implementation happens to sit.
+
+- **Class** when there is object identity, an own lifecycle, ownership, or
+  several operations over shared state: `TileColliderStreamer`, `InputScope`,
+  `LoaderScope`. If two calls only make sense against the same instance, that
+  instance is the API.
+- **Free function** for pure transformations, for policy and lookup callbacks,
+  and for **factories**. A factory stays a free function whether it returns a
+  function, a plain object or an instance - `createSampledChunkSource` returns a
+  `ChunkSource` object and is still a function, because nothing about the call
+  needs an object of its own.
+- **Constants stay free value exports**, never `static readonly` on a class. A
+  static ties the value to an object the tree shaker cannot take apart, so a
+  caller who wants one number drags the whole class into the bundle.
+
+Two carve-outs, both deliberate and not to be "unified":
+
+- **React hooks** stay free `use*` functions. That is React's convention, not a
+  deviation from this one.
+- **The package prefix in a name stays**, even where it stutters against the
+  package name on an ESM import (`tiledObjectAnchorOffset` in
+  `@codexo/exojs-tiled`). The full IIFE build is one flat `window.Exo` object
+  across every package, and there the prefix is the only marker of where a
+  symbol came from.
+
+Name a function for what it does: a verb first (`resolveTiledObjectAlignment`,
+`getWebGpuBlendState`, `createSampledChunkSource`). A noun-only export reads as a
+value at the call site and hides that it has to be called.
+
+Existing API is reshaped only where a change touches it anyway. This rule is not
+a licence for a rename campaign.
+
 ## Failure diagnostics: `assert`, `invariant`, typed error
 
 Every runtime failure the engine reports goes through one of three tools, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,6 +267,86 @@ Prefer a plain string union over an enum when there is no need to reference the
 members as values — `CanvasSizingMode` is a union, not an enum, because callers
 only ever write the literal.
 
+## Failure diagnostics: `assert`, `invariant`, typed error
+
+Every runtime failure the engine reports goes through one of three tools, and
+which one is right follows from a single question: **what kind of failure is
+this, and who can act on it?**
+
+| Tool                       | Use it for                                               | In production                                    |
+| -------------------------- | -------------------------------------------------------- | ------------------------------------------------ |
+| `assert` / `assertDefined` | Diagnosing misuse the type system cannot express         | stripped — the body is dead code under `__DEV__` |
+| `invariant`                | A contract breach that would corrupt state or memory     | always on, always throws                         |
+| Typed error class          | The environment: fetch, decode, device, serialized input | always on                                        |
+
+**Misuse belongs at `assert`.** Calling `play()` on a sprite name that was never
+defined, registering the same bus twice, reading a lazily created node before its
+subsystem finished initializing — all of these are programmer errors with a fix
+in the caller's source, and the dev build is where that fix gets found. Shipping
+the check into production would be a guardrail against user error, which the
+engine deliberately does not do; the dev build is exactly the place that rule
+points to. `assert` is not the weaker option here, it is the correct one.
+
+**`invariant` is the exception, not the upgrade.** Use it only where continuing
+past the broken condition would corrupt engine state, hand out a dangling
+resource, or write outside a buffer — cases where throwing in production is
+strictly better than the alternative. A misuse that merely produces a wrong
+picture does not qualify.
+
+**A typed error is for input the caller did not write.** A file that failed to
+fetch, bytes that failed to decode, a device that refused a limit, a serialized
+binding profile written by a newer build. The caller cannot fix these in source;
+they can only branch at runtime — retry, fall back, tell the user — which is why
+these stay on in production and carry a class.
+
+### When a failure earns its own error class
+
+The axis is **what the caller does**, not where the failure came from. An error
+gets its own class when a consumer branches on it and acts differently; an error
+that only ever gets logged does not need one. Do not build a taxonomy per
+subsystem: grouping by origin produces one base class per subsystem and answers a
+question no caller asks.
+
+The asset layer is the template. `AssetCacheError`, `AssetCacheMissError` and
+`AssetNetworkError` exist because callers act on them differently, and
+`AssetNetworkError` carries `status`/`statusText` because HTTP 404 and HTTP 503
+lead to different handling. `AssetDecoder` branches on them with `instanceof`.
+
+Carry the data the branch needs on the class — a status code, an offending id, a
+version number — and keep it `readonly`. Name the class after the failure, not
+the subsystem.
+
+### The argument-evaluation trap
+
+JavaScript evaluates arguments before entering the function, so the arguments of
+a stripped `assert` still run in production:
+
+```ts
+// The template literal allocates in production, even though the body is gone.
+assert(index < length, `index ${index} is out of bounds (${length})`);
+```
+
+For a trivial comparison and a short message that cost is negligible and the
+inline form is preferred. For anything that formats a string from several values,
+calls a function, or allocates an object, wrap the call so the arguments never
+run in production:
+
+```ts
+if (__DEV__) {
+  assert(isValidLayout(layout), `layout ${describeLayout(layout)} is not renderable`);
+}
+```
+
+A validation with side effects must always be wrapped this way — otherwise the
+production build keeps the effect and loses the check.
+
+### Not a sweep
+
+This policy governs new code and the sites a change already touches. The engine
+carries several hundred pre-existing `throw new Error` calls, `rendering` alone
+most of them; they are migrated subsystem by subsystem where misuse is silent
+today, not swept in bulk.
+
 ## Distribution
 
 - npm packages are **modular and self-contained**: `@codexo/exojs` ships Core only;

--- a/packages/exojs-particles/src/gpu/ParticleGpuState.ts
+++ b/packages/exojs-particles/src/gpu/ParticleGpuState.ts
@@ -7,7 +7,7 @@ import { fillShaderSource, reflectComputeBindings, WebGpuComputePipeline, WebGpu
 
 import type { UpdateModule } from '#modules/UpdateModule';
 import type { WgslContribution, WgslUniformField } from '#modules/WgslContribution';
-import { wgslUniformByteSize } from '#modules/WgslContribution';
+import { getWgslUniformByteSize } from '#modules/WgslContribution';
 import type { ParticleSystem } from '#ParticleSystem';
 
 import particleSimulateWgsl from './wgsl/particle-simulate.wgsl';
@@ -247,7 +247,7 @@ export class ParticleGpuState {
     for (const m of modules) {
       const c = m.wgsl!();
       const fields = c.uniforms ?? [];
-      const size = wgslUniformByteSize(fields);
+      const size = getWgslUniformByteSize(fields);
 
       uniformOffset = Math.ceil(uniformOffset / 16) * 16;
 

--- a/packages/exojs-particles/src/modules/WgslContribution.ts
+++ b/packages/exojs-particles/src/modules/WgslContribution.ts
@@ -77,12 +77,12 @@ export interface WgslContribution {
  *
  * Used by the codegen to size the system's combined uniform buffer.
  */
-export const wgslUniformByteSize = (fields: readonly WgslUniformField[]): number => {
+export const getWgslUniformByteSize = (fields: readonly WgslUniformField[]): number => {
   let offset = 0;
   let maxAlign = 4;
 
   for (const field of fields) {
-    const { size, align } = wgslFieldLayout(field.type);
+    const { size, align } = getWgslFieldLayout(field.type);
 
     offset = Math.ceil(offset / align) * align;
     offset += size;
@@ -93,7 +93,7 @@ export const wgslUniformByteSize = (fields: readonly WgslUniformField[]): number
 };
 
 /** Per-WGSL-primitive size and alignment in bytes. */
-export const wgslFieldLayout = (type: WgslPrimitive): { size: number; align: number } => {
+export const getWgslFieldLayout = (type: WgslPrimitive): { size: number; align: number } => {
   switch (type) {
     case 'f32':
     case 'i32':

--- a/packages/exojs-particles/src/modules/index.ts
+++ b/packages/exojs-particles/src/modules/index.ts
@@ -20,4 +20,4 @@ export { Turbulence } from './Turbulence';
 export { UpdateModule } from './UpdateModule';
 export { VelocityOverLifetime } from './VelocityOverLifetime';
 export type { WgslContribution, WgslPrimitive, WgslTextureBinding, WgslUniformField } from './WgslContribution';
-export { wgslFieldLayout, wgslUniformByteSize } from './WgslContribution';
+export { getWgslFieldLayout, getWgslUniformByteSize } from './WgslContribution';

--- a/packages/exojs-particles/test/particle-modules-wgsl.test.ts
+++ b/packages/exojs-particles/test/particle-modules-wgsl.test.ts
@@ -11,7 +11,7 @@ import { OrbitalForce } from '../src/modules/OrbitalForce';
 import { RepelFromPoint } from '../src/modules/RepelFromPoint';
 import { Turbulence } from '../src/modules/Turbulence';
 import { VelocityOverLifetime } from '../src/modules/VelocityOverLifetime';
-import { wgslFieldLayout, wgslUniformByteSize } from '../src/modules/WgslContribution';
+import { getWgslFieldLayout, getWgslUniformByteSize } from '../src/modules/WgslContribution';
 
 // These modules' `wgsl()` / `writeUniforms()` pair is CPU-side codegen: it
 // produces a WGSL source fragment (a string) and packs uniform bytes into a
@@ -22,18 +22,18 @@ import { wgslFieldLayout, wgslUniformByteSize } from '../src/modules/WgslContrib
 // tests don't exercise.
 
 describe('WgslContribution helpers', () => {
-  test('wgslFieldLayout reports size/align for every primitive', () => {
-    expect(wgslFieldLayout('f32')).toEqual({ size: 4, align: 4 });
-    expect(wgslFieldLayout('i32')).toEqual({ size: 4, align: 4 });
-    expect(wgslFieldLayout('u32')).toEqual({ size: 4, align: 4 });
-    expect(wgslFieldLayout('vec2<f32>')).toEqual({ size: 8, align: 8 });
-    expect(wgslFieldLayout('vec4<f32>')).toEqual({ size: 16, align: 16 });
+  test('getWgslFieldLayout reports size/align for every primitive', () => {
+    expect(getWgslFieldLayout('f32')).toEqual({ size: 4, align: 4 });
+    expect(getWgslFieldLayout('i32')).toEqual({ size: 4, align: 4 });
+    expect(getWgslFieldLayout('u32')).toEqual({ size: 4, align: 4 });
+    expect(getWgslFieldLayout('vec2<f32>')).toEqual({ size: 8, align: 8 });
+    expect(getWgslFieldLayout('vec4<f32>')).toEqual({ size: 16, align: 16 });
   });
 
-  test('wgslUniformByteSize packs scalars tightly', () => {
+  test('getWgslUniformByteSize packs scalars tightly', () => {
     // Two f32s (4 bytes, 4-align each) pack to 8 bytes, rounded to the
     // struct's own 4-byte alignment.
-    const size = wgslUniformByteSize([
+    const size = getWgslUniformByteSize([
       { name: 'a', type: 'f32' },
       { name: 'b', type: 'f32' },
     ]);
@@ -41,10 +41,10 @@ describe('WgslContribution helpers', () => {
     expect(size).toBe(8);
   });
 
-  test('wgslUniformByteSize pads scalar-then-vec2 to the vec2 alignment', () => {
+  test('getWgslUniformByteSize pads scalar-then-vec2 to the vec2 alignment', () => {
     // f32 (offset 0..4) then vec2<f32> (needs 8-byte alignment) pads to
     // offset 8, ending at 16; struct rounds to the largest alignment (8).
-    const size = wgslUniformByteSize([
+    const size = getWgslUniformByteSize([
       { name: 'a', type: 'f32' },
       { name: 'b', type: 'vec2<f32>' },
     ]);
@@ -52,10 +52,10 @@ describe('WgslContribution helpers', () => {
     expect(size).toBe(16);
   });
 
-  test('wgslUniformByteSize rounds the whole struct up to the largest field alignment', () => {
+  test('getWgslUniformByteSize rounds the whole struct up to the largest field alignment', () => {
     // f32 (4) + vec4<f32> (16-aligned) -> field starts at 16, ends at 32;
     // struct alignment is 16, 32 is already a multiple so no extra padding.
-    const size = wgslUniformByteSize([
+    const size = getWgslUniformByteSize([
       { name: 'a', type: 'f32' },
       { name: 'b', type: 'vec4<f32>' },
     ]);
@@ -63,8 +63,8 @@ describe('WgslContribution helpers', () => {
     expect(size).toBe(32);
   });
 
-  test('wgslUniformByteSize of an empty field list is zero', () => {
-    expect(wgslUniformByteSize([])).toBe(0);
+  test('getWgslUniformByteSize of an empty field list is zero', () => {
+    expect(getWgslUniformByteSize([])).toBe(0);
   });
 });
 

--- a/packages/exojs-tiled/src/TiledMap.ts
+++ b/packages/exojs-tiled/src/TiledMap.ts
@@ -25,7 +25,7 @@ import type {
   TiledTileData,
 } from './data';
 import { maskTiledGid, TILED_FLIPPED_DIAGONALLY_FLAG, TILED_FLIPPED_HORIZONTALLY_FLAG, TILED_FLIPPED_VERTICALLY_FLAG } from './gid';
-import { resolveTiledObjectAlignment, tiledObjectAnchorOffset } from './objectAlignment';
+import { getTiledObjectAnchorOffset, resolveTiledObjectAlignment } from './objectAlignment';
 import { createTiledLayer, TiledGroupLayer, TiledImageLayer, type TiledLayer, TiledObjectLayer, TiledTileLayer } from './TiledLayer';
 import type { TiledObject } from './TiledObject';
 import type { TiledTileset } from './TiledTileset';
@@ -615,7 +615,7 @@ const tileObjectAnchorOffset = (
 
   const alignment = resolveTiledObjectAlignment(owningTs.objectAlignment, orientation);
 
-  return tiledObjectAnchorOffset(alignment, width, height);
+  return getTiledObjectAnchorOffset(alignment, width, height);
 };
 
 /**

--- a/packages/exojs-tiled/src/objectAlignment.ts
+++ b/packages/exojs-tiled/src/objectAlignment.ts
@@ -45,7 +45,11 @@ export const resolveTiledObjectAlignment = (alignment: TiledObjectAlignment | un
  * `cornerX = object.x - offset.x`.
  * @advanced
  */
-export const tiledObjectAnchorOffset = (alignment: TiledResolvedObjectAlignment, width: number, height: number): { readonly x: number; readonly y: number } => {
+export const getTiledObjectAnchorOffset = (
+  alignment: TiledResolvedObjectAlignment,
+  width: number,
+  height: number,
+): { readonly x: number; readonly y: number } => {
   switch (alignment) {
     case 'topleft':
       return { x: 0, y: 0 };

--- a/packages/exojs-tiled/src/public.ts
+++ b/packages/exojs-tiled/src/public.ts
@@ -121,7 +121,7 @@ export { TiledTileset } from './TiledTileset';
 
 // ── Tile-object anchoring ─────────────────────────────────────────────────────
 export type { TiledResolvedObjectAlignment } from './objectAlignment';
-export { resolveTiledObjectAlignment, TILED_OBJECT_ALIGNMENTS, tiledObjectAnchorOffset } from './objectAlignment';
+export { getTiledObjectAnchorOffset, resolveTiledObjectAlignment, TILED_OBJECT_ALIGNMENTS } from './objectAlignment';
 
 // ── Wangset conversion ────────────────────────────────────────────────────────
 export { tiledWangSetToWangSet } from './wangSets';

--- a/packages/exojs-tiled/test/objectAlignment.test.ts
+++ b/packages/exojs-tiled/test/objectAlignment.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { TiledObjectAlignment, TiledOrientation } from '../src/data';
-import { resolveTiledObjectAlignment, tiledObjectAnchorOffset } from '../src/objectAlignment';
+import { getTiledObjectAnchorOffset, resolveTiledObjectAlignment } from '../src/objectAlignment';
 
 // Reference values taken from Tiled's own implementation:
 // `MapObject::alignment()` and `alignmentOffset()` in libtiled.
@@ -34,7 +34,7 @@ describe('resolveTiledObjectAlignment — default per map orientation', () => {
   });
 });
 
-describe('tiledObjectAnchorOffset — anchor position inside the bounding box', () => {
+describe('getTiledObjectAnchorOffset — anchor position inside the bounding box', () => {
   const W = 24;
   const H = 16;
 
@@ -49,10 +49,10 @@ describe('tiledObjectAnchorOffset — anchor position inside the bounding box', 
     ['bottom', W / 2, H],
     ['bottomright', W, H],
   ] as const)('%s → (%d, %d)', (alignment, x, y) => {
-    expect(tiledObjectAnchorOffset(alignment, W, H)).toEqual({ x, y });
+    expect(getTiledObjectAnchorOffset(alignment, W, H)).toEqual({ x, y });
   });
 
   it('is all-zero for a zero-sized object', () => {
-    expect(tiledObjectAnchorOffset('bottomright', 0, 0)).toEqual({ x: 0, y: 0 });
+    expect(getTiledObjectAnchorOffset('bottomright', 0, 0)).toEqual({ x: 0, y: 0 });
   });
 });

--- a/scripts/exo-full.entry.ts
+++ b/scripts/exo-full.entry.ts
@@ -73,7 +73,7 @@ export {
   TILED_OBJECT_ALIGNMENTS,
   tiledBuildInfo,
   tiledExtension,
-  tiledObjectAnchorOffset,
+  getTiledObjectAnchorOffset,
   tiledWangSetToWangSet,
   TiledFormatError,
   TiledGroupLayer,

--- a/site/src/content/api/asset-decode-error-options.json
+++ b/site/src/content/api/asset-decode-error-options.json
@@ -1,0 +1,121 @@
+{
+  "title": "AssetDecodeErrorOptions",
+  "description": "Construction options for an AssetDecodeError.",
+  "symbol": "AssetDecodeErrorOptions",
+  "kind": "interface",
+  "subsystem": "assets",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 3,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 3,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Construction options for an AssetDecodeError."
+      ],
+      "importLine": "import { AssetDecodeErrorOptions } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "assetType",
+          "signature": "assetType?: string",
+          "signatureTokens": [
+            {
+              "text": "assetType",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Asset type id the bytes were being decoded for, when known."
+        },
+        {
+          "name": "cause",
+          "signature": "cause?: unknown",
+          "signatureTokens": [
+            {
+              "text": "cause",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "The underlying failure - a DOMException from a browser decoder, a parser's own error."
+        },
+        {
+          "name": "message",
+          "signature": "message: string",
+          "signatureTokens": [
+            {
+              "text": "message",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "One-line, actionable summary (becomes the Error.message)."
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/assets/AssetDecodeError.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/assets/AssetDecodeError.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/assets/AssetDecodeError.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/assets/AssetDecodeError.ts"
+}

--- a/site/src/content/api/asset-decode-error.json
+++ b/site/src/content/api/asset-decode-error.json
@@ -1,0 +1,228 @@
+{
+  "title": "AssetDecodeError",
+  "description": "Raised when bytes that were successfully obtained cannot be turned into a resource: a malformed container index, an XML document the parser rejected, audio the browser could not decode, an empty buffer. Distinct from AssetNetworkError and AssetCacheError because the reaction differs: a transport failure is worth retrying and a cache failure is worth ignoring, while broken content stays broken - the asset has to be dropped or the file fixed. Narrow with `error instanceof AssetDecodeError`; the decoder's own error stays reachable through Error.cause.",
+  "symbol": "AssetDecodeError",
+  "kind": "class",
+  "subsystem": "assets",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 6,
+  "counts": {
+    "constructors": 1,
+    "methods": 0,
+    "properties": 5,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Raised when bytes that were successfully obtained cannot be turned into a resource: a malformed container index, an XML document the parser rejected, audio the browser could not decode, an empty buffer.",
+        "Distinct from AssetNetworkError and AssetCacheError because the reaction differs: a transport failure is worth retrying and a cache failure is worth ignoring, while broken content stays broken - the asset has to be dropped or the file fixed. Narrow with `error instanceof AssetDecodeError`; the decoder's own error stays reachable through Error.cause."
+      ],
+      "importLine": "import { AssetDecodeError } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "constructors",
+      "title": "Constructors",
+      "members": [
+        {
+          "name": "new",
+          "signature": "new(options: AssetDecodeErrorOptions): AssetDecodeError",
+          "signatureTokens": [
+            {
+              "text": "new",
+              "kind": "keyword"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "options",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AssetDecodeErrorOptions",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AssetDecodeError",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "options",
+              "type": "AssetDecodeErrorOptions",
+              "optional": false
+            }
+          ],
+          "returnType": "AssetDecodeError",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "assetType",
+          "signature": "assetType: null | string",
+          "signatureTokens": [
+            {
+              "text": "assetType",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "null",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "Asset type id the bytes were being decoded for, or null when the decoder is type-agnostic."
+        },
+        {
+          "name": "cause",
+          "signature": "cause?: unknown",
+          "signatureTokens": [
+            {
+              "text": "cause",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "message",
+          "signature": "message: string",
+          "signatureTokens": [
+            {
+              "text": "message",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "name",
+          "signature": "name: string",
+          "signatureTokens": [
+            {
+              "text": "name",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "stack",
+          "signature": "stack?: string",
+          "signatureTokens": [
+            {
+              "text": "stack",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/assets/AssetDecodeError.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/assets/AssetDecodeError.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/assets/AssetDecodeError.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/assets/AssetDecodeError.ts"
+}

--- a/site/src/content/api/asset-definitions.json
+++ b/site/src/content/api/asset-definitions.json
@@ -730,7 +730,7 @@
         },
         {
           "name": "sound",
-          "signature": "sound: { config: { playbackOptions?: Partial<PlaybackOptions>; poolSize?: number; source: string; sprites?: Readonly<Record<string, AudioSpriteClip>> }; resource: Sound }",
+          "signature": "sound: { config: { playbackOptions?: Partial<PlaybackOptions>; poolSize?: number; source: string; sprites?: Readonly<Record<string, AudioSpriteClip>> | string }; resource: Sound }",
           "signatureTokens": [
             {
               "text": "sound",
@@ -871,6 +871,14 @@
             {
               "text": ">",
               "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
             },
             {
               "text": " }",

--- a/site/src/content/api/audio-bus.json
+++ b/site/src/content/api/audio-bus.json
@@ -227,7 +227,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Append a effect to the end of the chain (before the pan stage). The chain is rebuilt in place; existing audio routes through the new effect on the next frame. Attaching does not transfer ownership: the caller keeps it and must destroy() the effect once it is no longer used anywhere. Neither AudioBus.removeEffect nor AudioBus.destroy destroys it. A no-op once the bus has been AudioBus.destroyed - without this guard the effect would silently accumulate in the (otherwise unused) internal list forever."
+          "description": "Append a effect to the end of the chain (before the pan stage). The chain is rebuilt in place; existing audio routes through the new effect on the next frame. Attaching does not transfer ownership: the caller keeps it and must destroy() the effect once it is no longer used anywhere. Neither AudioBus.removeEffect nor AudioBus.destroy destroys it. A no-op once the bus has been AudioBus.destroyed - without this guard the effect would silently accumulate in the (otherwise unused) internal list forever. Attaching the same effect twice is a caller error: the rebuilt chain would wire the effect's output back into its own input, producing a feedback loop. The dev build asserts; production ignores the second attach."
         },
         {
           "name": "destroy",

--- a/site/src/content/api/audio-input.json
+++ b/site/src/content/api/audio-input.json
@@ -116,7 +116,7 @@
             }
           ],
           "returnType": "Promise<AudioInput>",
-          "description": "Request microphone access and resolve with an AudioInput. Throws / rejects if the user denies permission or no input device is available."
+          "description": "Request microphone access and resolve with an AudioInput. Throws AudioUnsupportedError when the environment has no getUserMedia at all. When the API exists but the request fails, the browser's own DOMException is passed through unwrapped - its name (NotAllowedError for a denied permission, NotFoundError for a missing device) is the standard signal to branch on and is not worth hiding behind an engine class."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/audio-unsupported-error.json
+++ b/site/src/content/api/audio-unsupported-error.json
@@ -1,0 +1,220 @@
+{
+  "title": "AudioUnsupportedError",
+  "description": "Raised when the host environment provides no Web Audio API at all - a missing `AudioContext`, `OfflineAudioContext`, or `getUserMedia`. Distinct from a decode or playback failure on purpose: a decode failure is about one file and the rest of the audio system keeps working, while this means audio is unavailable for the lifetime of the page. Callers branch on it to disable audio features outright instead of retrying or skipping a single asset.",
+  "symbol": "AudioUnsupportedError",
+  "kind": "class",
+  "subsystem": "audio",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 6,
+  "counts": {
+    "constructors": 1,
+    "methods": 0,
+    "properties": 5,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Raised when the host environment provides no Web Audio API at all - a missing `AudioContext`, `OfflineAudioContext`, or `getUserMedia`.",
+        "Distinct from a decode or playback failure on purpose: a decode failure is about one file and the rest of the audio system keeps working, while this means audio is unavailable for the lifetime of the page. Callers branch on it to disable audio features outright instead of retrying or skipping a single asset."
+      ],
+      "importLine": "import { AudioUnsupportedError } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "constructors",
+      "title": "Constructors",
+      "members": [
+        {
+          "name": "new",
+          "signature": "new(api: string): AudioUnsupportedError",
+          "signatureTokens": [
+            {
+              "text": "new",
+              "kind": "keyword"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "api",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AudioUnsupportedError",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "api",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "AudioUnsupportedError",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "api",
+          "signature": "api: string",
+          "signatureTokens": [
+            {
+              "text": "api",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": "The global or method the environment does not provide."
+        },
+        {
+          "name": "cause",
+          "signature": "cause?: unknown",
+          "signatureTokens": [
+            {
+              "text": "cause",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "message",
+          "signature": "message: string",
+          "signatureTokens": [
+            {
+              "text": "message",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "name",
+          "signature": "name: string",
+          "signatureTokens": [
+            {
+              "text": "name",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "stack",
+          "signature": "stack?: string",
+          "signatureTokens": [
+            {
+              "text": "stack",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/audio/AudioUnsupportedError.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/audio/AudioUnsupportedError.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/audio/AudioUnsupportedError.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/audio/AudioUnsupportedError.ts"
+}

--- a/site/src/content/api/functions.json
+++ b/site/src/content/api/functions.json
@@ -854,7 +854,7 @@
           ],
           "params": [],
           "returnType": "AudioContext",
-          "description": "Return the global singleton AudioContext, creating it if it does not yet exist. Also starts interaction-unlock monitoring so the context will resume on the first user gesture. Throws if AudioContext is not available in the current environment."
+          "description": "Return the global singleton AudioContext, creating it if it does not yet exist. Also starts interaction-unlock monitoring so the context will resume on the first user gesture. Throws AudioUnsupportedError when the environment provides no AudioContext."
         },
         {
           "name": "getOfflineAudioContext",

--- a/site/src/content/api/input-binding-error.json
+++ b/site/src/content/api/input-binding-error.json
@@ -1,0 +1,199 @@
+{
+  "title": "InputBindingError",
+  "description": "Raised when serialized binding data cannot be read: a profile whose shape or version this build does not understand, a binding whose kind does not match the action it is applied to, or a token no control carries. Rebindings are persisted by the game and come back as untrusted input, so this is the one input failure a caller acts on at runtime rather than fixes in source: catch it, discard the saved profile, fall back to the declared defaults. Programmer errors - an action claimed by two maps, a reserved action name, a malformed pattern string written in code - stay a plain `Error` so a `catch` around a profile load does not swallow them.",
+  "symbol": "InputBindingError",
+  "kind": "class",
+  "subsystem": "input",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 5,
+  "counts": {
+    "constructors": 1,
+    "methods": 0,
+    "properties": 4,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Raised when serialized binding data cannot be read: a profile whose shape or version this build does not understand, a binding whose kind does not match the action it is applied to, or a token no control carries.",
+        "Rebindings are persisted by the game and come back as untrusted input, so this is the one input failure a caller acts on at runtime rather than fixes in source: catch it, discard the saved profile, fall back to the declared defaults. Programmer errors - an action claimed by two maps, a reserved action name, a malformed pattern string written in code - stay a plain `Error` so a `catch` around a profile load does not swallow them."
+      ],
+      "importLine": "import { InputBindingError } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "constructors",
+      "title": "Constructors",
+      "members": [
+        {
+          "name": "new",
+          "signature": "new(message: string): InputBindingError",
+          "signatureTokens": [
+            {
+              "text": "new",
+              "kind": "keyword"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "message",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "InputBindingError",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "message",
+              "type": "string",
+              "optional": false
+            }
+          ],
+          "returnType": "InputBindingError",
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "properties",
+      "title": "Properties",
+      "members": [
+        {
+          "name": "cause",
+          "signature": "cause?: unknown",
+          "signatureTokens": [
+            {
+              "text": "cause",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "unknown",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "message",
+          "signature": "message: string",
+          "signatureTokens": [
+            {
+              "text": "message",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "name",
+          "signature": "name: string",
+          "signatureTokens": [
+            {
+              "text": "name",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        },
+        {
+          "name": "stack",
+          "signature": "stack?: string",
+          "signatureTokens": [
+            {
+              "text": "stack",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/input/actions/InputBindingError.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/input/actions/InputBindingError.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/input/actions/InputBindingError.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/input/actions/InputBindingError.ts"
+}

--- a/site/src/content/api/particles-functions.json
+++ b/site/src/content/api/particles-functions.json
@@ -76,11 +76,11 @@
           "description": "Create a Particles extension with custom configuration. Returns an application-local descriptor - safe to pass to one Application only. For shared use, prefer particlesExtension."
         },
         {
-          "name": "wgslFieldLayout",
-          "signature": "wgslFieldLayout(type: WgslPrimitive): { align: number; size: number }",
+          "name": "getWgslFieldLayout",
+          "signature": "getWgslFieldLayout(type: WgslPrimitive): { align: number; size: number }",
           "signatureTokens": [
             {
-              "text": "wgslFieldLayout",
+              "text": "getWgslFieldLayout",
               "kind": "name"
             },
             {
@@ -155,11 +155,11 @@
           "description": "Per-WGSL-primitive size and alignment in bytes."
         },
         {
-          "name": "wgslUniformByteSize",
-          "signature": "wgslUniformByteSize(fields: readonly WgslUniformField[]): number",
+          "name": "getWgslUniformByteSize",
+          "signature": "getWgslUniformByteSize(fields: readonly WgslUniformField[]): number",
           "signatureTokens": [
             {
-              "text": "wgslUniformByteSize",
+              "text": "getWgslUniformByteSize",
               "kind": "name"
             },
             {

--- a/site/src/content/api/sound-asset-options.json
+++ b/site/src/content/api/sound-asset-options.json
@@ -92,7 +92,7 @@
         },
         {
           "name": "sprites",
-          "signature": "sprites?: Readonly<Record<string, AudioSpriteClip>>",
+          "signature": "sprites?: Readonly<Record<string, AudioSpriteClip>> | string",
           "signatureTokens": [
             {
               "text": "sprites",
@@ -141,11 +141,19 @@
             {
               "text": ">",
               "kind": "punctuation"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
             }
           ],
           "params": [],
           "returnType": null,
-          "description": "Named sub-regions of the decoded buffer, for use as an audio sprite sheet."
+          "description": "Named sub-regions of the decoded buffer, for use as an audio sprite sheet. A string is the source of a sidecar JSON document holding the same map (see SoundSpriteSheet). It is loaded through the sound's own dependency scope, so the sidecar is released with the sound, and it is resolved against the loader's base path like any other asset source - not relative to the audio file."
         }
       ],
       "paragraphs": [],

--- a/site/src/content/api/sound-sprite-sheet.json
+++ b/site/src/content/api/sound-sprite-sheet.json
@@ -1,0 +1,97 @@
+{
+  "title": "SoundSpriteSheet",
+  "description": "Contents of a sound sprite sidecar: the same shape SoundAssetOptions.sprites accepts inline, as a standalone JSON document. ```json { \"impact\": { \"start\": 0.5, \"end\": 0.8 }, \"hum\": { \"start\": 1.2, \"end\": 4.0, \"loop\": true } } ``` Times are seconds into the decoded buffer. This is ExoJS's own descriptor and the only format the loader reads: `audiosprite` and Howler atlases store `[offsetMs, durationMs]` tuples and are converted once at build time, not on every load.",
+  "symbol": "SoundSpriteSheet",
+  "kind": "type",
+  "subsystem": "assets",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 0,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Contents of a sound sprite sidecar: the same shape SoundAssetOptions.sprites accepts inline, as a standalone JSON document.",
+        "```json { \"impact\": { \"start\": 0.5, \"end\": 0.8 }, \"hum\": { \"start\": 1.2, \"end\": 4.0, \"loop\": true } } ```",
+        "Times are seconds into the decoded buffer. This is ExoJS's own descriptor and the only format the loader reads: `audiosprite` and Howler atlases store `[offsetMs, durationMs]` tuples and are converted once at build time, not on every load."
+      ],
+      "importLine": "import { SoundSpriteSheet } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "definition",
+      "title": "Definition",
+      "members": [
+        {
+          "name": "SoundSpriteSheet",
+          "signature": "Readonly<Record<string, AudioSpriteClip>>",
+          "signatureTokens": [
+            {
+              "text": "Readonly",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Record",
+              "kind": "type"
+            },
+            {
+              "text": "<",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "AudioSpriteClip",
+              "kind": "type"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            },
+            {
+              "text": ">",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/assets/factories/soundSprites.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/assets/factories/soundSprites.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/assets/factories/soundSprites.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/assets/factories/soundSprites.ts"
+}

--- a/site/src/content/api/tiled-functions.json
+++ b/site/src/content/api/tiled-functions.json
@@ -76,87 +76,11 @@
           "description": "Constructs the appropriate TiledLayer subclass for data.type."
         },
         {
-          "name": "resolveTiledObjectAlignment",
-          "signature": "resolveTiledObjectAlignment(alignment: TiledObjectAlignment | undefined, orientation: TiledOrientation): TiledResolvedObjectAlignment",
+          "name": "getTiledObjectAnchorOffset",
+          "signature": "getTiledObjectAnchorOffset(alignment: TiledResolvedObjectAlignment, width: number, height: number): { x: number; y: number }",
           "signatureTokens": [
             {
-              "text": "resolveTiledObjectAlignment",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": "alignment",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "TiledObjectAlignment",
-              "kind": "type"
-            },
-            {
-              "text": " | ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "undefined",
-              "kind": "keyword"
-            },
-            {
-              "text": ", ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "orientation",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "TiledOrientation",
-              "kind": "type"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "TiledResolvedObjectAlignment",
-              "kind": "type"
-            }
-          ],
-          "params": [
-            {
-              "name": "alignment",
-              "type": "TiledObjectAlignment | undefined",
-              "optional": false
-            },
-            {
-              "name": "orientation",
-              "type": "TiledOrientation",
-              "optional": false
-            }
-          ],
-          "returnType": "TiledResolvedObjectAlignment",
-          "description": "Resolve a tileset's objectalignment into a concrete alignment for tile objects on a map of the given orientation. Tiled's default ('unspecified', and an absent field) is orientation dependent: 'bottom' on an isometric map and 'bottomleft' on every other orientation, including staggered and hexagonal."
-        },
-        {
-          "name": "tiledObjectAnchorOffset",
-          "signature": "tiledObjectAnchorOffset(alignment: TiledResolvedObjectAlignment, width: number, height: number): { x: number; y: number }",
-          "signatureTokens": [
-            {
-              "text": "tiledObjectAnchorOffset",
+              "text": "getTiledObjectAnchorOffset",
               "kind": "name"
             },
             {
@@ -271,6 +195,82 @@
           ],
           "returnType": "{ x: number; y: number }",
           "description": "Offset of a tile object's stored x/y anchor from the top-left corner of its width × height bounding box, for an already-resolved alignment. Subtract this from the stored position to obtain the corner: cornerX = object.x - offset.x."
+        },
+        {
+          "name": "resolveTiledObjectAlignment",
+          "signature": "resolveTiledObjectAlignment(alignment: TiledObjectAlignment | undefined, orientation: TiledOrientation): TiledResolvedObjectAlignment",
+          "signatureTokens": [
+            {
+              "text": "resolveTiledObjectAlignment",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "alignment",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TiledObjectAlignment",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "undefined",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "orientation",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TiledOrientation",
+              "kind": "type"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "TiledResolvedObjectAlignment",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "alignment",
+              "type": "TiledObjectAlignment | undefined",
+              "optional": false
+            },
+            {
+              "name": "orientation",
+              "type": "TiledOrientation",
+              "optional": false
+            }
+          ],
+          "returnType": "TiledResolvedObjectAlignment",
+          "description": "Resolve a tileset's objectalignment into a concrete alignment for tile objects on a map of the given orientation. Tiled's default ('unspecified', and an absent field) is orientation dependent: 'bottom' on an isometric map and 'bottomleft' on every other orientation, including staggered and hexagonal."
         },
         {
           "name": "tiledWangSetToWangSet",

--- a/site/src/content/guide/assets/tiled-maps.mdx
+++ b/site/src/content/guide/assets/tiled-maps.mdx
@@ -184,13 +184,13 @@ chest.y; // 24
 <Callout type="pitfall" title="Rotation still pivots about the Tiled anchor">
 Tiled rotates a tile object's image about its alignment anchor, not about the bounding box
 corner. A tile object with a non-zero `rotation` therefore pivots about the anchor even though
-`x`/`y` now report the corner — recover the anchor with `tiledObjectAnchorOffset` if you need the
+`x`/`y` now report the corner — recover the anchor with `getTiledObjectAnchorOffset` if you need the
 exact pivot.
 </Callout>
 
 The two helpers behind this are exported for when you work with the parsed source model directly:
 `resolveTiledObjectAlignment(tileset.objectAlignment, map.orientation)` applies Tiled's
-orientation-dependent default, and `tiledObjectAnchorOffset(alignment, width, height)` returns the
+orientation-dependent default, and `getTiledObjectAnchorOffset(alignment, width, height)` returns the
 anchor's offset from the corner.
 
 ## Text objects

--- a/site/src/content/guide/audio/audio-basics.mdx
+++ b/site/src/content/guide/audio/audio-basics.mdx
@@ -247,6 +247,29 @@ application.audio.play(sound.sprite('impact'));
 
 Sprites can also be declared up front via the `sprites` constructor option. They are part of the `Sound` descriptor's data; clip ranges are validated against the buffer duration when defined.
 
+### Sprites from a sidecar file
+
+Writing the clip table in code stops scaling once a tool produces it. A `sound` asset therefore accepts a **source string** for `sprites`, naming a JSON sidecar that holds the same map:
+
+```json title="sfx.sprites.json"
+{
+  "impact": { "start": 0.5, "end": 0.8 },
+  "whoosh": { "start": 1.2, "end": 1.6, "loop": true }
+}
+```
+
+```ts
+import { Assets } from '@codexo/exojs';
+
+const assets = Assets.from({
+  sfx: { type: 'sound', source: 'sfx.ogg', sprites: 'sfx.sprites.json' },
+});
+```
+
+The sidecar is loaded through the sound's own asset scope, so it is claimed and released with the sound — one asset to configure, not two. Its source is resolved against the loader's base path exactly like the audio file, so it is *not* a path relative to `sfx.ogg`.
+
+A malformed sheet — not an object, a non-clip entry, a non-finite time, or a window that runs past the buffer — fails the load with an `AssetDecodeError` naming the sidecar. This is ExoJS's own descriptor and the only sprite format the loader reads: `audiosprite` and Howler atlases store `[offsetMs, durationMs]` tuples, which you convert once at build time rather than on every load.
+
 `sound.sprite(name)` is the named counterpart of `sound.clip(offset, duration)` — both return a `Sound` sharing the parent's decoded buffer, so they play through `app.audio.play()` like any other sound and carry their own voice pool and playback defaults (a sprite's `loop` flag becomes the sub-sound's `loop`). The sub-sound is memoized per name, so the pool really is shared across every play of that sprite; it is discarded when the name is redefined or removed. Looking up a name that was never defined throws.
 
 ## Examples

--- a/src/assets/AssetContainer.ts
+++ b/src/assets/AssetContainer.ts
@@ -1,3 +1,5 @@
+import { AssetDecodeError } from './AssetDecodeError';
+
 /**
  * Binary asset container (`.exoa`) - format constants, reader, and writer.
  *
@@ -135,7 +137,7 @@ export const encodeContainer = (inputs: readonly ContainerInput[]): ArrayBuffer 
 type Fail = (detail: string) => never;
 
 const fail: Fail = detail => {
-  throw new Error(`Invalid asset container: ${detail}.`);
+  throw new AssetDecodeError({ message: `Invalid asset container: ${detail}.`, assetType: 'container' });
 };
 
 const readEntry = (value: unknown, i: number, dataLength: number): ContainerEntry => {

--- a/src/assets/AssetDecodeError.ts
+++ b/src/assets/AssetDecodeError.ts
@@ -1,0 +1,33 @@
+/** Construction options for an {@link AssetDecodeError}. */
+export interface AssetDecodeErrorOptions {
+  /** One-line, actionable summary (becomes the {@link Error.message}). */
+  readonly message: string;
+  /** Asset type id the bytes were being decoded for, when known. */
+  readonly assetType?: string | undefined;
+  /** The underlying failure - a `DOMException` from a browser decoder, a parser's own error. */
+  readonly cause?: unknown;
+}
+
+/**
+ * Raised when bytes that were successfully obtained cannot be turned into a
+ * resource: a malformed container index, an XML document the parser rejected,
+ * audio the browser could not decode, an empty buffer.
+ *
+ * Distinct from {@link AssetNetworkError} and {@link AssetCacheError} because
+ * the reaction differs: a transport failure is worth retrying and a cache
+ * failure is worth ignoring, while broken content stays broken - the asset has
+ * to be dropped or the file fixed. Narrow with `error instanceof
+ * AssetDecodeError`; the decoder's own error stays reachable through
+ * {@link Error.cause}.
+ */
+export class AssetDecodeError extends Error {
+  /** Asset type id the bytes were being decoded for, or `null` when the decoder is type-agnostic. */
+  public readonly assetType: string | null;
+
+  public constructor(options: AssetDecodeErrorOptions) {
+    super(options.message, options.cause !== undefined ? { cause: options.cause } : undefined);
+
+    this.name = 'AssetDecodeError';
+    this.assetType = options.assetType ?? null;
+  }
+}

--- a/src/assets/AssetDecoder.ts
+++ b/src/assets/AssetDecoder.ts
@@ -4,7 +4,9 @@ import { unrestrictedNetwork } from '#core/Connectivity';
 import type { AssetCache } from './AssetCache';
 import { AssetCacheError } from './AssetCacheError';
 import { AssetCacheMissError } from './AssetCacheMissError';
+import { AssetDecodeError } from './AssetDecodeError';
 import type { AssetFactoryContext } from './AssetFactory';
+import { AssetNetworkError } from './AssetNetworkError';
 import type { AssetSourceCodec, SourceCodecContext } from './AssetSourceCodec';
 import type { AnyAssetType, AssetRequest } from './AssetType';
 import type { AssetTypeRegistry } from './AssetTypeRegistry';
@@ -258,22 +260,33 @@ export class AssetDecoder {
    * Wraps a construction failure in the "which asset, from where" envelope
    * callers see.
    *
-   * Three kinds of failure are rethrown unwrapped, because the envelope would
-   * cost more than it adds. A cancellation would lose the `AbortError` name the
-   * residency dispatches on to tell a deliberate cancel from a genuine failure.
-   * A cache miss and a store failure are already named, carry the namespace and
-   * source they concern, and are the errors an offline-capable caller
-   * dispatches on - `instanceof AssetCacheMissError` is how "not cached" is
-   * told from "could not load", and wrapping it takes that away.
+   * Failures that are already named are rethrown unwrapped, because the
+   * envelope would cost more than it adds. A cancellation would lose the
+   * `AbortError` name the residency dispatches on to tell a deliberate cancel
+   * from a genuine failure. A cache miss, a store failure and a transport
+   * failure carry the namespace, source or URL they concern and are the errors
+   * an offline-capable caller dispatches on - `instanceof AssetCacheMissError`
+   * is how "not cached" is told from "could not load", and wrapping it takes
+   * that away.
+   *
+   * A decode failure is the one case that gains from the envelope and must
+   * still survive as its own type, so it is rebuilt rather than replaced:
+   * "these bytes are broken" is only actionable together with which asset they
+   * belonged to.
    */
   private _describeFailure(asset: CanonicalAsset, error: unknown): unknown {
-    if (isAbortError(error) || error instanceof AssetCacheMissError || error instanceof AssetCacheError) {
+    if (isAbortError(error) || error instanceof AssetCacheMissError || error instanceof AssetCacheError || error instanceof AssetNetworkError) {
       return error;
     }
 
     const message = error instanceof Error ? error.message : String(error);
+    const envelope = `Failed to load "${asset.source}" from "${this._resolveUrl(asset.source)}": ${message}`;
 
-    return new Error(`Failed to load "${asset.source}" from "${this._resolveUrl(asset.source)}": ${message}`, { cause: error });
+    if (error instanceof AssetDecodeError) {
+      return new AssetDecodeError({ message: envelope, assetType: error.assetType ?? undefined, cause: error });
+    }
+
+    return new Error(envelope, { cause: error });
   }
 
   /**

--- a/src/assets/AssetDefinitions.ts
+++ b/src/assets/AssetDefinitions.ts
@@ -25,7 +25,7 @@ export interface AssetDefinitions {
   texture: { resource: Texture; config: { source: string; mimeType?: string; textureOptions?: Partial<TextureOptions> } };
   sound: {
     resource: Sound;
-    config: { source: string; playbackOptions?: Partial<PlaybackOptions>; poolSize?: number; sprites?: Readonly<Record<string, AudioSpriteClip>> };
+    config: { source: string; playbackOptions?: Partial<PlaybackOptions>; poolSize?: number; sprites?: Readonly<Record<string, AudioSpriteClip>> | string };
   };
   music: {
     resource: AudioStream;

--- a/src/assets/IndexedDbDatabase.ts
+++ b/src/assets/IndexedDbDatabase.ts
@@ -60,7 +60,7 @@ export class IndexedDbDatabase implements Database {
     migrations?: Record<number, (db: IDBDatabase, transaction: IDBTransaction) => boolean>,
   ) {
     if (!supportsIndexedDb) {
-      throw new Error('This browser does not support indexedDB!');
+      throw new AssetCacheError({ operation: 'connect', message: 'This host provides no IndexedDB, so no database can be opened.', store: name });
     }
 
     this.name = name;
@@ -224,6 +224,9 @@ export class IndexedDbDatabase implements Database {
         const migration = this._migrations[target];
 
         if (migration !== undefined && !migration(database, transaction)) {
+          // Left a plain Error on purpose: it is raised inside the IndexedDB
+          // upgrade handler, and `openIndexedDb` already wraps whatever escapes
+          // there into an AssetCacheError naming the database.
           throw new Error(`The migration to database version ${target} reported failure.`);
         }
       }

--- a/src/assets/IndexedDbStore.ts
+++ b/src/assets/IndexedDbStore.ts
@@ -94,7 +94,7 @@ export class IndexedDbStore implements CacheStore {
     const options = typeof nameOrOptions === 'string' ? { name: nameOrOptions } : nameOrOptions;
 
     if (!supportsIndexedDb) {
-      throw new Error('IndexedDbStore requires a host with IndexedDB support.');
+      throw new AssetCacheError({ operation: 'connect', message: 'IndexedDbStore requires a host with IndexedDB support.', store: options.name });
     }
 
     this._name = options.name;

--- a/src/assets/factories/SoundFactory.ts
+++ b/src/assets/factories/SoundFactory.ts
@@ -4,14 +4,24 @@ import { decodeAudioData } from '#audio/audio-context';
 import { type AudioSpriteClip, Sound } from '#audio/Sound';
 import type { PlaybackOptions } from '#core/types';
 
+import { loadSoundSpriteSheet } from './soundSprites';
+
 /** Options accepted by an asset of the built-in `sound` type. */
 export interface SoundAssetOptions {
   /** Initial playback settings forwarded to the {@link Sound} instance. */
   playbackOptions?: Partial<PlaybackOptions>;
   /** Concurrent voices the {@link Sound} pre-allocates; {@link Sound}'s own default when omitted. */
   poolSize?: number;
-  /** Named sub-regions of the decoded buffer, for use as an audio sprite sheet. */
-  sprites?: Readonly<Record<string, AudioSpriteClip>>;
+  /**
+   * Named sub-regions of the decoded buffer, for use as an audio sprite sheet.
+   *
+   * A string is the source of a sidecar JSON document holding the same map (see
+   * {@link SoundSpriteSheet}). It is loaded through the sound's own dependency
+   * scope, so the sidecar is released with the sound, and it is resolved against
+   * the loader's base path like any other asset source - not relative to the
+   * audio file.
+   */
+  sprites?: Readonly<Record<string, AudioSpriteClip>> | string;
 }
 
 /**
@@ -40,10 +50,24 @@ export class SoundFactory implements AssetFactory<ArrayBuffer, Sound, SoundAsset
       });
     }
 
-    return new Sound(audioBuffer, {
-      ...options.playbackOptions,
-      ...(options.poolSize !== undefined && { poolSize: options.poolSize }),
-      ...(options.sprites !== undefined && { sprites: options.sprites }),
-    });
+    const sidecar = typeof options.sprites === 'string' ? options.sprites : null;
+    const sprites = typeof options.sprites === 'string' ? await loadSoundSpriteSheet(options.sprites, context.dependencies) : options.sprites;
+
+    try {
+      return new Sound(audioBuffer, {
+        ...options.playbackOptions,
+        ...(options.poolSize !== undefined && { poolSize: options.poolSize }),
+        ...(sprites !== undefined && { sprites }),
+      });
+    } catch (error) {
+      // A clip that the sheet's own shape check accepts can still be rejected
+      // by `Sound` - only it knows the buffer duration. From a sidecar that is
+      // a content failure, not a caller mistake.
+      if (sidecar === null) throw error;
+
+      const message = error instanceof Error ? error.message : String(error);
+
+      throw new AssetDecodeError({ message: `Invalid sound sprite sheet "${sidecar}": ${message}`, assetType: 'sound', cause: error });
+    }
   }
 }

--- a/src/assets/factories/SoundFactory.ts
+++ b/src/assets/factories/SoundFactory.ts
@@ -1,3 +1,4 @@
+import { AssetDecodeError } from '#assets/AssetDecodeError';
 import type { AssetFactory, AssetFactoryContext } from '#assets/AssetFactory';
 import { decodeAudioData } from '#audio/audio-context';
 import { type AudioSpriteClip, Sound } from '#audio/Sound';
@@ -32,7 +33,9 @@ export class SoundFactory implements AssetFactory<ArrayBuffer, Sound, SoundAsset
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
 
-      throw new Error(`Failed to decode audio data: ${message} (if loaded as the wrong asset type, this file may not be an audio format at all).`, {
+      throw new AssetDecodeError({
+        message: `Failed to decode audio data: ${message} (if loaded as the wrong asset type, this file may not be an audio format at all).`,
+        assetType: 'sound',
         cause: error,
       });
     }

--- a/src/assets/factories/parseXml.ts
+++ b/src/assets/factories/parseXml.ts
@@ -1,9 +1,11 @@
+import { AssetDecodeError } from '#assets/AssetDecodeError';
+
 /**
  * Parses XML markup into a {@link Document} via the browser's `DOMParser`.
  *
- * Throws when the parser reports a malformed document; `DOMParser` signals that
- * by returning a document containing a `<parsererror>` element rather than by
- * throwing, so the check cannot be skipped.
+ * Throws {@link AssetDecodeError} when the parser reports a malformed document;
+ * `DOMParser` signals that by returning a document containing a `<parsererror>`
+ * element rather than by throwing, so the check cannot be skipped.
  * @internal
  */
 export const parseXmlDocument = (source: string): Document => {
@@ -11,7 +13,7 @@ export const parseXmlDocument = (source: string): Document => {
   const parseError = document.querySelector('parsererror');
 
   if (parseError) {
-    throw new Error(`XML parse error: ${parseError.textContent.trim() || 'unknown error'}`);
+    throw new AssetDecodeError({ message: `XML parse error: ${parseError.textContent.trim() || 'unknown error'}` });
   }
 
   return document;

--- a/src/assets/factories/soundSprites.ts
+++ b/src/assets/factories/soundSprites.ts
@@ -1,0 +1,65 @@
+import { Asset } from '#assets/Asset';
+import { AssetDecodeError } from '#assets/AssetDecodeError';
+import type { AssetDependencyScope } from '#assets/AssetFactory';
+import type { AudioSpriteClip } from '#audio/Sound';
+
+/**
+ * Contents of a sound sprite sidecar: the same shape
+ * {@link SoundAssetOptions.sprites} accepts inline, as a standalone JSON
+ * document.
+ *
+ * ```json
+ * { "impact": { "start": 0.5, "end": 0.8 }, "hum": { "start": 1.2, "end": 4.0, "loop": true } }
+ * ```
+ *
+ * Times are seconds into the decoded buffer. This is ExoJS's own descriptor and
+ * the only format the loader reads: `audiosprite` and Howler atlases store
+ * `[offsetMs, durationMs]` tuples and are converted once at build time, not on
+ * every load.
+ */
+export type SoundSpriteSheet = Readonly<Record<string, AudioSpriteClip>>;
+
+const isFiniteNumber = (value: unknown): value is number => typeof value === 'number' && Number.isFinite(value);
+
+const fail = (source: string, detail: string): never => {
+  throw new AssetDecodeError({ message: `Invalid sound sprite sheet "${source}": ${detail}.`, assetType: 'sound' });
+};
+
+/**
+ * Loads and validates a sound sprite sidecar through `scope`, so the sidecar's
+ * residency is tied to the sound that references it.
+ *
+ * `source` is an ordinary asset source resolved against the loader's base path,
+ * exactly like the sound's own - not a path relative to the audio file. Both
+ * halves of one sound are addressed the same way.
+ * @internal
+ */
+export const loadSoundSpriteSheet = async (source: string, scope: AssetDependencyScope): Promise<SoundSpriteSheet> => {
+  const data: unknown = await scope.load(Asset.type('json', source));
+
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) {
+    fail(source, 'expected an object mapping sprite names to clips');
+  }
+
+  const sheet: Record<string, AudioSpriteClip> = {};
+
+  for (const [name, clip] of Object.entries(data as Record<string, unknown>)) {
+    if (clip === null || typeof clip !== 'object') {
+      fail(source, `the entry "${name}" is not a clip object`);
+    }
+
+    const { start, end, loop } = clip as { start?: unknown; end?: unknown; loop?: unknown };
+
+    if (!isFiniteNumber(start) || !isFiniteNumber(end)) {
+      fail(source, `the entry "${name}" needs finite "start" and "end" times in seconds`);
+    }
+
+    if (loop !== undefined && typeof loop !== 'boolean') {
+      fail(source, `the entry "${name}" has a non-boolean "loop"`);
+    }
+
+    sheet[name] = { start: start as number, end: end as number, ...(loop !== undefined && { loop: loop as boolean }) };
+  }
+
+  return sheet;
+};

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -94,6 +94,7 @@ export type { MusicAssetOptions } from '#assets/factories/MusicFactory';
 export type { CsvAssetOptions } from '#assets/factories/parseCsv';
 export type { SubtitleFormat } from '#assets/factories/parseSubtitles';
 export type { SoundAssetOptions } from '#assets/factories/SoundFactory';
+export type { SoundSpriteSheet } from '#assets/factories/soundSprites';
 export type { SvgAssetOptions } from '#assets/factories/SvgFactory';
 export type { TextureAssetOptions } from '#assets/factories/TextureFactory';
 export type { VideoAssetOptions } from '#assets/factories/VideoFactory';

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -6,6 +6,8 @@ export type { AssetCacheErrorOptions, AssetCacheOperation } from './AssetCacheEr
 export { AssetCacheError } from './AssetCacheError';
 export { AssetCacheMissError } from './AssetCacheMissError';
 export type { AssetConstructor } from './AssetConstructor';
+export type { AssetDecodeErrorOptions } from './AssetDecodeError';
+export { AssetDecodeError } from './AssetDecodeError';
 export type {
   AnyAssetConfig,
   AssetDefinitions,

--- a/src/assets/utils.ts
+++ b/src/assets/utils.ts
@@ -1,3 +1,5 @@
+import { AssetDecodeError } from './AssetDecodeError';
+
 interface FileType {
   mimeType: string;
   pattern: number[];
@@ -131,13 +133,13 @@ const matchesWebmVideo = (arrayBuffer: ArrayBuffer): boolean => {
  * MIDI, AIFF, AVI, and AU). Falls back to `"text/plain"` when no pattern
  * matches.
  *
- * Throws if `arrayBuffer` contains no data.
+ * Throws {@link AssetDecodeError} when `arrayBuffer` contains no data.
  */
 export const determineMimeType = (arrayBuffer: ArrayBuffer): string => {
   const header = new Uint8Array(arrayBuffer);
 
   if (header.length === 0) {
-    throw new Error('Cannot determine mime type: No data.');
+    throw new AssetDecodeError({ message: 'Cannot determine mime type: the buffer is empty.' });
   }
 
   for (const type of fileTypes) {

--- a/src/audio/AudioBus.ts
+++ b/src/audio/AudioBus.ts
@@ -1,3 +1,4 @@
+import { assert } from '#core/dev';
 import { clamp } from '#math/utils';
 
 import { getAudioContext, isAudioContextReady, onAudioContextReady } from './audio-context';
@@ -139,9 +140,20 @@ export class AudioBus {
    * A no-op once the bus has been {@link AudioBus.destroy}ed - without this
    * guard the effect would silently accumulate in the (otherwise unused)
    * internal list forever.
+   *
+   * Attaching the same effect twice is a caller error: the rebuilt chain would
+   * wire the effect's output back into its own input, producing a feedback
+   * loop. The dev build asserts; production ignores the second attach.
    */
   public addEffect(effect: AudioEffect): this {
     if (this._destroyed) return this;
+
+    if (this._effects.includes(effect)) {
+      assert(false, 'AudioBus.addEffect: this effect is already attached to the bus.');
+
+      return this;
+    }
+
     this._effects.push(effect);
     this._rebuildEffectChain();
     return this;

--- a/src/audio/AudioInput.ts
+++ b/src/audio/AudioInput.ts
@@ -1,5 +1,7 @@
 import type { Destroyable } from '#core/types';
 
+import { AudioUnsupportedError } from './AudioUnsupportedError';
+
 /** Options for {@link AudioInput.open} - forwarded to `getUserMedia` audio constraints. */
 export interface AudioInputOptions {
   /** Specific input device id (from `enumerateDevices`). */
@@ -43,12 +45,18 @@ export class AudioInput implements Destroyable {
   }
 
   /**
-   * Request microphone access and resolve with an `AudioInput`. Throws / rejects
-   * if the user denies permission or no input device is available.
+   * Request microphone access and resolve with an `AudioInput`.
+   *
+   * Throws {@link AudioUnsupportedError} when the environment has no
+   * `getUserMedia` at all. When the API exists but the request fails, the
+   * browser's own `DOMException` is passed through unwrapped - its `name`
+   * (`NotAllowedError` for a denied permission, `NotFoundError` for a missing
+   * device) is the standard signal to branch on and is not worth hiding behind
+   * an engine class.
    */
   public static async open(options: AudioInputOptions = {}): Promise<AudioInput> {
     if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
-      throw new Error('AudioInput.open: getUserMedia is not available in this environment.');
+      throw new AudioUnsupportedError('navigator.mediaDevices.getUserMedia');
     }
 
     const constraints: MediaTrackConstraints = {};

--- a/src/audio/AudioUnsupportedError.ts
+++ b/src/audio/AudioUnsupportedError.ts
@@ -1,0 +1,21 @@
+/**
+ * Raised when the host environment provides no Web Audio API at all - a
+ * missing `AudioContext`, `OfflineAudioContext`, or `getUserMedia`.
+ *
+ * Distinct from a decode or playback failure on purpose: a decode failure is
+ * about one file and the rest of the audio system keeps working, while this
+ * means audio is unavailable for the lifetime of the page. Callers branch on
+ * it to disable audio features outright instead of retrying or skipping a
+ * single asset.
+ */
+export class AudioUnsupportedError extends Error {
+  /** The global or method the environment does not provide. */
+  public readonly api: string;
+
+  public constructor(api: string) {
+    super(`This environment does not provide ${api}, so audio is unavailable.`);
+
+    this.name = 'AudioUnsupportedError';
+    this.api = api;
+  }
+}

--- a/src/audio/BaseVoice.ts
+++ b/src/audio/BaseVoice.ts
@@ -1,3 +1,4 @@
+import { assert } from '#core/dev';
 import type { SceneNode } from '#core/SceneNode';
 import { Signal } from '#core/Signal';
 import { clamp, degreesToRadians } from '#math/utils';
@@ -170,8 +171,22 @@ export abstract class BaseVoice implements Voice, SpatialVoice {
     this._connectOutput();
   }
 
+  /**
+   * Append an effect to this voice's chain.
+   *
+   * Attaching the same effect twice is a caller error: the rebuilt chain would
+   * wire the effect's output back into its own input, producing a feedback
+   * loop. The dev build asserts; production ignores the second attach.
+   */
   public addEffect(effect: AudioEffect): this {
     if (this._ended) return this;
+
+    if (this._effects.includes(effect)) {
+      assert(false, 'Voice.addEffect: this effect is already attached to the voice.');
+
+      return this;
+    }
+
     this._effects.push(effect);
     this._rebuildEffectChain();
     return this;

--- a/src/audio/audio-context.ts
+++ b/src/audio/audio-context.ts
@@ -1,5 +1,7 @@
 import { Signal } from '#core/Signal';
 
+import { AudioUnsupportedError } from './AudioUnsupportedError';
+
 interface AudioContextEventTarget {
   addEventListener?: (type: string, listener: () => void) => void;
 }
@@ -29,7 +31,7 @@ const getExistingAudioContext = (): AudioContext | null => internalAudioContext;
 
 const getOrCreateAudioContext = (): AudioContext => {
   if (!supportsAudioContext()) {
-    throw new Error('This environment does not support AudioContext.');
+    throw new AudioUnsupportedError('AudioContext');
   }
 
   if (internalAudioContext === null) {
@@ -41,7 +43,7 @@ const getOrCreateAudioContext = (): AudioContext => {
 
 const getOrCreateOfflineAudioContext = (): OfflineAudioContext => {
   if (!supportsOfflineAudioContext()) {
-    throw new Error('This environment does not support OfflineAudioContext.');
+    throw new AudioUnsupportedError('OfflineAudioContext');
   }
 
   if (internalOfflineAudioContext === null) {
@@ -222,8 +224,8 @@ export const onAudioContextReady = new AudioContextReadySignal();
 /**
  * Return the global singleton `AudioContext`, creating it if it does not yet
  * exist. Also starts interaction-unlock monitoring so the context will resume
- * on the first user gesture. Throws if `AudioContext` is not available in the
- * current environment.
+ * on the first user gesture. Throws {@link AudioUnsupportedError} when the
+ * environment provides no `AudioContext`.
  */
 export const getAudioContext = (): AudioContext => {
   const audioContext = getOrCreateAudioContext();

--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -9,6 +9,7 @@ export { AudioInput } from './AudioInput';
 export { AudioListener, type AudioListenerTarget } from './AudioListener';
 export { AudioManager } from './AudioManager';
 export { AudioStream } from './AudioStream';
+export { AudioUnsupportedError } from './AudioUnsupportedError';
 export { BiquadEffect, type BiquadEffectOptions } from './BiquadEffect';
 export type { CrossFadeOptions } from './crossFade';
 export { crossFade } from './crossFade';

--- a/src/input/GamepadMapping.ts
+++ b/src/input/GamepadMapping.ts
@@ -1,3 +1,5 @@
+import { assert } from '#core/dev';
+
 import type { GamepadAxis } from './GamepadAxis';
 import type { GamepadAxisChannel } from './GamepadAxis';
 import type { GamepadButton } from './GamepadButton';
@@ -93,6 +95,18 @@ export class GamepadMapping {
   public readonly promptLabels: ReadonlyMap<GamepadPromptControl, string> | undefined;
 
   public constructor(data: GamepadMappingData) {
+    if (__DEV__) {
+      // Every control writes into one channel slot per frame, so two controls
+      // on the same channel overwrite each other in mapping order: the pad
+      // reports whichever ran last and the other control looks dead.
+      const seen = new Set<number>();
+
+      for (const control of [...data.buttons, ...data.axes]) {
+        assert(!seen.has(control.channel), `GamepadMapping: two controls write to the same channel (${control.channel}); each channel may be declared once.`);
+        seen.add(control.channel);
+      }
+    }
+
     this.family = data.family;
     this.layout = data.layout ?? GamepadMappingLayout.Standard;
     this.buttons = data.buttons;

--- a/src/input/actions/ActionBase.ts
+++ b/src/input/actions/ActionBase.ts
@@ -3,6 +3,7 @@ import type { InputToken } from '#input/InputToken';
 import { inputChannelFromToken, inputToken } from '#input/InputToken';
 import { slotZeroGamepadChannel } from '#input/types';
 
+import { InputBindingError } from './InputBindingError';
 import type { ActionKind, SerializedActionBinding } from './serialization';
 import type { ActionSample } from './types';
 
@@ -19,14 +20,14 @@ export type GamepadSlot = 0 | 1 | 2 | 3;
  * onto a pad slot - that happens later, in the owning map's resolve pass, and
  * doing it twice would land on the wrong device.
  *
- * @throws {Error} If no control carries `token`. Deserialization never falls
+ * @throws {InputBindingError} If no control carries `token`. Deserialization never falls
  * back to a nearby control - see {@link inputChannelFromToken}.
  */
 export const channelFromToken = (token: string): InputChannel => {
   const channel = inputChannelFromToken(token);
 
   if (channel === null) {
-    throw new Error(`Input binding: "${token}" is not a known input token. Bindings saved by a newer build cannot be applied to this one.`);
+    throw new InputBindingError(`Input binding: "${token}" is not a known input token. Bindings saved by a newer build cannot be applied to this one.`);
   }
 
   return channel;
@@ -35,12 +36,12 @@ export const channelFromToken = (token: string): InputChannel => {
 /** {@link channelFromToken} over a list, rejecting a non-array or non-string entry outright. */
 export const channelsFromTokens = (tokens: unknown, what: string): readonly InputChannel[] => {
   if (!Array.isArray(tokens)) {
-    throw new Error(`Input binding: ${what} must be an array of input tokens.`);
+    throw new InputBindingError(`Input binding: ${what} must be an array of input tokens.`);
   }
 
   return (tokens as readonly unknown[]).map(token => {
     if (typeof token !== 'string') {
-      throw new Error(`Input binding: ${what} must contain input tokens (strings), not ${typeof token}.`);
+      throw new InputBindingError(`Input binding: ${what} must contain input tokens (strings), not ${typeof token}.`);
     }
 
     return channelFromToken(token);
@@ -114,7 +115,7 @@ export abstract class ActionBase<Binding> {
   /**
    * Turn a persisted binding back into this kind's descriptor.
    *
-   * @throws {Error} On an unknown token or a structurally invalid entry. A
+   * @throws {InputBindingError} On an unknown token or a structurally invalid entry. A
    * profile is applied all-or-nothing, so throwing here aborts the whole
    * application before any action has been touched.
    *

--- a/src/input/actions/ActionMap.ts
+++ b/src/input/actions/ActionMap.ts
@@ -7,6 +7,7 @@ import type { AxisAction, AxisBinding } from './AxisAction';
 import type { BindingProfile } from './BindingProfile';
 import type { ButtonAction, ButtonBinding } from './ButtonAction';
 import type { ChordAction, ChordBinding } from './ChordAction';
+import { InputBindingError } from './InputBindingError';
 import type { SequenceAction, SequenceBinding } from './SequenceAction';
 import type { SerializedActionBinding } from './serialization';
 import type { ActionSample, OneOrMany } from './types';
@@ -273,7 +274,7 @@ class ActionMapBase<T extends ActionRecord> {
    * declared default - which is what lets a build add a new action without an
    * older save file freezing it.
    *
-   * @throws {Error} If an override names an action this map does not declare,
+   * @throws {InputBindingError} If an override names an action this map does not declare,
    * its kind does not match that action, or it contains an unknown input token.
    */
   public applyProfile(profile: BindingProfile | null): void {
@@ -285,7 +286,7 @@ class ActionMapBase<T extends ActionRecord> {
         const action = this._byName.get(name);
 
         if (action === undefined) {
-          throw new Error(`ActionMap: the profile overrides "${name}", which this map does not declare.`);
+          throw new InputBindingError(`ActionMap: the profile overrides "${name}", which this map does not declare.`);
         }
 
         changes.push([action, action._deserialize(profile.get(name)!)]);

--- a/src/input/actions/AxisAction.ts
+++ b/src/input/actions/AxisAction.ts
@@ -3,6 +3,7 @@ import { resolveGamepadSlotChannel } from '#input/types';
 
 import type { GamepadSlot } from './ActionBase';
 import { ActionBase, channelFromToken, channelsFromTokens, tokensFromChannels } from './ActionBase';
+import { InputBindingError } from './InputBindingError';
 import type { SerializedActionBinding, SerializedAxisEntry } from './serialization';
 import type { ActionOptions, ActionSample, AtLeastOne, OneOrMany } from './types';
 import { sampleStrongest, toChannels } from './types';
@@ -62,7 +63,7 @@ const serializeEntry = (binding: ResolvedAxisBinding): SerializedAxisEntry => {
 
 const deserializeEntry = (entry: unknown): AxisBinding => {
   if (entry === null || typeof entry !== 'object') {
-    throw new Error('AxisAction: every serialized binding entry must be an object.');
+    throw new InputBindingError('AxisAction: every serialized binding entry must be an object.');
   }
 
   const { direct, negative, positive } = entry as SerializedAxisEntry;
@@ -77,7 +78,7 @@ const deserializeEntry = (entry: unknown): AxisBinding => {
   };
 
   if (composite.negative === undefined && composite.positive === undefined) {
-    throw new Error('AxisAction: a serialized binding entry needs a "direct" token or a "negative"/"positive" group.');
+    throw new InputBindingError('AxisAction: a serialized binding entry needs a "direct" token or a "negative"/"positive" group.');
   }
 
   return composite as AxisBinding;
@@ -129,11 +130,11 @@ export class AxisAction extends ActionBase<OneOrMany<AxisBinding>> {
   /** @internal */
   public override _deserialize(data: SerializedActionBinding): OneOrMany<AxisBinding> {
     if (data.kind !== 'axis') {
-      throw new Error(`AxisAction: cannot apply a "${data.kind}" binding.`);
+      throw new InputBindingError(`AxisAction: cannot apply a "${data.kind}" binding.`);
     }
 
     if (!Array.isArray(data.binding)) {
-      throw new Error('AxisAction: a serialized axis binding must be an array of entries.');
+      throw new InputBindingError('AxisAction: a serialized axis binding must be an array of entries.');
     }
 
     return (data.binding as readonly unknown[]).map(deserializeEntry);

--- a/src/input/actions/BindingProfile.ts
+++ b/src/input/actions/BindingProfile.ts
@@ -1,3 +1,4 @@
+import { InputBindingError } from './InputBindingError';
 import type { SerializedActionBinding } from './serialization';
 
 /** Wire format {@link BindingProfile.toJSON} produces and {@link BindingProfile.fromJSON} accepts. */
@@ -80,30 +81,30 @@ export class BindingProfile {
    * profile is applied to a map, since only the map knows which action kind
    * each entry has to fit.
    *
-   * @throws {Error} If `data` is not a profile of a version this build
+   * @throws {InputBindingError} If `data` is not a profile of a version this build
    * understands, or an entry is not a `{ kind, binding }` pair. A malformed
    * save is reported rather than partially honoured.
    */
   public static fromJSON(data: unknown): BindingProfile {
     if (data === null || typeof data !== 'object') {
-      throw new Error('BindingProfile: expected a serialized profile object.');
+      throw new InputBindingError('BindingProfile: expected a serialized profile object.');
     }
 
     const { version, overrides } = data as Partial<BindingProfileData>;
 
     if (version !== currentVersion) {
-      throw new Error(`BindingProfile: unsupported profile version ${String(version)} (this build reads version ${currentVersion}).`);
+      throw new InputBindingError(`BindingProfile: unsupported profile version ${String(version)} (this build reads version ${currentVersion}).`);
     }
 
     if (overrides === undefined || typeof overrides !== 'object') {
-      throw new Error('BindingProfile: a serialized profile needs an "overrides" object.');
+      throw new InputBindingError('BindingProfile: a serialized profile needs an "overrides" object.');
     }
 
     const profile = new BindingProfile();
 
     for (const [action, binding] of Object.entries(overrides)) {
       if (binding === null || typeof binding !== 'object' || typeof binding.kind !== 'string' || !('binding' in binding)) {
-        throw new Error(`BindingProfile: the override for "${action}" is not a { kind, binding } pair.`);
+        throw new InputBindingError(`BindingProfile: the override for "${action}" is not a { kind, binding } pair.`);
       }
 
       profile.set(action, binding);

--- a/src/input/actions/ButtonAction.ts
+++ b/src/input/actions/ButtonAction.ts
@@ -4,6 +4,7 @@ import { resolveGamepadSlotChannel } from '#input/types';
 import type { GamepadSlot } from './ActionBase';
 import { channelsFromTokens, tokensFromChannels } from './ActionBase';
 import { ButtonLikeAction } from './ButtonLikeAction';
+import { InputBindingError } from './InputBindingError';
 import type { SerializedActionBinding } from './serialization';
 import type { ActionOptions, OneOrMany } from './types';
 import { toChannels } from './types';
@@ -52,7 +53,7 @@ export class ButtonAction extends ButtonLikeAction<ButtonBinding> {
   /** @internal */
   public override _deserialize(data: SerializedActionBinding): ButtonBinding {
     if (data.kind !== 'button') {
-      throw new Error(`ButtonAction: cannot apply a "${data.kind}" binding.`);
+      throw new InputBindingError(`ButtonAction: cannot apply a "${data.kind}" binding.`);
     }
 
     return channelsFromTokens(data.binding, 'a button binding');

--- a/src/input/actions/ChordAction.ts
+++ b/src/input/actions/ChordAction.ts
@@ -3,6 +3,7 @@ import { resolveGamepadSlotChannel } from '#input/types';
 import type { GamepadSlot } from './ActionBase';
 import { channelsFromTokens, tokensFromChannels } from './ActionBase';
 import { ButtonLikeAction } from './ButtonLikeAction';
+import { InputBindingError } from './InputBindingError';
 import { type InputAlternation, type InputChord, normalizeSequence, type ValidatedChordBinding } from './pattern';
 import type { SerializedActionBinding } from './serialization';
 import type { ActionOptions } from './types';
@@ -105,11 +106,11 @@ export class ChordAction<const Binding extends ChordBinding = ChordBinding> exte
   /** @internal */
   public override _deserialize(data: SerializedActionBinding): ChordBinding {
     if (data.kind !== 'chord') {
-      throw new Error(`ChordAction: cannot apply a "${data.kind}" binding.`);
+      throw new InputBindingError(`ChordAction: cannot apply a "${data.kind}" binding.`);
     }
 
     if (!Array.isArray(data.binding)) {
-      throw new Error('ChordAction: a serialized chord binding must be an array of alternatives.');
+      throw new InputBindingError('ChordAction: a serialized chord binding must be an array of alternatives.');
     }
 
     return (data.binding as readonly unknown[]).map(alternative => channelsFromTokens(alternative, 'a chord alternative'));

--- a/src/input/actions/InputBindingError.ts
+++ b/src/input/actions/InputBindingError.ts
@@ -1,0 +1,19 @@
+/**
+ * Raised when serialized binding data cannot be read: a profile whose shape or
+ * version this build does not understand, a binding whose kind does not match
+ * the action it is applied to, or a token no control carries.
+ *
+ * Rebindings are persisted by the game and come back as untrusted input, so
+ * this is the one input failure a caller acts on at runtime rather than fixes
+ * in source: catch it, discard the saved profile, fall back to the declared
+ * defaults. Programmer errors - an action claimed by two maps, a reserved
+ * action name, a malformed pattern string written in code - stay a plain
+ * `Error` so a `catch` around a profile load does not swallow them.
+ */
+export class InputBindingError extends Error {
+  public constructor(message: string) {
+    super(message);
+
+    this.name = 'InputBindingError';
+  }
+}

--- a/src/input/actions/SequenceAction.ts
+++ b/src/input/actions/SequenceAction.ts
@@ -2,6 +2,7 @@ import { resolveGamepadSlotChannel } from '#input/types';
 
 import type { GamepadSlot } from './ActionBase';
 import { ActionBase, channelsFromTokens, tokensFromChannels } from './ActionBase';
+import { InputBindingError } from './InputBindingError';
 import { type InputSequence, type NormalizedStep, normalizeSequence, type ValidatedSequenceBinding } from './pattern';
 import type { SerializedActionBinding } from './serialization';
 import type { ActionOptions, ActionSample } from './types';
@@ -122,16 +123,16 @@ export class SequenceAction<const Pattern extends SequenceBinding = SequenceBind
   /** @internal */
   public override _deserialize(data: SerializedActionBinding): SequenceBinding {
     if (data.kind !== 'sequence') {
-      throw new Error(`SequenceAction: cannot apply a "${data.kind}" binding.`);
+      throw new InputBindingError(`SequenceAction: cannot apply a "${data.kind}" binding.`);
     }
 
     if (!Array.isArray(data.binding)) {
-      throw new Error('SequenceAction: a serialized sequence binding must be an array of steps.');
+      throw new InputBindingError('SequenceAction: a serialized sequence binding must be an array of steps.');
     }
 
     return (data.binding as readonly unknown[]).map(step => {
       if (!Array.isArray(step)) {
-        throw new Error('SequenceAction: every serialized step must be an array of alternatives.');
+        throw new InputBindingError('SequenceAction: every serialized step must be an array of alternatives.');
       }
 
       return (step as readonly unknown[]).map(alternative => channelsFromTokens(alternative, 'a sequence alternative'));

--- a/src/input/actions/VectorAction.ts
+++ b/src/input/actions/VectorAction.ts
@@ -4,6 +4,7 @@ import { Vector } from '#math/Vector';
 
 import type { GamepadSlot } from './ActionBase';
 import { ActionBase, channelsFromTokens, tokensFromChannels } from './ActionBase';
+import { InputBindingError } from './InputBindingError';
 import type { SerializedActionBinding, SerializedVectorEntry } from './serialization';
 import type { ActionOptions, ActionSample, AtLeastOne, OneOrMany } from './types';
 import { sampleStrongest, toChannels } from './types';
@@ -60,7 +61,7 @@ const serializeEntry = (binding: ResolvedVectorBinding): SerializedVectorEntry =
 
 const deserializeEntry = (entry: unknown): VectorBinding => {
   if (entry === null || typeof entry !== 'object') {
-    throw new Error('VectorAction: every serialized binding entry must be an object.');
+    throw new InputBindingError('VectorAction: every serialized binding entry must be an object.');
   }
 
   const source = entry as Record<string, unknown>;
@@ -73,7 +74,7 @@ const deserializeEntry = (entry: unknown): VectorBinding => {
   }
 
   if (Object.keys(shape).length === 0) {
-    throw new Error('VectorAction: a serialized binding entry needs at least one of x, y, up, down, left, right.');
+    throw new InputBindingError('VectorAction: a serialized binding entry needs at least one of x, y, up, down, left, right.');
   }
 
   return shape as VectorBinding;
@@ -134,11 +135,11 @@ export class VectorAction extends ActionBase<OneOrMany<VectorBinding>> {
   /** @internal */
   public override _deserialize(data: SerializedActionBinding): OneOrMany<VectorBinding> {
     if (data.kind !== 'vector') {
-      throw new Error(`VectorAction: cannot apply a "${data.kind}" binding.`);
+      throw new InputBindingError(`VectorAction: cannot apply a "${data.kind}" binding.`);
     }
 
     if (!Array.isArray(data.binding)) {
-      throw new Error('VectorAction: a serialized vector binding must be an array of entries.');
+      throw new InputBindingError('VectorAction: a serialized vector binding must be an array of entries.');
     }
 
     return (data.binding as readonly unknown[]).map(deserializeEntry);

--- a/src/input/actions/index.ts
+++ b/src/input/actions/index.ts
@@ -11,6 +11,7 @@ export { ButtonAction } from './ButtonAction';
 export { ButtonLikeAction } from './ButtonLikeAction';
 export type { ChordBinding } from './ChordAction';
 export { ChordAction } from './ChordAction';
+export { InputBindingError } from './InputBindingError';
 export { InputScope } from './InputScope';
 export type { InputAlternation, InputChord, InputSequence, ValidatedChordBinding, ValidatedSequenceBinding } from './pattern';
 export type { SequenceActionOptions, SequenceBinding } from './SequenceAction';

--- a/src/math/geometry.ts
+++ b/src/math/geometry.ts
@@ -1,3 +1,5 @@
+import { assert } from '#core/dev';
+
 import { triangulate } from './triangulate';
 import { TAU } from './utils';
 import { Vector } from './Vector';
@@ -56,6 +58,11 @@ export const buildPath = (points: number[], width: number): MeshGeometryData => 
   if (points.length < 4) {
     throw new Error('At least two X/Y pairs are required to build a line.');
   }
+
+  // A trailing unpaired coordinate is read as the second half of a point that
+  // does not exist, which turns the last segment into NaN vertices - geometry
+  // that neither throws nor draws.
+  assert(points.length % 2 === 0, 'buildPath: points must hold (x, y) pairs, so its length must be even.');
 
   const lineWidth = width / 2;
   const firstPoint = new Vector(points[0], points[1]);

--- a/src/math/triangulate.ts
+++ b/src/math/triangulate.ts
@@ -1,3 +1,5 @@
+import { assert } from '#core/dev';
+
 /**
  * Triangulate a simple 2D polygon by ear-clipping.
  *
@@ -15,6 +17,11 @@
  * @returns triangle index list (length is multiple of 3)
  */
 export const triangulate = (vertices: ArrayLike<number>): Uint32Array => {
+  // An odd length is a caller error that cannot be reported by the return
+  // value: the trailing coordinate is dropped and the result looks like a
+  // successful triangulation of a polygon the caller never described.
+  assert(vertices.length % 2 === 0, 'triangulate: vertices must hold (x, y) pairs, so its length must be even.');
+
   const n = vertices.length >> 1;
 
   if (n < 3) {

--- a/src/rendering/webgpu/compute/reflectComputeBindings.ts
+++ b/src/rendering/webgpu/compute/reflectComputeBindings.ts
@@ -11,7 +11,7 @@ import type { ComputeBinding } from './WebGpuComputePipeline';
  * auto-assignment of group/binding numbers (unlike e.g. PlayCanvas's WGSL processor, which lets
  * shaders omit `@group`/`@binding` entirely and assigns them itself), no uniform-buffer member
  * byte-offset computation (that stays a JS-side concern - see `WgslContribution`/
- * `wgslUniformByteSize` in `@codexo/exojs-particles`). It only reads resource declarations that
+ * `getWgslUniformByteSize` in `@codexo/exojs-particles`). It only reads resource declarations that
  * already carry explicit `@group`/`@binding` attributes, the convention every ExoJS-authored
  * compute shader already follows.
  *

--- a/test/assets/asset-container.test.ts
+++ b/test/assets/asset-container.test.ts
@@ -1,5 +1,6 @@
 import { Asset } from '#assets/Asset';
 import { CONTAINER_HEADER_SIZE, CONTAINER_MAGIC, type ContainerInput, encodeContainer, parseContainer } from '#assets/AssetContainer';
+import { AssetDecodeError } from '#assets/AssetDecodeError';
 import { coreAssetTypes } from '#assets/coreAssetTypes';
 import { Loader } from '#assets/Loader';
 import { materializeAssetTypes } from '#extensions/materialize';
@@ -288,5 +289,8 @@ describe('Loader.loadContainer', () => {
     const loader = createCoreLoader();
 
     await expect(loader.loadContainer('bad.exoa')).rejects.toThrow(/Invalid asset container/);
+    // Broken bytes stay broken: the caller has to drop the container, not retry
+    // it, so the failure keeps its own type instead of a generic Error.
+    await expect(loader.loadContainer('bad.exoa')).rejects.toBeInstanceOf(AssetDecodeError);
   });
 });

--- a/test/assets/asset-decoder.test.ts
+++ b/test/assets/asset-decoder.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from 'vitest';
 
 import { AssetCache } from '#assets/AssetCache';
 import type { AssetConstructor } from '#assets/AssetConstructor';
+import { AssetDecodeError } from '#assets/AssetDecodeError';
 import { AssetDecoder } from '#assets/AssetDecoder';
 import { AssetTypeRegistry } from '#assets/AssetTypeRegistry';
 import type { CacheContext } from '#assets/CachePolicy';
@@ -90,6 +91,27 @@ describe('AssetDecoder', () => {
       /Failed to load "hero.png" from "hero.png": bad payload/,
     );
     expect(storeResource).not.toHaveBeenCalled();
+  });
+
+  test('_dispatchFetch keeps a decode failure its own type while adding the "which asset" envelope', async () => {
+    const { decoder, typeRegistry, canonical } = createDecoder();
+
+    typeRegistry.installAll([
+      testAssetType<string, string>({
+        id: 'typeA',
+        token: TypeA,
+        acquires: false,
+        create: async () => {
+          throw new AssetDecodeError({ message: 'not a PNG', assetType: 'typeA' });
+        },
+      }),
+    ]);
+
+    const promise = decoder._dispatchFetch(canonical(TypeA, 'hero.png'), undefined, undefined, fakeScope);
+
+    await expect(promise).rejects.toBeInstanceOf(AssetDecodeError);
+    await expect(promise).rejects.toThrow(/Failed to load "hero.png" from "hero.png": not a PNG/);
+    await expect(promise).rejects.toMatchObject({ assetType: 'typeA' });
   });
 
   test('_dispatchFetch rejects with a clear error when no type is installed for the token', async () => {

--- a/test/assets/indexed-db-database.test.ts
+++ b/test/assets/indexed-db-database.test.ts
@@ -56,7 +56,7 @@ describe('IndexedDbDatabase', () => {
 
     const { IndexedDbDatabase } = await import('#assets/IndexedDbDatabase');
 
-    expect(() => new IndexedDbDatabase('unsupported-db')).toThrow('This browser does not support indexedDB!');
+    expect(() => new IndexedDbDatabase('unsupported-db')).toThrow('This host provides no IndexedDB, so no database can be opened.');
   });
 
   describe('connect()', () => {

--- a/test/assets/loader-seamless.test.ts
+++ b/test/assets/loader-seamless.test.ts
@@ -1,6 +1,7 @@
 import { expectTypeOf } from 'vitest';
 
 import { Asset } from '#assets/Asset';
+import { AssetNetworkError } from '#assets/AssetNetworkError';
 import { Assets } from '#assets/Assets';
 import { coreAssetTypes } from '#assets/coreAssetTypes';
 import { Loader, LoadPriority } from '#assets/Loader';
@@ -317,7 +318,11 @@ describe('Loader seamless get (Texture)', () => {
 
     const handle = loader.get('gone.png');
 
-    await expect(handle.loaded).rejects.toThrow('Failed to load');
+    // The transport failure reaches the caller as itself: an AssetNetworkError
+    // already names the URL and carries the status, and re-wrapping it would
+    // take the branch away from an offline-capable caller.
+    await expect(handle.loaded).rejects.toThrow(AssetNetworkError);
+    await expect(handle.loaded).rejects.toThrow('Failed to fetch "gone.png" (404 Not Found).');
     expect(handle.loadState).toBe('failed');
     expect(handle.source).toBe(Texture.missing.source);
     expect(loader._peekResource(Texture, 'gone.png')).toBeNull();

--- a/test/assets/parse-xml.test.ts
+++ b/test/assets/parse-xml.test.ts
@@ -1,3 +1,4 @@
+import { AssetDecodeError } from '#assets/AssetDecodeError';
 import { parseXmlDocument } from '#assets/factories/parseXml';
 
 describe('parseXmlDocument', () => {
@@ -11,6 +12,7 @@ describe('parseXmlDocument', () => {
 
   test('throws with a clear message on malformed XML', () => {
     expect(() => parseXmlDocument('<root><unclosed></root>')).toThrow('XML parse error');
+    expect(() => parseXmlDocument('<root><unclosed></root>')).toThrow(AssetDecodeError);
   });
 
   test('falls back to "unknown error" when the detected parsererror element has no text content', () => {

--- a/test/assets/sound-factory.test.ts
+++ b/test/assets/sound-factory.test.ts
@@ -1,4 +1,6 @@
 import { AssetDecodeError } from '#assets/AssetDecodeError';
+import type { AssetDependencyScope, AssetFactoryContext } from '#assets/AssetFactory';
+import type { SoundAssetOptions } from '#assets/factories/SoundFactory';
 import { SoundFactory } from '#assets/factories/SoundFactory';
 import { Sound } from '#audio/Sound';
 
@@ -99,5 +101,54 @@ describe('SoundFactory', () => {
     await expect(promise).rejects.toMatchObject({ cause: decodeError });
     await expect(promise).rejects.toBeInstanceOf(AssetDecodeError);
     await expect(promise).rejects.toMatchObject({ assetType: 'sound' });
+  });
+});
+
+describe('SoundFactory - sprite sidecar', () => {
+  afterEach(() => {
+    decodeAudioDataMock.mockClear();
+  });
+
+  /** A dependency scope that answers one `json` load with `payload`. */
+  const sidecarContext = (sidecar: string, payload: unknown): AssetFactoryContext<SoundAssetOptions> => {
+    const load = vi.fn(async () => payload);
+
+    return factoryContext<SoundAssetOptions>(
+      { sprites: sidecar },
+      {
+        dependencies: { load, get: vi.fn(), createScope: vi.fn() } as unknown as AssetDependencyScope,
+      },
+    );
+  };
+
+  test('a string sprites option is loaded through the sound own dependency scope', async () => {
+    const context = sidecarContext('sfx.sprites.json', { impact: { start: 0.5, end: 0.8 }, hum: { start: 1, end: 1.5, loop: true } });
+
+    const sound = await new SoundFactory().create(new ArrayBuffer(8), context);
+
+    expect(sound.hasSprite('impact')).toBe(true);
+    expect(sound.sprite('hum').loop).toBe(true);
+    expect(context.dependencies.load).toHaveBeenCalledTimes(1);
+  });
+
+  test('a sidecar that is not an object mapping names to clips is a decode failure', async () => {
+    await expect(new SoundFactory().create(new ArrayBuffer(8), sidecarContext('sfx.json', [1, 2, 3]))).rejects.toBeInstanceOf(AssetDecodeError);
+    await expect(new SoundFactory().create(new ArrayBuffer(8), sidecarContext('sfx.json', { impact: 3 }))).rejects.toThrow(/is not a clip object/);
+    await expect(new SoundFactory().create(new ArrayBuffer(8), sidecarContext('sfx.json', { impact: { start: 0, end: 'x' } }))).rejects.toThrow(
+      /finite "start" and "end" times/,
+    );
+  });
+
+  test('a clip only the buffer duration can reject is reported against the sidecar, not the caller', async () => {
+    const promise = new SoundFactory().create(new ArrayBuffer(8), sidecarContext('sfx.json', { tail: { start: 0, end: 99 } }));
+
+    await expect(promise).rejects.toBeInstanceOf(AssetDecodeError);
+    await expect(promise).rejects.toThrow(/Invalid sound sprite sheet "sfx\.json"/);
+  });
+
+  test('an inline sprite map still reaches the Sound unchanged', async () => {
+    const sound = await new SoundFactory().create(new ArrayBuffer(8), factoryContext<SoundAssetOptions>({ sprites: { hit: { start: 0, end: 1 } } }));
+
+    expect(sound.hasSprite('hit')).toBe(true);
   });
 });

--- a/test/assets/sound-factory.test.ts
+++ b/test/assets/sound-factory.test.ts
@@ -1,3 +1,4 @@
+import { AssetDecodeError } from '#assets/AssetDecodeError';
 import { SoundFactory } from '#assets/factories/SoundFactory';
 import { Sound } from '#audio/Sound';
 
@@ -96,5 +97,7 @@ describe('SoundFactory', () => {
       'Failed to decode audio data: corrupt audio data (if loaded as the wrong asset type, this file may not be an audio format at all).',
     );
     await expect(promise).rejects.toMatchObject({ cause: decodeError });
+    await expect(promise).rejects.toBeInstanceOf(AssetDecodeError);
+    await expect(promise).rejects.toMatchObject({ assetType: 'sound' });
   });
 });

--- a/test/assets/utils.test.ts
+++ b/test/assets/utils.test.ts
@@ -11,7 +11,7 @@ const toBuffer = (bytes: number[]): ArrayBuffer => {
 
 describe('determineMimeType', () => {
   test('throws when the buffer is empty', () => {
-    expect(() => determineMimeType(new ArrayBuffer(0))).toThrow('Cannot determine mime type: No data.');
+    expect(() => determineMimeType(new ArrayBuffer(0))).toThrow('Cannot determine mime type: the buffer is empty.');
   });
 
   test('detects PNG by its magic bytes', () => {

--- a/test/audio/audio-bus.test.ts
+++ b/test/audio/audio-bus.test.ts
@@ -234,6 +234,18 @@ describe('AudioBus', () => {
     bus.destroy();
   });
 
+  test('addEffect refuses the same effect twice - a second attach would feed the effect its own output', () => {
+    const bus = new AudioBus('duplicate-effect');
+    const filter = new StubFilter();
+
+    bus.addEffect(filter);
+
+    expect(() => bus.addEffect(filter)).toThrow('already attached to the bus');
+
+    bus.removeEffect(filter);
+    bus.destroy();
+  });
+
   // 7. fadeIn / fadeOut schedule ramps
   test('fadeIn(500) schedules linearRamp on outputNode', () => {
     const spy = spyOnBusCreation();

--- a/test/audio/audio-context.test.ts
+++ b/test/audio/audio-context.test.ts
@@ -1,3 +1,5 @@
+import { AudioUnsupportedError } from '#audio/AudioUnsupportedError';
+
 import { mutable } from '../support/mutable';
 /**
  * Focused unit tests for `src/audio/audio-context.ts` - the lazy singleton
@@ -31,21 +33,21 @@ describe('audio/audio-context — unsupported environments', () => {
     Object.defineProperty(globalThis, 'AudioContext', { configurable: true, value: undefined });
 
     const { getAudioContext } = await import('#audio/audio-context');
-    expect(() => getAudioContext()).toThrow('This environment does not support AudioContext.');
+    expect(() => getAudioContext()).toThrow(new AudioUnsupportedError('AudioContext'));
   });
 
   it('getOfflineAudioContext() throws when OfflineAudioContext is unsupported', async () => {
     Object.defineProperty(globalThis, 'OfflineAudioContext', { configurable: true, value: undefined });
 
     const { getOfflineAudioContext } = await import('#audio/audio-context');
-    expect(() => getOfflineAudioContext()).toThrow('This environment does not support OfflineAudioContext.');
+    expect(() => getOfflineAudioContext()).toThrow(new AudioUnsupportedError('OfflineAudioContext'));
   });
 
   it('decodeAudioData() rejects when OfflineAudioContext is unsupported', async () => {
     Object.defineProperty(globalThis, 'OfflineAudioContext', { configurable: true, value: undefined });
 
     const { decodeAudioData } = await import('#audio/audio-context');
-    await expect(decodeAudioData(new ArrayBuffer(0))).rejects.toThrow('This environment does not support OfflineAudioContext.');
+    await expect(decodeAudioData(new ArrayBuffer(0))).rejects.toThrow(new AudioUnsupportedError('OfflineAudioContext'));
   });
 });
 

--- a/test/audio/audio-input.test.ts
+++ b/test/audio/audio-input.test.ts
@@ -3,6 +3,7 @@ import type { MockInstance } from 'vitest';
 import { getAudioContext } from '#audio/audio-context';
 import { AudioInput } from '#audio/AudioInput';
 import { AudioManager } from '#audio/AudioManager';
+import { AudioUnsupportedError } from '#audio/AudioUnsupportedError';
 import type { InputVoice } from '#audio/InputVoice';
 import { Sound } from '#audio/Sound';
 
@@ -310,13 +311,13 @@ describe('AudioInput / InputVoice', () => {
   test('open() throws when navigator is undefined', async () => {
     vi.stubGlobal('navigator', undefined);
 
-    await expect(AudioInput.open()).rejects.toThrow('AudioInput.open: getUserMedia is not available in this environment.');
+    await expect(AudioInput.open()).rejects.toThrow(new AudioUnsupportedError('navigator.mediaDevices.getUserMedia'));
   });
 
   test('open() throws when navigator.mediaDevices.getUserMedia is unavailable', async () => {
     vi.stubGlobal('navigator', { mediaDevices: {} });
 
-    await expect(AudioInput.open()).rejects.toThrow('AudioInput.open: getUserMedia is not available in this environment.');
+    await expect(AudioInput.open()).rejects.toThrow(new AudioUnsupportedError('navigator.mediaDevices.getUserMedia'));
   });
 
   test('open() forwards deviceId to the getUserMedia constraints', async () => {

--- a/test/audio/voice-effects.test.ts
+++ b/test/audio/voice-effects.test.ts
@@ -87,6 +87,19 @@ describe('Voice — per-voice effects', () => {
     sound.destroy();
   });
 
+  test('addEffect refuses the same effect twice - a second attach would feed the effect its own output', () => {
+    const manager = new AudioManager();
+    const sound = new Sound(makeBufferStub());
+    const voice = manager.play(sound);
+    const fx = makeStubEffect();
+
+    voice.addEffect(fx);
+
+    expect(() => voice.addEffect(fx)).toThrow('already attached to the voice');
+
+    sound.destroy();
+  });
+
   test('addEffect returns the voice for chaining', () => {
     const manager = new AudioManager();
     const sound = new Sound(makeBufferStub());

--- a/test/core/__snapshots__/root-index-snapshot.test.ts.snap
+++ b/test/core/__snapshots__/root-index-snapshot.test.ts.snap
@@ -104,6 +104,7 @@ exports[`root index export surface snapshot > sorted runtime export names match 
   "IndexedDbKeyValueStore",
   "IndexedDbStore",
   "InputBinding",
+  "InputBindingError",
   "InputManager",
   "InputScope",
   "InteractionEvent",

--- a/test/core/__snapshots__/root-index-snapshot.test.ts.snap
+++ b/test/core/__snapshots__/root-index-snapshot.test.ts.snap
@@ -25,6 +25,7 @@ exports[`root index export surface snapshot > sorted runtime export names match 
   "AudioListener",
   "AudioManager",
   "AudioStream",
+  "AudioUnsupportedError",
   "AxisAction",
   "BinaryAsset",
   "BinaryAssetType",

--- a/test/core/__snapshots__/root-index-snapshot.test.ts.snap
+++ b/test/core/__snapshots__/root-index-snapshot.test.ts.snap
@@ -14,6 +14,7 @@ exports[`root index export surface snapshot > sorted runtime export names match 
   "AssetCache",
   "AssetCacheError",
   "AssetCacheMissError",
+  "AssetDecodeError",
   "AssetNetworkError",
   "AssetRef",
   "AssetType",

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -261,6 +261,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "InputAlternation: type alias",
   "InputApplicationOptions: interface",
   "InputBinding: class",
+  "InputBindingError: class",
   "InputBindingOptions: interface",
   "InputChannel: type alias",
   "InputChord: type alias",

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -35,6 +35,8 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "AssetCacheOperation: type alias",
   "AssetCacheOptions: interface",
   "AssetConstructor: type alias",
+  "AssetDecodeError: class",
+  "AssetDecodeErrorOptions: interface",
   "AssetDefinitions: interface",
   "AssetDependencyScope: type alias",
   "AssetFactory: interface",

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -503,6 +503,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "SoundOptions: interface",
   "SoundPlayOptions: interface",
   "SoundPoolStrategy: enum",
+  "SoundSpriteSheet: type alias",
   "SourceCodecContext: interface",
   "SourceKey: type alias",
   "SpatialSmoothingSettings: interface",

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -69,6 +69,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "AudioManager: class",
   "AudioSpriteClip: interface",
   "AudioStream: class",
+  "AudioUnsupportedError: class",
   "AutoBackendConfig: interface",
   "AxisAction: class",
   "AxisBinding: type alias",

--- a/test/input/action-rebinding.test.ts
+++ b/test/input/action-rebinding.test.ts
@@ -9,6 +9,7 @@ import { AxisAction } from '#input/actions/AxisAction';
 import { BindingProfile } from '#input/actions/BindingProfile';
 import { ButtonAction } from '#input/actions/ButtonAction';
 import { ChordAction } from '#input/actions/ChordAction';
+import { InputBindingError } from '#input/actions/InputBindingError';
 import { SequenceAction } from '#input/actions/SequenceAction';
 import type { ActionSample, ChannelEvent } from '#input/actions/types';
 import { VectorAction } from '#input/actions/VectorAction';
@@ -205,6 +206,26 @@ describe('binding serialization', () => {
     const profile = new BindingProfile().set('crouch', { kind: 'button', binding: ['keyboard.key-c'] });
 
     expect(() => map.applyProfile(profile)).toThrow(/does not declare/);
+  });
+
+  test('reports every unreadable-save failure as InputBindingError, so a load can fall back to defaults', () => {
+    const map = new ActionMap({ jump: new ButtonAction(Keyboard.Space) });
+
+    expect(() => BindingProfile.fromJSON(null)).toThrow(InputBindingError);
+    expect(() => BindingProfile.fromJSON({ version: 2, overrides: {} })).toThrow(InputBindingError);
+    expect(() => map.applyProfile(new BindingProfile().set('jump', { kind: 'button', binding: ['keyboard.hyperspace'] }))).toThrow(InputBindingError);
+    expect(() => map.applyProfile(new BindingProfile().set('jump', { kind: 'axis', binding: [{ direct: 'gamepad.axis.left-stick-x' }] }))).toThrow(
+      InputBindingError,
+    );
+    expect(() => map.applyProfile(new BindingProfile().set('crouch', { kind: 'button', binding: ['keyboard.key-c'] }))).toThrow(InputBindingError);
+  });
+
+  test('leaves a programmer error a plain Error, so a catch around a profile load does not swallow it', () => {
+    const shared = new ButtonAction(Keyboard.Space);
+    const map = new ActionMap({ jump: shared });
+
+    expect(() => (map as unknown as { rebind(name: string, binding: unknown): void }).rebind('nope', Keyboard.J)).not.toThrow(InputBindingError);
+    expect(() => new ActionMap({ other: shared })).not.toThrow(InputBindingError);
   });
 });
 

--- a/test/input/gamepad-mapping-data.test.ts
+++ b/test/input/gamepad-mapping-data.test.ts
@@ -278,6 +278,17 @@ describe('custom devices', () => {
     expect(GamepadPromptLayouts.getControlLabels(mapping).get('ButtonSouth')).toBe('Trigger');
   });
 
+  test('rejects two controls on the same channel - one would silently overwrite the other every frame', () => {
+    expect(
+      () =>
+        new GamepadMapping({
+          family: GamepadMappingFamily.ArcadeStick,
+          buttons: [new GamepadButton(0, GamepadButton.South), new GamepadButton(1, GamepadButton.South)],
+          axes: [],
+        }),
+    ).toThrow('two controls write to the same channel');
+  });
+
   test('layout defaults to standard when the data omits it', () => {
     const mapping = new GamepadMapping({ family: GamepadMappingFamily.ArcadeStick, buttons: [], axes: [] });
 

--- a/test/math/geometry.test.ts
+++ b/test/math/geometry.test.ts
@@ -466,3 +466,9 @@ describe('buildRoundedRectangle', () => {
     expect(data.points[1]).toBeCloseTo(data.points[last - 1]);
   });
 });
+
+describe('buildPath - argument checks', () => {
+  test('rejects an odd-length point list, which would build the last segment from NaN', () => {
+    expect(() => buildPath([0, 0, 10, 10, 20], 4)).toThrow('length must be even');
+  });
+});

--- a/test/math/triangulate.test.ts
+++ b/test/math/triangulate.test.ts
@@ -289,3 +289,11 @@ test('output length is always a multiple of 3', () => {
     expect(result.length % 3).toBe(0);
   }
 });
+
+// ---------------------------------------------------------------------------
+// 10. An odd vertex count is a caller error the return value cannot report
+// ---------------------------------------------------------------------------
+
+test('rejects an odd-length vertex list instead of dropping the trailing coordinate', () => {
+  expect(() => triangulate([0, 0, 10, 0, 5, 10, 3])).toThrow('length must be even');
+});

--- a/test/rendering/parity/evidence.json
+++ b/test/rendering/parity/evidence.json
@@ -1,8 +1,8 @@
 {
   "stamps": {
     "chromium": {
-      "measuredAt": "2026-08-18",
-      "commit": "ab42a315",
+      "measuredAt": "2026-08-27",
+      "commit": "cec2d14ef",
       "platform": "win32"
     },
     "firefox": {
@@ -29,6 +29,17 @@
     },
     {
       "scene": "blend/additive-overlap",
+      "property": "oracle-agreement",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "blend/additive-overlap",
       "property": "renders-something",
       "feature": "BlendMode",
       "browser": "chromium",
@@ -49,6 +60,174 @@
       "delta": 0
     },
     {
+      "scene": "blend/additive-solid-overlap",
+      "property": "cross-backend-parity",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "blend/additive-solid-overlap",
+      "property": "oracle-agreement",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "oracle",
+      "delta": 0,
+      "note": "4 computed pixel(s) within 1 of additive blending: out = src + dst, clamped"
+    },
+    {
+      "scene": "blend/additive-solid-overlap",
+      "property": "renders-something",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "sampled",
+      "delta": null,
+      "note": "1792/4096 pixels drawn"
+    },
+    {
+      "scene": "blend/additive-solid-overlap",
+      "property": "repeat-render-determinism",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "blend/alpha-over-solid",
+      "property": "cross-backend-parity",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "blend/alpha-over-solid",
+      "property": "oracle-agreement",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "oracle",
+      "delta": 1,
+      "note": "2 computed pixel(s) within 2 of premultiplied source-over: out = src*a + dst*(1 - a), with src = blue at a = 0.5 over opaque red"
+    },
+    {
+      "scene": "blend/alpha-over-solid",
+      "property": "renders-something",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "sampled",
+      "delta": null,
+      "note": "2304/4096 pixels drawn"
+    },
+    {
+      "scene": "blend/alpha-over-solid",
+      "property": "repeat-render-determinism",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "filter/color-matrix-channel-swap",
+      "property": "cross-backend-parity",
+      "feature": "ColorMatrixFilter",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "filter/color-matrix-channel-swap",
+      "property": "oracle-agreement",
+      "feature": "ColorMatrixFilter",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "oracle",
+      "delta": 0,
+      "note": "1 computed pixel(s) within 2 of RGBA = M*RGBA with R and B swapped, over an opaque (64, 128, 192) fill"
+    },
+    {
+      "scene": "filter/color-matrix-channel-swap",
+      "property": "renders-something",
+      "feature": "ColorMatrixFilter",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "sampled",
+      "delta": null,
+      "note": "2304/4096 pixels drawn"
+    },
+    {
+      "scene": "filter/color-matrix-channel-swap",
+      "property": "repeat-render-determinism",
+      "feature": "ColorMatrixFilter",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "gradient/linear-black-to-white",
+      "property": "cross-backend-parity",
+      "feature": "Gradient",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "gradient/linear-black-to-white",
+      "property": "oracle-agreement",
+      "feature": "Gradient",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "oracle",
+      "delta": 1,
+      "note": "3 computed pixel(s) within 4 of a two-stop black-to-white ramp across the shape bounds: channel = 255 * (x + 0.5) / 64"
+    },
+    {
+      "scene": "gradient/linear-black-to-white",
+      "property": "renders-something",
+      "feature": "Gradient",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "sampled",
+      "delta": null,
+      "note": "4096/4096 pixels drawn"
+    },
+    {
+      "scene": "gradient/linear-black-to-white",
+      "property": "repeat-render-determinism",
+      "feature": "Gradient",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
       "scene": "graphics/overlapping-fills",
       "property": "cross-backend-parity",
       "feature": "Graphics",
@@ -57,6 +236,17 @@
       "support": "supported",
       "evidence": "frame-equal",
       "delta": 0
+    },
+    {
+      "scene": "graphics/overlapping-fills",
+      "property": "oracle-agreement",
+      "feature": "Graphics",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "graphics/overlapping-fills",
@@ -91,6 +281,17 @@
     },
     {
       "scene": "graphics/solid-rectangle",
+      "property": "oracle-agreement",
+      "feature": "Graphics",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "graphics/solid-rectangle",
       "property": "renders-something",
       "feature": "Graphics",
       "browser": "chromium",
@@ -119,6 +320,17 @@
       "support": "supported",
       "evidence": "traced",
       "delta": 0
+    },
+    {
+      "scene": "mask/triangle-clip",
+      "property": "oracle-agreement",
+      "feature": "Mask",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "mask/triangle-clip",
@@ -153,6 +365,17 @@
     },
     {
       "scene": "mesh/mirrored-uvs",
+      "property": "oracle-agreement",
+      "feature": "Mesh",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "mesh/mirrored-uvs",
       "property": "renders-something",
       "feature": "Mesh",
       "browser": "chromium",
@@ -184,6 +407,17 @@
     },
     {
       "scene": "mesh/textured-quad",
+      "property": "oracle-agreement",
+      "feature": "Mesh",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "mesh/textured-quad",
       "property": "renders-something",
       "feature": "Mesh",
       "browser": "chromium",
@@ -212,6 +446,17 @@
       "support": "supported",
       "evidence": "traced",
       "delta": 0
+    },
+    {
+      "scene": "nine-slice/stretched",
+      "property": "oracle-agreement",
+      "feature": "NineSlice",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "nine-slice/stretched",
@@ -246,6 +491,17 @@
     },
     {
       "scene": "nine-slice/unstretched",
+      "property": "oracle-agreement",
+      "feature": "NineSlice",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "nine-slice/unstretched",
       "property": "renders-something",
       "feature": "NineSlice",
       "browser": "chromium",
@@ -277,6 +533,17 @@
     },
     {
       "scene": "particles/static-quad",
+      "property": "oracle-agreement",
+      "feature": "Particles",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "particles/static-quad",
       "property": "renders-something",
       "feature": "Particles",
       "browser": "chromium",
@@ -305,6 +572,17 @@
       "support": "supported",
       "evidence": "frame-equal",
       "delta": 0
+    },
+    {
+      "scene": "render-batch/custom-material-instance-attributes",
+      "property": "oracle-agreement",
+      "feature": "RenderBatch",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "render-batch/custom-material-instance-attributes",
@@ -339,6 +617,17 @@
     },
     {
       "scene": "render-batch/default-material",
+      "property": "oracle-agreement",
+      "feature": "RenderBatch",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "render-batch/default-material",
       "property": "renders-something",
       "feature": "RenderBatch",
       "browser": "chromium",
@@ -370,6 +659,17 @@
     },
     {
       "scene": "repeating/tiled",
+      "property": "oracle-agreement",
+      "feature": "RepeatingSprite",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "repeating/tiled",
       "property": "renders-something",
       "feature": "RepeatingSprite",
       "browser": "chromium",
@@ -398,6 +698,17 @@
       "support": "supported",
       "evidence": "frame-equal",
       "delta": 0
+    },
+    {
+      "scene": "sprite/canvas-texture",
+      "property": "oracle-agreement",
+      "feature": "Sprite",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "sprite/canvas-texture",
@@ -432,6 +743,17 @@
     },
     {
       "scene": "sprite/origin",
+      "property": "oracle-agreement",
+      "feature": "Sprite",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "sprite/origin",
       "property": "renders-something",
       "feature": "Sprite",
       "browser": "chromium",
@@ -463,6 +785,17 @@
     },
     {
       "scene": "sprite/translated",
+      "property": "oracle-agreement",
+      "feature": "Sprite",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "sprite/translated",
       "property": "renders-something",
       "feature": "Sprite",
       "browser": "chromium",
@@ -491,6 +824,17 @@
       "support": "supported",
       "evidence": "frame-equal",
       "delta": 0
+    },
+    {
+      "scene": "text/sdf-glyphs",
+      "property": "oracle-agreement",
+      "feature": "Text",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "text/sdf-glyphs",
@@ -525,6 +869,17 @@
     },
     {
       "scene": "tilemap/two-by-two",
+      "property": "oracle-agreement",
+      "feature": "Tilemap",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "tilemap/two-by-two",
       "property": "renders-something",
       "feature": "Tilemap",
       "browser": "chromium",
@@ -556,6 +911,17 @@
     },
     {
       "scene": "tint/half-intensity",
+      "property": "oracle-agreement",
+      "feature": "Tint",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "tint/half-intensity",
       "property": "renders-something",
       "feature": "Tint",
       "browser": "chromium",
@@ -587,6 +953,17 @@
     },
     {
       "scene": "transform/flipped-x",
+      "property": "oracle-agreement",
+      "feature": "Transform",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "transform/flipped-x",
       "property": "renders-something",
       "feature": "Transform",
       "browser": "chromium",
@@ -618,6 +995,17 @@
     },
     {
       "scene": "transform/nested-parent-offset",
+      "property": "oracle-agreement",
+      "feature": "Transform",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "transform/nested-parent-offset",
       "property": "renders-something",
       "feature": "Transform",
       "browser": "chromium",
@@ -649,6 +1037,17 @@
     },
     {
       "scene": "transform/rotated-quarter-turn",
+      "property": "oracle-agreement",
+      "feature": "Transform",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "transform/rotated-quarter-turn",
       "property": "renders-something",
       "feature": "Transform",
       "browser": "chromium",
@@ -677,6 +1076,17 @@
       "support": "supported",
       "evidence": "traced",
       "delta": 0
+    },
+    {
+      "scene": "transform/scaled-2x",
+      "property": "oracle-agreement",
+      "feature": "Transform",
+      "browser": "chromium",
+      "backend": "webgl2",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "transform/scaled-2x",
@@ -711,6 +1121,17 @@
     },
     {
       "scene": "blend/additive-overlap",
+      "property": "oracle-agreement",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "blend/additive-overlap",
       "property": "renders-something",
       "feature": "BlendMode",
       "browser": "chromium",
@@ -731,6 +1152,174 @@
       "delta": 0
     },
     {
+      "scene": "blend/additive-solid-overlap",
+      "property": "cross-backend-parity",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "blend/additive-solid-overlap",
+      "property": "oracle-agreement",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "oracle",
+      "delta": 0,
+      "note": "4 computed pixel(s) within 1 of additive blending: out = src + dst, clamped"
+    },
+    {
+      "scene": "blend/additive-solid-overlap",
+      "property": "renders-something",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "sampled",
+      "delta": null,
+      "note": "1792/4096 pixels drawn"
+    },
+    {
+      "scene": "blend/additive-solid-overlap",
+      "property": "repeat-render-determinism",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "blend/alpha-over-solid",
+      "property": "cross-backend-parity",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "blend/alpha-over-solid",
+      "property": "oracle-agreement",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "oracle",
+      "delta": 1,
+      "note": "2 computed pixel(s) within 2 of premultiplied source-over: out = src*a + dst*(1 - a), with src = blue at a = 0.5 over opaque red"
+    },
+    {
+      "scene": "blend/alpha-over-solid",
+      "property": "renders-something",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "sampled",
+      "delta": null,
+      "note": "2304/4096 pixels drawn"
+    },
+    {
+      "scene": "blend/alpha-over-solid",
+      "property": "repeat-render-determinism",
+      "feature": "BlendMode",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "filter/color-matrix-channel-swap",
+      "property": "cross-backend-parity",
+      "feature": "ColorMatrixFilter",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "filter/color-matrix-channel-swap",
+      "property": "oracle-agreement",
+      "feature": "ColorMatrixFilter",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "oracle",
+      "delta": 0,
+      "note": "1 computed pixel(s) within 2 of RGBA = M*RGBA with R and B swapped, over an opaque (64, 128, 192) fill"
+    },
+    {
+      "scene": "filter/color-matrix-channel-swap",
+      "property": "renders-something",
+      "feature": "ColorMatrixFilter",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "sampled",
+      "delta": null,
+      "note": "2304/4096 pixels drawn"
+    },
+    {
+      "scene": "filter/color-matrix-channel-swap",
+      "property": "repeat-render-determinism",
+      "feature": "ColorMatrixFilter",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "gradient/linear-black-to-white",
+      "property": "cross-backend-parity",
+      "feature": "Gradient",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
+      "scene": "gradient/linear-black-to-white",
+      "property": "oracle-agreement",
+      "feature": "Gradient",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "oracle",
+      "delta": 1,
+      "note": "3 computed pixel(s) within 4 of a two-stop black-to-white ramp across the shape bounds: channel = 255 * (x + 0.5) / 64"
+    },
+    {
+      "scene": "gradient/linear-black-to-white",
+      "property": "renders-something",
+      "feature": "Gradient",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "sampled",
+      "delta": null,
+      "note": "4096/4096 pixels drawn"
+    },
+    {
+      "scene": "gradient/linear-black-to-white",
+      "property": "repeat-render-determinism",
+      "feature": "Gradient",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "supported",
+      "evidence": "frame-equal",
+      "delta": 0
+    },
+    {
       "scene": "graphics/overlapping-fills",
       "property": "cross-backend-parity",
       "feature": "Graphics",
@@ -739,6 +1328,17 @@
       "support": "supported",
       "evidence": "frame-equal",
       "delta": 0
+    },
+    {
+      "scene": "graphics/overlapping-fills",
+      "property": "oracle-agreement",
+      "feature": "Graphics",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "graphics/overlapping-fills",
@@ -773,6 +1373,17 @@
     },
     {
       "scene": "graphics/solid-rectangle",
+      "property": "oracle-agreement",
+      "feature": "Graphics",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "graphics/solid-rectangle",
       "property": "renders-something",
       "feature": "Graphics",
       "browser": "chromium",
@@ -801,6 +1412,17 @@
       "support": "supported",
       "evidence": "traced",
       "delta": 0
+    },
+    {
+      "scene": "mask/triangle-clip",
+      "property": "oracle-agreement",
+      "feature": "Mask",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "mask/triangle-clip",
@@ -835,6 +1457,17 @@
     },
     {
       "scene": "mesh/mirrored-uvs",
+      "property": "oracle-agreement",
+      "feature": "Mesh",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "mesh/mirrored-uvs",
       "property": "renders-something",
       "feature": "Mesh",
       "browser": "chromium",
@@ -866,6 +1499,17 @@
     },
     {
       "scene": "mesh/textured-quad",
+      "property": "oracle-agreement",
+      "feature": "Mesh",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "mesh/textured-quad",
       "property": "renders-something",
       "feature": "Mesh",
       "browser": "chromium",
@@ -894,6 +1538,17 @@
       "support": "supported",
       "evidence": "traced",
       "delta": 0
+    },
+    {
+      "scene": "nine-slice/stretched",
+      "property": "oracle-agreement",
+      "feature": "NineSlice",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "nine-slice/stretched",
@@ -928,6 +1583,17 @@
     },
     {
       "scene": "nine-slice/unstretched",
+      "property": "oracle-agreement",
+      "feature": "NineSlice",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "nine-slice/unstretched",
       "property": "renders-something",
       "feature": "NineSlice",
       "browser": "chromium",
@@ -959,6 +1625,17 @@
     },
     {
       "scene": "particles/static-quad",
+      "property": "oracle-agreement",
+      "feature": "Particles",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "particles/static-quad",
       "property": "renders-something",
       "feature": "Particles",
       "browser": "chromium",
@@ -987,6 +1664,17 @@
       "support": "supported",
       "evidence": "frame-equal",
       "delta": 0
+    },
+    {
+      "scene": "render-batch/custom-material-instance-attributes",
+      "property": "oracle-agreement",
+      "feature": "RenderBatch",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "render-batch/custom-material-instance-attributes",
@@ -1021,6 +1709,17 @@
     },
     {
       "scene": "render-batch/default-material",
+      "property": "oracle-agreement",
+      "feature": "RenderBatch",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "render-batch/default-material",
       "property": "renders-something",
       "feature": "RenderBatch",
       "browser": "chromium",
@@ -1052,6 +1751,17 @@
     },
     {
       "scene": "repeating/tiled",
+      "property": "oracle-agreement",
+      "feature": "RepeatingSprite",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "repeating/tiled",
       "property": "renders-something",
       "feature": "RepeatingSprite",
       "browser": "chromium",
@@ -1080,6 +1790,17 @@
       "support": "supported",
       "evidence": "frame-equal",
       "delta": 0
+    },
+    {
+      "scene": "sprite/canvas-texture",
+      "property": "oracle-agreement",
+      "feature": "Sprite",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "sprite/canvas-texture",
@@ -1114,6 +1835,17 @@
     },
     {
       "scene": "sprite/origin",
+      "property": "oracle-agreement",
+      "feature": "Sprite",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "sprite/origin",
       "property": "renders-something",
       "feature": "Sprite",
       "browser": "chromium",
@@ -1145,6 +1877,17 @@
     },
     {
       "scene": "sprite/translated",
+      "property": "oracle-agreement",
+      "feature": "Sprite",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "sprite/translated",
       "property": "renders-something",
       "feature": "Sprite",
       "browser": "chromium",
@@ -1173,6 +1916,17 @@
       "support": "supported",
       "evidence": "frame-equal",
       "delta": 0
+    },
+    {
+      "scene": "text/sdf-glyphs",
+      "property": "oracle-agreement",
+      "feature": "Text",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "text/sdf-glyphs",
@@ -1207,6 +1961,17 @@
     },
     {
       "scene": "tilemap/two-by-two",
+      "property": "oracle-agreement",
+      "feature": "Tilemap",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "tilemap/two-by-two",
       "property": "renders-something",
       "feature": "Tilemap",
       "browser": "chromium",
@@ -1238,6 +2003,17 @@
     },
     {
       "scene": "tint/half-intensity",
+      "property": "oracle-agreement",
+      "feature": "Tint",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "tint/half-intensity",
       "property": "renders-something",
       "feature": "Tint",
       "browser": "chromium",
@@ -1269,6 +2045,17 @@
     },
     {
       "scene": "transform/flipped-x",
+      "property": "oracle-agreement",
+      "feature": "Transform",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "transform/flipped-x",
       "property": "renders-something",
       "feature": "Transform",
       "browser": "chromium",
@@ -1300,6 +2087,17 @@
     },
     {
       "scene": "transform/nested-parent-offset",
+      "property": "oracle-agreement",
+      "feature": "Transform",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "transform/nested-parent-offset",
       "property": "renders-something",
       "feature": "Transform",
       "browser": "chromium",
@@ -1331,6 +2129,17 @@
     },
     {
       "scene": "transform/rotated-quarter-turn",
+      "property": "oracle-agreement",
+      "feature": "Transform",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
+    },
+    {
+      "scene": "transform/rotated-quarter-turn",
       "property": "renders-something",
       "feature": "Transform",
       "browser": "chromium",
@@ -1359,6 +2168,17 @@
       "support": "supported",
       "evidence": "traced",
       "delta": 0
+    },
+    {
+      "scene": "transform/scaled-2x",
+      "property": "oracle-agreement",
+      "feature": "Transform",
+      "browser": "chromium",
+      "backend": "webgpu",
+      "support": "unknown",
+      "evidence": "none",
+      "delta": null,
+      "note": "property does not apply to this scene"
     },
     {
       "scene": "transform/scaled-2x",

--- a/test/rendering/parity/matrix.test.ts
+++ b/test/rendering/parity/matrix.test.ts
@@ -10,10 +10,12 @@
 
 import { crossBackendParity } from './properties/crossBackendParity';
 import { determinism } from './properties/determinism';
+import { oracleAgreement } from './properties/oracleAgreement';
 import { rendersSomething } from './properties/rendersSomething';
 import { runParityMatrix } from './runner';
 import { clippingScenes } from './scenes/clipping';
 import { colourScenes } from './scenes/colour';
+import { computedColourScenes } from './scenes/computedColour';
 import { graphicsScenes } from './scenes/graphics';
 import { meshScenes } from './scenes/mesh';
 import { nineSliceScenes } from './scenes/nineSlice';
@@ -37,12 +39,13 @@ const scenes: readonly Scene[] = [
   ...transformScenes,
   ...graphicsScenes,
   ...colourScenes,
+  ...computedColourScenes,
   ...clippingScenes,
   ...textScenes,
   ...tilemapScenes,
   ...particleScenes,
 ];
 
-const properties: readonly Property[] = [crossBackendParity, determinism, rendersSomething];
+const properties: readonly Property[] = [crossBackendParity, determinism, rendersSomething, oracleAgreement];
 
 runParityMatrix(scenes, properties);

--- a/test/rendering/parity/properties/crossBackendParity.ts
+++ b/test/rendering/parity/properties/crossBackendParity.ts
@@ -5,13 +5,16 @@
  * it does *not* catch: if both backends are wrong in the same way, they still
  * agree. Correctness against an independent expectation is the oracle
  * property's job.
+ *
+ * One case it refuses outright: two empty frames match perfectly and would
+ * otherwise fill a row with a claim about nothing.
  */
 
 import { Color } from '#core/Color';
 
 import { readWebGl2Frame, readWebGpuFrame, renderWebGl2Once, renderWebGpuOnce, webGl2Available, webGpuAvailable } from '../../browser/_backendSetup';
 import { openWebGl2, openWebGpu } from '../backends';
-import { maxChannelDelta, pixelsExceeding } from '../frames';
+import { drawnPixelCount, maxChannelDelta, pixelsExceeding } from '../frames';
 import type { CrossBackendProperty, PropertyResult } from '../types';
 
 /**
@@ -56,6 +59,16 @@ export const crossBackendParity: CrossBackendProperty = {
 
       const glFrame = readWebGl2Frame(gl, scene.size);
       const gpuFrame = readWebGpuFrame(gpu, scene.size);
+
+      // Two empty frames are byte-identical, so the comparison below would
+      // report a perfect match about nothing at all. `renders-something` covers
+      // the same ground as its own row, but a green parity row claiming
+      // `traced` is the misleading one, so emptiness is a precondition here
+      // rather than a neighbouring property's business.
+      if (drawnPixelCount(glFrame) === 0 && drawnPixelCount(gpuFrame) === 0) {
+        return { support: 'divergent', evidence: 'none', delta: null, note: 'both backends rendered an empty frame - nothing was compared' };
+      }
+
       const delta = maxChannelDelta(glFrame, gpuFrame);
 
       if (delta === 0) {

--- a/test/rendering/parity/properties/oracleAgreement.ts
+++ b/test/rendering/parity/properties/oracleAgreement.ts
@@ -1,0 +1,111 @@
+/**
+ * The rendered pixel must match an expectation computed without a renderer.
+ *
+ * This is the one property that can say a frame is *right* rather than merely
+ * consistent. Cross-backend parity and determinism both compare a rendering
+ * against another rendering, so two backends that compute a colour the same
+ * wrong way agree perfectly, and a backend that computes it wrongly every time
+ * is perfectly deterministic.
+ *
+ * It applies only to scenes that declare a {@link SceneOracle}, which is the
+ * point: where a pixel traces back to its source texel, the gap is already
+ * closed - a `traced` verdict is itself a renderer-independent expectation.
+ * What it cannot cover is computed colour, where the output is a function of
+ * several inputs and no texel to trace. That is what this property is for.
+ */
+
+import { Color } from '#core/Color';
+
+import { readWebGl2Frame, readWebGpuFrame, renderWebGl2Once, renderWebGpuOnce, webGl2Available, webGpuAvailable } from '../../browser/_backendSetup';
+import { openWebGl2, openWebGpu } from '../backends';
+import type { OracleSample, PerBackendProperty, PropertyResult, SceneOracle } from '../types';
+
+const channels = ['R', 'G', 'B', 'A'] as const;
+
+const readPixel = (frame: ArrayLike<number>, size: number, sample: OracleSample): readonly [number, number, number, number] => {
+  const i = (sample.y * size + sample.x) * 4;
+
+  return [frame[i] ?? 0, frame[i + 1] ?? 0, frame[i + 2] ?? 0, frame[i + 3] ?? 0];
+};
+
+const compare = (frame: ArrayLike<number>, size: number, oracle: SceneOracle): PropertyResult => {
+  const samples = oracle.samples();
+  let worst = 0;
+  let worstNote: string | null = null;
+
+  for (const sample of samples) {
+    const actual = readPixel(frame, size, sample);
+
+    for (let c = 0; c < 4; c++) {
+      const delta = Math.abs(actual[c]! - sample.expect[c]!);
+
+      if (delta > worst) {
+        worst = delta;
+        worstNote = `${sample.describe} at (${sample.x}, ${sample.y}): ${channels[c]} is ${actual[c]}, expected ${sample.expect[c]}`;
+      }
+    }
+  }
+
+  if (worst <= oracle.tolerance) {
+    return {
+      support: 'supported',
+      evidence: 'oracle',
+      delta: worst,
+      note: `${samples.length} computed pixel(s) within ${oracle.tolerance} of ${oracle.reason}`,
+    };
+  }
+
+  return {
+    support: 'divergent',
+    evidence: 'oracle',
+    delta: worst,
+    note: `${worstNote} (tolerance ${oracle.tolerance}; ${oracle.reason})`,
+  };
+};
+
+export const oracleAgreement: PerBackendProperty = {
+  name: 'oracle-agreement',
+  scope: 'per-backend',
+  appliesTo: scene => scene.oracle !== undefined,
+
+  run: async ({ scene, skip }, backend): Promise<PropertyResult> => {
+    // `appliesTo` already gated this, but the type has to be narrowed here too.
+    const oracle = scene.oracle;
+
+    if (oracle === undefined) {
+      return { support: 'unknown', evidence: 'none', delta: null, note: 'scene declares no oracle' };
+    }
+
+    if (backend === 'webgl2') {
+      if (!webGl2Available()) {
+        return { support: 'unavailable', evidence: 'none', delta: null, note: 'no WebGL2 context in this browser' };
+      }
+
+      const gl = await openWebGl2(scene);
+
+      try {
+        renderWebGl2Once(gl, scene.build(), Color.black);
+
+        return compare(readWebGl2Frame(gl, scene.size), scene.size, oracle);
+      } finally {
+        gl.destroy();
+      }
+    }
+
+    if (!(await webGpuAvailable())) {
+      return { support: 'unavailable', evidence: 'none', delta: null, note: 'no WebGPU adapter in this browser' };
+    }
+
+    const gpu = await openWebGpu(scene);
+
+    try {
+      if (!(await renderWebGpuOnce({ skip }, gpu, scene.build(), Color.black))) {
+        return { support: 'unknown', evidence: 'none', delta: null, note: 'WebGPU device lost mid-run' };
+      }
+
+      return compare(readWebGpuFrame(gpu, scene.size), scene.size, oracle);
+    } finally {
+      gpu.destroy();
+    }
+  },
+};

--- a/test/rendering/parity/scenes/computedColour.ts
+++ b/test/rendering/parity/scenes/computedColour.ts
@@ -1,0 +1,203 @@
+/**
+ * Scenes whose output colour is *computed* from known inputs rather than
+ * sampled from a texel.
+ *
+ * This is the one class the rest of the matrix structurally cannot verify.
+ * Where a pixel traces back to the texel it came from, the expectation is
+ * already renderer-independent; a blend, a colour matrix or a gradient stop has
+ * no texel to trace, and comparing the two backends only shows that they agree.
+ * Every scene here therefore carries an oracle: the expected pixel follows from
+ * the scene's own inputs and the documented blend arithmetic, computed on the
+ * CPU.
+ *
+ * The inputs are deliberately flat solids at exact values. A wrong colour space,
+ * an unpremultiplied source or a reversed gradient moves these pixels by tens of
+ * steps, so the tolerances stay small enough to be worth something.
+ */
+
+import { Color } from '#core/Color';
+import { Container } from '#rendering/Container';
+import { ColorMatrixFilter } from '#rendering/filters/ColorMatrixFilter';
+import { LinearGradient } from '#rendering/gradient/LinearGradient';
+import { Graphics } from '#rendering/primitives/Graphics';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { DataTexture } from '#rendering/texture/DataTexture';
+import { BlendModes, TextureFormat } from '#rendering/types';
+
+import type { OracleSample, Scene } from '../types';
+
+const CANVAS = 64;
+
+/**
+ * The additive pair, named rather than taken from `Color`'s CSS table: the
+ * oracle reads these same objects, so the expected sum cannot drift away from
+ * what the scene actually drew.
+ */
+const ADDITIVE_BACKDROP = new Color(200, 40, 0, 1);
+const ADDITIVE_OVERLAY = new Color(80, 160, 0, 1);
+
+/**
+ * A flat opaque square as a sprite rather than a `Graphics` fill: node alpha
+ * and blend mode live on `Drawable`, and `Graphics` is a `Container`.
+ */
+const square = (color: Color, x: number, y: number, size: number): Sprite => {
+  const data = new Uint8Array(size * size * 4);
+
+  for (let i = 0; i < size * size; i++) {
+    data[i * 4] = color.r;
+    data[i * 4 + 1] = color.g;
+    data[i * 4 + 2] = color.b;
+    data[i * 4 + 3] = 255;
+  }
+
+  const sprite = new Sprite(new DataTexture({ width: size, height: size, format: TextureFormat.Rgba8, data }));
+
+  sprite.setPosition(x, y);
+
+  return sprite;
+};
+
+const rooted = (...children: readonly RenderNode[]): Container => {
+  const root = new Container();
+
+  for (const child of children) root.addChild(child);
+
+  return root;
+};
+
+/** The cleared canvas, sampled where nothing was drawn - the cheapest way to catch a scene that covered everything. */
+const clearedAt = (x: number, y: number): OracleSample => ({ x, y, expect: [0, 0, 0, 255], describe: 'cleared background' });
+
+export const computedColourScenes: readonly Scene[] = [
+  {
+    // Source-over with a half-transparent source is where a premultiply
+    // mistake shows: an unpremultiplied source doubles its own contribution,
+    // so the overlap reads far brighter than the arithmetic allows.
+    name: 'blend/alpha-over-solid',
+    feature: 'BlendMode',
+    size: CANVAS,
+    fixture: 'opaque-solid',
+    nearestSampled: false,
+    build: () => {
+      const overlay = square(Color.blue, 8, 8, 48);
+
+      // Transparency comes from the tint's alpha: the engine has no node-level
+      // alpha, and this is the path the shader premultiplies.
+      overlay.tint = new Color(255, 255, 255, 0.5);
+
+      return rooted(square(Color.red, 8, 8, 48), overlay);
+    },
+    oracle: {
+      reason: 'premultiplied source-over: out = src*a + dst*(1 - a), with src = blue at a = 0.5 over opaque red',
+      // The half of an odd 8-bit value has to land somewhere, and the source is
+      // premultiplied before the target quantises it a second time.
+      tolerance: 2,
+      samples: () => [{ x: 32, y: 32, expect: [128, 0, 128, 255], describe: 'blue at 50% over red' }, clearedAt(2, 2)],
+    },
+  },
+  {
+    // Additive is `one`/`one` on both colour and alpha, so every value here is
+    // an exact integer and the tolerance can be a single step.
+    name: 'blend/additive-solid-overlap',
+    feature: 'BlendMode',
+    size: CANVAS,
+    fixture: 'opaque-solid',
+    nearestSampled: false,
+    build: () => {
+      const overlay = square(ADDITIVE_OVERLAY, 24, 24, 32);
+
+      overlay.blendMode = BlendModes.Additive;
+
+      return rooted(square(ADDITIVE_BACKDROP, 8, 8, 32), overlay);
+    },
+    oracle: {
+      reason: 'additive blending: out = src + dst, clamped',
+      tolerance: 1,
+      samples: () => {
+        const sum = (a: number, b: number): number => Math.min(255, a + b);
+
+        return [
+          { x: 12, y: 12, expect: [ADDITIVE_BACKDROP.r, ADDITIVE_BACKDROP.g, ADDITIVE_BACKDROP.b, 255], describe: 'backdrop only' },
+          {
+            x: 32,
+            y: 32,
+            expect: [
+              sum(ADDITIVE_BACKDROP.r, ADDITIVE_OVERLAY.r),
+              sum(ADDITIVE_BACKDROP.g, ADDITIVE_OVERLAY.g),
+              sum(ADDITIVE_BACKDROP.b, ADDITIVE_OVERLAY.b),
+              255,
+            ],
+            describe: 'backdrop + overlay overlap',
+          },
+          { x: 48, y: 48, expect: [ADDITIVE_OVERLAY.r, ADDITIVE_OVERLAY.g, ADDITIVE_OVERLAY.b, 255], describe: 'overlay over the cleared canvas' },
+          clearedAt(2, 2),
+        ];
+      },
+    },
+  },
+  {
+    // A channel swap is the strictest colour-matrix check that stays exact: it
+    // moves whole channels, so a transposed matrix, a row/column mix-up or a
+    // straight/premultiplied confusion cannot land on the right answer by
+    // accident.
+    name: 'filter/color-matrix-channel-swap',
+    feature: 'ColorMatrixFilter',
+    size: CANVAS,
+    fixture: 'opaque-solid',
+    nearestSampled: false,
+    build: () => {
+      const root = rooted(square(new Color(64, 128, 192, 1), 8, 8, 48));
+
+      // Rows are [r, g, b, a, offset]: red takes blue, blue takes red.
+      root.filters = [new ColorMatrixFilter([0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0])];
+
+      return root;
+    },
+    oracle: {
+      reason: 'RGBA = M*RGBA with R and B swapped, over an opaque (64, 128, 192) fill',
+      // The filter grades on straight alpha, so an opaque pixel makes one round
+      // trip through the render target and back.
+      tolerance: 2,
+      samples: () => [{ x: 32, y: 32, expect: [192, 128, 64, 255], describe: 'swapped fill' }],
+    },
+  },
+  {
+    // A ramp is the only colour path here whose expectation depends on *where*
+    // the pixel is, which is what makes a reversed or misaligned gradient
+    // visible rather than merely different.
+    name: 'gradient/linear-black-to-white',
+    feature: 'Gradient',
+    size: CANVAS,
+    fixture: 'interpolated',
+    nearestSampled: false,
+    build: () => {
+      const graphics = new Graphics();
+
+      graphics.fillStyle = new LinearGradient(
+        [
+          { offset: 0, color: Color.black },
+          { offset: 1, color: Color.white },
+        ],
+        [0, 0],
+        [1, 0],
+      );
+      graphics.drawRectangle(0, 0, CANVAS, CANVAS);
+
+      return rooted(graphics);
+    },
+    oracle: {
+      reason: 'a two-stop black-to-white ramp across the shape bounds: channel = 255 * (x + 0.5) / 64',
+      // The ramp is rasterized to a 256px texture and sampled with linear
+      // filtering, so the expectation carries a texel of slack on either side.
+      // A reversed or misaligned gradient is off by tens of steps, not four.
+      tolerance: 4,
+      samples: () =>
+        [16, 32, 48].map(x => {
+          const value = Math.round((255 * (x + 0.5)) / CANVAS);
+
+          return { x, y: 32, expect: [value, value, value, 255] as const, describe: `ramp at x=${x}` };
+        }),
+    },
+  },
+];

--- a/test/rendering/parity/types.ts
+++ b/test/rendering/parity/types.ts
@@ -31,6 +31,39 @@ export type { EvidenceClass, EvidenceRow, SupportState } from './evidenceSink';
  */
 export type FixtureKind = 'self-describing' | 'colour-modified' | 'opaque-solid' | 'interpolated';
 
+/** One pixel whose value follows from the scene's own inputs, not from a previous run. */
+export interface OracleSample {
+  /** Canvas coordinates of the pixel to read. */
+  readonly x: number;
+  readonly y: number;
+  /** Expected RGBA in 0..255, computed on the CPU from the scene's inputs. */
+  readonly expect: readonly [number, number, number, number];
+  /** What this pixel is, in the scene's own terms - read back on failure. */
+  readonly describe: string;
+}
+
+/**
+ * An independent expectation for a scene, which is what separates correctness
+ * from agreement: two backends that compute the same colour wrongly still match
+ * each other, and no comparison between them can say so.
+ *
+ * Only worth declaring where the expected value is genuinely derivable - a
+ * blend of two known colours, a colour matrix applied to a known input, a stop
+ * interpolated along a gradient. A hardcoded table read off a previous run is a
+ * golden image with extra steps and does not belong here.
+ */
+export interface SceneOracle {
+  /** Why these pixels are computable without a renderer. Ends up in the evidence note. */
+  readonly reason: string;
+  /**
+   * Largest per-channel deviation the arithmetic itself permits, in 8-bit
+   * steps. Covers quantisation on the way through an 8-bit render target and
+   * the rounding of a premultiply, never a disagreement about what to compute.
+   */
+  readonly tolerance: number;
+  readonly samples: () => readonly OracleSample[];
+}
+
 export interface Scene {
   /** Stable identifier, `feature/variant` by convention. Used as the matrix key. */
   readonly name: string;
@@ -70,6 +103,12 @@ export interface Scene {
    * renderer would be worse than no row at all.
    */
   readonly wireRenderers?: (backend: RenderBackend) => void;
+  /**
+   * Expected pixel values derived from this scene's own inputs. Declaring one
+   * is what lets the scene reach `oracle` evidence; without it the scene can
+   * only be compared against another rendering of itself.
+   */
+  readonly oracle?: SceneOracle;
 }
 
 /** What a property observed. `support` and `evidence` are deliberately separate axes. */


### PR DESCRIPTION
Closes the four work packages of group A from the open-decision backlog (ADR 0004): the ones that had no precondition and could be taken in any order. Thirteen commits, one per step.

## Diagnostics — `ME-80`, `ME-81`

The three-way split (`assert`/`assertDefined`, `invariant`, typed error) existed in `src/core/dev.ts` but was written down nowhere, so ten files imported it while the main subsystems threw a bare `Error` several hundred times. `CONTRIBUTING.md` now states which tool fits which failure, when a failure earns its own error class, and the argument-evaluation trap that makes a formatted assert message allocate in production.

`audio`, `input`, `math` and the untyped remainder of `assets` were then evaluated against it. Three classes earn their place:

| Class | Raised for | What the caller does |
| --- | --- | --- |
| `AudioUnsupportedError` | no `AudioContext` / `OfflineAudioContext` / `getUserMedia` | disable audio outright |
| `InputBindingError` | an unreadable saved binding profile (22 sites) | discard the save, fall back to defaults |
| `AssetDecodeError` | bytes that arrived intact and will not decode | drop the asset; a retry will not help |

Both ADR expectations were confirmed rather than assumed: `math` gains none, `input` exactly one. `AudioInput.open()` deliberately keeps passing the browser's `DOMException` through — its `name` is the standard branch key. Programmer errors stay a plain `Error` so a `catch` around a profile load does not swallow a bug. The 414 pre-existing throws are not swept.

Four silent misuses turned up in the same pass and are now asserted: the same audio effect attached twice (a feedback loop in the graph), two gamepad controls on one channel, and an odd-length coordinate list in `triangulate()`/`buildPath()`.

One real defect fell out of it: `AssetDecoder` wrapped every failure but three in a plain `Error`, so an `AssetNetworkError` — documented as narrowable, carrying `status`/`statusText` — never reached a caller as itself.

## Audio sprite sidecar — `NEU-O2`

`sprites` on a `sound` asset now also takes a source string naming a JSON sidecar with the same map. It loads through the sound's own dependency scope, the way `LdtkProject` claims its atlases, so one asset is configured instead of two. The path resolves against the loader's base path like any other asset source — deliberately *not* relative to the audio file. No foreign-format adapter: `audiosprite` and Howler do not even share a file layout, so that conversion belongs in a build step.

## API convention — `NEU-X2`

`CONTRIBUTING.md` gains *Free function or class member?*, including the two carve-outs (React `use*`, and the package prefix that the flat `window.Exo` bundle needs). Slice 1 is the whole rename: `tiledObjectAnchorOffset`, `wgslFieldLayout` and `wgslUniformByteSize` become `get*`. **Breaking**, pre-1.0, no shims.

## Parity oracle — `ME-82`

`oracle` was the matrix's strongest evidence class and appeared **zero** times in the checked-in evidence: every property compared a rendering against another rendering. A scene can now declare a `SceneOracle` — expected pixels derived on the CPU from its own inputs — and `oracle-agreement` checks them per backend. Four new scenes cover the class a traced pixel cannot reach: premultiplied source-over, additive blending, a colour-matrix channel swap and a linear gradient ramp. Evidence goes 0 → 8 `oracle` rows.

No blanket mandate: where a pixel traces back to its source texel the expectation is already renderer-independent. And `cross-backend-parity` now refuses two empty frames instead of reporting a `traced` match about nothing.

Both were proved RED. The additive oracle was red on its first run and caught a genuine wrong assumption (`Color.green` is CSS green, not lime), so its expectation now derives from the same colour objects the scene draws with.

## Validation

`gates typecheck` / `lint` / `sync` / `site`, `pnpm test` (10 998), `pnpm test:alloc`, `pnpm test:parity` 138/138, plus the pre-push browser and WebGPU lanes. `git diff --check` clean.

https://claude.ai/code/session_0164QPPaBfzxFjPvTQZJsiZC
