### PR TITLE
Cut Color's named table to the RGB cube, take packed and hex input, name the numeric outputs apart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,33 @@ release and includes intentional breaking changes; see **Changed** and
 
 ### Added
 
+- **`Color` takes packed numbers and hex strings.** A number is read as
+  `0xRRGGBB`, with alpha as its own argument; a string may be any of the four
+  CSS forms, alpha last:
+
+  ```ts
+  new Color(0xff6347); // packed, opaque
+  new Color(0xff6347, 0.5); // packed, with alpha
+  Color.fromHex('#f63'); // #RGB, #RGBA, #RRGGBB, #RRGGBBAA
+  Color.from(value, alpha?); // any of those, plus a Color or { r, g, b, a }
+  ```
+
+  The channel form is untouched: three or more arguments still mean
+  `(r, g, b, a?)`. Only a call with one or two arguments takes the packed
+  reading, and there were none in this repository.
+
+  A number deliberately stops at six digits. JavaScript keeps no leading zeros,
+  so `0x00FF00FF` (opaque green as RGBA) and `0xFF00FF` (magenta as RGB) are the
+  _same_ value at runtime, and `0x000000FF` (opaque black) is indistinguishable
+  from `0x0000FF` (blue). Any "wider than `0xFFFFFF` means RGBA" heuristic
+  silently misreads every colour whose red channel is zero. A string keeps its
+  length and has no such problem.
+
+  New alongside them: `color.setHex(value, alpha?)` overwrites in place for
+  loops where the factory's allocation would land in the frame budget, and
+  `Color.toRgb()` returns the `0xRRGGBB` the constructor accepts, so the two
+  round-trip.
+
 - **Audio sprite tables can live in a sidecar file.** `sprites` on a `sound`
   asset now also accepts a source string naming a JSON sidecar that holds the
   same `{ name: { start, end, loop? } }` map, so a table a tool produced no
@@ -977,6 +1004,39 @@ state, claims, inFlight, background }` — for diagnostics and support bundles.
   device while measuring `NEU-S4`.
 
 ### Changed
+
+- **BREAKING - `Color` keeps eleven named constants instead of 142.** The class
+  predefined every CSS named colour as a shared static. They cost 1.6 kB gzip in
+  the bundle, cannot be tree-shaken (a `static readonly` is part of one class
+  initializer, so an app that uses only `Color.red` shipped all 142 - measured),
+  and the engine itself used eight of them.
+
+  What remains is the eight corners of the RGB cube plus both transparent ends:
+  `black`, `red`, `green`, `blue`, `cyan`, `magenta`, `yellow`, `white`,
+  `transparentBlack`, `transparentWhite`, and `transparent` as CSS `transparent`
+  (defined as `rgba(0, 0, 0, 0)`, so it is the same value as `transparentBlack`).
+  Anything else is a value, not a vocabulary item: `new Color(0x6495ed)`.
+
+  For scale: Pixi has no named colour statics at all, Phaser none, Excalibur 24.
+
+  **`Color.green` changes value.** It was CSS green (`#008000`) and is now the
+  cube corner (`#00ff00`, CSS `lime`). Code that read `Color.green` and expected
+  the darker shade needs `new Color(0x008000)`.
+
+- **BREAKING - `Color.toRgba()` is now `Color.toRgba8()`.** Every caller writes
+  it into a `Uint32Array` row, and that is what it is: one RGBA8 texel as a
+  little-endian `Uint32`, matching `TextureFormat.Rgba8`. The old name invited
+  reading it as a colour literal, which it is not - written out it is
+  `0xAABBGGRR`, the reverse of the `0xRRGGBB` the constructor takes. Use
+  `toRgb()` when a literal is what you want.
+
+- **BREAKING - `Color.toString()` no longer takes a `prefixed` argument.** The
+  unprefixed and alpha-carrying forms moved to `toHex(alpha?, prefixed?)`;
+  `toString()` stays the six-digit CSS form, so a colour can still be handed
+  straight to a canvas or style property.
+
+- **The default clear colour is opaque black**, not cornflower blue. The old
+  default was inherited from XNA's new-project template.
 
 - **BREAKING - three noun-only function exports are renamed.** A noun reads as a
   value at the call site and hides that it has to be called:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,8 +285,14 @@ _is_, not from where the implementation happens to sit.
   static ties the value to an object the tree shaker cannot take apart, so a
   caller who wants one number drags the whole class into the bundle.
 
-Two carve-outs, both deliberate and not to be "unified":
+Three carve-outs, all deliberate and not to be "unified":
 
+- **Named constructors** stay static members of the type they construct:
+  `Color.from`, `Color.fromHex`, `Assets.from`. The factory rule above is about
+  standalone builders, whose only tie to a type is their return value; a named
+  constructor belongs to its type the way its instance methods do, is discovered
+  through it, and reads as an alternative to `new`. Pixi, Three and Excalibur all
+  place them this way.
 - **React hooks** stay free `use*` functions. That is React's convention, not a
   deviation from this one.
 - **The package prefix in a name stays**, even where it stutters against the

--- a/examples/application-scenes/camera-and-view.js
+++ b/examples/application-scenes/camera-and-view.js
@@ -13,7 +13,7 @@ class CameraViewScene extends Scene {
     this.camera = new View(0, 0, width, height);
     this.world = new Graphics();
     this.world.lineWidth = 2;
-    this.world.lineColor = Color.darkGray;
+    this.world.lineColor = new Color(0xa9a9a9);
     for (let x = -1200; x <= 1200; x += 120) {
       this.world.drawLine(x, -900, x, 900);
     }

--- a/examples/application-scenes/camera-and-view.ts
+++ b/examples/application-scenes/camera-and-view.ts
@@ -16,7 +16,7 @@ class CameraViewScene extends Scene {
 
     this.world = new Graphics();
     this.world.lineWidth = 2;
-    this.world.lineColor = Color.darkGray;
+    this.world.lineColor = new Color(0xa9a9a9);
 
     for (let x = -1200; x <= 1200; x += 120) {
       this.world.drawLine(x, -900, x, 900);

--- a/examples/geometry-graphics/graphics-gradient.js
+++ b/examples/geometry-graphics/graphics-gradient.js
@@ -73,7 +73,7 @@ const app = new Application({
     mount: document.body,
     sizing: new FixedResolutionCanvasSizing(),
   },
-  clearColor: Color.midnightBlue,
+  clearColor: new Color(0x191970),
 });
 app.start(GraphicsGradientScene).catch(() => {
   app.element?.remove();

--- a/examples/geometry-graphics/graphics-gradient.ts
+++ b/examples/geometry-graphics/graphics-gradient.ts
@@ -95,7 +95,7 @@ const app = new Application({
     mount: document.body,
     sizing: new FixedResolutionCanvasSizing(),
   },
-  clearColor: Color.midnightBlue,
+  clearColor: new Color(0x191970),
 });
 
 app.start(GraphicsGradientScene).catch(() => {

--- a/examples/geometry-graphics/graphics-primitives.js
+++ b/examples/geometry-graphics/graphics-primitives.js
@@ -12,16 +12,16 @@ class GraphicsPrimitivesScene extends Scene {
     this.sceneRoot = new Container();
     this.sceneRoot.setPosition(width / 2, height / 2);
     this.panel = new Graphics();
-    this.panel.fillColor = Color.darkSlateBlue;
+    this.panel.fillColor = new Color(0x483d8b);
     this.panel.drawRectangle(-190, -130, 380, 260);
     this.circle = new Graphics();
-    this.circle.fillColor = Color.tomato;
+    this.circle.fillColor = new Color(0xff6347);
     this.circle.drawCircle(-92, -6, 48);
     this.diamond = new Graphics();
-    this.diamond.fillColor = Color.goldenrod;
+    this.diamond.fillColor = new Color(0xdaa520);
     this.diamond.drawPolygon([0, -70, 70, 0, 0, 70, -70, 0]);
     this.star = new Graphics();
-    this.star.fillColor = Color.mediumSeaGreen;
+    this.star.fillColor = new Color(0x3cb371);
     this.star.drawStar(108, 12, 5, 58, 26, -18);
     this.sceneRoot.addChild(this.panel, this.circle, this.diamond, this.star);
   }
@@ -46,7 +46,7 @@ const app = new Application({
     mount: document.body,
     sizing: new FixedResolutionCanvasSizing(),
   },
-  clearColor: Color.midnightBlue,
+  clearColor: new Color(0x191970),
   backend: { type: 'webgpu' },
 });
 app.start(GraphicsPrimitivesScene).catch(() => {

--- a/examples/geometry-graphics/graphics-primitives.ts
+++ b/examples/geometry-graphics/graphics-primitives.ts
@@ -15,19 +15,19 @@ class GraphicsPrimitivesScene extends Scene {
     this.sceneRoot.setPosition(width / 2, height / 2);
 
     this.panel = new Graphics();
-    this.panel.fillColor = Color.darkSlateBlue;
+    this.panel.fillColor = new Color(0x483d8b);
     this.panel.drawRectangle(-190, -130, 380, 260);
 
     this.circle = new Graphics();
-    this.circle.fillColor = Color.tomato;
+    this.circle.fillColor = new Color(0xff6347);
     this.circle.drawCircle(-92, -6, 48);
 
     this.diamond = new Graphics();
-    this.diamond.fillColor = Color.goldenrod;
+    this.diamond.fillColor = new Color(0xdaa520);
     this.diamond.drawPolygon([0, -70, 70, 0, 0, 70, -70, 0]);
 
     this.star = new Graphics();
-    this.star.fillColor = Color.mediumSeaGreen;
+    this.star.fillColor = new Color(0x3cb371);
     this.star.drawStar(108, 12, 5, 58, 26, -18);
 
     this.sceneRoot.addChild(this.panel, this.circle, this.diamond, this.star);
@@ -57,7 +57,7 @@ const app = new Application({
     mount: document.body,
     sizing: new FixedResolutionCanvasSizing(),
   },
-  clearColor: Color.midnightBlue,
+  clearColor: new Color(0x191970),
   backend: { type: 'webgpu' },
 });
 

--- a/examples/geometry-graphics/immediate-mode-rendering.js
+++ b/examples/geometry-graphics/immediate-mode-rendering.js
@@ -74,7 +74,7 @@ class ImmediateModeScene extends Scene {
     const centerX = width / 2;
     const centerY = height / 2;
     // --- Procedural gears: each drawn with its own drawGeometry call. ---
-    const gearPalette = [Color.gold, Color.skyBlue, Color.hotPink, Color.mediumSpringGreen, Color.orange, Color.mediumPurple];
+    const gearPalette = [new Color(0xffd700), new Color(0x87ceeb), new Color(0xff69b4), new Color(0x00fa9a), new Color(0xffa500), new Color(0x9370db)];
     this.gears = [];
     for (let i = 0; i < GEAR_COUNT; i++) {
       const tint = gearPalette[i % gearPalette.length];
@@ -93,7 +93,7 @@ class ImmediateModeScene extends Scene {
     // --- Instanced spark field: one small quad, FIELD_COUNT instances. ---
     this.sparkGeometry = polygonGeometry(7, 4, Color.white, Color.white);
     this.sparkBatch = new RenderBatch(this.sparkGeometry);
-    const sparkPalette = [Color.skyBlue, Color.aquamarine, Color.gold, Color.hotPink, Color.white];
+    const sparkPalette = [new Color(0x87ceeb), new Color(0x7fffd4), new Color(0xffd700), new Color(0xff69b4), Color.white];
     this.sparks = [];
     for (let i = 0; i < FIELD_COUNT; i++) {
       const tint = sparkPalette[i % sparkPalette.length];

--- a/examples/geometry-graphics/immediate-mode-rendering.ts
+++ b/examples/geometry-graphics/immediate-mode-rendering.ts
@@ -103,7 +103,7 @@ class ImmediateModeScene extends Scene {
     const centerY = height / 2;
 
     // --- Procedural gears: each drawn with its own drawGeometry call. ---
-    const gearPalette = [Color.gold, Color.skyBlue, Color.hotPink, Color.mediumSpringGreen, Color.orange, Color.mediumPurple];
+    const gearPalette = [new Color(0xffd700), new Color(0x87ceeb), new Color(0xff69b4), new Color(0x00fa9a), new Color(0xffa500), new Color(0x9370db)];
 
     this.gears = [];
     for (let i = 0; i < GEAR_COUNT; i++) {
@@ -126,7 +126,7 @@ class ImmediateModeScene extends Scene {
     this.sparkGeometry = polygonGeometry(7, 4, Color.white, Color.white);
     this.sparkBatch = new RenderBatch(this.sparkGeometry);
 
-    const sparkPalette = [Color.skyBlue, Color.aquamarine, Color.gold, Color.hotPink, Color.white];
+    const sparkPalette = [new Color(0x87ceeb), new Color(0x7fffd4), new Color(0xffd700), new Color(0xff69b4), Color.white];
 
     this.sparks = [];
     for (let i = 0; i < FIELD_COUNT; i++) {

--- a/examples/guides/audio-reactive-scene/beat-hooks.ts
+++ b/examples/guides/audio-reactive-scene/beat-hooks.ts
@@ -19,7 +19,7 @@ class BeatHookScene extends Scene {
     // Mid-band -> particle tint cycling
     this.detector.onBeat.add((info: BeatInfo) => {
       if (info.beatInBar === 2 || info.beatInBar === 4) {
-        this.burst.config.tint = new Constant(info.beatInBar === 2 ? Color.orange : Color.skyBlue);
+        this.burst.config.tint = new Constant(info.beatInBar === 2 ? new Color(0xffa500) : new Color(0x87ceeb));
         this.burst.reset();
       }
     });

--- a/examples/guides/graphics/dynamic-graphics.ts
+++ b/examples/guides/graphics/dynamic-graphics.ts
@@ -8,7 +8,7 @@ class BarChartScene extends Scene {
   override update(delta: Seconds): void {
     this.g.clear();
 
-    this.g.fillColor = Color.tomato;
+    this.g.fillColor = new Color(0xff6347);
     for (let i = 0; i < this.values.length; i++) {
       const h = this.values[i] * 200;
       this.g.drawRectangle(i * 30, -h, 26, h);
@@ -23,7 +23,7 @@ class GroupedShapesScene extends Scene {
   // #region guide:shape-group
   override init(): void {
     this.group = new Graphics();
-    this.group.fillColor = Color.goldenrod;
+    this.group.fillColor = new Color(0xdaa520);
     this.group.drawCircle(-40, 0, 20);
     this.group.drawCircle(40, 0, 20);
     this.group.drawRectangle(-10, -15, 20, 30);

--- a/examples/guides/immediate-mode/draw-calls.ts
+++ b/examples/guides/immediate-mode/draw-calls.ts
@@ -18,7 +18,7 @@ class GeometryScene extends Scene {
   private elapsed = 0;
   private transform = new Matrix();
   private triangle = triangleGeometry;
-  private tints = [Color.tomato, Color.goldenrod, Color.mediumSeaGreen, Color.cornflowerBlue, Color.orchid];
+  private tints = [new Color(0xff6347), new Color(0xdaa520), new Color(0x3cb371), new Color(0x6495ed), new Color(0xda70d6)];
 
   // #region guide:draw-geometry
   override draw(context: RenderingContext): void {

--- a/examples/guides/performance/cull-area.ts
+++ b/examples/guides/performance/cull-area.ts
@@ -8,7 +8,7 @@ const debris = new Container();
 
 for (let i = 0; i < 300; i++) {
   const shard = new Graphics();
-  shard.fillColor = Color.slateGray;
+  shard.fillColor = new Color(0x708090);
   shard.drawCircle(0, 0, 2);
   shard.x = Math.random() * 200;
   shard.y = Math.random() * 200;

--- a/examples/performance/multi-texture-stress.js
+++ b/examples/performance/multi-texture-stress.js
@@ -81,10 +81,10 @@ app.start(MultiTextureStressScene).catch(() => {
 });
 function createTextureInfos() {
   return [
-    createTextureInfo('#10213a', '#ffd166', '#fff3c4', 'circle', [Color.white, Color.gold, Color.khaki, Color.orange]),
-    createTextureInfo('#1f1632', '#ff6b9a', '#ffd3ea', 'diamond', [Color.white, Color.hotPink, Color.violet, Color.plum]),
-    createTextureInfo('#0d2b26', '#4ade80', '#d9ffe9', 'star', [Color.white, Color.mediumSpringGreen, Color.limeGreen, Color.aquamarine]),
-    createTextureInfo('#112744', '#7dd3fc', '#e7f9ff', 'triangle', [Color.white, Color.skyBlue, Color.deepSkyBlue, Color.cornflowerBlue]),
+    createTextureInfo('#10213a', '#ffd166', '#fff3c4', 'circle', [Color.white, new Color(0xffd700), new Color(0xf0e68c), new Color(0xffa500)]),
+    createTextureInfo('#1f1632', '#ff6b9a', '#ffd3ea', 'diamond', [Color.white, new Color(0xff69b4), new Color(0xee82ee), new Color(0xdda0dd)]),
+    createTextureInfo('#0d2b26', '#4ade80', '#d9ffe9', 'star', [Color.white, new Color(0x00fa9a), new Color(0x32cd32), new Color(0x7fffd4)]),
+    createTextureInfo('#112744', '#7dd3fc', '#e7f9ff', 'triangle', [Color.white, new Color(0x87ceeb), new Color(0x00bfff), new Color(0x6495ed)]),
   ];
 }
 function createTextureInfo(background, accent, detail, shape, palette) {

--- a/examples/performance/multi-texture-stress.ts
+++ b/examples/performance/multi-texture-stress.ts
@@ -124,10 +124,10 @@ app.start(MultiTextureStressScene).catch(() => {
 
 function createTextureInfos(): TextureInfo[] {
   return [
-    createTextureInfo('#10213a', '#ffd166', '#fff3c4', 'circle', [Color.white, Color.gold, Color.khaki, Color.orange]),
-    createTextureInfo('#1f1632', '#ff6b9a', '#ffd3ea', 'diamond', [Color.white, Color.hotPink, Color.violet, Color.plum]),
-    createTextureInfo('#0d2b26', '#4ade80', '#d9ffe9', 'star', [Color.white, Color.mediumSpringGreen, Color.limeGreen, Color.aquamarine]),
-    createTextureInfo('#112744', '#7dd3fc', '#e7f9ff', 'triangle', [Color.white, Color.skyBlue, Color.deepSkyBlue, Color.cornflowerBlue]),
+    createTextureInfo('#10213a', '#ffd166', '#fff3c4', 'circle', [Color.white, new Color(0xffd700), new Color(0xf0e68c), new Color(0xffa500)]),
+    createTextureInfo('#1f1632', '#ff6b9a', '#ffd3ea', 'diamond', [Color.white, new Color(0xff69b4), new Color(0xee82ee), new Color(0xdda0dd)]),
+    createTextureInfo('#0d2b26', '#4ade80', '#d9ffe9', 'star', [Color.white, new Color(0x00fa9a), new Color(0x32cd32), new Color(0x7fffd4)]),
+    createTextureInfo('#112744', '#7dd3fc', '#e7f9ff', 'triangle', [Color.white, new Color(0x87ceeb), new Color(0x00bfff), new Color(0x6495ed)]),
   ];
 }
 

--- a/examples/performance/particle-stress.js
+++ b/examples/performance/particle-stress.js
@@ -25,7 +25,7 @@ class TintCycle extends UpdateModule {
     const { elapsed } = particles.timing;
     for (let i = 0; i < particles.count; i++) {
       if (elapsed[i] === 0) {
-        color[i] = this.palette[this.next++ % this.palette.length].toRgba();
+        color[i] = this.palette[this.next++ % this.palette.length].toRgba8();
       }
     }
   }
@@ -45,7 +45,7 @@ class ParticleStressScene extends Scene {
         rate: 240,
         force: { x: 10, y: 120 },
         scaleStart: 0.94,
-        palette: [Color.orange, Color.tomato, Color.gold, Color.mistyRose],
+        palette: [new Color(0xffa500), new Color(0xff6347), new Color(0xffd700), new Color(0xffe4e1)],
         positionRangeX: 28,
         positionRangeY: 12,
         velocityRangeX: 90,
@@ -64,7 +64,7 @@ class ParticleStressScene extends Scene {
         rate: 320,
         force: { x: 0, y: 150 },
         scaleStart: 0.88,
-        palette: [Color.skyBlue, Color.deepSkyBlue, Color.mediumTurquoise, Color.white],
+        palette: [new Color(0x87ceeb), new Color(0x00bfff), new Color(0x48d1cc), Color.white],
         positionRangeX: 38,
         positionRangeY: 16,
         velocityRangeX: 130,
@@ -83,7 +83,7 @@ class ParticleStressScene extends Scene {
         rate: 240,
         force: { x: -12, y: 118 },
         scaleStart: 0.92,
-        palette: [Color.violet, Color.hotPink, Color.deepPink, Color.plum],
+        palette: [new Color(0xee82ee), new Color(0xff69b4), new Color(0xff1493), new Color(0xdda0dd)],
         positionRangeX: 26,
         positionRangeY: 10,
         velocityRangeX: 95,

--- a/examples/performance/particle-stress.ts
+++ b/examples/performance/particle-stress.ts
@@ -48,7 +48,7 @@ class TintCycle extends UpdateModule {
 
     for (let i = 0; i < particles.count; i++) {
       if (elapsed[i] === 0) {
-        color[i] = this.palette[this.next++ % this.palette.length].toRgba();
+        color[i] = this.palette[this.next++ % this.palette.length].toRgba8();
       }
     }
   }
@@ -72,7 +72,7 @@ class ParticleStressScene extends Scene {
         rate: 240,
         force: { x: 10, y: 120 },
         scaleStart: 0.94,
-        palette: [Color.orange, Color.tomato, Color.gold, Color.mistyRose],
+        palette: [new Color(0xffa500), new Color(0xff6347), new Color(0xffd700), new Color(0xffe4e1)],
         positionRangeX: 28,
         positionRangeY: 12,
         velocityRangeX: 90,
@@ -92,7 +92,7 @@ class ParticleStressScene extends Scene {
         rate: 320,
         force: { x: 0, y: 150 },
         scaleStart: 0.88,
-        palette: [Color.skyBlue, Color.deepSkyBlue, Color.mediumTurquoise, Color.white],
+        palette: [new Color(0x87ceeb), new Color(0x00bfff), new Color(0x48d1cc), Color.white],
         positionRangeX: 38,
         positionRangeY: 16,
         velocityRangeX: 130,
@@ -112,7 +112,7 @@ class ParticleStressScene extends Scene {
         rate: 240,
         force: { x: -12, y: 118 },
         scaleStart: 0.92,
-        palette: [Color.violet, Color.hotPink, Color.deepPink, Color.plum],
+        palette: [new Color(0xee82ee), new Color(0xff69b4), new Color(0xff1493), new Color(0xdda0dd)],
         positionRangeX: 26,
         positionRangeY: 10,
         velocityRangeX: 95,

--- a/examples/performance/sprite-stress.js
+++ b/examples/performance/sprite-stress.js
@@ -13,7 +13,7 @@ class SpriteStressScene extends Scene {
     this.spriteLayer = new Container();
     this.spriteLayer.setPosition(width / 2, height / 2);
     const frameChoices = [new Rectangle(0, 0, 64, 64), new Rectangle(64, 0, 64, 64), new Rectangle(0, 64, 64, 64), new Rectangle(64, 64, 64, 64)];
-    const tintPalette = [Color.white, Color.skyBlue, Color.gold, Color.hotPink, Color.mediumSpringGreen, Color.orange];
+    const tintPalette = [Color.white, new Color(0x87ceeb), new Color(0xffd700), new Color(0xff69b4), new Color(0x00fa9a), new Color(0xffa500)];
     let index = 0;
     for (let row = 0; row < GRID_ROWS; row++) {
       for (let column = 0; column < GRID_COLUMNS; column++) {

--- a/examples/performance/sprite-stress.ts
+++ b/examples/performance/sprite-stress.ts
@@ -37,7 +37,7 @@ class SpriteStressScene extends Scene {
     this.spriteLayer.setPosition(width / 2, height / 2);
 
     const frameChoices = [new Rectangle(0, 0, 64, 64), new Rectangle(64, 0, 64, 64), new Rectangle(0, 64, 64, 64), new Rectangle(64, 64, 64, 64)];
-    const tintPalette = [Color.white, Color.skyBlue, Color.gold, Color.hotPink, Color.mediumSpringGreen, Color.orange];
+    const tintPalette = [Color.white, new Color(0x87ceeb), new Color(0xffd700), new Color(0xff69b4), new Color(0x00fa9a), new Color(0xffa500)];
 
     let index = 0;
 

--- a/examples/scene-graph/retained-container.js
+++ b/examples/scene-graph/retained-container.js
@@ -82,7 +82,7 @@ class RetainedContainerScene extends Scene {
     // toggle on the instance itself - the tier is chosen at construction.
     const group = retained ? new RetainedContainer() : new Container();
     const frames = [new Rectangle(0, 0, 64, 64), new Rectangle(64, 0, 64, 64), new Rectangle(0, 64, 64, 64), new Rectangle(64, 64, 64, 64)];
-    const palette = [Color.white, Color.skyBlue, Color.gold, Color.mediumSpringGreen, Color.hotPink, Color.mediumPurple];
+    const palette = [Color.white, new Color(0x87ceeb), new Color(0xffd700), new Color(0x00fa9a), new Color(0xff69b4), new Color(0x9370db)];
     let index = 0;
     for (let row = 0; row < FIELD_ROWS; row++) {
       for (let column = 0; column < FIELD_COLUMNS; column++) {

--- a/examples/scene-graph/retained-container.ts
+++ b/examples/scene-graph/retained-container.ts
@@ -107,7 +107,7 @@ class RetainedContainerScene extends Scene {
     const group = retained ? new RetainedContainer() : new Container();
 
     const frames = [new Rectangle(0, 0, 64, 64), new Rectangle(64, 0, 64, 64), new Rectangle(0, 64, 64, 64), new Rectangle(64, 64, 64, 64)];
-    const palette = [Color.white, Color.skyBlue, Color.gold, Color.mediumSpringGreen, Color.hotPink, Color.mediumPurple];
+    const palette = [Color.white, new Color(0x87ceeb), new Color(0xffd700), new Color(0x00fa9a), new Color(0xff69b4), new Color(0x9370db)];
 
     let index = 0;
 

--- a/examples/tilemap/tiled-map-import.js
+++ b/examples/tilemap/tiled-map-import.js
@@ -51,7 +51,7 @@ class TiledMapImportScene extends Scene {
     }
     this.zoneObjects = zones.objects.slice();
     this.overlay.lineWidth = 3;
-    this.overlay.lineColor = Color.gold;
+    this.overlay.lineColor = new Color(0xffd700);
     this.hud = mountControls({
       title: 'Tiled Map Import & Object Query',
       controls: [{ keys: 'panel', action: 'cycle the ObjectLayer.query() filter' }],
@@ -73,7 +73,7 @@ class TiledMapImportScene extends Scene {
   redrawQuery(matches) {
     this.overlay.clear();
     this.overlay.lineWidth = 3;
-    this.overlay.lineColor = Color.gold;
+    this.overlay.lineColor = new Color(0xffd700);
     for (const object of matches) {
       if (object.kind === ObjectKind.Point) {
         this.overlay.drawCircle(object.x, object.y, 10);

--- a/examples/tilemap/tiled-map-import.ts
+++ b/examples/tilemap/tiled-map-import.ts
@@ -60,7 +60,7 @@ class TiledMapImportScene extends Scene {
     this.zoneObjects = zones.objects.slice();
 
     this.overlay.lineWidth = 3;
-    this.overlay.lineColor = Color.gold;
+    this.overlay.lineColor = new Color(0xffd700);
 
     this.hud = mountControls({
       title: 'Tiled Map Import & Object Query',
@@ -86,7 +86,7 @@ class TiledMapImportScene extends Scene {
   private redrawQuery(matches: TileMapObject[]): void {
     this.overlay.clear();
     this.overlay.lineWidth = 3;
-    this.overlay.lineColor = Color.gold;
+    this.overlay.lineColor = new Color(0xffd700);
 
     for (const object of matches) {
       if (object.kind === ObjectKind.Point) {

--- a/packages/create-exo-app/templates/game-starter/src/objects/Player.ts
+++ b/packages/create-exo-app/templates/game-starter/src/objects/Player.ts
@@ -6,7 +6,7 @@ export class Player extends Graphics {
   public constructor() {
     super();
     // Circle drawn at local origin so the node position is the visual center
-    this.fillColor = Color.tomato;
+    this.fillColor = new Color(0xff6347);
     this.drawCircle(0, 0, 20);
   }
 }

--- a/packages/create-exo-app/templates/minimal/src/main.ts
+++ b/packages/create-exo-app/templates/minimal/src/main.ts
@@ -8,7 +8,7 @@ const app = new Application({
     width: 800,
     height: 600,
   },
-  clearColor: Color.cornflowerBlue,
+  clearColor: new Color(0x6495ed),
 });
 
 document.body.append(app.canvas);

--- a/packages/exojs-particles/src/distributions/ColorGradient.ts
+++ b/packages/exojs-particles/src/distributions/ColorGradient.ts
@@ -99,6 +99,6 @@ export class ColorGradient implements LifetimeFunction<Color> {
    * path; suitable for direct write into a `Uint32Array` instance buffer.
    */
   public evaluateRgba(t: number): number {
-    return this.evaluate(t, this._scratch).toRgba();
+    return this.evaluate(t, this._scratch).toRgba8();
   }
 }

--- a/packages/exojs-particles/src/modules/spawnFields.ts
+++ b/packages/exojs-particles/src/modules/spawnFields.ts
@@ -60,7 +60,7 @@ export const fillParticle = (particle: ParticleWriter, fields: ParticleSpawnFiel
   }
 
   if (fields.tint) {
-    particle.color = fields.tint.sample(color).toRgba();
+    particle.color = fields.tint.sample(color).toRgba8();
   }
 
   if (fields.textureIndex) {

--- a/packages/exojs-tilemap/src/webgl2/WebGl2TileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgl2/WebGl2TileChunkRenderer.ts
@@ -123,7 +123,7 @@ export class WebGl2TileChunkRenderer extends AbstractWebGl2Renderer<TileChunkNod
     const backend = this.getBackend();
 
     const blendMode = node.blendMode;
-    const tintRgba = node.tint.toRgba();
+    const tintRgba = node.tint.toRgba8();
 
     const command = backend.activeDrawCommand;
     const nodeIndex = command !== null ? command.nodeIndex : backend._pushTransform(node);

--- a/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
+++ b/packages/exojs-tilemap/src/webgpu/WebGpuTileChunkRenderer.ts
@@ -233,7 +233,7 @@ export class WebGpuTileChunkRenderer extends AbstractWebGpuRenderer<TileChunkNod
     }
 
     const blendMode = node.blendMode;
-    const tintRgba = node.tint.toRgba();
+    const tintRgba = node.tint.toRgba8();
 
     const command = backend.activeDrawCommand;
     const nodeIndex = command !== null ? command.nodeIndex : backend._pushTransform(node);

--- a/site/src/content/api/application-options.json
+++ b/site/src/content/api/application-options.json
@@ -124,7 +124,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": "The colour every frame starts from. Applied by the engine's own per-frame clear (see ApplicationOptions.autoClear) and readable/assignable later as Application.clearColor. Default: cornflower blue."
+          "description": "The colour every frame starts from. Applied by the engine's own per-frame clear (see ApplicationOptions.autoClear) and readable/assignable later as Application.clearColor. Default: opaque black."
         },
         {
           "name": "connectivity",

--- a/site/src/content/api/color-input.json
+++ b/site/src/content/api/color-input.json
@@ -1,0 +1,156 @@
+{
+  "title": "ColorInput",
+  "description": "Anything Color.from accepts. A number is always `0xRRGGBB` and never carries alpha - see Color.from for why the packed form stops at six digits.",
+  "symbol": "ColorInput",
+  "kind": "type",
+  "subsystem": "core",
+  "importPath": "@codexo/exojs",
+  "tier": "stable",
+  "memberCount": 0,
+  "counts": {
+    "constructors": 0,
+    "methods": 0,
+    "properties": 0,
+    "events": 0
+  },
+  "sections": [
+    {
+      "id": "import",
+      "title": "Import",
+      "members": [],
+      "paragraphs": [
+        "Anything Color.from accepts.",
+        "A number is always `0xRRGGBB` and never carries alpha - see Color.from for why the packed form stops at six digits."
+      ],
+      "importLine": "import { ColorInput } from '@codexo/exojs'",
+      "sourceLink": null
+    },
+    {
+      "id": "definition",
+      "title": "Definition",
+      "members": [
+        {
+          "name": "ColorInput",
+          "signature": "Color | number | string | { a?: number; b: number; g: number; r: number }",
+          "signatureTokens": [
+            {
+              "text": "Color",
+              "kind": "type"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "{ ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "a",
+              "kind": "name"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "; ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "b",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "; ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "g",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": "; ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "r",
+              "kind": "name"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": " }",
+              "kind": "punctuation"
+            }
+          ],
+          "params": [],
+          "returnType": null,
+          "description": ""
+        }
+      ],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": null
+    },
+    {
+      "id": "source",
+      "title": "Source",
+      "members": [],
+      "paragraphs": [],
+      "importLine": null,
+      "sourceLink": {
+        "label": "src/core/Color.ts",
+        "href": "https://github.com/Exoridus/ExoJS/blob/main/src/core/Color.ts"
+      }
+    }
+  ],
+  "sourcePath": "src/core/Color.ts",
+  "sourceUrl": "https://github.com/Exoridus/ExoJS/blob/main/src/core/Color.ts"
+}

--- a/site/src/content/api/color.json
+++ b/site/src/content/api/color.json
@@ -1,16 +1,16 @@
 {
   "title": "Color",
-  "description": "32-bit RGBA color value with channel-wise accessors. Red, green, and blue are integers in 0..255; alpha is a float in 0..1. Out-of-range values are saturated on assignment (RGB clamped to 0..255 and truncated to an integer, alpha clamped to 0..1) - values outside the range no longer wrap around. The class predefines every CSS named color as a static readonly instance (`Color.aliceBlue`, `Color.cornflowerBlue`, ...). These shared instances are intentionally shared - do not mutate them; clone first if you need to customize a starting color. Internally caches the packed RGBA32 representation and a normalized `Float32Array` for upload to GPU buffers; both are invalidated on channel writes and rebuilt lazily.",
+  "description": "32-bit RGBA color value with channel-wise accessors. Red, green, and blue are integers in 0..255; alpha is a float in 0..1. Out-of-range values are saturated on assignment (RGB clamped to 0..255 and truncated to an integer, alpha clamped to 0..1) - values outside the range no longer wrap around. The class predefines the eight corners of the RGB cube plus the two transparent ends as shared static instances (`Color.black`, `Color.magenta`, `Color.transparent`, ...). These instances are shared on purpose - do not mutate them; Color.clone first if you need a mutable starting point. Any other color is written as a value: `new Color(0x6495ed)`, `Color.fromHex('#6495ed')`, or channel by channel. Internally caches the packed RGBA32 representation and a normalized `Float32Array` for upload to GPU buffers; both are invalidated on channel writes and rebuilt lazily.",
   "symbol": "Color",
   "kind": "class",
   "subsystem": "core",
   "importPath": "@codexo/exojs",
   "tier": "stable",
-  "memberCount": 155,
+  "memberCount": 30,
   "counts": {
-    "constructors": 1,
-    "methods": 8,
-    "properties": 146,
+    "constructors": 2,
+    "methods": 13,
+    "properties": 15,
     "events": 0
   },
   "sections": [
@@ -20,7 +20,7 @@
       "members": [],
       "paragraphs": [
         "32-bit RGBA color value with channel-wise accessors. Red, green, and blue are integers in 0..255; alpha is a float in 0..1. Out-of-range values are saturated on assignment (RGB clamped to 0..255 and truncated to an integer, alpha clamped to 0..1) - values outside the range no longer wrap around.",
-        "The class predefines every CSS named color as a static readonly instance (`Color.aliceBlue`, `Color.cornflowerBlue`, ...). These shared instances are intentionally shared - do not mutate them; clone first if you need to customize a starting color.",
+        "The class predefines the eight corners of the RGB cube plus the two transparent ends as shared static instances (`Color.black`, `Color.magenta`, `Color.transparent`, ...). These instances are shared on purpose - do not mutate them; Color.clone first if you need a mutable starting point. Any other color is written as a value: `new Color(0x6495ed)`, `Color.fromHex('#6495ed')`, or channel by channel.",
         "Internally caches the packed RGBA32 representation and a normalized `Float32Array` for upload to GPU buffers; both are invalidated on channel writes and rebuilt lazily."
       ],
       "importLine": "import { Color } from '@codexo/exojs'",
@@ -32,7 +32,83 @@
       "members": [
         {
           "name": "new",
-          "signature": "new(r: number, g: number, b: number, a: number): Color",
+          "signature": "new(rgb?: number, alpha?: number): Color",
+          "signatureTokens": [
+            {
+              "text": "new",
+              "kind": "keyword"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "rgb",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "alpha",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Color",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "rgb",
+              "type": "number",
+              "optional": true
+            },
+            {
+              "name": "alpha",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "Color",
+          "description": "Build from a packed 0xRRGGBB value, with alpha as a separate argument. The packed form deliberately stops at six digits: JavaScript numbers carry no leading zeros, so 0x00FF00FF (opaque green as RGBA) and 0xFF00FF (magenta as RGB) are the *same* value at runtime and cannot be told apart. Use a string ('#00ff00ff') when alpha belongs in the literal."
+        },
+        {
+          "name": "new",
+          "signature": "new(r: number, g: number, b: number, a?: number): Color",
           "signatureTokens": [
             {
               "text": "new",
@@ -95,6 +171,10 @@
               "kind": "param"
             },
             {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
               "text": ": ",
               "kind": "punctuation"
             },
@@ -134,11 +214,11 @@
             {
               "name": "a",
               "type": "number",
-              "optional": false
+              "optional": true
             }
           ],
           "returnType": "Color",
-          "description": ""
+          "description": "Build channel by channel. RGB are 0..255 integers, alpha is a 0..1 float."
         }
       ],
       "paragraphs": [],
@@ -424,6 +504,86 @@
           "description": "Set any subset of channels. Omitted parameters default to the current channel value (use this for \"set red, leave the rest\"). RGB are clamped to 0..255; alpha is clamped to 0..1."
         },
         {
+          "name": "setHex",
+          "signature": "setHex(value: number | string, alpha?: number): this",
+          "signatureTokens": [
+            {
+              "text": "setHex",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "alpha",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "this",
+              "kind": "keyword"
+            }
+          ],
+          "params": [
+            {
+              "name": "value",
+              "type": "number | string",
+              "optional": false
+            },
+            {
+              "name": "alpha",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "this",
+          "description": "Overwrite this color from a hex value, in place. Same input forms as Color.fromHex; use this instead of the factory in a loop, where the factory's allocation would land in the frame budget."
+        },
+        {
           "name": "toArray",
           "signature": "toArray(normalized: boolean): Float32Array",
           "signatureTokens": [
@@ -471,11 +631,11 @@
           "description": "Return an RGBA Float32Array view backed by an internal cache. Pass normalized = true to map RGB into 0..1 (typical for shader uploads); default returns 0..255 RGB and 0..1 alpha. The returned array is the same instance across calls - copy it if you need a stable snapshot."
         },
         {
-          "name": "toRgba",
-          "signature": "toRgba(): number",
+          "name": "toHex",
+          "signature": "toHex(alpha: boolean, prefixed: boolean): string",
           "signatureTokens": [
             {
-              "text": "toRgba",
+              "text": "toHex",
               "kind": "name"
             },
             {
@@ -483,32 +643,19 @@
               "kind": "punctuation"
             },
             {
-              "text": ")",
-              "kind": "punctuation"
+              "text": "alpha",
+              "kind": "param"
             },
             {
               "text": ": ",
               "kind": "punctuation"
             },
             {
-              "text": "number",
+              "text": "boolean",
               "kind": "keyword"
-            }
-          ],
-          "params": [],
-          "returnType": "number",
-          "description": "Return the color packed into a single 32-bit RGBA value (R in low byte, A in high byte). Cached after first call until any channel is written. RGB is preserved at every alpha - a fully transparent red and a fully transparent black pack to different values."
-        },
-        {
-          "name": "toString",
-          "signature": "toString(prefixed: boolean): string",
-          "signatureTokens": [
-            {
-              "text": "toString",
-              "kind": "name"
             },
             {
-              "text": "(",
+              "text": ", ",
               "kind": "punctuation"
             },
             {
@@ -538,13 +685,257 @@
           ],
           "params": [
             {
+              "name": "alpha",
+              "type": "boolean",
+              "optional": false
+            },
+            {
               "name": "prefixed",
               "type": "boolean",
               "optional": false
             }
           ],
           "returnType": "string",
-          "description": "Return the RGB channels as a 6-digit hex string. Pass prefixed = false to omit the leading #. Alpha is not included - use Color.toRgba for the full RGBA32 packed form."
+          "description": "Return the color as a hex string. alpha = true appends the alpha pair (#RRGGBBAA, CSS order); prefixed = false omits the leading #. Unlike Color.toRgb, the alpha form is unambiguous here: a string still carries its own length, so it can be read back by Color.fromHex exactly as written."
+        },
+        {
+          "name": "toRgb",
+          "signature": "toRgb(): number",
+          "signatureTokens": [
+            {
+              "text": "toRgb",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "number",
+          "description": "Return the RGB channels packed as 0xRRGGBB - the exact form the constructor and Color.fromHex accept, so the two round-trip. Alpha is not included; it cannot be, for the reason the constructor gives."
+        },
+        {
+          "name": "toRgba8",
+          "signature": "toRgba8(): number",
+          "signatureTokens": [
+            {
+              "text": "toRgba8",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "number",
+          "description": "Return one RGBA8 texel as a little-endian Uint32 - the value written into a Uint32Array row for GPU upload (R in the low byte, A in the high byte), matching TextureFormat.Rgba8. This is a pixel format, **not** a color literal: written out it reads 0xAABBGGRR, the reverse of the 0xRRGGBB the constructor takes. Do not feed it back into Color.from; use Color.toRgb for that. Cached after first call until any channel is written. RGB is preserved at every alpha - a fully transparent red and a fully transparent black pack to different values."
+        },
+        {
+          "name": "toString",
+          "signature": "toString(): string",
+          "signatureTokens": [
+            {
+              "text": "toString",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            }
+          ],
+          "params": [],
+          "returnType": "string",
+          "description": "The six-digit hex form, so a color can be handed straight to a CSS or canvas property."
+        },
+        {
+          "name": "from",
+          "signature": "from(value: ColorInput, alpha?: number): Color",
+          "signatureTokens": [
+            {
+              "text": "from",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "ColorInput",
+              "kind": "type"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "alpha",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Color",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "value",
+              "type": "ColorInput",
+              "optional": false
+            },
+            {
+              "name": "alpha",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "Color",
+          "description": "Build from a packed 0xRRGGBB number, a hex string, another color, or a plain { r, g, b, a } object. alpha overrides whatever the value carried. A number never carries alpha here - see the constructor for why six digits is the limit. Hex strings have no such problem, because their length is still there to read: '#f0f', '#f0fc', '#ff00ff' and '#ff00ffcc' are all accepted, alpha last, as CSS Color 4 spells them."
+        },
+        {
+          "name": "fromHex",
+          "signature": "fromHex(value: number | string, alpha?: number): Color",
+          "signatureTokens": [
+            {
+              "text": "fromHex",
+              "kind": "name"
+            },
+            {
+              "text": "(",
+              "kind": "punctuation"
+            },
+            {
+              "text": "value",
+              "kind": "param"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": " | ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "string",
+              "kind": "keyword"
+            },
+            {
+              "text": ", ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "alpha",
+              "kind": "param"
+            },
+            {
+              "text": "?",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "number",
+              "kind": "keyword"
+            },
+            {
+              "text": ")",
+              "kind": "punctuation"
+            },
+            {
+              "text": ": ",
+              "kind": "punctuation"
+            },
+            {
+              "text": "Color",
+              "kind": "type"
+            }
+          ],
+          "params": [
+            {
+              "name": "value",
+              "type": "number | string",
+              "optional": false
+            },
+            {
+              "name": "alpha",
+              "type": "number",
+              "optional": true
+            }
+          ],
+          "returnType": "Color",
+          "description": "Build from a hex value in either spelling: a 0xRRGGBB number, or a string in any of the four CSS forms (#RGB, #RGBA, #RRGGBB, #RRGGBBAA, with or without the leading #). alpha overrides an alpha the string carried. Throws on a string that is not one of those forms. The check stays on in production because this is an input parser: a hex value often comes from a document or a theme rather than from source, and quietly returning black would hide the broken input rather than report it."
         }
       ],
       "paragraphs": [],
@@ -556,179 +947,11 @@
       "title": "Properties",
       "members": [
         {
-          "name": "aliceBlue",
-          "signature": "aliceBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "aliceBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "antiqueWhite",
-          "signature": "antiqueWhite: Color",
-          "signatureTokens": [
-            {
-              "text": "antiqueWhite",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "aqua",
-          "signature": "aqua: Color",
-          "signatureTokens": [
-            {
-              "text": "aqua",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "aquamarine",
-          "signature": "aquamarine: Color",
-          "signatureTokens": [
-            {
-              "text": "aquamarine",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "azure",
-          "signature": "azure: Color",
-          "signatureTokens": [
-            {
-              "text": "azure",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "beige",
-          "signature": "beige: Color",
-          "signatureTokens": [
-            {
-              "text": "beige",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "bisque",
-          "signature": "bisque: Color",
-          "signatureTokens": [
-            {
-              "text": "bisque",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
           "name": "black",
           "signature": "black: Color",
           "signatureTokens": [
             {
               "text": "black",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "blanchedAlmond",
-          "signature": "blanchedAlmond: Color",
-          "signatureTokens": [
-            {
-              "text": "blanchedAlmond",
               "kind": "name"
             },
             {
@@ -766,851 +989,11 @@
           "description": ""
         },
         {
-          "name": "blueViolet",
-          "signature": "blueViolet: Color",
-          "signatureTokens": [
-            {
-              "text": "blueViolet",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "brown",
-          "signature": "brown: Color",
-          "signatureTokens": [
-            {
-              "text": "brown",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "burlyWood",
-          "signature": "burlyWood: Color",
-          "signatureTokens": [
-            {
-              "text": "burlyWood",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "cadetBlue",
-          "signature": "cadetBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "cadetBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "chartreuse",
-          "signature": "chartreuse: Color",
-          "signatureTokens": [
-            {
-              "text": "chartreuse",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "chocolate",
-          "signature": "chocolate: Color",
-          "signatureTokens": [
-            {
-              "text": "chocolate",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "coral",
-          "signature": "coral: Color",
-          "signatureTokens": [
-            {
-              "text": "coral",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "cornflowerBlue",
-          "signature": "cornflowerBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "cornflowerBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "cornsilk",
-          "signature": "cornsilk: Color",
-          "signatureTokens": [
-            {
-              "text": "cornsilk",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "crimson",
-          "signature": "crimson: Color",
-          "signatureTokens": [
-            {
-              "text": "crimson",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
           "name": "cyan",
           "signature": "cyan: Color",
           "signatureTokens": [
             {
               "text": "cyan",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkBlue",
-          "signature": "darkBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "darkBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkCyan",
-          "signature": "darkCyan: Color",
-          "signatureTokens": [
-            {
-              "text": "darkCyan",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkGoldenrod",
-          "signature": "darkGoldenrod: Color",
-          "signatureTokens": [
-            {
-              "text": "darkGoldenrod",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkGray",
-          "signature": "darkGray: Color",
-          "signatureTokens": [
-            {
-              "text": "darkGray",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkGreen",
-          "signature": "darkGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "darkGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkKhaki",
-          "signature": "darkKhaki: Color",
-          "signatureTokens": [
-            {
-              "text": "darkKhaki",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkMagenta",
-          "signature": "darkMagenta: Color",
-          "signatureTokens": [
-            {
-              "text": "darkMagenta",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkOliveGreen",
-          "signature": "darkOliveGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "darkOliveGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkOrange",
-          "signature": "darkOrange: Color",
-          "signatureTokens": [
-            {
-              "text": "darkOrange",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkOrchid",
-          "signature": "darkOrchid: Color",
-          "signatureTokens": [
-            {
-              "text": "darkOrchid",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkRed",
-          "signature": "darkRed: Color",
-          "signatureTokens": [
-            {
-              "text": "darkRed",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkSalmon",
-          "signature": "darkSalmon: Color",
-          "signatureTokens": [
-            {
-              "text": "darkSalmon",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkSeaGreen",
-          "signature": "darkSeaGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "darkSeaGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkSlateBlue",
-          "signature": "darkSlateBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "darkSlateBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkSlateGray",
-          "signature": "darkSlateGray: Color",
-          "signatureTokens": [
-            {
-              "text": "darkSlateGray",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkTurquoise",
-          "signature": "darkTurquoise: Color",
-          "signatureTokens": [
-            {
-              "text": "darkTurquoise",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "darkViolet",
-          "signature": "darkViolet: Color",
-          "signatureTokens": [
-            {
-              "text": "darkViolet",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "deepPink",
-          "signature": "deepPink: Color",
-          "signatureTokens": [
-            {
-              "text": "deepPink",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "deepSkyBlue",
-          "signature": "deepSkyBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "deepSkyBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "dimGray",
-          "signature": "dimGray: Color",
-          "signatureTokens": [
-            {
-              "text": "dimGray",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "dodgerBlue",
-          "signature": "dodgerBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "dodgerBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "firebrick",
-          "signature": "firebrick: Color",
-          "signatureTokens": [
-            {
-              "text": "firebrick",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "floralWhite",
-          "signature": "floralWhite: Color",
-          "signatureTokens": [
-            {
-              "text": "floralWhite",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "forestGreen",
-          "signature": "forestGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "forestGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "fuchsia",
-          "signature": "fuchsia: Color",
-          "signatureTokens": [
-            {
-              "text": "fuchsia",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "gainsboro",
-          "signature": "gainsboro: Color",
-          "signatureTokens": [
-            {
-              "text": "gainsboro",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "ghostWhite",
-          "signature": "ghostWhite: Color",
-          "signatureTokens": [
-            {
-              "text": "ghostWhite",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "gold",
-          "signature": "gold: Color",
-          "signatureTokens": [
-            {
-              "text": "gold",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "goldenrod",
-          "signature": "goldenrod: Color",
-          "signatureTokens": [
-            {
-              "text": "goldenrod",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "gray",
-          "signature": "gray: Color",
-          "signatureTokens": [
-            {
-              "text": "gray",
               "kind": "name"
             },
             {
@@ -1648,1271 +1031,11 @@
           "description": ""
         },
         {
-          "name": "greenYellow",
-          "signature": "greenYellow: Color",
-          "signatureTokens": [
-            {
-              "text": "greenYellow",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "honeydew",
-          "signature": "honeydew: Color",
-          "signatureTokens": [
-            {
-              "text": "honeydew",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "hotPink",
-          "signature": "hotPink: Color",
-          "signatureTokens": [
-            {
-              "text": "hotPink",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "indianRed",
-          "signature": "indianRed: Color",
-          "signatureTokens": [
-            {
-              "text": "indianRed",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "indigo",
-          "signature": "indigo: Color",
-          "signatureTokens": [
-            {
-              "text": "indigo",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "ivory",
-          "signature": "ivory: Color",
-          "signatureTokens": [
-            {
-              "text": "ivory",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "khaki",
-          "signature": "khaki: Color",
-          "signatureTokens": [
-            {
-              "text": "khaki",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lavender",
-          "signature": "lavender: Color",
-          "signatureTokens": [
-            {
-              "text": "lavender",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lavenderBlush",
-          "signature": "lavenderBlush: Color",
-          "signatureTokens": [
-            {
-              "text": "lavenderBlush",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lawnGreen",
-          "signature": "lawnGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "lawnGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lemonChiffon",
-          "signature": "lemonChiffon: Color",
-          "signatureTokens": [
-            {
-              "text": "lemonChiffon",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightBlue",
-          "signature": "lightBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "lightBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightCoral",
-          "signature": "lightCoral: Color",
-          "signatureTokens": [
-            {
-              "text": "lightCoral",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightCyan",
-          "signature": "lightCyan: Color",
-          "signatureTokens": [
-            {
-              "text": "lightCyan",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightGoldenrodYellow",
-          "signature": "lightGoldenrodYellow: Color",
-          "signatureTokens": [
-            {
-              "text": "lightGoldenrodYellow",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightGray",
-          "signature": "lightGray: Color",
-          "signatureTokens": [
-            {
-              "text": "lightGray",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightGreen",
-          "signature": "lightGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "lightGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightPink",
-          "signature": "lightPink: Color",
-          "signatureTokens": [
-            {
-              "text": "lightPink",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightSalmon",
-          "signature": "lightSalmon: Color",
-          "signatureTokens": [
-            {
-              "text": "lightSalmon",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightSeaGreen",
-          "signature": "lightSeaGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "lightSeaGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightSkyBlue",
-          "signature": "lightSkyBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "lightSkyBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightSlateGray",
-          "signature": "lightSlateGray: Color",
-          "signatureTokens": [
-            {
-              "text": "lightSlateGray",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightSteelBlue",
-          "signature": "lightSteelBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "lightSteelBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lightYellow",
-          "signature": "lightYellow: Color",
-          "signatureTokens": [
-            {
-              "text": "lightYellow",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "lime",
-          "signature": "lime: Color",
-          "signatureTokens": [
-            {
-              "text": "lime",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "limeGreen",
-          "signature": "limeGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "limeGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "linen",
-          "signature": "linen: Color",
-          "signatureTokens": [
-            {
-              "text": "linen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
           "name": "magenta",
           "signature": "magenta: Color",
           "signatureTokens": [
             {
               "text": "magenta",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "maroon",
-          "signature": "maroon: Color",
-          "signatureTokens": [
-            {
-              "text": "maroon",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "mediumAquamarine",
-          "signature": "mediumAquamarine: Color",
-          "signatureTokens": [
-            {
-              "text": "mediumAquamarine",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "mediumBlue",
-          "signature": "mediumBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "mediumBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "mediumOrchid",
-          "signature": "mediumOrchid: Color",
-          "signatureTokens": [
-            {
-              "text": "mediumOrchid",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "mediumPurple",
-          "signature": "mediumPurple: Color",
-          "signatureTokens": [
-            {
-              "text": "mediumPurple",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "mediumSeaGreen",
-          "signature": "mediumSeaGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "mediumSeaGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "mediumSlateBlue",
-          "signature": "mediumSlateBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "mediumSlateBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "mediumSpringGreen",
-          "signature": "mediumSpringGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "mediumSpringGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "mediumTurquoise",
-          "signature": "mediumTurquoise: Color",
-          "signatureTokens": [
-            {
-              "text": "mediumTurquoise",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "mediumVioletRed",
-          "signature": "mediumVioletRed: Color",
-          "signatureTokens": [
-            {
-              "text": "mediumVioletRed",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "midnightBlue",
-          "signature": "midnightBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "midnightBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "mintCream",
-          "signature": "mintCream: Color",
-          "signatureTokens": [
-            {
-              "text": "mintCream",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "mistyRose",
-          "signature": "mistyRose: Color",
-          "signatureTokens": [
-            {
-              "text": "mistyRose",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "moccasin",
-          "signature": "moccasin: Color",
-          "signatureTokens": [
-            {
-              "text": "moccasin",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "navajoWhite",
-          "signature": "navajoWhite: Color",
-          "signatureTokens": [
-            {
-              "text": "navajoWhite",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "navy",
-          "signature": "navy: Color",
-          "signatureTokens": [
-            {
-              "text": "navy",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "oldLace",
-          "signature": "oldLace: Color",
-          "signatureTokens": [
-            {
-              "text": "oldLace",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "olive",
-          "signature": "olive: Color",
-          "signatureTokens": [
-            {
-              "text": "olive",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "oliveDrab",
-          "signature": "oliveDrab: Color",
-          "signatureTokens": [
-            {
-              "text": "oliveDrab",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "orange",
-          "signature": "orange: Color",
-          "signatureTokens": [
-            {
-              "text": "orange",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "orangeRed",
-          "signature": "orangeRed: Color",
-          "signatureTokens": [
-            {
-              "text": "orangeRed",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "orchid",
-          "signature": "orchid: Color",
-          "signatureTokens": [
-            {
-              "text": "orchid",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "paleGoldenrod",
-          "signature": "paleGoldenrod: Color",
-          "signatureTokens": [
-            {
-              "text": "paleGoldenrod",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "paleGreen",
-          "signature": "paleGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "paleGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "paleTurquoise",
-          "signature": "paleTurquoise: Color",
-          "signatureTokens": [
-            {
-              "text": "paleTurquoise",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "paleVioletRed",
-          "signature": "paleVioletRed: Color",
-          "signatureTokens": [
-            {
-              "text": "paleVioletRed",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "papayaWhip",
-          "signature": "papayaWhip: Color",
-          "signatureTokens": [
-            {
-              "text": "papayaWhip",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "peachPuff",
-          "signature": "peachPuff: Color",
-          "signatureTokens": [
-            {
-              "text": "peachPuff",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "peru",
-          "signature": "peru: Color",
-          "signatureTokens": [
-            {
-              "text": "peru",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "pink",
-          "signature": "pink: Color",
-          "signatureTokens": [
-            {
-              "text": "pink",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "plum",
-          "signature": "plum: Color",
-          "signatureTokens": [
-            {
-              "text": "plum",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "powderBlue",
-          "signature": "powderBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "powderBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "purple",
-          "signature": "purple: Color",
-          "signatureTokens": [
-            {
-              "text": "purple",
               "kind": "name"
             },
             {
@@ -2950,11 +1073,11 @@
           "description": ""
         },
         {
-          "name": "rosyBrown",
-          "signature": "rosyBrown: Color",
+          "name": "transparent",
+          "signature": "transparent: Color",
           "signatureTokens": [
             {
-              "text": "rosyBrown",
+              "text": "transparent",
               "kind": "name"
             },
             {
@@ -2968,385 +1091,7 @@
           ],
           "params": [],
           "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "royalBlue",
-          "signature": "royalBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "royalBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "saddleBrown",
-          "signature": "saddleBrown: Color",
-          "signatureTokens": [
-            {
-              "text": "saddleBrown",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "salmon",
-          "signature": "salmon: Color",
-          "signatureTokens": [
-            {
-              "text": "salmon",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "sandyBrown",
-          "signature": "sandyBrown: Color",
-          "signatureTokens": [
-            {
-              "text": "sandyBrown",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "seaGreen",
-          "signature": "seaGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "seaGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "seaShell",
-          "signature": "seaShell: Color",
-          "signatureTokens": [
-            {
-              "text": "seaShell",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "sienna",
-          "signature": "sienna: Color",
-          "signatureTokens": [
-            {
-              "text": "sienna",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "silver",
-          "signature": "silver: Color",
-          "signatureTokens": [
-            {
-              "text": "silver",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "skyBlue",
-          "signature": "skyBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "skyBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "slateBlue",
-          "signature": "slateBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "slateBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "slateGray",
-          "signature": "slateGray: Color",
-          "signatureTokens": [
-            {
-              "text": "slateGray",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "snow",
-          "signature": "snow: Color",
-          "signatureTokens": [
-            {
-              "text": "snow",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "springGreen",
-          "signature": "springGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "springGreen",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "steelBlue",
-          "signature": "steelBlue: Color",
-          "signatureTokens": [
-            {
-              "text": "steelBlue",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "tan",
-          "signature": "tan: Color",
-          "signatureTokens": [
-            {
-              "text": "tan",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "teal",
-          "signature": "teal: Color",
-          "signatureTokens": [
-            {
-              "text": "teal",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "thistle",
-          "signature": "thistle: Color",
-          "signatureTokens": [
-            {
-              "text": "thistle",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "tomato",
-          "signature": "tomato: Color",
-          "signatureTokens": [
-            {
-              "text": "tomato",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
+          "description": "CSS transparent, which is defined as rgba(0, 0, 0, 0) - the same instance as Color.transparentBlack."
         },
         {
           "name": "transparentBlack",
@@ -3391,69 +1136,6 @@
           "description": ""
         },
         {
-          "name": "turquoise",
-          "signature": "turquoise: Color",
-          "signatureTokens": [
-            {
-              "text": "turquoise",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "violet",
-          "signature": "violet: Color",
-          "signatureTokens": [
-            {
-              "text": "violet",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "wheat",
-          "signature": "wheat: Color",
-          "signatureTokens": [
-            {
-              "text": "wheat",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
           "name": "white",
           "signature": "white: Color",
           "signatureTokens": [
@@ -3475,53 +1157,11 @@
           "description": ""
         },
         {
-          "name": "whiteSmoke",
-          "signature": "whiteSmoke: Color",
-          "signatureTokens": [
-            {
-              "text": "whiteSmoke",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
           "name": "yellow",
           "signature": "yellow: Color",
           "signatureTokens": [
             {
               "text": "yellow",
-              "kind": "name"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "Color",
-              "kind": "type"
-            }
-          ],
-          "params": [],
-          "returnType": null,
-          "description": ""
-        },
-        {
-          "name": "yellowGreen",
-          "signature": "yellowGreen: Color",
-          "signatureTokens": [
-            {
-              "text": "yellowGreen",
               "kind": "name"
             },
             {

--- a/site/src/content/guide/rendering/graphics.mdx
+++ b/site/src/content/guide/rendering/graphics.mdx
@@ -21,8 +21,8 @@ Use `Graphics` when you need shapes that are defined in code rather than loaded 
 import { Color, Graphics } from '@codexo/exojs';
 
 const g = new Graphics();
-g.fillColor = Color.tomato;
-g.lineColor = Color.darkRed;
+g.fillColor = new Color(0xff6347);
+g.lineColor = new Color(0x8b0000);
 g.lineWidth = 3;
 
 g.drawRectangle(0, 0, 120, 80);
@@ -36,12 +36,37 @@ import { Color, Graphics } from '@codexo/exojs';
 
 const g = new Graphics();
 
-g.fillColor = Color.tomato;
+g.fillColor = new Color(0xff6347);
 g.drawCircle(0, 0, 30);
 
-g.fillColor = Color.steelBlue;
+g.fillColor = new Color(0x4682b4);
 g.drawRectangle(40, -20, 60, 40);
 ```
+
+## Writing a color
+
+`Color` takes four spellings, and which one to reach for follows from whether alpha belongs in the literal:
+
+```ts
+import { Color } from '@codexo/exojs';
+
+new Color(0xff6347); // packed 0xRRGGBB, opaque
+new Color(0xff6347, 0.5); // packed, with alpha as its own argument
+new Color(255, 99, 71, 0.5); // channel by channel: RGB 0..255, alpha 0..1
+Color.fromHex('#ff6347cc'); // #RGB, #RGBA, #RRGGBB or #RRGGBBAA, alpha last
+```
+
+A **number is always `0xRRGGBB` and never carries alpha.** That is not a limitation of the parser but of the number: JavaScript keeps no leading zeros, so `0x00FF00FF` (opaque green, read as RGBA) and `0xFF00FF` (magenta, read as RGB) are the *same* value at runtime and cannot be told apart. A string still carries its own length, so `'#00ff00ff'` is unambiguous — put alpha in a string, or pass it separately.
+
+`Color.from(value, alpha?)` accepts any of those plus another `Color` or a plain `{ r, g, b, a }`, which is what a config or a serialized document usually holds. In a loop, prefer `color.setHex(...)` — it overwrites in place instead of allocating.
+
+The named constants are the eight corners of the RGB cube plus the two transparent ends:
+
+`Color.black`, `Color.red`, `Color.green`, `Color.blue`, `Color.cyan`, `Color.magenta`, `Color.yellow`, `Color.white`, `Color.transparentBlack`, `Color.transparentWhite`, and `Color.transparent` (CSS `transparent`, the same value as `transparentBlack`).
+
+Anything else is a value rather than a name — write `new Color(0x6495ed)`, not a lookup. These instances are shared, so `clone()` before mutating one.
+
+Going the other way, `toRgb()` gives back the `0xRRGGBB` the constructor takes, and `toHex(alpha?)` the string form. `toRgba8()` is a different thing despite the similar name: one RGBA8 texel as a little-endian `Uint32` for GPU upload, written `0xAABBGGRR`. Do not feed it back into `Color.from`.
 
 ## Built-in shapes
 

--- a/site/src/content/guide/rendering/text.mdx
+++ b/site/src/content/guide/rendering/text.mdx
@@ -32,7 +32,7 @@ import { Color, Text } from '@codexo/exojs';
 const label = new Text('Hello', { fillColor: Color.black, fontSize: 24 });
 
 label.style.fontSize = 32;            // re-lays out the glyphs on the next draw
-label.style.fillColor = Color.tomato; // shader-side colour only — no atlas work
+label.style.fillColor = new Color(0xff6347); // shader-side colour only — no atlas work
 ```
 
 ## Font loading
@@ -91,7 +91,7 @@ import { Color, Text } from '@codexo/exojs';
 
 const banner = new Text('Level Up', {
     fontSize: 48,
-    gradientColors: [Color.white, Color.tomato], // white on top, tomato at the bottom
+    gradientColors: [Color.white, new Color(0xff6347)], // white on top, tomato at the bottom
 });
 ```
 

--- a/site/src/content/guide/runtime/application.mdx
+++ b/site/src/content/guide/runtime/application.mdx
@@ -59,7 +59,7 @@ import { Application, Color } from '@codexo/exojs';
 const app = new Application();
 
 function onLowHealth(isLow: boolean) {
-    app.clearColor = isLow ? Color.darkRed : Color.cornflowerBlue;
+    app.clearColor = isLow ? new Color(0x8b0000) : new Color(0x6495ed);
 }
 ```
 

--- a/src/core/Application.ts
+++ b/src/core/Application.ts
@@ -225,7 +225,7 @@ export interface ApplicationOptions<Registry extends SceneRegistryShape<Registry
   /**
    * The colour every frame starts from. Applied by the engine's own per-frame
    * clear (see {@link ApplicationOptions.autoClear}) and readable/assignable
-   * later as {@link Application.clearColor}. Default: cornflower blue.
+   * later as {@link Application.clearColor}. Default: opaque black.
    */
   clearColor?: Color;
   /**
@@ -761,7 +761,7 @@ export class Application<Registry extends SceneRegistryShape<Registry> = {}> {
       }
 
       this.options = {
-        clearColor: appSettings.clearColor ?? Color.cornflowerBlue,
+        clearColor: appSettings.clearColor ?? Color.black,
         autoClear: appSettings.autoClear ?? true,
         backend: appSettings.backend ?? defaultBackendConfig,
         canvas: {

--- a/src/core/Color.ts
+++ b/src/core/Color.ts
@@ -1,9 +1,26 @@
 import { clamp } from '#math/utils';
 
+import { assert } from './dev';
 import type { Cloneable } from './types';
 
 /** Clamp a value into the 0..255 integer channel range (saturating, not wrapping). */
 const toChannel = (value: number): number => clamp(value, 0, 255) | 0;
+
+/** Largest packed value the numeric colour form can express: `0xRRGGBB`, alpha excluded by design. */
+const MAX_PACKED_RGB = 0xffffff;
+
+/**
+ * Anything {@link Color.from} accepts.
+ *
+ * A number is always `0xRRGGBB` and never carries alpha - see {@link Color.from}
+ * for why the packed form stops at six digits.
+ */
+export type ColorInput = Color | number | string | { r: number; g: number; b: number; a?: number };
+
+const HEX_PATTERN = /^#?(?:[\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i;
+
+/** Expand a 3- or 4-digit shorthand by doubling each digit (`f0f` becomes `ff00ff`); longer forms pass through. */
+const expandShorthand = (digits: string): string => (digits.length > 4 ? digits : [...digits].map(digit => digit + digit).join(''));
 
 /**
  * 32-bit RGBA color value with channel-wise accessors. Red, green, and blue
@@ -11,10 +28,12 @@ const toChannel = (value: number): number => clamp(value, 0, 255) | 0;
  * saturated on assignment (RGB clamped to 0..255 and truncated to an integer,
  * alpha clamped to 0..1) - values outside the range no longer wrap around.
  *
- * The class predefines every CSS named color as a static readonly instance
- * (`Color.aliceBlue`, `Color.cornflowerBlue`, ...). These shared instances are
- * intentionally shared - do not mutate them; clone first if you need to
- * customize a starting color.
+ * The class predefines the eight corners of the RGB cube plus the two
+ * transparent ends as shared static instances (`Color.black`, `Color.magenta`,
+ * `Color.transparent`, ...). These instances are shared on purpose - do not
+ * mutate them; {@link Color.clone} first if you need a mutable starting point.
+ * Any other color is written as a value: `new Color(0x6495ed)`,
+ * `Color.fromHex('#6495ed')`, or channel by channel.
  *
  * Internally caches the packed RGBA32 representation and a normalized
  * `Float32Array` for upload to GPU buffers; both are invalidated on
@@ -28,11 +47,73 @@ export class Color implements Cloneable<Color> {
   private _rgba: number | null = null;
   private _array: Float32Array | null = null;
 
-  public constructor(r = 0, g = 0, b = 0, a = 1) {
+  /**
+   * Build from a packed `0xRRGGBB` value, with alpha as a separate argument.
+   *
+   * The packed form deliberately stops at six digits: JavaScript numbers carry
+   * no leading zeros, so `0x00FF00FF` (opaque green as RGBA) and `0xFF00FF`
+   * (magenta as RGB) are the *same* value at runtime and cannot be told apart.
+   * Use a string (`'#00ff00ff'`) when alpha belongs in the literal.
+   */
+  public constructor(rgb?: number, alpha?: number);
+  /** Build channel by channel. RGB are 0..255 integers, alpha is a 0..1 float. */
+  // Kept separate on purpose: collapsing them into `(r?, g?, b?, a?)` would let
+  // the IDE offer `r, g` for a two-argument call, which is exactly the reading
+  // this overload pair exists to rule out - two arguments mean a packed value
+  // and its alpha, never two channels.
+  // eslint-disable-next-line @typescript-eslint/unified-signatures
+  public constructor(r: number, g: number, b: number, a?: number);
+  public constructor(r = 0, g?: number, b?: number, a = 1) {
+    if (b === undefined) {
+      assert(r >= 0 && r <= MAX_PACKED_RGB, 'Color: a packed color must be in 0x000000..0xFFFFFF - alpha is a separate argument.');
+
+      this._r = (r >> 16) & 0xff;
+      this._g = (r >> 8) & 0xff;
+      this._b = r & 0xff;
+      this._a = clamp(g ?? 1, 0, 1);
+
+      return;
+    }
+
     this._r = toChannel(r);
-    this._g = toChannel(g);
+    this._g = toChannel(g ?? 0);
     this._b = toChannel(b);
     this._a = clamp(a, 0, 1);
+  }
+
+  /**
+   * Build from a packed `0xRRGGBB` number, a hex string, another color, or a
+   * plain `{ r, g, b, a }` object. `alpha` overrides whatever the value carried.
+   *
+   * A number never carries alpha here - see the constructor for why six digits
+   * is the limit. Hex strings have no such problem, because their length is
+   * still there to read: `'#f0f'`, `'#f0fc'`, `'#ff00ff'` and `'#ff00ffcc'` are
+   * all accepted, alpha last, as CSS Color 4 spells them.
+   */
+  public static from(value: ColorInput, alpha?: number): Color {
+    if (value instanceof Color) {
+      return new Color(value.r, value.g, value.b, alpha ?? value.a);
+    }
+
+    if (typeof value === 'object') {
+      return new Color(value.r, value.g, value.b, alpha ?? value.a ?? 1);
+    }
+
+    return Color.fromHex(value, alpha);
+  }
+
+  /**
+   * Build from a hex value in either spelling: a `0xRRGGBB` number, or a string
+   * in any of the four CSS forms (`#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`, with
+   * or without the leading `#`). `alpha` overrides an alpha the string carried.
+   *
+   * Throws on a string that is not one of those forms. The check stays on in
+   * production because this is an input parser: a hex value often comes from a
+   * document or a theme rather than from source, and quietly returning black
+   * would hide the broken input rather than report it.
+   */
+  public static fromHex(value: string | number, alpha?: number): Color {
+    return new Color().setHex(value, alpha);
   }
 
   public get r(): number {
@@ -87,6 +168,29 @@ export class Color implements Cloneable<Color> {
     return this;
   }
 
+  /**
+   * Overwrite this color from a hex value, in place. Same input forms as
+   * {@link Color.fromHex}; use this instead of the factory in a loop, where the
+   * factory's allocation would land in the frame budget.
+   */
+  public setHex(value: string | number, alpha?: number): this {
+    if (typeof value === 'number') {
+      assert(value >= 0 && value <= MAX_PACKED_RGB, 'Color: a packed color must be in 0x000000..0xFFFFFF - alpha is a separate argument.');
+
+      return this.set((value >> 16) & 0xff, (value >> 8) & 0xff, value & 0xff, alpha ?? 1);
+    }
+
+    if (!HEX_PATTERN.test(value)) {
+      throw new Error(`Color: "${value}" is not a hex color. Expected #RGB, #RGBA, #RRGGBB or #RRGGBBAA.`);
+    }
+
+    const digits = expandShorthand(value.startsWith('#') ? value.slice(1) : value);
+    const packed = Number.parseInt(digits.slice(0, 6), 16);
+    const carried = digits.length === 8 ? Number.parseInt(digits.slice(6), 16) / 255 : 1;
+
+    return this.set((packed >> 16) & 0xff, (packed >> 8) & 0xff, packed & 0xff, alpha ?? carried);
+  }
+
   public copy(color: Color): this {
     return this.set(color.r, color.g, color.b, color.a);
   }
@@ -126,21 +230,47 @@ export class Color implements Cloneable<Color> {
   }
 
   /**
-   * Return the RGB channels as a 6-digit hex string. Pass `prefixed = false`
-   * to omit the leading `#`. Alpha is not included - use {@link Color.toRgba}
-   * for the full RGBA32 packed form.
+   * Return the RGB channels packed as `0xRRGGBB` - the exact form the
+   * constructor and {@link Color.fromHex} accept, so the two round-trip.
+   * Alpha is not included; it cannot be, for the reason the constructor gives.
    */
-  public toString(prefixed = true): string {
-    return `${prefixed ? '#' : ''}${((1 << 24) | (this._r << 16) | (this._g << 8) | this._b).toString(16).slice(1)}`;
+  public toRgb(): number {
+    return (this._r << 16) | (this._g << 8) | this._b;
   }
 
   /**
-   * Return the color packed into a single 32-bit RGBA value (R in low byte,
-   * A in high byte). Cached after first call until any channel is written. RGB
-   * is preserved at every alpha - a fully transparent red and a fully
-   * transparent black pack to different values.
+   * Return the color as a hex string. `alpha = true` appends the alpha pair
+   * (`#RRGGBBAA`, CSS order); `prefixed = false` omits the leading `#`.
+   *
+   * Unlike {@link Color.toRgb}, the alpha form is unambiguous here: a string
+   * still carries its own length, so it can be read back by
+   * {@link Color.fromHex} exactly as written.
    */
-  public toRgba(): number {
+  public toHex(alpha = false, prefixed = true): string {
+    const rgb = ((1 << 24) | (this._r << 16) | (this._g << 8) | this._b).toString(16).slice(1);
+    const suffix = alpha ? ((this._a * 255) | 0 | (1 << 8)).toString(16).slice(1) : '';
+
+    return `${prefixed ? '#' : ''}${rgb}${suffix}`;
+  }
+
+  /** The six-digit hex form, so a color can be handed straight to a CSS or canvas property. */
+  public toString(): string {
+    return this.toHex();
+  }
+
+  /**
+   * Return one RGBA8 texel as a little-endian `Uint32` - the value written into
+   * a `Uint32Array` row for GPU upload (R in the low byte, A in the high byte),
+   * matching `TextureFormat.Rgba8`.
+   *
+   * This is a pixel format, **not** a color literal: written out it reads
+   * `0xAABBGGRR`, the reverse of the `0xRRGGBB` the constructor takes. Do not
+   * feed it back into {@link Color.from}; use {@link Color.toRgb} for that.
+   * Cached after first call until any channel is written. RGB is preserved at
+   * every alpha - a fully transparent red and a fully transparent black pack to
+   * different values.
+   */
+  public toRgba8(): number {
     if (this._rgba === null) {
       this._rgba = ((((this._a * 255) | 0) << 24) | (this._b << 16) | (this._g << 8) | this._r) >>> 0;
     }
@@ -154,146 +284,19 @@ export class Color implements Cloneable<Color> {
     }
   }
 
-  public static readonly aliceBlue = new Color(240, 248, 255, 1);
-  public static readonly antiqueWhite = new Color(250, 235, 215, 1);
-  public static readonly aqua = new Color(0, 255, 255, 1);
-  public static readonly aquamarine = new Color(127, 255, 212, 1);
-  public static readonly azure = new Color(240, 255, 255, 1);
-  public static readonly beige = new Color(245, 245, 220, 1);
-  public static readonly bisque = new Color(255, 228, 196, 1);
+  // The eight corners of the RGB cube, plus both transparent ends. A named
+  // color that is not a corner is a value, not a vocabulary item: write it as
+  // `new Color(0x6495ed)` rather than expecting a name for it.
   public static readonly black = new Color(0, 0, 0, 1);
-  public static readonly blanchedAlmond = new Color(255, 235, 205, 1);
-  public static readonly blue = new Color(0, 0, 255, 1);
-  public static readonly blueViolet = new Color(138, 43, 226, 1);
-  public static readonly brown = new Color(165, 42, 42, 1);
-  public static readonly burlyWood = new Color(222, 184, 135, 1);
-  public static readonly cadetBlue = new Color(95, 158, 160, 1);
-  public static readonly chartreuse = new Color(127, 255, 0, 1);
-  public static readonly chocolate = new Color(210, 105, 30, 1);
-  public static readonly coral = new Color(255, 127, 80, 1);
-  public static readonly cornflowerBlue = new Color(100, 149, 237, 1);
-  public static readonly cornsilk = new Color(255, 248, 220, 1);
-  public static readonly crimson = new Color(220, 20, 60, 1);
-  public static readonly cyan = new Color(0, 255, 255, 1);
-  public static readonly darkBlue = new Color(0, 0, 139, 1);
-  public static readonly darkCyan = new Color(0, 139, 139, 1);
-  public static readonly darkGoldenrod = new Color(184, 134, 11, 1);
-  public static readonly darkGray = new Color(169, 169, 169, 1);
-  public static readonly darkGreen = new Color(0, 100, 0, 1);
-  public static readonly darkKhaki = new Color(189, 183, 107, 1);
-  public static readonly darkMagenta = new Color(139, 0, 139, 1);
-  public static readonly darkOliveGreen = new Color(85, 107, 47, 1);
-  public static readonly darkOrange = new Color(255, 140, 0, 1);
-  public static readonly darkOrchid = new Color(153, 50, 204, 1);
-  public static readonly darkRed = new Color(139, 0, 0, 1);
-  public static readonly darkSalmon = new Color(233, 150, 122, 1);
-  public static readonly darkSeaGreen = new Color(143, 188, 139, 1);
-  public static readonly darkSlateBlue = new Color(72, 61, 139, 1);
-  public static readonly darkSlateGray = new Color(47, 79, 79, 1);
-  public static readonly darkTurquoise = new Color(0, 206, 209, 1);
-  public static readonly darkViolet = new Color(148, 0, 211, 1);
-  public static readonly deepPink = new Color(255, 20, 147, 1);
-  public static readonly deepSkyBlue = new Color(0, 191, 255, 1);
-  public static readonly dimGray = new Color(105, 105, 105, 1);
-  public static readonly dodgerBlue = new Color(30, 144, 255, 1);
-  public static readonly firebrick = new Color(178, 34, 34, 1);
-  public static readonly floralWhite = new Color(255, 250, 240, 1);
-  public static readonly forestGreen = new Color(34, 139, 34, 1);
-  public static readonly fuchsia = new Color(255, 0, 255, 1);
-  public static readonly gainsboro = new Color(220, 220, 220, 1);
-  public static readonly ghostWhite = new Color(248, 248, 255, 1);
-  public static readonly gold = new Color(255, 215, 0, 1);
-  public static readonly goldenrod = new Color(218, 165, 32, 1);
-  public static readonly gray = new Color(128, 128, 128, 1);
-  public static readonly green = new Color(0, 128, 0, 1);
-  public static readonly greenYellow = new Color(173, 255, 47, 1);
-  public static readonly honeydew = new Color(240, 255, 240, 1);
-  public static readonly hotPink = new Color(255, 105, 180, 1);
-  public static readonly indianRed = new Color(205, 92, 92, 1);
-  public static readonly indigo = new Color(75, 0, 130, 1);
-  public static readonly ivory = new Color(255, 255, 240, 1);
-  public static readonly khaki = new Color(240, 230, 140, 1);
-  public static readonly lavender = new Color(230, 230, 250, 1);
-  public static readonly lavenderBlush = new Color(255, 240, 245, 1);
-  public static readonly lawnGreen = new Color(124, 252, 0, 1);
-  public static readonly lemonChiffon = new Color(255, 250, 205, 1);
-  public static readonly lightBlue = new Color(173, 216, 230, 1);
-  public static readonly lightCoral = new Color(240, 128, 128, 1);
-  public static readonly lightCyan = new Color(224, 255, 255, 1);
-  public static readonly lightGoldenrodYellow = new Color(250, 250, 210, 1);
-  public static readonly lightGray = new Color(211, 211, 211, 1);
-  public static readonly lightGreen = new Color(144, 238, 144, 1);
-  public static readonly lightPink = new Color(255, 182, 193, 1);
-  public static readonly lightSalmon = new Color(255, 160, 122, 1);
-  public static readonly lightSeaGreen = new Color(32, 178, 170, 1);
-  public static readonly lightSkyBlue = new Color(135, 206, 250, 1);
-  public static readonly lightSlateGray = new Color(119, 136, 153, 1);
-  public static readonly lightSteelBlue = new Color(176, 196, 222, 1);
-  public static readonly lightYellow = new Color(255, 255, 224, 1);
-  public static readonly lime = new Color(0, 255, 0, 1);
-  public static readonly limeGreen = new Color(50, 205, 50, 1);
-  public static readonly linen = new Color(250, 240, 230, 1);
-  public static readonly magenta = new Color(255, 0, 255, 1);
-  public static readonly maroon = new Color(128, 0, 0, 1);
-  public static readonly mediumAquamarine = new Color(102, 205, 170, 1);
-  public static readonly mediumBlue = new Color(0, 0, 205, 1);
-  public static readonly mediumOrchid = new Color(186, 85, 211, 1);
-  public static readonly mediumPurple = new Color(147, 112, 219, 1);
-  public static readonly mediumSeaGreen = new Color(60, 179, 113, 1);
-  public static readonly mediumSlateBlue = new Color(123, 104, 238, 1);
-  public static readonly mediumSpringGreen = new Color(0, 250, 154, 1);
-  public static readonly mediumTurquoise = new Color(72, 209, 204, 1);
-  public static readonly mediumVioletRed = new Color(199, 21, 133, 1);
-  public static readonly midnightBlue = new Color(25, 25, 112, 1);
-  public static readonly mintCream = new Color(245, 255, 250, 1);
-  public static readonly mistyRose = new Color(255, 228, 225, 1);
-  public static readonly moccasin = new Color(255, 228, 181, 1);
-  public static readonly navajoWhite = new Color(255, 222, 173, 1);
-  public static readonly navy = new Color(0, 0, 128, 1);
-  public static readonly oldLace = new Color(253, 245, 230, 1);
-  public static readonly olive = new Color(128, 128, 0, 1);
-  public static readonly oliveDrab = new Color(107, 142, 35, 1);
-  public static readonly orange = new Color(255, 165, 0, 1);
-  public static readonly orangeRed = new Color(255, 69, 0, 1);
-  public static readonly orchid = new Color(218, 112, 214, 1);
-  public static readonly paleGoldenrod = new Color(238, 232, 170, 1);
-  public static readonly paleGreen = new Color(152, 251, 152, 1);
-  public static readonly paleTurquoise = new Color(175, 238, 238, 1);
-  public static readonly paleVioletRed = new Color(219, 112, 147, 1);
-  public static readonly papayaWhip = new Color(255, 239, 213, 1);
-  public static readonly peachPuff = new Color(255, 218, 185, 1);
-  public static readonly peru = new Color(205, 133, 63, 1);
-  public static readonly pink = new Color(255, 192, 203, 1);
-  public static readonly plum = new Color(221, 160, 221, 1);
-  public static readonly powderBlue = new Color(176, 224, 230, 1);
-  public static readonly purple = new Color(128, 0, 128, 1);
   public static readonly red = new Color(255, 0, 0, 1);
-  public static readonly rosyBrown = new Color(188, 143, 143, 1);
-  public static readonly royalBlue = new Color(65, 105, 225, 1);
-  public static readonly saddleBrown = new Color(139, 69, 19, 1);
-  public static readonly salmon = new Color(250, 128, 114, 1);
-  public static readonly sandyBrown = new Color(244, 164, 96, 1);
-  public static readonly seaGreen = new Color(46, 139, 87, 1);
-  public static readonly seaShell = new Color(255, 245, 238, 1);
-  public static readonly sienna = new Color(160, 82, 45, 1);
-  public static readonly silver = new Color(192, 192, 192, 1);
-  public static readonly skyBlue = new Color(135, 206, 235, 1);
-  public static readonly slateBlue = new Color(106, 90, 205, 1);
-  public static readonly slateGray = new Color(112, 128, 144, 1);
-  public static readonly snow = new Color(255, 250, 250, 1);
-  public static readonly springGreen = new Color(0, 255, 127, 1);
-  public static readonly steelBlue = new Color(70, 130, 180, 1);
-  public static readonly tan = new Color(210, 180, 140, 1);
-  public static readonly teal = new Color(0, 128, 128, 1);
-  public static readonly thistle = new Color(216, 191, 216, 1);
-  public static readonly tomato = new Color(255, 99, 71, 1);
+  public static readonly green = new Color(0, 255, 0, 1);
+  public static readonly blue = new Color(0, 0, 255, 1);
+  public static readonly cyan = new Color(0, 255, 255, 1);
+  public static readonly magenta = new Color(255, 0, 255, 1);
+  public static readonly yellow = new Color(255, 255, 0, 1);
+  public static readonly white = new Color(255, 255, 255, 1);
   public static readonly transparentBlack = new Color(0, 0, 0, 0);
   public static readonly transparentWhite = new Color(255, 255, 255, 0);
-  public static readonly turquoise = new Color(64, 224, 208, 1);
-  public static readonly violet = new Color(238, 130, 238, 1);
-  public static readonly wheat = new Color(245, 222, 179, 1);
-  public static readonly white = new Color(255, 255, 255, 1);
-  public static readonly whiteSmoke = new Color(245, 245, 245, 1);
-  public static readonly yellow = new Color(255, 255, 0, 1);
-  public static readonly yellowGreen = new Color(154, 205, 50, 1);
+  /** CSS `transparent`, which is defined as `rgba(0, 0, 0, 0)` - the same instance as {@link Color.transparentBlack}. */
+  public static readonly transparent = Color.transparentBlack;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -18,6 +18,7 @@ export { Capabilities, type HostRealm } from './capabilities';
 export { Clock } from './Clock';
 export type { DecompressFormat } from './Codec';
 export { Codec } from './Codec';
+export type { ColorInput } from './Color';
 export { Color } from './Color';
 export type { ConnectivityState, NetworkMode } from './Connectivity';
 export { Connectivity } from './Connectivity';

--- a/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2NineSliceSpriteRenderer.ts
@@ -103,7 +103,7 @@ export class WebGl2NineSliceSpriteRenderer extends AbstractWebGl2Renderer<NineSl
 
     const texture = sprite.texture;
     const blendMode = sprite.blendMode;
-    const tintRgba = sprite.tint.toRgba();
+    const tintRgba = sprite.tint.toRgba8();
 
     const command = backend.activeDrawCommand;
     const nodeIndex = command !== null ? command.nodeIndex : backend._pushTransform(sprite);

--- a/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
+++ b/src/rendering/webgl2/WebGl2RepeatingSpriteRenderer.ts
@@ -276,7 +276,7 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     f32[idx + 5] = uvParamY;
     f32[idx + 6] = offsetU;
     f32[idx + 7] = uvParamW;
-    u32[idx + 8] = sprite.tint.toRgba();
+    u32[idx + 8] = sprite.tint.toRgba8();
     u32[idx + 9] = nodeIndex >>> 0;
 
     this._shaderQuadCount++;
@@ -288,7 +288,7 @@ export class WebGl2RepeatingSpriteRenderer extends AbstractWebGl2Renderer<Repeat
     const quads: readonly RepeatingSpriteQuad[] = sprite.quads;
 
     const flipY = sprite.texture instanceof Texture && sprite.texture.flipY;
-    const tint = sprite.tint.toRgba();
+    const tint = sprite.tint.toRgba8();
 
     let offset = 0;
 

--- a/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuNineSliceSpriteRenderer.ts
@@ -249,7 +249,7 @@ export class WebGpuNineSliceSpriteRenderer extends AbstractWebGpuRenderer<NineSl
 
       u32[offset + 4] = uMin | (vMin << 16);
       u32[offset + 5] = uMax | (vMax << 16);
-      u32[offset + 6] = sprite.tint.toRgba();
+      u32[offset + 6] = sprite.tint.toRgba8();
       u32[offset + 7] = nodeIndex >>> 0;
 
       this._quadIndex++;

--- a/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
+++ b/src/rendering/webgpu/WebGpuRepeatingSpriteRenderer.ts
@@ -365,7 +365,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     f32[offset + 5] = uvParamY;
     f32[offset + 6] = offsetU;
     f32[offset + 7] = uvParamW;
-    u32[offset + 8] = sprite.tint.toRgba();
+    u32[offset + 8] = sprite.tint.toRgba8();
     u32[offset + 9] = nodeIndex >>> 0;
 
     this._shaderQuadCount++;
@@ -379,7 +379,7 @@ export class WebGpuRepeatingSpriteRenderer extends AbstractWebGpuRenderer<Repeat
     if (quads.length === 0) return;
 
     const flipY = sprite.texture instanceof Texture && sprite.texture.flipY;
-    const tint = sprite.tint.toRgba();
+    const tint = sprite.tint.toRgba8();
     const words = geoStrideBytes / 4;
 
     this._ensureGeoCapacity(this._geoQuadCount + quads.length);

--- a/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
+++ b/test/core/__snapshots__/root-index-type-inventory.test.ts.snap
@@ -148,6 +148,7 @@ exports[`root index type-level export inventory > all exported symbols with kind
   "CollisionResponse: interface",
   "CollisionType: const enum",
   "Color: class",
+  "ColorInput: type alias",
   "ColorMatrixEntries: type alias",
   "ColorMatrixFilter: class",
   "ColorTextureFormat: type alias",

--- a/test/core/color.test.ts
+++ b/test/core/color.test.ts
@@ -67,11 +67,11 @@ describe('Color — channel saturation', () => {
     const color = new Color(300, 0, 0, 1);
 
     expect(color.toString()).toBe('#ff0000');
-    expect(color.toRgba()).toBe(0xff0000ff);
+    expect(color.toRgba8()).toBe(0xff0000ff);
   });
 });
 
-// toRgba() must preserve RGB at every alpha. The old `this._a && ...` guard
+// toRgba8() must preserve RGB at every alpha. The old `this._a && ...` guard
 // collapsed any fully-transparent color to 0, so transparent red == transparent
 // black - which loses hue when alpha is animated 0 -> 1 or the packed value is
 // unpacked downstream.
@@ -80,13 +80,124 @@ describe('Color — toRgba packs RGB at every alpha', () => {
     const transparentRed = new Color(255, 0, 0, 0);
     const transparentBlack = new Color(0, 0, 0, 0);
 
-    expect(transparentRed.toRgba()).toBe(0x000000ff); // a=0, b=0, g=0, r=255
-    expect(transparentBlack.toRgba()).toBe(0x00000000);
-    expect(transparentRed.toRgba()).not.toBe(transparentBlack.toRgba());
+    expect(transparentRed.toRgba8()).toBe(0x000000ff); // a=0, b=0, g=0, r=255
+    expect(transparentBlack.toRgba8()).toBe(0x00000000);
+    expect(transparentRed.toRgba8()).not.toBe(transparentBlack.toRgba8());
   });
 
   test('alpha occupies the high byte', () => {
-    expect(new Color(0, 0, 0, 1).toRgba()).toBe(0xff000000);
-    expect(new Color(0, 0, 0, 0.5).toRgba()).toBe(0x7f000000); // (0.5*255 | 0) = 127 = 0x7f
+    expect(new Color(0, 0, 0, 1).toRgba8()).toBe(0xff000000);
+    expect(new Color(0, 0, 0, 0.5).toRgba8()).toBe(0x7f000000); // (0.5*255 | 0) = 127 = 0x7f
+  });
+});
+
+// The numeric colour form is `0xRRGGBB` only. A packed number carries no
+// leading zeros, so an eight-digit RGBA literal collides with a six-digit RGB
+// one (`0x00FF00FF === 0xFF00FF`); alpha therefore travels separately, or in a
+// string, where the length is still readable.
+describe('Color — packed and hex input', () => {
+  test('a single number is read as 0xRRGGBB', () => {
+    const color = new Color(0x6495ed);
+
+    expect([color.r, color.g, color.b, color.a]).toEqual([0x64, 0x95, 0xed, 1]);
+  });
+
+  test('the second argument is alpha in the packed form', () => {
+    expect(new Color(0xff00ff, 0.25).a).toBe(0.25);
+  });
+
+  test('no arguments is opaque black, as before', () => {
+    expect([...new Color().toArray()]).toEqual([0, 0, 0, 1]);
+  });
+
+  test('three or more arguments stay channel-wise', () => {
+    const color = new Color(0x64, 0x95, 0xed);
+
+    expect([color.r, color.g, color.b]).toEqual([0x64, 0x95, 0xed]);
+  });
+
+  test('a packed value wider than 0xFFFFFF is rejected in a dev build', () => {
+    expect(() => new Color(0xff00ff00)).toThrow(/0x000000\.\.0xFFFFFF/);
+  });
+
+  test.each([
+    ['#f0f', 255, 0, 255, 1],
+    ['#f0f8', 255, 0, 255, 0x88 / 255],
+    ['#ff00ff', 255, 0, 255, 1],
+    ['#ff00ffcc', 255, 0, 255, 0xcc / 255],
+    ['ff00ff', 255, 0, 255, 1],
+  ])('fromHex(%s) reads the CSS form, alpha last', (hex, r, g, b, a) => {
+    const color = Color.fromHex(hex as string);
+
+    expect([color.r, color.g, color.b]).toEqual([r, g, b]);
+    expect(color.a).toBeCloseTo(a as number, 5);
+  });
+
+  test('an explicit alpha overrides one the string carried', () => {
+    expect(Color.fromHex('#ff00ffcc', 0.5).a).toBe(0.5);
+  });
+
+  test('a string that is not a hex colour throws, in every build', () => {
+    expect(() => Color.fromHex('#gg0000')).toThrow(/not a hex color/);
+    expect(() => Color.fromHex('#ff00f')).toThrow(/not a hex color/);
+    expect(() => Color.fromHex('rgb(255, 0, 255)')).toThrow(/not a hex color/);
+  });
+
+  test('from() accepts every input form', () => {
+    const source = new Color(0xff00ff, 0.5);
+
+    expect(Color.from(source).equals(source)).toBe(true);
+    expect(Color.from(source, 1).a).toBe(1);
+    expect(Color.from({ r: 255, g: 0, b: 255 }).toRgb()).toBe(0xff00ff);
+    expect(Color.from(0xff00ff).toRgb()).toBe(0xff00ff);
+    expect(Color.from('#f0f').toRgb()).toBe(0xff00ff);
+  });
+
+  test('setHex overwrites in place and returns the same instance', () => {
+    const color = new Color(0x000000);
+    const returned = color.setHex('#ff00ff');
+
+    expect(returned).toBe(color);
+    expect(color.toRgb()).toBe(0xff00ff);
+  });
+});
+
+describe('Color — numeric and string output', () => {
+  test('toRgb round-trips through the constructor', () => {
+    expect(new Color(new Color(0x6495ed).toRgb()).toRgb()).toBe(0x6495ed);
+  });
+
+  test('toHex round-trips through fromHex, with and without alpha', () => {
+    const color = new Color(0x6495ed, 0.8);
+
+    expect(Color.fromHex(color.toHex()).toRgb()).toBe(0x6495ed);
+    expect(Color.fromHex(color.toHex(true)).a).toBeCloseTo(0.8, 2);
+    expect(color.toHex(false, false)).toBe('6495ed');
+  });
+
+  test('toRgba8 is the reverse byte order of toRgb and must not be fed back in', () => {
+    const color = new Color(0xff0000);
+
+    expect(color.toRgb()).toBe(0xff0000);
+    expect(color.toRgba8()).toBe(0xff0000ff);
+  });
+});
+
+describe('Color — named constants', () => {
+  test('the eight corners of the RGB cube are the whole vocabulary', () => {
+    expect(Color.black.toRgb()).toBe(0x000000);
+    expect(Color.red.toRgb()).toBe(0xff0000);
+    expect(Color.green.toRgb()).toBe(0x00ff00);
+    expect(Color.blue.toRgb()).toBe(0x0000ff);
+    expect(Color.cyan.toRgb()).toBe(0x00ffff);
+    expect(Color.magenta.toRgb()).toBe(0xff00ff);
+    expect(Color.yellow.toRgb()).toBe(0xffff00);
+    expect(Color.white.toRgb()).toBe(0xffffff);
+  });
+
+  test('transparent is CSS transparent, which is the same value as transparentBlack', () => {
+    expect(Color.transparent).toBe(Color.transparentBlack);
+    expect([Color.transparent.toRgb(), Color.transparent.a]).toEqual([0x000000, 0]);
+    expect(Color.transparentWhite.toRgb()).toBe(0xffffff);
   });
 });

--- a/test/rendering/browser/webgl2-graphics-solid-fill.test.ts
+++ b/test/rendering/browser/webgl2-graphics-solid-fill.test.ts
@@ -83,9 +83,9 @@ describe('Graphics solid fill WebGL2 browser', () => {
     try {
       render(backend, graphics);
 
-      // Inside the rectangle: solid fill color (Color.green is (0, 128, 0)).
-      expectPixelNear(readWebGl2Pixel(backend, 32, 32), [0, 128, 0, 255]);
-      expectPixelNear(readWebGl2Pixel(backend, 10, 10), [0, 128, 0, 255]);
+      // Inside the rectangle: solid fill color (Color.green is the cube corner, (0, 255, 0)).
+      expectPixelNear(readWebGl2Pixel(backend, 32, 32), [0, 255, 0, 255]);
+      expectPixelNear(readWebGl2Pixel(backend, 10, 10), [0, 255, 0, 255]);
       // Outside the rectangle: clear color.
       expectPixelNear(readWebGl2Pixel(backend, 2, 2), [0, 0, 0, 255]);
       expectPixelNear(readWebGl2Pixel(backend, 62, 62), [0, 0, 0, 255]);

--- a/test/rendering/browser/webgl2-particles.test.ts
+++ b/test/rendering/browser/webgl2-particles.test.ts
@@ -233,7 +233,7 @@ describe('WebGL2 ParticleSystem — solid color', () => {
     try {
       const particle = system.emit()!;
 
-      particle.color = new Color(0, 255, 0).toRgba();
+      particle.color = new Color(0, 255, 0).toRgba8();
       system.setPosition(32, 32);
       root.addChild(system);
 
@@ -266,7 +266,7 @@ describe('WebGL2 ParticleSystem — ribbon', () => {
         const particle = system.emit()!;
 
         particle.position.x = x;
-        particle.color = new Color(0, 255, 0).toRgba();
+        particle.color = new Color(0, 255, 0).toRgba8();
       }
 
       system.setPosition(32, 32);
@@ -308,7 +308,7 @@ describe('WebGL2 ParticleSystem — ribbon', () => {
 
         particle.position.x = i === 0 ? -16 : 16;
         particle.scale.x = scales[i]!;
-        particle.color = new Color(0, 255, 0).toRgba();
+        particle.color = new Color(0, 255, 0).toRgba8();
       }
 
       system.setPosition(32, 32);
@@ -380,7 +380,7 @@ describe('WebGL2 ParticleSystem — mesh', () => {
       particle.scale.set(0.5, 0.5);
       // 180 degrees puts the right angle at the bottom-right instead of the top-left.
       particle.rotation = 180;
-      particle.color = new Color(0, 255, 0).toRgba();
+      particle.color = new Color(0, 255, 0).toRgba8();
 
       system.setPosition(32, 32);
       root.addChild(system);
@@ -412,7 +412,7 @@ describe('WebGL2 ParticleSystem — mesh mutation', () => {
     try {
       const particle = system.emit()!;
 
-      particle.color = new Color(0, 255, 0).toRgba();
+      particle.color = new Color(0, 255, 0).toRgba8();
       system.setPosition(32, 32);
       root.addChild(system);
 

--- a/test/rendering/browser/webgpu-graphics-solid-fill.test.ts
+++ b/test/rendering/browser/webgpu-graphics-solid-fill.test.ts
@@ -102,9 +102,9 @@ describe('WebGPU Graphics solid fill', () => {
 
       const readPixel = readWebGpuPixels(backend, canvasSize);
 
-      // Inside the rectangle: solid fill color (Color.green is (0, 128, 0)).
-      expectPixelNear(readPixel(32, 32), [0, 128, 0, 255]);
-      expectPixelNear(readPixel(10, 10), [0, 128, 0, 255]);
+      // Inside the rectangle: solid fill color (Color.green is the cube corner, (0, 255, 0)).
+      expectPixelNear(readPixel(32, 32), [0, 255, 0, 255]);
+      expectPixelNear(readPixel(10, 10), [0, 255, 0, 255]);
       // Outside the rectangle: clear color.
       expectPixelNear(readPixel(2, 2), [0, 0, 0, 255]);
       expectPixelNear(readPixel(62, 62), [0, 0, 0, 255]);

--- a/test/rendering/browser/webgpu-particles-single-pass.test.ts
+++ b/test/rendering/browser/webgpu-particles-single-pass.test.ts
@@ -166,7 +166,7 @@ const createTintedSystem = (texture: Texture, color: RgbaTuple, x: number, y: nu
   const system = new ParticleSystem(texture, { capacity: 4 });
   const particle = system.emit()!;
 
-  particle.color = new Color(color[0], color[1], color[2]).toRgba();
+  particle.color = new Color(color[0], color[1], color[2]).toRgba8();
   system.setPosition(x, y);
 
   return system;
@@ -299,7 +299,7 @@ describe('WebGPU particle single-pass frame', () => {
 
       const particle = gpuSystem.emit()!;
 
-      particle.color = new Color(particleColors[0]![0], particleColors[0]![1], particleColors[0]![2]).toRgba();
+      particle.color = new Color(particleColors[0]![0], particleColors[0]![1], particleColors[0]![2]).toRgba8();
       particle.lifetime = 100;
       gpuSystem.setPosition(15, 40);
 

--- a/test/rendering/browser/webgpu-particles.test.ts
+++ b/test/rendering/browser/webgpu-particles.test.ts
@@ -209,7 +209,7 @@ describe('WebGPU ParticleSystem — solid color', () => {
     try {
       const particle = system.emit()!;
 
-      particle.color = new Color(0, 255, 0).toRgba();
+      particle.color = new Color(0, 255, 0).toRgba8();
       system.setPosition(32, 32);
       root.addChild(system);
 
@@ -247,7 +247,7 @@ describe('WebGPU ParticleSystem — ribbon', () => {
         const particle = system.emit()!;
 
         particle.position.x = x;
-        particle.color = new Color(0, 255, 0).toRgba();
+        particle.color = new Color(0, 255, 0).toRgba8();
       }
 
       system.setPosition(32, 32);
@@ -335,7 +335,7 @@ describe('WebGPU ParticleSystem — mesh', () => {
       particle.scale.set(0.5, 0.5);
       // 180 degrees puts the right angle at the bottom-right instead of the top-left.
       particle.rotation = 180;
-      particle.color = new Color(0, 255, 0).toRgba();
+      particle.color = new Color(0, 255, 0).toRgba8();
 
       system.setPosition(32, 32);
       root.addChild(system);
@@ -382,7 +382,7 @@ describe('WebGPU ParticleSystem — mesh on the GPU compute path', () => {
 
       const particle = system.emit()!;
 
-      particle.color = new Color(0, 255, 0).toRgba();
+      particle.color = new Color(0, 255, 0).toRgba8();
       particle.lifetime = 10;
       system.setPosition(32, 32);
       root.addChild(system);

--- a/test/rendering/gradient.test.ts
+++ b/test/rendering/gradient.test.ts
@@ -21,7 +21,7 @@ describe('Gradient toTexture()', () => {
       { offset: 0.5, color: Color.cyan },
       { offset: 0.6, color: Color.magenta },
       { offset: 0.7, color: Color.yellow },
-      { offset: 0.8, color: Color.gray },
+      { offset: 0.8, color: new Color(0x808080) },
       { offset: 1.7, color: Color.red },
     ]);
 

--- a/test/rendering/webgpu-backend.test.ts
+++ b/test/rendering/webgpu-backend.test.ts
@@ -1649,7 +1649,7 @@ describe('WebGpuBackend', () => {
       particle.scale.x = 2;
       particle.scale.y = 3;
       particle.rotation = 45;
-      particle.color = Color.red.toRgba();
+      particle.color = Color.red.toRgba8();
 
       await manager.initialize();
 
@@ -1693,7 +1693,7 @@ describe('WebGpuBackend', () => {
       secondParticle.position.set(20, 24);
       secondParticle.rotation = 20;
       secondParticle.scale.set(2, 2);
-      secondParticle.color = Color.red.toRgba();
+      secondParticle.color = Color.red.toRgba8();
 
       sourceCanvas.width = 16;
       sourceCanvas.height = 16;
@@ -1734,7 +1734,7 @@ describe('WebGpuBackend', () => {
       sourceCanvas.height = 16;
       texture.updateSource();
 
-      particle.color = Color.red.toRgba();
+      particle.color = Color.red.toRgba8();
       system.blendMode = BlendModes.Additive;
 
       await manager.initialize();
@@ -1783,7 +1783,7 @@ describe('WebGpuBackend', () => {
       sourceCanvas.height = 16;
       texture.updateSource();
 
-      particle.color = Color.red.toRgba();
+      particle.color = Color.red.toRgba8();
       system.blendMode = BlendModes.Screen;
 
       await manager.initialize();
@@ -1878,7 +1878,7 @@ describe('WebGpuBackend', () => {
       await manager.initialize();
 
       manager.setRenderTarget(renderTexture);
-      manager.clear(Color.cornflowerBlue);
+      manager.clear(new Color(0x6495ed));
       graphics.render(manager);
       manager.setRenderTarget(null);
       manager.clear(Color.black);
@@ -1939,7 +1939,7 @@ describe('WebGpuBackend', () => {
       await manager.initialize();
 
       manager.setRenderTarget(renderTexture);
-      manager.clear(Color.cornflowerBlue);
+      manager.clear(new Color(0x6495ed));
       graphics.render(manager);
       manager.setRenderTarget(null);
       manager.clear(Color.black);
@@ -2366,14 +2366,14 @@ describe('WebGpuBackend', () => {
 
       await manager.initialize();
 
-      manager.setClearColor(Color.cornflowerBlue);
+      manager.setClearColor(new Color(0x6495ed));
       manager.clear(); // no arg — should use stored clearColor
       manager.flush();
 
       // createColorAttachment uses _clearColor; verify the value propagated
-      expect(manager.clearColor.r).toBe(Color.cornflowerBlue.r);
-      expect(manager.clearColor.g).toBe(Color.cornflowerBlue.g);
-      expect(manager.clearColor.b).toBe(Color.cornflowerBlue.b);
+      expect(manager.clearColor.r).toBe(new Color(0x6495ed).r);
+      expect(manager.clearColor.g).toBe(new Color(0x6495ed).g);
+      expect(manager.clearColor.b).toBe(new Color(0x6495ed).b);
     } finally {
       environment.restore();
     }


### PR DESCRIPTION
`Color` predefined all 142 CSS named colours as shared statics, took only channel arguments, and gave its packed output a name that reads like a colour literal but is not one. All three are addressed here. **Breaking, pre-1.0, no shims.**

## The named table is cut to eleven

Measured, not assumed: the table costs **1,604 B gzip** in the IIFE bundle (5,264 B minified), and it cannot be tree-shaken — a `static readonly` is part of one class initializer, so an app bundling only `Color.red` still ships all 142. Verified with esbuild: 6.5 kB out, `aliceBlue` present.

The engine itself used eight of them. Across examples, guides and tests, 46 distinct names appeared — and the popular ones (`cornflowerBlue`, `tomato`, `gold`, `skyBlue`) were all documentation, not engine code.

What survives is a closed rule instead of a taste: **every combination of r, g, b ∈ {0, 255}**, plus both transparent ends.

`black` `red` `green` `blue` `cyan` `magenta` `yellow` `white` `transparentBlack` `transparentWhite` `transparent`

`transparent` is an alias rather than a twelfth value: CSS defines it as `rgba(0, 0, 0, 0)`, which is exactly `transparentBlack`.

For scale, in the libraries checked locally: Pixi 8.19 has **no** named statics (one `Color.shared`, documented as mutable and dangerous; CSS names only as input strings via a 3.5 kB colord plugin), Phaser 4.2 has none at all, Excalibur 0.32 has 24 as `static get`.

⚠️ **`Color.green` changes value** — CSS green `#008000` → the cube corner `#00ff00`. This is the one change a compiler cannot catch. Two browser tests pinned the old value and are updated; anything expecting the darker shade wants `new Color(0x008000)`.

## Input: a number is `0xRRGGBB`, a string is CSS hex

```ts
new Color(0xff6347);            // packed, opaque
new Color(0xff6347, 0.5);       // packed, alpha as its own argument
new Color(255, 99, 71, 0.5);    // channel by channel, unchanged
Color.fromHex('#f63c');         // #RGB, #RGBA, #RRGGBB, #RRGGBBAA — alpha last
Color.from(value, alpha?);      // any of those, plus a Color or { r, g, b, a }
color.setHex('#ff6347');        // in place, for loops where allocation matters
```

Three or more arguments still mean `(r, g, b, a?)`; only a one- or two-argument call takes the packed reading, and this repository had **zero** of those (194 use three or four).

The packed form stops at six digits on purpose, and this is the load-bearing part of the design: JavaScript keeps no leading zeros, so

```
0x00FF00FF  // opaque green read as RGBA  = 16711935
0xFF00FF    // magenta read as RGB        = 16711935   ← the same number
0x000000FF  // opaque black read as RGBA  = 255
0x0000FF    // blue read as RGB           = 255        ← the same number
```

Any "wider than `0xFFFFFF` means RGBA" heuristic silently misreads every colour whose red channel is zero — pure green, pure blue, cyan, every black with alpha. Pixi reached the same conclusion and accepts numbers only in `0…0xFFFFFF` (`Color.js:656`). A string still carries its own length, so alpha belongs there or in its own argument.

## Output: the two numeric forms are named apart

| Method | Returns |
| --- | --- |
| `toRgb()` | `0xRRGGBB` — round-trips with the constructor |
| `toHex(alpha?, prefixed?)` | `'#rrggbb'` / `'#rrggbbaa'` |
| `toRgba8()` | one RGBA8 texel as a little-endian `Uint32`, matching `TextureFormat.Rgba8` |

`toRgba()` is renamed to `toRgba8()`. All ten callers write it into a `Uint32Array` row — it is a pixel format, and written out it reads `0xAABBGGRR`, the reverse of what the constructor takes. Feeding it back into `Color.from` was never right; now the name says so.

`toString()` loses its `prefixed` argument (no caller used it) and stays the six-digit CSS form.

The ambiguity above is **input-only**: an eight-digit *return* value is a contract, not a guess, which is why `toHex(true)` may carry alpha while a numeric input may not.

## Also

- The default clear colour is opaque black. Cornflower blue was inherited from XNA's new-project template, never a decision this engine made.
- `CONTRIBUTING.md` gains a **named-constructor carve-out**: the factory rule that landed last week would otherwise have read as a ban on `Color.from` a week later.
- New guide section *Writing a color* in `rendering/graphics.mdx`.
- `Color.fromCss()` — resolving named/`hsl()`/`oklch()` values through the runtime's own CSS parser — is deliberately **not** here. It is on the roadmap as a consideration, with the mechanics already checked (inline-style round-trip, *not* `getComputedStyle`, which needs an attached element and forces style resolution) and the three open questions: a platform dependency inside `core`, jsdom's partial CSS support, and how modern syntaxes serialise back.

## Validation

`gates typecheck` / `lint`, `pnpm test` (11,017), the two changed browser tests re-run in their own lanes, plus the full pre-push lane set including Chromium WebGL2 and WebGPU. 81 call sites migrated across 22 files; example `.js` artefacts regenerated.

https://claude.ai/code/session_0164QPPaBfzxFjPvTQZJsiZC
