### PR TITLE
Retention: one product per render target, a changed-record index, incremental tints, and the order-stream measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1588,6 +1588,21 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   an open pass first, an extra submit). 1024 quads is 24 KiB and covers
   normal text scenes in a single allocation, in both `WebGpuTextRenderer` and
   `WebGl2TextRenderer`.
+- **A root drawn to two render targets in one frame keeps its retention.** A
+  captured product is compiled for the target it was recorded against, and a
+  root held exactly one. Drawing the same root into a `RenderTexture` and onto
+  the screen within the same frame - a minimap, a portal, a mirror, a
+  post-processing source - therefore had each draw discard the other's product
+  and capture again, every frame, with no steady state to settle into. Measured
+  on a 2000-leaf scrolling world with the indexed tier refused: all 20 draws of
+  a 10-frame window missed their keys and walked the scene graph (28 809 nodes
+  culled), against 0 for the same scene drawn twice to a single target. A root
+  now holds one product per render target, at most two, evicting the least
+  recently used one beyond that - the screen plus one offscreen target is the
+  case that recurs every frame, and each product is a full instruction set plus
+  its recorded entries. A third target in one frame re-captures exactly as
+  before. Roots served by the indexed slot tier were never affected: that tier
+  is keyed on the backend alone.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1588,6 +1588,23 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   an open pass first, an extra submit). 1024 quads is 24 KiB and covers
   normal text scenes in a single allocation, in both `WebGpuTextRenderer` and
   `WebGl2TextRenderer`.
+- **A moved node writes one entry instead of climbing its ancestor chain.**
+  Every own-transform mutation used to walk from the node to the scene root,
+  offering the moved row to the enclosing transform group and to every render
+  root above it, because a moved node cannot know which retained products
+  recorded it. That walk ran on every `setPosition` in a scene with any
+  retention live. The engine now keeps one changed-record index: a mutation
+  marks the node once, and each retained product pulls the marks it cares about
+  against the row map it already keeps - a recorded node costs it a map hit
+  rather than the mutator a walk.
+
+  The index is bounded by construction, which is what separates it from a
+  change journal: a node marked a thousand times in a frame holds one entry,
+  ordering comes from the node's own mark sequence, and the marks live in a
+  ring of eight generations. A product that has not looked for longer than that
+  is told so and rebuilds, rather than being handed a partial answer. Nothing
+  is marked at all while no retained consumer exists.
+
 - **A root drawn to two render targets in one frame keeps its retention.** A
   captured product is compiled for the target it was recorded against, and a
   root held exactly one. Drawing the same root into a `RenderTexture` and onto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1588,6 +1588,26 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   an open pass first, an extra submit). 1024 quads is 24 KiB and covers
   normal text scenes in a single allocation, in both `WebGpuTextRenderer` and
   `WebGl2TextRenderer`.
+- **A tint change rewrites one row instead of throwing the recording away.**
+  Tinting per frame - a hit flash, a selection highlight, a fade - used to
+  invalidate the whole retained product on every frame it happened, because a
+  tint is a content change and content changes rebuild. Tint lives in a
+  per-row store parallel to the transform rows, though, so it is the one
+  content change a recorded product can express in place. A tint write now
+  marks its own channel in the changed-record index, and a product whose only
+  change since it last looked is tints writes those rows (`_patchTintRow` on
+  both backends) and replays.
+
+  Everything else still rebuilds, deliberately: a different texture, geometry
+  or blend mode decides which batch a node belongs to, and no row write says
+  that. The split is what makes the question answerable - "only tints changed"
+  is a property of the marks rather than a guess from a revision that every
+  kind of change bumps.
+
+  Writing through the `tint` instance in place (`sprite.tint.r = 8`) still
+  bypasses the setter and is not observed at all; assign a colour, or call
+  `invalidateContent()` after mutating one.
+
 - **A moved node writes one entry instead of climbing its ancestor chain.**
   Every own-transform mutation used to walk from the node to the scene root,
   offering the moved row to the enclosing transform group and to every render

--- a/site/src/content/api/abstract-text.json
+++ b/site/src/content/api/abstract-text.json
@@ -1729,7 +1729,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame."
+          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame. A retained product recognises a tint-only change and rewrites the affected row rather than re-recording, so tinting per frame stays cheap. Writing through the returned tint instance instead (sprite.tint.r = 8) bypasses that entirely and is not observed at all - assign a colour, or call RenderNode.invalidateContent after mutating in place."
         },
         {
           "name": "syncDirty",

--- a/site/src/content/api/animated-sprite.json
+++ b/site/src/content/api/animated-sprite.json
@@ -2063,7 +2063,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame."
+          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame. A retained product recognises a tint-only change and rewrites the affected row rather than re-recording, so tinting per frame stays cheap. Writing through the returned tint instance instead (sprite.tint.r = 8) bypasses that entirely and is not observed at all - assign a colour, or call RenderNode.invalidateContent after mutating in place."
         },
         {
           "name": "stop",

--- a/site/src/content/api/bitmap-text.json
+++ b/site/src/content/api/bitmap-text.json
@@ -1761,7 +1761,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame."
+          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame. A retained product recognises a tint-only change and rewrites the affected row rather than re-recording, so tinting per frame stays cheap. Writing through the returned tint instance instead (sprite.tint.r = 8) bypasses that entirely and is not observed at all - assign a colour, or call RenderNode.invalidateContent after mutating in place."
         },
         {
           "name": "syncDirty",

--- a/site/src/content/api/drawable.json
+++ b/site/src/content/api/drawable.json
@@ -1491,7 +1491,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame."
+          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame. A retained product recognises a tint-only change and rewrites the affected row rather than re-recording, so tinting per frame stays cheap. Writing through the returned tint instance instead (sprite.tint.r = 8) bypasses that entirely and is not observed at all - assign a colour, or call RenderNode.invalidateContent after mutating in place."
         },
         {
           "name": "updateBounds",

--- a/site/src/content/api/mesh.json
+++ b/site/src/content/api/mesh.json
@@ -1541,7 +1541,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame."
+          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame. A retained product recognises a tint-only change and rewrites the affected row rather than re-recording, so tinting per frame stays cheap. Writing through the returned tint instance instead (sprite.tint.r = 8) bypasses that entirely and is not observed at all - assign a colour, or call RenderNode.invalidateContent after mutating in place."
         },
         {
           "name": "updateBounds",

--- a/site/src/content/api/nine-slice-sprite.json
+++ b/site/src/content/api/nine-slice-sprite.json
@@ -1785,7 +1785,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame."
+          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame. A retained product recognises a tint-only change and rewrites the affected row rather than re-recording, so tinting per frame stays cheap. Writing through the returned tint instance instead (sprite.tint.r = 8) bypasses that entirely and is not observed at all - assign a colour, or call RenderNode.invalidateContent after mutating in place."
         },
         {
           "name": "updateBounds",

--- a/site/src/content/api/particle-system.json
+++ b/site/src/content/api/particle-system.json
@@ -2183,7 +2183,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame."
+          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame. A retained product recognises a tint-only change and rewrites the affected row rather than re-recording, so tinting per frame stays cheap. Writing through the returned tint instance instead (sprite.tint.r = 8) bypasses that entirely and is not observed at all - assign a colour, or call RenderNode.invalidateContent after mutating in place."
         },
         {
           "name": "update",

--- a/site/src/content/api/repeating-sprite.json
+++ b/site/src/content/api/repeating-sprite.json
@@ -1680,7 +1680,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame."
+          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame. A retained product recognises a tint-only change and rewrites the affected row rather than re-recording, so tinting per frame stays cheap. Writing through the returned tint instance instead (sprite.tint.r = 8) bypasses that entirely and is not observed at all - assign a colour, or call RenderNode.invalidateContent after mutating in place."
         },
         {
           "name": "updateBounds",

--- a/site/src/content/api/retained-container.json
+++ b/site/src/content/api/retained-container.json
@@ -6,10 +6,10 @@
   "subsystem": "rendering",
   "importPath": "@codexo/exojs",
   "tier": "advanced",
-  "memberCount": 95,
+  "memberCount": 94,
   "counts": {
     "constructors": 1,
-    "methods": 43,
+    "methods": 42,
     "properties": 37,
     "events": 14
   },
@@ -69,53 +69,6 @@
       "id": "methods",
       "title": "Methods",
       "members": [
-        {
-          "name": "_enqueueDirtyTransformRow",
-          "signature": "_enqueueDirtyTransformRow(node: RenderNode): void",
-          "signatureTokens": [
-            {
-              "text": "_enqueueDirtyTransformRow",
-              "kind": "name"
-            },
-            {
-              "text": "(",
-              "kind": "punctuation"
-            },
-            {
-              "text": "node",
-              "kind": "param"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "RenderNode",
-              "kind": "type"
-            },
-            {
-              "text": ")",
-              "kind": "punctuation"
-            },
-            {
-              "text": ": ",
-              "kind": "punctuation"
-            },
-            {
-              "text": "void",
-              "kind": "keyword"
-            }
-          ],
-          "params": [
-            {
-              "name": "node",
-              "type": "RenderNode",
-              "optional": false
-            }
-          ],
-          "returnType": "void",
-          "description": "The descendant transform-move seam: a descendant's own transform moved. Queue its row on the fragment; _collectContent patches the queued rows in place on a content/structure-clean frame instead of re-collecting. The group's OWN move does not route here - _markOwnTransformDirty above handles it as a one-matrix group move. Gated on a live committed recording: only the recorded-instruction tier ever consumes a queued row. On every tier without one - entry replay, and a recording-less group (e.g. an escaped-branch group, whose _fragment.dispose() drops any recording) - transforms are re-read live and _reconcileTransformRows would just drain the queue unread on the next collect. Skipping the enqueue there is free: nothing else observes the queue between now and that drain. (A recording backend lacking patch support DOES still enqueue here - hasRecording is true - and _reconcileTransformRows is the one that drops the recording and falls back to entry replay.)"
-        },
         {
           "name": "_markOwnTransformDirty",
           "signature": "_markOwnTransformDirty(): void",

--- a/site/src/content/api/sprite.json
+++ b/site/src/content/api/sprite.json
@@ -1685,7 +1685,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame."
+          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame. A retained product recognises a tint-only change and rewrites the affected row rather than re-recording, so tinting per frame stays cheap. Writing through the returned tint instance instead (sprite.tint.r = 8) bypasses that entirely and is not observed at all - assign a colour, or call RenderNode.invalidateContent after mutating in place."
         },
         {
           "name": "updateBounds",

--- a/site/src/content/api/text.json
+++ b/site/src/content/api/text.json
@@ -1713,7 +1713,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame."
+          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame. A retained product recognises a tint-only change and rewrites the affected row rather than re-recording, so tinting per frame stays cheap. Writing through the returned tint instance instead (sprite.tint.r = 8) bypasses that entirely and is not observed at all - assign a colour, or call RenderNode.invalidateContent after mutating in place."
         },
         {
           "name": "syncDirty",

--- a/site/src/content/api/video.json
+++ b/site/src/content/api/video.json
@@ -2144,7 +2144,7 @@
             }
           ],
           "returnType": "this",
-          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame."
+          "description": "Set the tint colour by copying color into the internal Color instance. Invalidates the render cache so the change is picked up on the next frame. A retained product recognises a tint-only change and rewrites the affected row rather than re-recording, so tinting per frame stays cheap. Writing through the returned tint instance instead (sprite.tint.r = 8) bypasses that entirely and is not observed at all - assign a colour, or call RenderNode.invalidateContent after mutating in place."
         },
         {
           "name": "setVolume",

--- a/src/core/NodeDirtyIndex.ts
+++ b/src/core/NodeDirtyIndex.ts
@@ -1,0 +1,232 @@
+import type { SceneNode } from './SceneNode';
+
+/**
+ * What changed about a node. A single mark carries a mask, so one mutation that
+ * touches two channels costs one entry.
+ * @internal
+ */
+export const enum DirtyChannel {
+  /** The node's own transform moved; its baked row is out of date. */
+  Transform = 1 << 0,
+}
+
+/**
+ * Generations retained at once. A consumer that has not looked for longer than
+ * this rebuilds from the scene graph instead, which is the same answer it gets
+ * today when its keys no longer match - so the window is a cost/benefit choice,
+ * not a correctness one.
+ *
+ * Eight frames: long enough that a root drawn every frame, or every other frame
+ * behind a paused scene, always finds its cursor inside the window, and short
+ * enough that the retained marks stay proportional to what recently moved
+ * rather than to the scene.
+ */
+const RETAINED_GENERATIONS = 8;
+
+/**
+ * One generation's marks. `nodes` keeps its backing store across recycles;
+ * `count` is the logical length.
+ */
+interface DirtyBucket {
+  generation: number;
+  /** Mark sequence when this generation opened - the window test reads it. */
+  firstSequence: number;
+  count: number;
+  readonly nodes: SceneNode[];
+  readonly channels: number[];
+}
+
+const createBucket = (): DirtyBucket => ({ generation: -1, firstSequence: 0, count: 0, nodes: [], channels: [] });
+
+/**
+ * The changed-record index: which nodes changed since a given point, in time
+ * proportional to what recently changed rather than to the scene.
+ *
+ * One index for the whole process, and deliberately not one per consumer. A
+ * moved node has no idea which retained products recorded it - render roots may
+ * overlap, a transform-group boundary may sit between them, a node may be under
+ * several - so a push model has to walk the ancestor chain on every single
+ * mutation and offer the node to each consumer it passes. That walk is what
+ * this replaces: a mutation writes one entry, and each consumer resolves the
+ * entries it cares about through the row map it already keeps.
+ *
+ * **An index, not a journal.** A node marked repeatedly holds ONE entry per
+ * generation, and what carries the ordering is the node's own mark sequence -
+ * its per-record revision. A thousand writes to one node in a frame therefore
+ * cost one entry and one number, and the retained marks are bounded by the
+ * number of distinct nodes that changed in the window, never by the number of
+ * changes. Falling out of the window is reported rather than papered over:
+ * {@link covers} answers `false` and the consumer rebuilds.
+ *
+ * Marking is gated by the caller (see `SceneNode`'s consumer counts), so a
+ * scene with no retained consumer writes nothing here.
+ * @internal
+ */
+class NodeDirtyIndex {
+  private _generation = 0;
+  private _slot = 0;
+  private _sequence = 0;
+  private _windowStartSequence = 0;
+  private readonly _buckets: DirtyBucket[] = Array.from({ length: RETAINED_GENERATIONS }, createBucket);
+
+  public constructor() {
+    this._buckets[0]!.generation = 0;
+  }
+
+  /**
+   * The current mark sequence: a consumer stores it once it has accounted for
+   * everything so far and passes it back to {@link readSince}.
+   */
+  public get sequence(): number {
+    return this._sequence;
+  }
+
+  /**
+   * Open the next generation, recycling the bucket that falls out of the
+   * window. Called once per frame - not once per render, which would rotate the
+   * window several times a frame and push every consumer out of it.
+   */
+  public advance(): void {
+    this._generation++;
+    this._slot = this._generation % RETAINED_GENERATIONS;
+
+    const bucket = this._buckets[this._slot]!;
+
+    bucket.generation = this._generation;
+    bucket.firstSequence = this._sequence;
+    bucket.count = 0;
+
+    const oldestGeneration = this._generation - RETAINED_GENERATIONS + 1;
+    const oldest = this._buckets[((oldestGeneration % RETAINED_GENERATIONS) + RETAINED_GENERATIONS) % RETAINED_GENERATIONS]!;
+
+    if (oldest.generation === oldestGeneration) {
+      this._windowStartSequence = oldest.firstSequence;
+    }
+  }
+
+  /**
+   * Record that `node` changed on `channels`, and stamp it with a fresh mark
+   * sequence. A node already marked in this generation keeps its entry and has
+   * the channels folded into it; the new sequence is what makes the repeat
+   * visible to a consumer that read in between.
+   */
+  public mark(node: SceneNode, channels: number): void {
+    const bucket = this._buckets[this._slot]!;
+
+    node._dirtyMarkSequence = ++this._sequence;
+
+    if (node._dirtyMarkGeneration === this._generation) {
+      bucket.channels[node._dirtyMarkSlot] = bucket.channels[node._dirtyMarkSlot]! | channels;
+
+      return;
+    }
+
+    // Retire the entry an earlier retained generation may still hold for this
+    // node, so the window carries exactly one live entry per node. Without it a
+    // node marked in two retained generations would be visited twice by one
+    // read, and a consumer that writes on every visit - a renderer patching its
+    // own private row - would do the work twice.
+    if (node._dirtyMarkGeneration >= 0) {
+      const previous = this._buckets[node._dirtyMarkGeneration % RETAINED_GENERATIONS]!;
+
+      if (previous.generation === node._dirtyMarkGeneration && previous.nodes[node._dirtyMarkSlot] === node) {
+        previous.channels[node._dirtyMarkSlot] = 0;
+      }
+    }
+
+    const slot = bucket.count++;
+
+    node._dirtyMarkGeneration = this._generation;
+    node._dirtyMarkSlot = slot;
+
+    if (slot < bucket.nodes.length) {
+      bucket.nodes[slot] = node;
+      bucket.channels[slot] = channels;
+    } else {
+      bucket.nodes.push(node);
+      bucket.channels.push(channels);
+    }
+  }
+
+  /**
+   * Whether the window still reaches back to `sequence`, i.e. whether an answer
+   * about everything since then would be complete.
+   */
+  public covers(sequence: number): boolean {
+    return sequence >= this._windowStartSequence;
+  }
+
+  /**
+   * Visit every node marked on `channels` after `sequence`, oldest generation
+   * first. Returns `false` when `sequence` has fallen out of the window - the
+   * caller must then treat the channel as unproven and rebuild - or when
+   * `visit` stopped the walk, which is how a consumer abandons an attempt on
+   * the first change it cannot apply.
+   *
+   * A node is visited at most once per read: re-marking retires the entry an
+   * older retained generation held for it, so the window never carries the same
+   * node twice.
+   */
+  public readSince(sequence: number, channels: number, visit: (node: SceneNode) => boolean): boolean {
+    if (!this.covers(sequence)) {
+      return false;
+    }
+
+    for (let step = Math.max(0, this._generation - RETAINED_GENERATIONS + 1); step <= this._generation; step++) {
+      const bucket = this._buckets[step % RETAINED_GENERATIONS]!;
+
+      if (bucket.generation !== step) {
+        continue;
+      }
+
+      for (let index = 0; index < bucket.count; index++) {
+        const node = bucket.nodes[index]!;
+
+        if ((bucket.channels[index]! & channels) !== 0 && node._dirtyMarkSequence > sequence && !visit(node)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Whether anything at all was marked on `channels` after `sequence` - the
+   * question a consumer asks before deciding that a frame changed nothing it
+   * owns. `false` also when the window no longer covers `sequence`, so pair it
+   * with {@link covers} wherever the difference between "quiet" and
+   * "unprovable" matters.
+   */
+  public hasMarksSince(sequence: number, channels: number): boolean {
+    let marked = false;
+
+    this.readSince(sequence, channels, () => {
+      marked = true;
+
+      return false;
+    });
+
+    return marked;
+  }
+
+  /** Drop every mark and start over - for tests and for a full teardown. */
+  public reset(): void {
+    for (const bucket of this._buckets) {
+      bucket.generation = -1;
+      bucket.firstSequence = 0;
+      bucket.count = 0;
+      bucket.nodes.length = 0;
+      bucket.channels.length = 0;
+    }
+
+    this._generation = 0;
+    this._slot = 0;
+    this._sequence = 0;
+    this._windowStartSequence = 0;
+    this._buckets[0]!.generation = 0;
+  }
+}
+
+/** The process-wide changed-record index; see {@link NodeDirtyIndex}. @internal */
+export const nodeDirtyIndex = new NodeDirtyIndex();

--- a/src/core/NodeDirtyIndex.ts
+++ b/src/core/NodeDirtyIndex.ts
@@ -8,6 +8,21 @@ import type { SceneNode } from './SceneNode';
 export const enum DirtyChannel {
   /** The node's own transform moved; its baked row is out of date. */
   Transform = 1 << 0,
+  /**
+   * The node's visual content changed in a way a recorded product cannot
+   * express by rewriting a row - a different texture, geometry, blend mode,
+   * filter, or visibility. A consumer that sees one has to rebuild.
+   */
+  Content = 1 << 1,
+  /**
+   * Only the node's tint changed. Split out of {@link Content} because it is
+   * the one content change a recorded product CAN express in place: tint lives
+   * in a per-row store parallel to the transform rows, so the change is a row
+   * write rather than a re-record. A tint write marks this channel and not
+   * `Content`, which is what lets a consumer tell "only tints moved" from
+   * "something changed that I cannot patch".
+   */
+  Tint = 1 << 2,
 }
 
 /**
@@ -112,26 +127,25 @@ class NodeDirtyIndex {
    */
   public mark(node: SceneNode, channels: number): void {
     const bucket = this._buckets[this._slot]!;
+    const live = node._dirtyMarkGeneration >= 0 ? this._buckets[node._dirtyMarkGeneration % RETAINED_GENERATIONS]! : null;
+    const held = live !== null && live.generation === node._dirtyMarkGeneration && live.nodes[node._dirtyMarkSlot] === node;
 
     node._dirtyMarkSequence = ++this._sequence;
 
-    if (node._dirtyMarkGeneration === this._generation) {
-      bucket.channels[node._dirtyMarkSlot] = bucket.channels[node._dirtyMarkSlot]! | channels;
-
+    // Repeating the SAME channels keeps the entry and only moves the sequence
+    // on: a node written a thousand times in a frame stays one entry, which is
+    // what makes this an index rather than a journal.
+    if (held && node._dirtyMarkGeneration === this._generation && live.channels[node._dirtyMarkSlot] === channels) {
       return;
     }
 
-    // Retire the entry an earlier retained generation may still hold for this
-    // node, so the window carries exactly one live entry per node. Without it a
-    // node marked in two retained generations would be visited twice by one
-    // read, and a consumer that writes on every visit - a renderer patching its
-    // own private row - would do the work twice.
-    if (node._dirtyMarkGeneration >= 0) {
-      const previous = this._buckets[node._dirtyMarkGeneration % RETAINED_GENERATIONS]!;
-
-      if (previous.generation === node._dirtyMarkGeneration && previous.nodes[node._dirtyMarkSlot] === node) {
-        previous.channels[node._dirtyMarkSlot] = 0;
-      }
+    // Different channels, or an older generation: retire the entry that is
+    // still standing and open a new one. Retiring matters twice over - a node
+    // left in two buckets would be visited twice by one read, and an entry
+    // whose mask had accumulated both a content change and a later tint could
+    // no longer say which of them a given cursor is looking at.
+    if (held) {
+      live.channels[node._dirtyMarkSlot] = 0;
     }
 
     const slot = bucket.count++;
@@ -167,7 +181,7 @@ class NodeDirtyIndex {
    * older retained generation held for it, so the window never carries the same
    * node twice.
    */
-  public readSince(sequence: number, channels: number, visit: (node: SceneNode) => boolean): boolean {
+  public readSince(sequence: number, channels: number, visit: (node: SceneNode, marked: number) => boolean): boolean {
     if (!this.covers(sequence)) {
       return false;
     }
@@ -182,7 +196,9 @@ class NodeDirtyIndex {
       for (let index = 0; index < bucket.count; index++) {
         const node = bucket.nodes[index]!;
 
-        if ((bucket.channels[index]! & channels) !== 0 && node._dirtyMarkSequence > sequence && !visit(node)) {
+        const marked = bucket.channels[index]!;
+
+        if ((marked & channels) !== 0 && node._dirtyMarkSequence > sequence && !visit(node, marked)) {
           return false;
         }
       }

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -1182,9 +1182,13 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
    * stale ancestor. N same-path mutations between two reads cost
    * O(depth + N) stamps instead of O(N * depth).
    */
-  protected _markContentDirty(): void {
+  protected _markContentDirty(channels: number = DirtyChannel.Content): void {
     const revision = nextNodeRevision();
     const epoch = dirtyWalkEpoch;
+
+    if (transformGroupBoundaryCount > 0 || retainedRenderRootCount > 0) {
+      nodeDirtyIndex.mark(this, channels);
+    }
 
     this._nodeRevision.touchContent(revision);
     this._contentWalkEpoch = epoch;

--- a/src/core/SceneNode.ts
+++ b/src/core/SceneNode.ts
@@ -28,6 +28,7 @@ import type { RenderNode } from '#rendering/RenderNode';
 import type { View } from '#rendering/View';
 
 import { Bounds } from './Bounds';
+import { DirtyChannel, nodeDirtyIndex } from './NodeDirtyIndex';
 import { nextNodeRevision, NodeRevision } from './NodeRevision';
 import type { Stage } from './Stage';
 
@@ -630,24 +631,6 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   /**
-   * @internal - the nearest enclosing retained transform group
-   * is notified when a descendant's OWN transform moves, so it can patch that
-   * node's group-owned transform row in place (O(1)) instead of re-collecting
-   * the whole subtree. No-op on a plain node; {@link RetainedContainer}
-   * overrides it to enqueue the row on its fragment.
-   */
-  public _enqueueDirtyTransformRow(_node: RenderNode): void {}
-
-  /**
-   * @internal - the render-root counterpart of {@link _enqueueDirtyTransformRow}:
-   * a descendant's own transform moved, and this node may own an automatic
-   * render-root representation with that node's row baked into its recording.
-   * No-op on a plain node and on any node that never served as a render root;
-   * {@link RenderNode} forwards it to its representation when one exists.
-   */
-  public _enqueueRetainedRootRow(_node: RenderNode): void {}
-
-  /**
    * Whether this node opts back OUT of a parent transform-group boundary and
    * resolves world-space transforms. Overridden by RenderNode for
    * barrier-effect nodes (filters/mask/clip/cacheAsTexture), whose effect
@@ -1167,14 +1150,17 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   private _transformWalkEpoch = 0;
 
   /**
-   * @internal - dirty-transform-row dedup stamp: the enclosing group's
-   * dirty-row epoch at the last time this node was enqueued. Compared against
-   * that group's current epoch to skip a second push in the same collect cycle
-   * (see {@link RetainedGroupFragment.enqueueDirtyTransformRow}). The epoch is a
-   * globally unique monotonic value, so a stale stamp can never falsely match a
-   * different cycle - a false dedup would drop a move (stale render).
+   * @internal - {@link NodeDirtyIndex} bookkeeping: the generation this node was
+   * last marked in and the slot it took in that generation's bucket (a second
+   * mark in the same generation folds into that slot), plus the mark sequence
+   * of the most recent mark - this node's own change revision, and what a
+   * consumer's cursor is compared against. Only the index reads or writes these.
    */
-  public _dirtyRowStamp = 0;
+  public _dirtyMarkGeneration = -1;
+  /** @internal - see {@link _dirtyMarkGeneration}. */
+  public _dirtyMarkSlot = -1;
+  /** @internal - see {@link _dirtyMarkGeneration}. */
+  public _dirtyMarkSequence = 0;
 
   /**
    * @internal - mark this node's content dirty and propagate the stamp up to
@@ -1286,52 +1272,28 @@ export class SceneNode implements Collidable, ObservableVectorOwner {
   }
 
   /**
-   * Hand this node to every consumer that owns a baked copy of its transform
-   * row, so each can fast-patch that row instead of re-collecting.
+   * Record that this node's transform moved, for every consumer that owns a
+   * baked copy of its row.
    *
-   * Two kinds of consumer, one walk:
-   *
-   * - The nearest enclosing transform-group boundary - and only the nearest:
-   *   that group owns this node's group-local row, and an outer group recorded
-   *   the inner one as a nested boundary, not as rows of its own.
-   * - EVERY ancestor that owns an automatic render-root representation. Roots
-   *   may overlap (`render(world)` alongside `render(world.hud)`) and there is
-   *   no exclusive owner slot, so the walk cannot stop at the first one. A
-   *   representation whose fragment holds no recording ignores the call.
+   * One entry in the shared index, not a walk. A moved node cannot know which
+   * retained products recorded it - render roots may overlap
+   * (`render(world)` alongside `render(world.hud)`), a transform-group boundary
+   * may sit between them, and there is no exclusive owner slot - so offering
+   * the node to each consumer meant climbing the whole ancestor chain on every
+   * single mutation. Each consumer now resolves the marks it cares about
+   * against the row map it already keeps, and the ones it recorded cost it a
+   * map hit rather than the mutator a walk.
    *
    * Runs on every own-transform mutation, so it must not allocate - and
-   * short-circuits to a single pair of count checks while neither consumer kind
-   * exists anywhere.
+   * short-circuits to a single pair of count checks while no consumer of either
+   * kind exists anywhere.
    */
   private _notifyEnclosingRetainedGroup(): void {
     if (transformGroupBoundaryCount === 0 && retainedRenderRootCount === 0) {
       return;
     }
 
-    const node = this as unknown as RenderNode;
-    let boundaryNotified = transformGroupBoundaryCount === 0;
-    let ancestor: Container | null = this._parentNode;
-
-    while (ancestor !== null) {
-      if (!boundaryNotified && ancestor._isTransformGroupBoundary) {
-        ancestor._enqueueDirtyTransformRow(node);
-        boundaryNotified = true;
-      }
-
-      if (retainedRenderRootCount > 0) {
-        ancestor._enqueueRetainedRootRow(node);
-      }
-
-      // Both consumers found nothing left to visit: a boundary was notified and
-      // no representation can be above it either, because a fragment that
-      // contains a boundary records it as a live re-dispatch and owns no rows
-      // below it. Walking on would be pure cost.
-      if (boundaryNotified && retainedRenderRootCount === 0) {
-        return;
-      }
-
-      ancestor = ancestor.parent;
-    }
+    nodeDirtyIndex.mark(this, DirtyChannel.Transform);
   }
 
   private _setPositionDirty(): void {

--- a/src/rendering/Drawable.ts
+++ b/src/rendering/Drawable.ts
@@ -135,11 +135,17 @@ export class Drawable extends RenderNode {
   /**
    * Set the tint colour by copying `color` into the internal {@link Color} instance.
    * Invalidates the render cache so the change is picked up on the next frame.
+   *
+   * A retained product recognises a tint-only change and rewrites the affected
+   * row rather than re-recording, so tinting per frame stays cheap. Writing
+   * through the returned {@link tint} instance instead (`sprite.tint.r = 8`)
+   * bypasses that entirely and is not observed at all - assign a colour, or
+   * call {@link RenderNode.invalidateContent} after mutating in place.
    */
   public setTint(color: Color): this {
     if (color) {
       this._tint.copy(color);
-      this.invalidateCache();
+      this._invalidateTint();
     }
 
     return this;

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -1,4 +1,5 @@
 import { Color } from '#core/Color';
+import { DirtyChannel } from '#core/NodeDirtyIndex';
 import { registerRetainedRenderRoot, SceneNode, unregisterRetainedRenderRoot } from '#core/SceneNode';
 import { Signal } from '#core/Signal';
 import type { InteractionEvent, InteractionEventType } from '#input/InteractionEvent';
@@ -678,6 +679,20 @@ export abstract class RenderNode extends SceneNode {
    */
   public invalidateContent(): this {
     this._markContentDirty();
+
+    return this;
+  }
+
+  /**
+   * @internal - cache invalidation for a change whose ONLY visual effect is
+   * this node's tint. Content-dirties exactly as {@link invalidateCache} does,
+   * so every consumer that cannot patch a tint still rebuilds; the difference
+   * is the channel it marks, which is what lets a retained product recognise a
+   * tint-only delta and rewrite the row instead of the product.
+   */
+  public _invalidateTint(): this {
+    this._cacheDirty = true;
+    this._markContentDirty(DirtyChannel.Tint);
 
     return this;
   }

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -565,13 +565,7 @@ export abstract class RenderNode extends SceneNode {
    * the first place, and would stay on plain collect forever.
    */
   public override _enqueueRetainedRootRow(node: RenderNode): void {
-    const representation = this._retainedRoot;
-
-    if (!representation?.fragment.hasCapture) {
-      return;
-    }
-
-    representation.fragment.enqueueDirtyTransformRow(node);
+    this._retainedRoot?.enqueueDirtyTransformRow(node);
   }
 
   /** @internal */

--- a/src/rendering/RenderNode.ts
+++ b/src/rendering/RenderNode.ts
@@ -555,19 +555,6 @@ export abstract class RenderNode extends SceneNode {
     return this._retainedRoot;
   }
 
-  /**
-   * @internal - the descendant transform-move seam for the automatic root
-   * representation. Gated on a live CAPTURE, not on a live recording as
-   * {@link RetainedContainer._enqueueDirtyTransformRow} is: the root treats a
-   * queued move as its proof that the transform channel is accounted for, and
-   * that proof has to exist one tier earlier. Without it a scene that moves
-   * something every frame would never see the clean frame it needs to record in
-   * the first place, and would stay on plain collect forever.
-   */
-  public override _enqueueRetainedRootRow(node: RenderNode): void {
-    this._retainedRoot?.enqueueDirtyTransformRow(node);
-  }
-
   /** @internal */
   protected _collectContent(_builder: RenderPlanBuilder): void {
     // Overridden by Drawable/Container.

--- a/src/rendering/RenderStats.ts
+++ b/src/rendering/RenderStats.ts
@@ -1,3 +1,5 @@
+import { nodeDirtyIndex } from '#core/NodeDirtyIndex';
+
 /**
  * Per-frame rendering counters collected by the backend each tick.
  * Expose live performance data for debugging and profiling tools.
@@ -114,6 +116,11 @@ export const createRenderStats = (): RenderStats => ({
  * read 0 after the first frame.
  */
 export const resetRenderStats = (stats: RenderStats): RenderStats => {
+  // The dirty index counts in frames, and this is where a frame begins. Opening
+  // a generation per render instead would rotate the window several times in a
+  // frame that draws more than one root and push every consumer out of it.
+  nodeDirtyIndex.advance();
+
   stats.frame++;
   stats.submittedNodes = 0;
   stats.culledNodes = 0;

--- a/src/rendering/RetainedContainer.ts
+++ b/src/rendering/RetainedContainer.ts
@@ -114,32 +114,6 @@ export class RetainedContainer extends Container {
     this._getStage()?.interaction._notifyTransformGroupMoved(this);
   }
 
-  /**
-   * The descendant transform-move seam: a descendant's own transform moved. Queue
-   * its row on the fragment; {@link _collectContent} patches the queued rows in
-   * place on a content/structure-clean frame instead of re-collecting. The
-   * group's OWN move does not route here - {@link _markOwnTransformDirty}
-   * above handles it as a one-matrix group move.
-   *
-   * Gated on a live committed recording: only the recorded-instruction
-   * tier ever consumes a queued row. On every tier without one - entry
-   * replay, and a recording-less group (e.g. an escaped-branch group, whose
-   * `_fragment.dispose()` drops any recording) - transforms are re-read live
-   * and {@link _reconcileTransformRows} would just drain the queue unread on
-   * the next collect. Skipping the enqueue there is free: nothing else
-   * observes the queue between now and that drain. (A recording backend
-   * lacking patch support DOES still enqueue here -
-   * `hasRecording` is true - and {@link _reconcileTransformRows} is the one
-   * that drops the recording and falls back to entry replay.)
-   */
-  public override _enqueueDirtyTransformRow(node: RenderNode): void {
-    if (this._fragment.instructions?.hasRecording !== true) {
-      return;
-    }
-
-    this._fragment.enqueueDirtyTransformRow(node);
-  }
-
   // ── Group-local bounds aggregate cache ──────────────────────────────────
   // The group-local child aggregate only changes when the SUBTREE changes,
   // which the content/structure revisions already key exactly - a group move
@@ -278,7 +252,7 @@ export class RetainedContainer extends Container {
       // dirties. The recorded instruction set's baked transform rows are stale
       // for those nodes - patch the changed rows in place (O(k)), or drop the
       // recording so entry replay re-reads live transforms this frame.
-      if (this._fragment.hasDirtyTransformRows()) {
+      if (this._fragment.hasUnseenTransformMarks()) {
         this._reconcileTransformRows(builder.backend);
       }
 
@@ -348,15 +322,40 @@ export class RetainedContainer extends Container {
   }
 
   /**
-   * Reconcile the queued transform-only moves against the recorded
-   * instruction set before replay. Only DIRECT drawable children are in this
-   * group's patch contract - a move nested below a sub-container drops the
-   * recording, so the frame entry-replays with live transforms and re-records.
-   * The mechanics live in {@link reconcileRetainedTransformRows}; the render-root
-   * representation shares them with a wider eligibility rule.
+   * Reconcile the marked transform-only moves against the recorded instruction
+   * set before replay.
+   *
+   * This group owns a move exactly when it is the NEAREST enclosing boundary:
+   * a move below a nested group belongs to that group's own rows, and one
+   * outside this subtree belongs to another consumer entirely. Of the moves it
+   * does own, only DIRECT drawable children are in its patch contract - a
+   * deeper one has no row here, so the recording is dropped and the frame
+   * entry-replays with live transforms and re-records. The mechanics live in
+   * {@link reconcileRetainedTransformRows}; the render-root representation
+   * shares them with a wider ownership rule.
    */
   private _reconcileTransformRows(backend: RenderBackend): void {
-    reconcileRetainedTransformRows(this._fragment, backend, node => node.parent === this);
+    reconcileRetainedTransformRows(
+      this._fragment,
+      backend,
+      node => this._ownsMove(node),
+      node => (node.parent as unknown as RetainedContainer) === this,
+    );
+  }
+
+  /** Whether this group is the nearest transform-group boundary above `node`. */
+  private _ownsMove(node: RenderNode): boolean {
+    let parent = node.parent;
+
+    while (parent !== null) {
+      if (parent._isTransformGroupBoundary) {
+        return (parent as unknown as RetainedContainer) === this;
+      }
+
+      parent = parent.parent;
+    }
+
+    return false;
   }
 
   /**

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -998,6 +998,12 @@ export class RenderPlanBuilder {
 
     const ancestryStamp = node._globalTransformStamp;
 
+    // Settle WHICH product this draw is about before anything reads or writes
+    // one: the same root drawn into a render texture and onto the screen in the
+    // same frame holds one product per target, and every check below is about
+    // the selected one.
+    representation.selectCaptureSlot(backend, target);
+
     // Persistent-indexed tier, ABOVE the capture decision. A root whose source
     // the backend can serve from slot-addressed stores does not produce entries
     // at all: the frame either re-issues the order stream the last selection
@@ -1011,7 +1017,7 @@ export class RenderPlanBuilder {
     // descendant move patches its baked row in place instead of invalidating,
     // which is what keeps a partly-dynamic scene on the recorded tier.
     if (
-      representation.isCleanIgnoringTransform(contentRevision, structureRevision, ancestryStamp, view, backend, target) &&
+      representation.isCleanIgnoringTransform(contentRevision, structureRevision, ancestryStamp, view) &&
       representation.reconcileTransform(transformRevision, view, backend)
     ) {
       const set = representation.fragment.instructions;
@@ -1081,7 +1087,6 @@ export class RenderPlanBuilder {
       ancestryStamp,
       view,
       backend,
-      target,
       this._peekCurrentScopeEntries(),
       this._peekCurrentScopeEntryCount(),
     );

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -1018,7 +1018,7 @@ export class RenderPlanBuilder {
     // which is what keeps a partly-dynamic scene on the recorded tier.
     if (
       representation.isCleanIgnoringTransform(contentRevision, structureRevision, ancestryStamp, view) &&
-      representation.reconcileTransform(transformRevision, view, backend)
+      representation.reconcileTransform(transformRevision, view, backend, node)
     ) {
       const set = representation.fragment.instructions;
 

--- a/src/rendering/plan/RenderPlanBuilder.ts
+++ b/src/rendering/plan/RenderPlanBuilder.ts
@@ -1017,6 +1017,7 @@ export class RenderPlanBuilder {
     // descendant move patches its baked row in place instead of invalidating,
     // which is what keeps a partly-dynamic scene on the recorded tier.
     if (
+      representation.reconcileContent(contentRevision, node) &&
       representation.isCleanIgnoringTransform(contentRevision, structureRevision, ancestryStamp, view) &&
       representation.reconcileTransform(transformRevision, view, backend, node)
     ) {

--- a/src/rendering/plan/RetainedCaptureSlot.ts
+++ b/src/rendering/plan/RetainedCaptureSlot.ts
@@ -1,0 +1,430 @@
+import { Bounds } from '#core/Bounds';
+import { type ReadonlyRectangle, Rectangle } from '#math/Rectangle';
+import type { Drawable } from '#rendering/Drawable';
+import type { RenderBackend } from '#rendering/RenderBackend';
+import type { View } from '#rendering/View';
+
+import { CaptureThrashSuppressor, CaptureVerdict } from './CaptureThrashSuppressor';
+import type { ScopeEntry } from './RenderScope';
+import { RetainedGroupFragment } from './RetainedGroupFragment';
+import { reconcileRetainedTransformRows } from './retainedTransformRowPatch';
+
+/** The render target a product was compiled against (backend-owned identity). */
+export type RenderTargetIdentity = RenderBackend['renderTarget'];
+
+/**
+ * One captured product of a render root, together with the keys it is valid
+ * under and the thrash state that decides whether capturing it again is worth
+ * the frame.
+ *
+ * A slot belongs to exactly one (backend, render target) pair for as long as it
+ * is held. That pairing is what makes it a slot rather than a field: the same
+ * root drawn into a `RenderTexture` and onto the screen in one frame produces
+ * two products that are individually valid and mutually useless, and a single
+ * field would have each draw discard the other's work every frame.
+ * {@link RetainedRootRepresentation} owns the small set and decides which slot
+ * a draw gets; everything below this line is unaware that more than one exists.
+ *
+ * Only the capture tier lives here. The persistent source, its membership and
+ * the backend's slot stores are keyed on the node and the backend alone, so
+ * they stay on the representation and are shared by every target.
+ * @internal
+ */
+export class RetainedCaptureSlot {
+  public readonly fragment = new RetainedGroupFragment();
+
+  private _hasCapture = false;
+  private _contentRevision = -1;
+  private _structureRevision = -1;
+  private _transformRevision = -1;
+  private _ancestryStamp = -1;
+  /**
+   * The pair this slot is held for. Written when the slot is handed out, not
+   * when a capture lands, so a slot whose capture was invalidated or suppressed
+   * still answers for its target instead of being handed to the other one.
+   */
+  private _backend: RenderBackend | null = null;
+  private _target: RenderTargetIdentity | null = null;
+  private _view: View | null = null;
+  private _viewUpdateId = -1;
+
+  /**
+   * Whether the capturing collect dropped at least one node on the view test.
+   * A capture that culled nothing can be replayed under any view that still
+   * contains {@link _keptBounds}; a capture that culled something can only be
+   * replayed under a view inside {@link _captureCullRect}, because outside that
+   * rect a previously-culled node may have entered the view and no index exists
+   * to find it.
+   */
+  private _culledDuringCapture = true;
+  /** Union of the rects the view test compared for every kept, cullable node. */
+  private readonly _keptBounds = new Bounds();
+  private _keptEmpty = true;
+  /**
+   * The rect the capturing collect actually culled against - the view rect grown
+   * by the capture margin (`RenderPlanBuilder.cullRect`). Every node the capture
+   * dropped lies outside it, so any view still INSIDE it selects the same nodes
+   * and the product replays unchanged.
+   */
+  private readonly _captureCullRect = new Rectangle();
+  private _hasCaptureCullRect = false;
+  /**
+   * Whether the capturing collect READ the view - i.e. produced content that is
+   * a function of the camera, not merely positioned by it.
+   *
+   * Such a capture may only be replayed under the very same view. Both view
+   * tolerances below reason about the SELECTION of nodes (what a cull test would
+   * have dropped), and that reasoning is sound only while each node's recorded
+   * draw is what a fresh collect would produce again. A node that rebuilds its
+   * geometry from `view.center` breaks that premise: replaying it paints the
+   * camera position it was captured at. `ImageLayerNode` and `TileLayerNode` do
+   * exactly this, and contract 9 of the architecture freeze reserves the right
+   * for any node, which is why this is observed rather than declared.
+   */
+  private _viewDependentCapture = false;
+
+  // Thrash suppression over the FULL key (see `shouldSuppressCapture`). The
+  // state machine is shared with a group's fragment; only the key is this
+  // tier's own, and it is the wider of the two.
+  private readonly _thrash = new CaptureThrashSuppressor();
+  private _observedContent = -1;
+  private _observedStructure = -1;
+  private _observedTransform = -1;
+  private _observedView: View | null = null;
+  private _observedViewUpdateId = -1;
+
+  /**
+   * Whether the captured product can be replayed as-is this frame.
+   *
+   * The revision/identity keys are exact compares. The view key is not, and it
+   * has two independent ways to pass, because the captured records - world-space
+   * bounds, material keys, baked transform rows - carry no view state of their
+   * own (the recorded batches resolve projection live at replay):
+   *
+   * - **The view still fits the capture's cull rect.** Every node the capture
+   *   dropped was outside that rect, hence outside this view too; every node it
+   *   kept is still drawn, and any that no longer meets the view is clipped
+   *   rather than wrong. This is the case that survives a moving camera over a
+   *   scene with off-screen content - the margin exists to make it common.
+   * - **Nothing was culled and the view still contains every kept node.** Then
+   *   the selection is trivially the whole subtree and stays that way. This one
+   *   also covers a view that GREW past the capture rect (a zoom-out), which the
+   *   first test cannot.
+   */
+  public isCleanIgnoringTransform(contentRevision: number, structureRevision: number, ancestryStamp: number, view: View): boolean {
+    if (!this.matchesNonViewKeys(contentRevision, structureRevision, ancestryStamp)) {
+      return false;
+    }
+
+    if (this._view === view && this._viewUpdateId === view.updateId) {
+      return true;
+    }
+
+    if (this._viewDependentCapture) {
+      // The view moved and the capture is a function of it: neither tolerance
+      // applies, because both only argue about which nodes a cull test admits.
+      return false;
+    }
+
+    if (this._viewFitsCaptureCullRect(view)) {
+      return true;
+    }
+
+    if (this._culledDuringCapture) {
+      return false;
+    }
+
+    return this._keptEmpty || view.getBounds().containsRect(this._keptBounds.getRect());
+  }
+
+  /**
+   * Every key except the view: whether the captured product still describes the
+   * same subtree. Backend and target are not compared here - a slot is only ever
+   * handed to the pair it is held for, so they are settled before the frame
+   * reaches this check.
+   *
+   * Split out from {@link isCleanIgnoringTransform} because the view key is the
+   * only one that is not an exact compare, and reading the exact half on its own
+   * is what makes the tolerant half legible.
+   */
+  public matchesNonViewKeys(contentRevision: number, structureRevision: number, ancestryStamp: number): boolean {
+    return (
+      this._hasCapture && this._contentRevision === contentRevision && this._structureRevision === structureRevision && this._ancestryStamp === ancestryStamp
+    );
+  }
+
+  /** Whether this slot is the one held for `backend` drawing into `target`. */
+  public matchesKey(backend: RenderBackend, target: RenderTargetIdentity | null): boolean {
+    return this._backend === backend && this._target === target;
+  }
+
+  /** Whether this slot holds a product at all - an unkeyed or evicted slot does not. */
+  public get hasCapture(): boolean {
+    return this._hasCapture;
+  }
+
+  /**
+   * Hand this slot to a different pair, discarding whatever it held. The
+   * product is bound to the target it was compiled for, so nothing about it
+   * survives the move.
+   */
+  public retarget(backend: RenderBackend, target: RenderTargetIdentity | null): void {
+    this.invalidate();
+    this._backend = backend;
+    this._target = target;
+  }
+
+  /** Whether this view lies entirely inside the rect the capture culled against. */
+  private _viewFitsCaptureCullRect(view: View): boolean {
+    return this._hasCaptureCullRect && this._captureCullRect.containsRect(view.getBounds());
+  }
+
+  /**
+   * Settle the transform channel for a frame whose other keys already match:
+   * `true` means the product may be replayed, `false` that the frame must
+   * re-collect.
+   *
+   * Transform-only descendant moves are the one change class that does NOT
+   * invalidate here. The moved nodes arrive through the same seam a
+   * {@link RetainedContainer} uses, and their baked rows are patched in place
+   * (O(k)) rather than re-derived - which is what keeps a scene with a few
+   * percent of moving nodes on the recorded tier.
+   *
+   * The queue is fed from a live capture onward, one tier earlier than a group's
+   * - a group only needs it on the recorded tier, whereas the root needs the
+   * queue as its PROOF that every move was accounted for. Without that proof one
+   * frame earlier, a scene that moves something every frame would never reach the
+   * clean frame it has to record on.
+   *
+   * The guards that make that sound against per-child view culling - which a
+   * group does not have to face, since it suppresses culling inside itself and
+   * is culled as a whole - live in {@link _canReconcileMovedNodes}.
+   */
+  public reconcileTransform(transformRevision: number, view: View, backend: RenderBackend): boolean {
+    if (!this.fragment.hasDirtyTransformRows()) {
+      // Nothing queued. Either nothing moved (revisions agree), or a move
+      // happened while no recording was live - the enqueue gate skips those, so
+      // there is no proof the queue saw everything and the frame re-collects.
+      return this._transformRevision === transformRevision;
+    }
+
+    if (!this._canReconcileMovedNodes(view)) {
+      this._dropRecording();
+
+      return false;
+    }
+
+    if (!reconcileRetainedTransformRows(this.fragment, backend, () => true)) {
+      return false;
+    }
+
+    this._transformRevision = transformRevision;
+
+    return true;
+  }
+
+  /**
+   * Whether every queued move can be applied to the captured product, growing
+   * the kept-union by each moved node's CURRENT cull rect on the way.
+   *
+   * Two rejections, one per direction a move can break the selection:
+   *
+   * - **A moved node the capture never recorded, on a capture that culled.** It
+   *   is not in the product, so it may be one of the culled ones - and it may
+   *   have just moved INTO the view, which replay would silently omit. Patching
+   *   cannot help: there is no row to patch. (On the recorded tier the row patch
+   *   would catch this too, but the entry-replay tier has no such check, and
+   *   this must hold on both.) When the capture culled nothing, every visible
+   *   node is in the product and no such node exists.
+   * - **A moved node that left the view, when only the kept-union rule is
+   *   carrying validity.** Replaying would keep drawing it where a real collect
+   *   would have dropped it - which matters because that rule's whole premise is
+   *   that nothing was culled. Under the capture-rect rule the premise is
+   *   different and this cannot go wrong: an out-of-view node that is still
+   *   drawn is clipped, not wrong.
+   */
+  private _canReconcileMovedNodes(view: View): boolean {
+    const viewRect = view.getBounds();
+    const insideCaptureRect = this._viewFitsCaptureCullRect(view);
+
+    for (let index = 0; index < this.fragment.dirtyTransformRowCount; index++) {
+      const node = this.fragment.dirtyTransformRowAt(index);
+
+      if (this._culledDuringCapture && this.fragment.recordedDraw(node as unknown as Drawable) === undefined) {
+        return false;
+      }
+
+      if (!node.cullable) {
+        // Never culled: its position cannot change the selection.
+        continue;
+      }
+
+      const rect = node.cullArea ?? node.getBounds();
+
+      if (!insideCaptureRect && !viewRect.intersectsWith(rect)) {
+        return false;
+      }
+
+      this._keptBounds.addRect(rect);
+      this._keptEmpty = false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Give up the recorded tier without giving up the capture: the queue is
+   * drained so no stale row survives, and dropping the recording closes the
+   * enqueue gate so nothing accumulates until the next collect re-records.
+   */
+  private _dropRecording(): void {
+    this.fragment.instructions?.invalidate();
+    this.fragment.clearDirtyTransformRows();
+  }
+
+  /** The active capture was replayed at least once - it earned its keep. */
+  public markReplayed(): void {
+    this._thrash.markReplayed();
+    this.fragment.markReplayed();
+  }
+
+  /**
+   * Decide, on a frame whose key check already failed, whether the snapshot
+   * should be skipped. Mutates the suppression state machine; call exactly once
+   * per such frame, before collecting. Returns `true` to skip the capture.
+   *
+   * Same shape as {@link RetainedGroupFragment.shouldSuppressCapture} but keyed
+   * on the FULL root key including the view: without the view in the observed
+   * tuple, a panning camera over a partly-culled scene would alternate between
+   * suppressed and recovered forever instead of settling.
+   */
+  public shouldSuppressCapture(contentRevision: number, structureRevision: number, transformRevision: number, view: View): boolean {
+    const keyUnchanged =
+      this._observedContent === contentRevision &&
+      this._observedStructure === structureRevision &&
+      this._observedTransform === transformRevision &&
+      this._observedView === view &&
+      this._observedViewUpdateId === view.updateId;
+    const verdict = this._thrash.evaluate(this._hasCapture, keyUnchanged);
+
+    if (verdict === CaptureVerdict.Capture) {
+      return false;
+    }
+
+    if (verdict === CaptureVerdict.InvalidateAndSuppress) {
+      this.invalidate();
+      this._thrash.suppress();
+    }
+
+    this._observe(contentRevision, structureRevision, transformRevision, view);
+
+    return true;
+  }
+
+  /**
+   * Arm cull-union accumulation for the collect that is about to run, and record
+   * the rect that collect will cull against - the view's rect plus the capture
+   * margin, which is what later lets a moved view be judged in O(1).
+   */
+  public beginCapture(cullRect: ReadonlyRectangle): void {
+    this._keptBounds.reset();
+    this._keptEmpty = true;
+    this._culledDuringCapture = false;
+    this._viewDependentCapture = false;
+    this._captureCullRect.set(cullRect.x, cullRect.y, cullRect.width, cullRect.height);
+    this._hasCaptureCullRect = true;
+  }
+
+  /**
+   * The collect being captured read the view (see {@link _viewDependentCapture}).
+   * Called from `RenderPlanBuilder`'s public view getter, so it fires for any
+   * node - engine or third-party - without one having to declare itself.
+   */
+  public noteViewRead(): void {
+    this._viewDependentCapture = true;
+  }
+
+  /** A node passed the view test; `rect` is exactly what `inView` compared. */
+  public noteKept(rect: ReadonlyRectangle): void {
+    this._keptBounds.addRect(rect);
+    this._keptEmpty = false;
+  }
+
+  /**
+   * {@link noteKept} for a caller that holds the compared extent as four numbers
+   * rather than a rectangle - the source selection, whose items store it that
+   * way. Materialising a `Rectangle` per item just to hand it over would cost
+   * more than the fold.
+   */
+  public noteKeptCoords(minX: number, minY: number, maxX: number, maxY: number): void {
+    this._keptBounds.addCoords(minX, minY).addCoords(maxX, maxY);
+    this._keptEmpty = false;
+  }
+
+  /** A node was dropped by the view test - the capture is view-locked. */
+  public noteCulled(): void {
+    this._culledDuringCapture = true;
+  }
+
+  /** Snapshot the root scope's entries and key the capture. */
+  public commitCapture(
+    contentRevision: number,
+    structureRevision: number,
+    transformRevision: number,
+    ancestryStamp: number,
+    view: View,
+    backend: RenderBackend,
+    entries: readonly ScopeEntry[],
+    entryCount: number,
+  ): void {
+    // `true`: nested transform groups are recorded as live re-dispatches, so a
+    // `RetainedContainer` under a render root keeps its own retention tier
+    // untouched (see the snapshot policy in `RetainedGroupFragment`).
+    this.fragment.capture(contentRevision, structureRevision, backend, entries, entryCount, true);
+
+    this._contentRevision = contentRevision;
+    this._structureRevision = structureRevision;
+    this._transformRevision = transformRevision;
+    this._ancestryStamp = ancestryStamp;
+    this._view = view;
+    this._viewUpdateId = view.updateId;
+    this._hasCapture = true;
+    this._thrash.markCaptured();
+  }
+
+  /**
+   * Drop the capture and its recording; the GPU bundle is kept (grow-only).
+   *
+   * The SOURCE deliberately survives. It is keyed on the node's own revisions
+   * and validates itself, so it stays correct across anything that invalidates a
+   * capture - and the loudest caller here is capture suppression, where the
+   * frame that just lost its capture is exactly the one that most needs a cheap
+   * path to fall back to.
+   */
+  public invalidate(): void {
+    this.fragment.invalidate();
+    this._hasCapture = false;
+    this._thrash.reset();
+    this._keptBounds.reset();
+    this._keptEmpty = true;
+    this._culledDuringCapture = true;
+    this._viewDependentCapture = false;
+    this._hasCaptureCullRect = false;
+    this._view = null;
+  }
+
+  /** Release the product and the retained GPU resources behind it. */
+  public dispose(): void {
+    this.invalidate();
+    this.fragment.dispose();
+    this._keptBounds.destroy();
+  }
+
+  private _observe(contentRevision: number, structureRevision: number, transformRevision: number, view: View): void {
+    this._observedContent = contentRevision;
+    this._observedStructure = structureRevision;
+    this._observedTransform = transformRevision;
+    this._observedView = view;
+    this._observedViewUpdateId = view.updateId;
+  }
+}

--- a/src/rendering/plan/RetainedCaptureSlot.ts
+++ b/src/rendering/plan/RetainedCaptureSlot.ts
@@ -8,7 +8,7 @@ import type { View } from '#rendering/View';
 import { CaptureThrashSuppressor, CaptureVerdict } from './CaptureThrashSuppressor';
 import type { ScopeEntry } from './RenderScope';
 import { RetainedGroupFragment } from './RetainedGroupFragment';
-import { forEachMovedNode, isUnder, reconcileRetainedTransformRows } from './retainedTransformRowPatch';
+import { forEachMovedNode, isUnder, reconcileRetainedTintRows, reconcileRetainedTransformRows } from './retainedTransformRowPatch';
 
 /** The render target a product was compiled against (backend-owned identity). */
 export type RenderTargetIdentity = RenderBackend['renderTarget'];
@@ -93,6 +93,36 @@ export class RetainedCaptureSlot {
   private _observedTransform = -1;
   private _observedView: View | null = null;
   private _observedViewUpdateId = -1;
+
+  /**
+   * Settle the CONTENT channel for a frame whose content revision moved:
+   * `true` means the product still describes the subtree and may go on to the
+   * key check, `false` that the frame must rebuild.
+   *
+   * A tint change is the one content change that does not have to invalidate.
+   * It lives in a per-row store parallel to the transform rows, so the product
+   * can be corrected in place exactly as a move is - which matters because
+   * tinting per frame (a hit flash, a selection highlight, a fade) is an
+   * ordinary thing to do and used to throw the whole recording away every
+   * frame it happened.
+   *
+   * Everything else still rebuilds, and deliberately: a different texture,
+   * geometry or blend mode changes which batch a node belongs to, and no row
+   * write expresses that.
+   */
+  public reconcileContent(contentRevision: number, root: RenderNode): boolean {
+    if (this._contentRevision === contentRevision) {
+      return true;
+    }
+
+    if (!this._hasCapture || !reconcileRetainedTintRows(this.fragment, node => isUnder(node, root))) {
+      return false;
+    }
+
+    this._contentRevision = contentRevision;
+
+    return true;
+  }
 
   /**
    * Whether the captured product can be replayed as-is this frame.

--- a/src/rendering/plan/RetainedCaptureSlot.ts
+++ b/src/rendering/plan/RetainedCaptureSlot.ts
@@ -2,12 +2,13 @@ import { Bounds } from '#core/Bounds';
 import { type ReadonlyRectangle, Rectangle } from '#math/Rectangle';
 import type { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
+import type { RenderNode } from '#rendering/RenderNode';
 import type { View } from '#rendering/View';
 
 import { CaptureThrashSuppressor, CaptureVerdict } from './CaptureThrashSuppressor';
 import type { ScopeEntry } from './RenderScope';
 import { RetainedGroupFragment } from './RetainedGroupFragment';
-import { reconcileRetainedTransformRows } from './retainedTransformRowPatch';
+import { forEachMovedNode, isUnder, reconcileRetainedTransformRows } from './retainedTransformRowPatch';
 
 /** The render target a product was compiled against (backend-owned identity). */
 export type RenderTargetIdentity = RenderBackend['renderTarget'];
@@ -192,7 +193,7 @@ export class RetainedCaptureSlot {
    *
    * The queue is fed from a live capture onward, one tier earlier than a group's
    * - a group only needs it on the recorded tier, whereas the root needs the
-   * queue as its PROOF that every move was accounted for. Without that proof one
+   * marks as its PROOF that every move was accounted for. Without that proof one
    * frame earlier, a scene that moves something every frame would never reach the
    * clean frame it has to record on.
    *
@@ -200,21 +201,29 @@ export class RetainedCaptureSlot {
    * group does not have to face, since it suppresses culling inside itself and
    * is culled as a whole - live in {@link _canReconcileMovedNodes}.
    */
-  public reconcileTransform(transformRevision: number, view: View, backend: RenderBackend): boolean {
-    if (!this.fragment.hasDirtyTransformRows()) {
-      // Nothing queued. Either nothing moved (revisions agree), or a move
-      // happened while no recording was live - the enqueue gate skips those, so
-      // there is no proof the queue saw everything and the frame re-collects.
-      return this._transformRevision === transformRevision;
+  public reconcileTransform(transformRevision: number, view: View, backend: RenderBackend, root: RenderNode): boolean {
+    if (this._transformRevision === transformRevision) {
+      // Nothing below this root moved since the capture, whatever else the
+      // index may hold for other roots.
+      return true;
     }
 
-    if (!this._canReconcileMovedNodes(view)) {
+    if (!this.fragment.transformMarksProvable) {
+      // The index no longer covers this product's cursor, so the marks cannot
+      // prove the moves were all seen - which is the same answer a queue gave
+      // when a move happened while no recording was live.
+      return false;
+    }
+
+    const owns = (node: RenderNode): boolean => isUnder(node, root);
+
+    if (!this._canReconcileMovedNodes(view, owns)) {
       this._dropRecording();
 
       return false;
     }
 
-    if (!reconcileRetainedTransformRows(this.fragment, backend, () => true)) {
+    if (!reconcileRetainedTransformRows(this.fragment, backend, owns, () => true)) {
       return false;
     }
 
@@ -224,7 +233,7 @@ export class RetainedCaptureSlot {
   }
 
   /**
-   * Whether every queued move can be applied to the captured product, growing
+   * Whether every marked move can be applied to the captured product, growing
    * the kept-union by each moved node's CURRENT cull rect on the way.
    *
    * Two rejections, one per direction a move can break the selection:
@@ -243,20 +252,18 @@ export class RetainedCaptureSlot {
    *   different and this cannot go wrong: an out-of-view node that is still
    *   drawn is clipped, not wrong.
    */
-  private _canReconcileMovedNodes(view: View): boolean {
+  private _canReconcileMovedNodes(view: View, owns: (node: RenderNode) => boolean): boolean {
     const viewRect = view.getBounds();
     const insideCaptureRect = this._viewFitsCaptureCullRect(view);
 
-    for (let index = 0; index < this.fragment.dirtyTransformRowCount; index++) {
-      const node = this.fragment.dirtyTransformRowAt(index);
-
+    return forEachMovedNode(this.fragment, owns, node => {
       if (this._culledDuringCapture && this.fragment.recordedDraw(node as unknown as Drawable) === undefined) {
         return false;
       }
 
       if (!node.cullable) {
         // Never culled: its position cannot change the selection.
-        continue;
+        return true;
       }
 
       const rect = node.cullArea ?? node.getBounds();
@@ -267,19 +274,19 @@ export class RetainedCaptureSlot {
 
       this._keptBounds.addRect(rect);
       this._keptEmpty = false;
-    }
 
-    return true;
+      return true;
+    });
   }
 
   /**
-   * Give up the recorded tier without giving up the capture: the queue is
-   * drained so no stale row survives, and dropping the recording closes the
-   * enqueue gate so nothing accumulates until the next collect re-records.
+   * Give up the recorded tier without giving up the capture: the cursor moves
+   * up so no stale mark is re-read, and dropping the recording sends the next
+   * frame through entry replay with live transforms.
    */
   private _dropRecording(): void {
     this.fragment.instructions?.invalidate();
-    this.fragment.clearDirtyTransformRows();
+    this.fragment.markTransformsSeen();
   }
 
   /** The active capture was replayed at least once - it earned its keep. */

--- a/src/rendering/plan/RetainedGroupFragment.ts
+++ b/src/rendering/plan/RetainedGroupFragment.ts
@@ -154,6 +154,11 @@ export class RetainedGroupFragment {
   // it. Starts at -1, which no sequence reaches, so a fragment that never
   // accounted for anything is unprovable rather than silently up to date.
   private _transformCursor = -1;
+  // The same for the content channel: what this fragment has accounted for of
+  // the tint rows it baked. Separate from the transform cursor because the two
+  // channels are settled by different frames - a product may replay a move
+  // without a tint having changed, and the other way round.
+  private _contentCursor = -1;
 
   /** Snapshot policy for nested transform groups - see {@link _snapshotInto}. */
   private _deferTransformGroups = false;
@@ -259,6 +264,16 @@ export class RetainedGroupFragment {
    */
   public markTransformsSeen(): void {
     this._transformCursor = nodeDirtyIndex.sequence;
+  }
+
+  /** The mark sequence this fragment's baked tint rows are current as of. */
+  public get contentCursor(): number {
+    return this._contentCursor;
+  }
+
+  /** Every content-channel mark so far is accounted for - patched in, or read live. */
+  public markContentSeen(): void {
+    this._contentCursor = nodeDirtyIndex.sequence;
   }
 
   /**
@@ -388,6 +403,7 @@ export class RetainedGroupFragment {
     // A full (re)capture reads every child's current transform: any queued
     // transform-only moves are subsumed and must not double-patch afterwards.
     this.markTransformsSeen();
+    this.markContentSeen();
 
     this._entryCount = this._snapshotInto(this._entries, entries, entryCount);
 
@@ -410,6 +426,7 @@ export class RetainedGroupFragment {
     this._entryCount = 0;
     this._rowMap = null;
     this.markTransformsSeen();
+    this.markContentSeen();
     this._thrash.reset();
     this._recordableFor = null;
     this._instructions?.invalidate();

--- a/src/rendering/plan/RetainedGroupFragment.ts
+++ b/src/rendering/plan/RetainedGroupFragment.ts
@@ -1,3 +1,4 @@
+import { DirtyChannel, nodeDirtyIndex } from '#core/NodeDirtyIndex';
 import type { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { RenderNode } from '#rendering/RenderNode';
@@ -76,7 +77,6 @@ export type RetainedFragmentEntry = RetainedFragmentDraw | RetainedFragmentGroup
  * - can never equal a fragment's current epoch, making a false dedup (a dropped
  * move → stale render) impossible.
  */
-let nextDirtyRowEpoch = 1;
 
 /**
  * Whole-command-range fragment cache for one {@link RetainedContainer}.
@@ -142,28 +142,18 @@ export class RetainedGroupFragment {
   // Computed with the row map; -1 when there are no draws.
   private _rowMinIndex = -1;
 
-  // Nodes whose OWN transform moved since the last collect, pushed by
-  // the SceneNode seam through the enclosing group. A plain array (not a Set),
-  // held with an explicit LOGICAL length: the per-frame reset rewinds
-  // `_dirtyRowCount` and leaves the physical array alone, so the next frame
-  // overwrites the slots it already has.
+  // The dirty-index mark sequence this fragment's baked transform rows are
+  // current as of. Everything marked up to it has either been patched in or was
+  // read live by the capture that set it; a later mark is a move this fragment
+  // has not accounted for yet.
   //
-  // `length = 0` would be wrong here, not merely different. V8 hands the
-  // backing store back on a shrink to zero, so the refill re-grows from empty
-  // through the whole doubling sequence - measured at ~27 bytes per queued node
-  // per frame, which made this queue the single largest allocation in a scene
-  // where every node moves (28.6 KB/frame at 1000 nodes). Dedup is O(1) via a
-  // per-node epoch stamp keyed on `_dirtyRowEpoch` - a globally unique value
-  // bumped on every reset, so a stale stamp never falsely dedups.
-  //
-  // Slots at or beyond `_dirtyRowCount` keep whatever node they last held.
-  // That retains nothing a live subtree does not already retain, and it cannot
-  // outlive a node's removal: removing a child moves the subtree's structure
-  // revision, and the next build therefore recaptures or invalidates - both of
-  // which drop the references through {@link _dropDirtyTransformRows}.
-  private readonly _dirtyTransformRows: RenderNode[] = [];
-  private _dirtyRowCount = 0;
-  private _dirtyRowEpoch = nextDirtyRowEpoch++;
+  // A cursor rather than a queue of its own. Holding one queue per fragment
+  // meant every mutation had to be offered to every fragment above the moved
+  // node, and each of them had to keep and grow an array; the index keeps one
+  // entry per changed node per generation regardless of how many fragments read
+  // it. Starts at -1, which no sequence reaches, so a fragment that never
+  // accounted for anything is unprovable rather than silently up to date.
+  private _transformCursor = -1;
 
   /** Snapshot policy for nested transform groups - see {@link _snapshotInto}. */
   private _deferTransformGroups = false;
@@ -254,57 +244,35 @@ export class RetainedGroupFragment {
     return currentMin;
   }
 
-  /** Record that `node`'s own transform moved (from the SceneNode seam). */
-  public enqueueDirtyTransformRow(node: RenderNode): void {
-    // O(1) dedup: skip a repeat push in the same cycle without scanning.
-    if (node._dirtyRowStamp === this._dirtyRowEpoch) {
-      return;
-    }
-
-    node._dirtyRowStamp = this._dirtyRowEpoch;
-
-    const index = this._dirtyRowCount++;
-
-    if (index < this._dirtyTransformRows.length) {
-      this._dirtyTransformRows[index] = node;
-    } else {
-      this._dirtyTransformRows.push(node);
-    }
-  }
-
-  /** `true` when at least one transform-only move is queued for this frame. */
-  public hasDirtyTransformRows(): boolean {
-    return this._dirtyRowCount > 0;
-  }
-
-  /** How many moved nodes are queued for this frame. */
-  public get dirtyTransformRowCount(): number {
-    return this._dirtyRowCount;
-  }
-
-  /** Queued moved node `index` (insertion order, deduped); callers hold `index < dirtyTransformRowCount`. */
-  public dirtyTransformRowAt(index: number): RenderNode {
-    return this._dirtyTransformRows[index]!;
-  }
-
-  /** Drop the queue - after patching them, or after a full re-collect subsumed them. */
-  public clearDirtyTransformRows(): void {
-    // Rewinding the logical length keeps the backing store for the next frame
-    // (see the field comment); a fresh epoch invalidates every prior dedup
-    // stamp in O(1).
-    this._dirtyRowCount = 0;
-    this._dirtyRowEpoch = nextDirtyRowEpoch++;
+  /**
+   * The mark sequence this fragment's baked rows are current as of, or `-1`
+   * while it has never accounted for anything. Passed to
+   * {@link NodeDirtyIndex.readSince} to enumerate the moves since.
+   */
+  public get transformCursor(): number {
+    return this._transformCursor;
   }
 
   /**
-   * Drop the queue AND its references - the structural counterpart of
-   * {@link clearDirtyTransformRows}, for the two paths that follow a change in
-   * what the subtree contains. Keeping the backing store across those would let
-   * a removed node stay reachable through a slot nothing will overwrite again.
+   * Every move marked so far is accounted for - after patching the rows, after
+   * a capture read them live, or after a re-collect subsumed them.
    */
-  private _dropDirtyTransformRows(): void {
-    this._dirtyTransformRows.length = 0;
-    this.clearDirtyTransformRows();
+  public markTransformsSeen(): void {
+    this._transformCursor = nodeDirtyIndex.sequence;
+  }
+
+  /**
+   * Whether a move this fragment has not accounted for has been marked since.
+   * `false` also when the index no longer covers the cursor, in which case the
+   * caller must treat the channel as unproven rather than as quiet.
+   */
+  public hasUnseenTransformMarks(): boolean {
+    return nodeDirtyIndex.hasMarksSince(this._transformCursor, DirtyChannel.Transform);
+  }
+
+  /** Whether the index still covers everything since this fragment's cursor. */
+  public get transformMarksProvable(): boolean {
+    return nodeDirtyIndex.covers(this._transformCursor);
   }
 
   /** The group's instruction set, or `null` if recording was never armed. */
@@ -419,7 +387,7 @@ export class RetainedGroupFragment {
     this._rowMap = null;
     // A full (re)capture reads every child's current transform: any queued
     // transform-only moves are subsumed and must not double-patch afterwards.
-    this._dropDirtyTransformRows();
+    this.markTransformsSeen();
 
     this._entryCount = this._snapshotInto(this._entries, entries, entryCount);
 
@@ -441,7 +409,7 @@ export class RetainedGroupFragment {
     this._entries.length = 0;
     this._entryCount = 0;
     this._rowMap = null;
-    this._dropDirtyTransformRows();
+    this.markTransformsSeen();
     this._thrash.reset();
     this._recordableFor = null;
     this._instructions?.invalidate();

--- a/src/rendering/plan/RetainedInstructionSet.ts
+++ b/src/rendering/plan/RetainedInstructionSet.ts
@@ -45,6 +45,15 @@ export interface RetainedGroupBundle {
    * (which re-reads live transforms) or a re-record.
    */
   _patchTransformRow?(localRow: number, floats: Float32Array): void;
+  /**
+   * Fast patch: overwrite one group-local tint row in place with `bytes`
+   * (`TRANSFORM_TINT_BYTES_PER_ROW` = one rgba8 texel / one packed `u32`) and
+   * mark only its sub-range for upload, WITHOUT bumping the generation - the
+   * recorded instance bytes reference the row by index and stay valid, only the
+   * colour behind the index changed. Absent on backends without patch support -
+   * a tint change then re-records, which is what every backend did before.
+   */
+  _patchTintRow?(localRow: number, bytes: Uint8Array): void;
   /** Release the bundle's GPU resources (container destroy / disengage). */
   destroy?(): void;
 }

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -118,26 +118,12 @@ export class RetainedRootRepresentation {
     return this._capture.fragment;
   }
 
-  /**
-   * Offer a moved descendant's baked transform row to every product that holds
-   * one, not only to the one this frame draws: a product compiled for another
-   * target is replayed on a later draw and would otherwise replay the position
-   * the node has left.
-   */
-  public enqueueDirtyTransformRow(node: RenderNode): void {
-    for (const slot of this._captureSlots) {
-      if (slot.fragment.hasCapture) {
-        slot.fragment.enqueueDirtyTransformRow(node);
-      }
-    }
-  }
-
   public isCleanIgnoringTransform(contentRevision: number, structureRevision: number, ancestryStamp: number, view: View): boolean {
     return this._capture.isCleanIgnoringTransform(contentRevision, structureRevision, ancestryStamp, view);
   }
 
-  public reconcileTransform(transformRevision: number, view: View, backend: RenderBackend): boolean {
-    return this._capture.reconcileTransform(transformRevision, view, backend);
+  public reconcileTransform(transformRevision: number, view: View, backend: RenderBackend, root: RenderNode): boolean {
+    return this._capture.reconcileTransform(transformRevision, view, backend, root);
   }
 
   public markReplayed(): void {

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -118,6 +118,10 @@ export class RetainedRootRepresentation {
     return this._capture.fragment;
   }
 
+  public reconcileContent(contentRevision: number, root: RenderNode): boolean {
+    return this._capture.reconcileContent(contentRevision, root);
+  }
+
   public isCleanIgnoringTransform(contentRevision: number, structureRevision: number, ancestryStamp: number, view: View): boolean {
     return this._capture.isCleanIgnoringTransform(contentRevision, structureRevision, ancestryStamp, view);
   }

--- a/src/rendering/plan/RetainedRootRepresentation.ts
+++ b/src/rendering/plan/RetainedRootRepresentation.ts
@@ -1,10 +1,8 @@
-import { Bounds } from '#core/Bounds';
 import { type ReadonlyRectangle, Rectangle } from '#math/Rectangle';
-import type { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
+import type { RenderNode } from '#rendering/RenderNode';
 import type { View } from '#rendering/View';
 
-import { CaptureThrashSuppressor, CaptureVerdict } from './CaptureThrashSuppressor';
 import { DerivedRootProduct } from './DerivedRootProduct';
 import {
   type PersistentSlotBackend,
@@ -15,11 +13,18 @@ import {
 } from './PersistentSlotDraw';
 import { RenderRootSource } from './RenderRootSource';
 import type { ScopeEntry } from './RenderScope';
-import { RetainedGroupFragment } from './RetainedGroupFragment';
-import { reconcileRetainedTransformRows } from './retainedTransformRowPatch';
+import { type RenderTargetIdentity, RetainedCaptureSlot } from './RetainedCaptureSlot';
+import type { RetainedGroupFragment } from './RetainedGroupFragment';
 
-/** The render target a product was compiled against (backend-owned identity). */
-type RenderTargetIdentity = RenderBackend['renderTarget'];
+/**
+ * Products one root may hold at once. Two, and not as a first guess: a slot
+ * carries a full instruction set plus the recorded entries behind it, which is
+ * the dominant memory position for a large root, and "the screen plus one
+ * offscreen target" covers the cases that recur every frame - minimap, portal,
+ * mirror, post-processing source. A third target in the same frame falls back
+ * to re-capturing, which is what every target did before the set existed.
+ */
+const MAX_CAPTURE_SLOTS = 2;
 
 /**
  * The automatic persistent render representation of one **render root** - the
@@ -37,7 +42,9 @@ type RenderTargetIdentity = RenderBackend['renderTarget'];
  * - the root's own global-transform stamp - a render root is not a closed
  *   dependency boundary, so an ancestor ABOVE it moving must invalidate even
  *   though it stamps none of the root's revisions;
- * - the backend's render target - compiled products are pass/target-specific;
+ * - the backend's render target - compiled products are pass/target-specific,
+ *   so a root drawn to more than one target holds one product per target (see
+ *   {@link selectCaptureSlot});
  * - the view SELECTION (see {@link isClean}) - per-child culling is view
  *   dependent even though the captured records are not.
  *
@@ -48,52 +55,131 @@ type RenderTargetIdentity = RenderBackend['renderTarget'];
  * @internal
  */
 export class RetainedRootRepresentation {
-  public readonly fragment = new RetainedGroupFragment();
-
-  private _hasCapture = false;
-  private _contentRevision = -1;
-  private _structureRevision = -1;
-  private _transformRevision = -1;
-  private _ancestryStamp = -1;
-  private _backend: RenderBackend | null = null;
-  private _target: RenderTargetIdentity | null = null;
-  private _view: View | null = null;
-  private _viewUpdateId = -1;
+  /**
+   * The products this root holds, most recently used first, one per
+   * (backend, render target) pair. Kept as a short array rather than a map: it
+   * is at most {@link MAX_CAPTURE_SLOTS} long, so a linear scan is the whole
+   * lookup and the order doubles as the eviction order.
+   */
+  private readonly _captureSlots: RetainedCaptureSlot[] = [new RetainedCaptureSlot()];
+  /** The slot the current draw reads and writes; see {@link selectCaptureSlot}. */
+  private _capture: RetainedCaptureSlot = this._captureSlots[0]!;
 
   /**
-   * Whether the capturing collect dropped at least one node on the view test.
-   * A capture that culled nothing can be replayed under any view that still
-   * contains {@link _keptBounds}; a capture that culled something can only be
-   * replayed under a view inside {@link _captureCullRect}, because outside that
-   * rect a previously-culled node may have entered the view and no index exists
-   * to find it.
-   */
-  private _culledDuringCapture = true;
-  /** Union of the rects the view test compared for every kept, cullable node. */
-  private readonly _keptBounds = new Bounds();
-  private _keptEmpty = true;
-  /**
-   * The rect the capturing collect actually culled against - the view rect grown
-   * by the capture margin (`RenderPlanBuilder.cullRect`). Every node the capture
-   * dropped lies outside it, so any view still INSIDE it selects the same nodes
-   * and the product replays unchanged.
-   */
-  private readonly _captureCullRect = new Rectangle();
-  private _hasCaptureCullRect = false;
-  /**
-   * Whether the capturing collect READ the view - i.e. produced content that is
-   * a function of the camera, not merely positioned by it.
+   * Point this representation at the product held for `backend` drawing into
+   * `target`, evicting the least recently used one when a new pair arrives and
+   * the set is full. Call once per draw, before anything else on the capture
+   * tier is asked or told.
    *
-   * Such a capture may only be replayed under the very same view. Both view
-   * tolerances below reason about the SELECTION of nodes (what a cull test would
-   * have dropped), and that reasoning is sound only while each node's recorded
-   * draw is what a fresh collect would produce again. A node that rebuilds its
-   * geometry from `view.center` breaks that premise: replaying it paints the
-   * camera position it was captured at. `ImageLayerNode` and `TileLayerNode` do
-   * exactly this, and contract 9 of the architecture freeze reserves the right
-   * for any node, which is why this is observed rather than declared.
+   * Everything from here to {@link commitCapture} then reads one product and is
+   * unaware of the others, which is what keeps the tier's reasoning about views,
+   * cull rects and thrash unchanged from when there was a single field.
    */
-  private _viewDependentCapture = false;
+  public selectCaptureSlot(backend: RenderBackend, target: RenderTargetIdentity | null): void {
+    const slots = this._captureSlots;
+
+    for (let index = 0; index < slots.length; index++) {
+      const slot = slots[index]!;
+
+      if (slot.matchesKey(backend, target)) {
+        this._promote(index);
+        this._capture = slot;
+
+        return;
+      }
+    }
+
+    // An untouched slot has a null key and matches nothing, so the first draw of
+    // a root lands here and simply claims it.
+    const reused = slots.length < MAX_CAPTURE_SLOTS && slots[0]!.hasCapture ? this._addSlot() : slots[slots.length - 1]!;
+
+    reused.retarget(backend, target);
+    this._promote(slots.indexOf(reused));
+    this._capture = reused;
+  }
+
+  /** Move the slot at `index` to the front of the eviction order. */
+  private _promote(index: number): void {
+    if (index > 0) {
+      this._captureSlots.unshift(...this._captureSlots.splice(index, 1));
+    }
+  }
+
+  private _addSlot(): RetainedCaptureSlot {
+    const slot = new RetainedCaptureSlot();
+
+    this._captureSlots.push(slot);
+
+    return slot;
+  }
+
+  /** The product the selected slot holds - the recorded entries and instruction set. */
+  public get fragment(): RetainedGroupFragment {
+    return this._capture.fragment;
+  }
+
+  /**
+   * Offer a moved descendant's baked transform row to every product that holds
+   * one, not only to the one this frame draws: a product compiled for another
+   * target is replayed on a later draw and would otherwise replay the position
+   * the node has left.
+   */
+  public enqueueDirtyTransformRow(node: RenderNode): void {
+    for (const slot of this._captureSlots) {
+      if (slot.fragment.hasCapture) {
+        slot.fragment.enqueueDirtyTransformRow(node);
+      }
+    }
+  }
+
+  public isCleanIgnoringTransform(contentRevision: number, structureRevision: number, ancestryStamp: number, view: View): boolean {
+    return this._capture.isCleanIgnoringTransform(contentRevision, structureRevision, ancestryStamp, view);
+  }
+
+  public reconcileTransform(transformRevision: number, view: View, backend: RenderBackend): boolean {
+    return this._capture.reconcileTransform(transformRevision, view, backend);
+  }
+
+  public markReplayed(): void {
+    this._capture.markReplayed();
+  }
+
+  public shouldSuppressCapture(contentRevision: number, structureRevision: number, transformRevision: number, view: View): boolean {
+    return this._capture.shouldSuppressCapture(contentRevision, structureRevision, transformRevision, view);
+  }
+
+  public beginCapture(cullRect: ReadonlyRectangle): void {
+    this._capture.beginCapture(cullRect);
+  }
+
+  public noteViewRead(): void {
+    this._capture.noteViewRead();
+  }
+
+  public noteKept(rect: ReadonlyRectangle): void {
+    this._capture.noteKept(rect);
+  }
+
+  public noteKeptCoords(minX: number, minY: number, maxX: number, maxY: number): void {
+    this._capture.noteKeptCoords(minX, minY, maxX, maxY);
+  }
+
+  public noteCulled(): void {
+    this._capture.noteCulled();
+  }
+
+  public commitCapture(
+    contentRevision: number,
+    structureRevision: number,
+    transformRevision: number,
+    ancestryStamp: number,
+    view: View,
+    backend: RenderBackend,
+    entries: readonly ScopeEntry[],
+    entryCount: number,
+  ): void {
+    this._capture.commitCapture(contentRevision, structureRevision, transformRevision, ancestryStamp, view, backend, entries, entryCount);
+  }
 
   /**
    * The persistent items this root can re-select from, or `null` while it has
@@ -169,92 +255,6 @@ export class RetainedRootRepresentation {
    * next view change would reach the same conclusion at the same cost.
    */
   private _sourceUnbuildable = false;
-
-  // Thrash suppression over the FULL key (see `shouldSuppressCapture`). The
-  // state machine is shared with a group's fragment; only the key is this
-  // tier's own, and it is the wider of the two.
-  private readonly _thrash = new CaptureThrashSuppressor();
-  private _observedContent = -1;
-  private _observedStructure = -1;
-  private _observedTransform = -1;
-  private _observedView: View | null = null;
-  private _observedViewUpdateId = -1;
-
-  /**
-   * Whether the captured product can be replayed as-is this frame.
-   *
-   * The revision/identity keys are exact compares. The view key is not, and it
-   * has two independent ways to pass, because the captured records - world-space
-   * bounds, material keys, baked transform rows - carry no view state of their
-   * own (the recorded batches resolve projection live at replay):
-   *
-   * - **The view still fits the capture's cull rect.** Every node the capture
-   *   dropped was outside that rect, hence outside this view too; every node it
-   *   kept is still drawn, and any that no longer meets the view is clipped
-   *   rather than wrong. This is the case that survives a moving camera over a
-   *   scene with off-screen content - the margin exists to make it common.
-   * - **Nothing was culled and the view still contains every kept node.** Then
-   *   the selection is trivially the whole subtree and stays that way. This one
-   *   also covers a view that GREW past the capture rect (a zoom-out), which the
-   *   first test cannot.
-   */
-  public isCleanIgnoringTransform(
-    contentRevision: number,
-    structureRevision: number,
-    ancestryStamp: number,
-    view: View,
-    backend: RenderBackend,
-    target: RenderTargetIdentity | null,
-  ): boolean {
-    if (!this.matchesNonViewKeys(contentRevision, structureRevision, ancestryStamp, backend, target)) {
-      return false;
-    }
-
-    if (this._view === view && this._viewUpdateId === view.updateId) {
-      return true;
-    }
-
-    if (this._viewDependentCapture) {
-      // The view moved and the capture is a function of it: neither tolerance
-      // applies, because both only argue about which nodes a cull test admits.
-      return false;
-    }
-
-    if (this._viewFitsCaptureCullRect(view)) {
-      return true;
-    }
-
-    if (this._culledDuringCapture) {
-      return false;
-    }
-
-    return this._keptEmpty || view.getBounds().containsRect(this._keptBounds.getRect());
-  }
-
-  /**
-   * Every key except the view: whether the captured product still describes the
-   * same subtree, compiled for the same backend and target.
-   *
-   * Split out from {@link isCleanIgnoringTransform} because the view key is the
-   * only one of the six that is not an exact compare, and reading the exact half
-   * on its own is what makes the tolerant half legible.
-   */
-  public matchesNonViewKeys(
-    contentRevision: number,
-    structureRevision: number,
-    ancestryStamp: number,
-    backend: RenderBackend,
-    target: RenderTargetIdentity | null,
-  ): boolean {
-    return (
-      this._hasCapture &&
-      this._contentRevision === contentRevision &&
-      this._structureRevision === structureRevision &&
-      this._ancestryStamp === ancestryStamp &&
-      this._backend === backend &&
-      this._target === target
-    );
-  }
 
   /** The persistent items, or `null` while this root has never built any. */
   public get source(): RenderRootSource | null {
@@ -442,268 +442,18 @@ export class RetainedRootRepresentation {
     this._sourceUnbuildable = true;
   }
 
-  /** Whether this view lies entirely inside the rect the capture culled against. */
-  private _viewFitsCaptureCullRect(view: View): boolean {
-    return this._hasCaptureCullRect && this._captureCullRect.containsRect(view.getBounds());
-  }
-
-  /**
-   * Settle the transform channel for a frame whose other keys already match:
-   * `true` means the product may be replayed, `false` that the frame must
-   * re-collect.
-   *
-   * Transform-only descendant moves are the one change class that does NOT
-   * invalidate here. The moved nodes arrive through the same seam a
-   * {@link RetainedContainer} uses, and their baked rows are patched in place
-   * (O(k)) rather than re-derived - which is what keeps a scene with a few
-   * percent of moving nodes on the recorded tier.
-   *
-   * The queue is fed from a live capture onward, one tier earlier than a group's
-   * - a group only needs it on the recorded tier, whereas the root needs the
-   * queue as its PROOF that every move was accounted for. Without that proof one
-   * frame earlier, a scene that moves something every frame would never reach the
-   * clean frame it has to record on.
-   *
-   * The guards that make that sound against per-child view culling - which a
-   * group does not have to face, since it suppresses culling inside itself and
-   * is culled as a whole - live in {@link _canReconcileMovedNodes}.
-   */
-  public reconcileTransform(transformRevision: number, view: View, backend: RenderBackend): boolean {
-    if (!this.fragment.hasDirtyTransformRows()) {
-      // Nothing queued. Either nothing moved (revisions agree), or a move
-      // happened while no recording was live - the enqueue gate skips those, so
-      // there is no proof the queue saw everything and the frame re-collects.
-      return this._transformRevision === transformRevision;
-    }
-
-    if (!this._canReconcileMovedNodes(view)) {
-      this._dropRecording();
-
-      return false;
-    }
-
-    if (!reconcileRetainedTransformRows(this.fragment, backend, () => true)) {
-      return false;
-    }
-
-    this._transformRevision = transformRevision;
-
-    return true;
-  }
-
-  /**
-   * Whether every queued move can be applied to the captured product, growing
-   * the kept-union by each moved node's CURRENT cull rect on the way.
-   *
-   * Two rejections, one per direction a move can break the selection:
-   *
-   * - **A moved node the capture never recorded, on a capture that culled.** It
-   *   is not in the product, so it may be one of the culled ones - and it may
-   *   have just moved INTO the view, which replay would silently omit. Patching
-   *   cannot help: there is no row to patch. (On the recorded tier the row patch
-   *   would catch this too, but the entry-replay tier has no such check, and
-   *   this must hold on both.) When the capture culled nothing, every visible
-   *   node is in the product and no such node exists.
-   * - **A moved node that left the view, when only the kept-union rule is
-   *   carrying validity.** Replaying would keep drawing it where a real collect
-   *   would have dropped it - which matters because that rule's whole premise is
-   *   that nothing was culled. Under the capture-rect rule the premise is
-   *   different and this cannot go wrong: an out-of-view node that is still
-   *   drawn is clipped, not wrong.
-   */
-  private _canReconcileMovedNodes(view: View): boolean {
-    const viewRect = view.getBounds();
-    const insideCaptureRect = this._viewFitsCaptureCullRect(view);
-
-    for (let index = 0; index < this.fragment.dirtyTransformRowCount; index++) {
-      const node = this.fragment.dirtyTransformRowAt(index);
-
-      if (this._culledDuringCapture && this.fragment.recordedDraw(node as unknown as Drawable) === undefined) {
-        return false;
-      }
-
-      if (!node.cullable) {
-        // Never culled: its position cannot change the selection.
-        continue;
-      }
-
-      const rect = node.cullArea ?? node.getBounds();
-
-      if (!insideCaptureRect && !viewRect.intersectsWith(rect)) {
-        return false;
-      }
-
-      this._keptBounds.addRect(rect);
-      this._keptEmpty = false;
-    }
-
-    return true;
-  }
-
-  /**
-   * Give up the recorded tier without giving up the capture: the queue is
-   * drained so no stale row survives, and dropping the recording closes the
-   * enqueue gate so nothing accumulates until the next collect re-records.
-   */
-  private _dropRecording(): void {
-    this.fragment.instructions?.invalidate();
-    this.fragment.clearDirtyTransformRows();
-  }
-
-  /** The active capture was replayed at least once - it earned its keep. */
-  public markReplayed(): void {
-    this._thrash.markReplayed();
-    this.fragment.markReplayed();
-  }
-
-  /**
-   * Decide, on a frame whose key check already failed, whether the snapshot
-   * should be skipped. Mutates the suppression state machine; call exactly once
-   * per such frame, before collecting. Returns `true` to skip the capture.
-   *
-   * Same shape as {@link RetainedGroupFragment.shouldSuppressCapture} but keyed
-   * on the FULL root key including the view: without the view in the observed
-   * tuple, a panning camera over a partly-culled scene would alternate between
-   * suppressed and recovered forever instead of settling.
-   */
-  public shouldSuppressCapture(contentRevision: number, structureRevision: number, transformRevision: number, view: View): boolean {
-    const keyUnchanged =
-      this._observedContent === contentRevision &&
-      this._observedStructure === structureRevision &&
-      this._observedTransform === transformRevision &&
-      this._observedView === view &&
-      this._observedViewUpdateId === view.updateId;
-    const verdict = this._thrash.evaluate(this._hasCapture, keyUnchanged);
-
-    if (verdict === CaptureVerdict.Capture) {
-      return false;
-    }
-
-    if (verdict === CaptureVerdict.InvalidateAndSuppress) {
-      this.invalidate();
-      this._thrash.suppress();
-    }
-
-    this._observe(contentRevision, structureRevision, transformRevision, view);
-
-    return true;
-  }
-
-  /**
-   * Arm cull-union accumulation for the collect that is about to run, and record
-   * the rect that collect will cull against - the view's rect plus the capture
-   * margin, which is what later lets a moved view be judged in O(1).
-   */
-  public beginCapture(cullRect: ReadonlyRectangle): void {
-    this._keptBounds.reset();
-    this._keptEmpty = true;
-    this._culledDuringCapture = false;
-    this._viewDependentCapture = false;
-    this._captureCullRect.set(cullRect.x, cullRect.y, cullRect.width, cullRect.height);
-    this._hasCaptureCullRect = true;
-  }
-
-  /**
-   * The collect being captured read the view (see {@link _viewDependentCapture}).
-   * Called from `RenderPlanBuilder`'s public view getter, so it fires for any
-   * node - engine or third-party - without one having to declare itself.
-   */
-  public noteViewRead(): void {
-    this._viewDependentCapture = true;
-  }
-
-  /** A node passed the view test; `rect` is exactly what `inView` compared. */
-  public noteKept(rect: ReadonlyRectangle): void {
-    this._keptBounds.addRect(rect);
-    this._keptEmpty = false;
-  }
-
-  /**
-   * {@link noteKept} for a caller that holds the compared extent as four numbers
-   * rather than a rectangle - the source selection, whose items store it that
-   * way. Materialising a `Rectangle` per item just to hand it over would cost
-   * more than the fold.
-   */
-  public noteKeptCoords(minX: number, minY: number, maxX: number, maxY: number): void {
-    this._keptBounds.addCoords(minX, minY).addCoords(maxX, maxY);
-    this._keptEmpty = false;
-  }
-
-  /** A node was dropped by the view test - the capture is view-locked. */
-  public noteCulled(): void {
-    this._culledDuringCapture = true;
-  }
-
-  /** Snapshot the root scope's entries and key the capture. */
-  public commitCapture(
-    contentRevision: number,
-    structureRevision: number,
-    transformRevision: number,
-    ancestryStamp: number,
-    view: View,
-    backend: RenderBackend,
-    target: RenderTargetIdentity | null,
-    entries: readonly ScopeEntry[],
-    entryCount: number,
-  ): void {
-    // `true`: nested transform groups are recorded as live re-dispatches, so a
-    // `RetainedContainer` under a render root keeps its own retention tier
-    // untouched (see the snapshot policy in `RetainedGroupFragment`).
-    this.fragment.capture(contentRevision, structureRevision, backend, entries, entryCount, true);
-
-    this._contentRevision = contentRevision;
-    this._structureRevision = structureRevision;
-    this._transformRevision = transformRevision;
-    this._ancestryStamp = ancestryStamp;
-    this._view = view;
-    this._viewUpdateId = view.updateId;
-    this._backend = backend;
-    this._target = target;
-    this._hasCapture = true;
-    this._thrash.markCaptured();
-  }
-
-  /**
-   * Drop the capture and its recording; the GPU bundle is kept (grow-only).
-   *
-   * The SOURCE deliberately survives. It is keyed on the node's own revisions
-   * and validates itself, so it stays correct across anything that invalidates a
-   * capture - and the loudest caller here is capture suppression, where the
-   * frame that just lost its capture is exactly the one that most needs a cheap
-   * path to fall back to.
-   */
-  public invalidate(): void {
-    this.fragment.invalidate();
-    this._hasCapture = false;
-    this._thrash.reset();
-    this._keptBounds.reset();
-    this._keptEmpty = true;
-    this._culledDuringCapture = true;
-    this._viewDependentCapture = false;
-    this._hasCaptureCullRect = false;
-    this._view = null;
-    this._backend = null;
-    this._target = null;
-  }
-
-  /** Release the capture AND the retained GPU resources (node destroy). */
+  /** Release every product AND the retained GPU resources (node destroy). */
   public dispose(): void {
     this.releasePersistentSlots();
-    this.invalidate();
-    this.fragment.dispose();
+
+    for (const slot of this._captureSlots) {
+      slot.dispose();
+    }
+
     this._source?.invalidate();
     this._source = null;
     this._derivedProduct?.release();
     this._derivedProduct = null;
     this._sourceUnbuildable = false;
-    this._keptBounds.destroy();
-  }
-
-  private _observe(contentRevision: number, structureRevision: number, transformRevision: number, view: View): void {
-    this._observedContent = contentRevision;
-    this._observedStructure = structureRevision;
-    this._observedTransform = transformRevision;
-    this._observedView = view;
-    this._observedViewUpdateId = view.updateId;
   }
 }

--- a/src/rendering/plan/retainedTransformRowPatch.ts
+++ b/src/rendering/plan/retainedTransformRowPatch.ts
@@ -1,3 +1,4 @@
+import { DirtyChannel, nodeDirtyIndex } from '#core/NodeDirtyIndex';
 import type { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { RenderNode } from '#rendering/RenderNode';
@@ -116,28 +117,61 @@ export const tryPatchRetainedTransformRow = (
 };
 
 /**
- * Rewrite each queued node's snapshotted screen AABB in its captured draw record.
+ * Visit every node whose transform moved since `fragment` last accounted for
+ * one and that `owns` claims. `false` means the index no longer covers the
+ * fragment's cursor, or `visit` abandoned the walk - either way the caller
+ * cannot treat the channel as settled.
+ *
+ * The ownership test is the caller's, because the two consumers draw the
+ * boundary differently: a {@link RetainedContainer} owns the moves whose
+ * NEAREST enclosing boundary it is (a move below a nested group belongs to that
+ * group's rows, not to its own), while a render root owns every move in its
+ * subtree. Marks outside the caller's subtree belong to another consumer and
+ * are skipped without being looked at twice.
+ * @internal
+ */
+export const forEachMovedNode = (fragment: RetainedGroupFragment, owns: (node: RenderNode) => boolean, visit: (node: RenderNode) => boolean): boolean =>
+  nodeDirtyIndex.readSince(fragment.transformCursor, DirtyChannel.Transform, node => {
+    const moved = node as unknown as RenderNode;
+
+    return !owns(moved) || visit(moved);
+  });
+
+/** Whether `node` lies anywhere below `ancestor`. */
+export const isUnder = (node: RenderNode, ancestor: RenderNode): boolean => {
+  let parent = node.parent;
+
+  while (parent !== null) {
+    if ((parent as unknown as RenderNode) === ancestor) {
+      return true;
+    }
+
+    parent = parent.parent;
+  }
+
+  return false;
+};
+
+/**
+ * Rewrite a moved node's snapshotted screen AABB in its captured draw record.
  * A record whose extent is one move out of date is not a rendering error by
  * itself - the replay re-derives nothing from it - but the optimizer reads it to
  * decide whether a batch run may be reordered past an intervening draw, and a
  * stale extent can hide a real overlap.
  */
-const refreshRetainedDrawBounds = (fragment: RetainedGroupFragment): void => {
-  for (let index = 0; index < fragment.dirtyTransformRowCount; index++) {
-    const node = fragment.dirtyTransformRowAt(index);
-    const record = fragment.recordedDraw(node as unknown as Drawable);
+const refreshRetainedDrawBounds = (fragment: RetainedGroupFragment, node: RenderNode): void => {
+  const record = fragment.recordedDraw(node as unknown as Drawable);
 
-    if (record === undefined) {
-      continue;
-    }
-
-    const bounds = node.getBounds();
-
-    record.minX = bounds.left;
-    record.minY = bounds.top;
-    record.maxX = bounds.right;
-    record.maxY = bounds.bottom;
+  if (record === undefined) {
+    return;
   }
+
+  const bounds = node.getBounds();
+
+  record.minX = bounds.left;
+  record.minY = bounds.top;
+  record.maxX = bounds.right;
+  record.maxY = bounds.bottom;
 };
 
 /**
@@ -149,15 +183,27 @@ const refreshRetainedDrawBounds = (fragment: RetainedGroupFragment): void => {
  * correct, O(entries), the rare path. Without a patchable recording there is
  * nothing to reconcile and the queue is simply drained.
  *
- * `isEligible` is the caller's own membership rule: a {@link RetainedContainer}
- * admits only its DIRECT children (deeper nodes are not in its patch contract),
- * the render-root representation admits every recorded node.
+ * Two caller rules, and they are not the same question. `owns` says which
+ * marked moves are this fragment's business at all - one below a nested
+ * transform group belongs to that group's rows, one outside the subtree to
+ * another consumer entirely, and both are skipped. `isEligible` says which of
+ * the moves it does own may be patched: a {@link RetainedContainer} admits only
+ * its DIRECT children, because a deeper node's row is recorded but its group-
+ * local basis runs through an intermediate container the patch does not
+ * re-derive; the render-root representation admits every recorded node. An
+ * owned move that is not eligible drops the recording rather than being
+ * skipped - it is a real change to a product that cannot express it.
  *
  * Returns `false` when the recording was dropped - the caller must then treat its
  * product as stale for this frame.
  * @internal
  */
-export const reconcileRetainedTransformRows = (fragment: RetainedGroupFragment, backend: RenderBackend, isEligible: (node: RenderNode) => boolean): boolean => {
+export const reconcileRetainedTransformRows = (
+  fragment: RetainedGroupFragment,
+  backend: RenderBackend,
+  owns: (node: RenderNode) => boolean,
+  isEligible: (node: RenderNode) => boolean,
+): boolean => {
   const set = fragment.instructions;
 
   if (!set?.hasRecording) {
@@ -166,11 +212,16 @@ export const reconcileRetainedTransformRows = (fragment: RetainedGroupFragment, 
     // tier) or the fragment sits on entry replay. Both re-read each node's live
     // transform, so there is no row to patch. Only the RECORD's snapshotted
     // screen AABB is stale, and the optimizer's reorder-safety test reads it -
-    // refresh those, drain, and report the moves as accounted for.
-    refreshRetainedDrawBounds(fragment);
-    fragment.clearDirtyTransformRows();
+    // refresh those and report the moves as accounted for.
+    const complete = forEachMovedNode(fragment, owns, node => {
+      refreshRetainedDrawBounds(fragment, node);
 
-    return true;
+      return true;
+    });
+
+    fragment.markTransformsSeen();
+
+    return complete;
   }
 
   const bundle = set.ownedBundle;
@@ -182,7 +233,7 @@ export const reconcileRetainedTransformRows = (fragment: RetainedGroupFragment, 
     // live transforms; without this the stale rows would keep being spliced and
     // the moved node would render frozen.
     set.invalidate();
-    fragment.clearDirtyTransformRows();
+    fragment.markTransformsSeen();
 
     return false;
   }
@@ -194,23 +245,22 @@ export const reconcileRetainedTransformRows = (fragment: RetainedGroupFragment, 
   // store row (see RetainedGroupFragment.recordedRowBase).
   const base = fragment.recordedRowBase();
   const patchableBundle = bundle as PatchableRetainedGroupBundle;
-  let patched = true;
 
-  refreshRetainedDrawBounds(fragment);
+  const patched = forEachMovedNode(fragment, owns, node => {
+    refreshRetainedDrawBounds(fragment, node);
 
-  for (let index = 0; index < fragment.dirtyTransformRowCount; index++) {
-    const node = fragment.dirtyTransformRowAt(index);
+    return isEligible(node) && tryPatchRetainedTransformRow(node, fragment, patchableBundle, backend, base);
+  });
 
-    if (!isEligible(node) || !tryPatchRetainedTransformRow(node, fragment, patchableBundle, backend, base)) {
-      // Ineligible: drop the baked recording. Validation now fails, so the caller
-      // falls back to entry replay (live transforms) and re-records this frame.
-      set.invalidate();
-      patched = false;
-      break;
-    }
+  if (!patched) {
+    // A move this fragment owns but cannot patch - not a recorded draw, or the
+    // index no longer covers the cursor. Drop the baked recording: validation
+    // now fails, so the caller falls back to entry replay (live transforms) and
+    // re-records this frame.
+    set.invalidate();
   }
 
-  fragment.clearDirtyTransformRows();
+  fragment.markTransformsSeen();
 
   return patched;
 };

--- a/src/rendering/plan/retainedTransformRowPatch.ts
+++ b/src/rendering/plan/retainedTransformRowPatch.ts
@@ -2,7 +2,7 @@ import { DirtyChannel, nodeDirtyIndex } from '#core/NodeDirtyIndex';
 import type { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { RenderNode } from '#rendering/RenderNode';
-import { packTransformRow, TRANSFORM_FLOATS_PER_ROW } from '#rendering/TransformBuffer';
+import { packTintRow, packTransformRow, TRANSFORM_FLOATS_PER_ROW, TRANSFORM_TINT_BYTES_PER_ROW } from '#rendering/TransformBuffer';
 
 import type { RetainedGroupFragment } from './RetainedGroupFragment';
 import type { RetainedGroupBundle } from './RetainedInstructionSet';
@@ -60,6 +60,9 @@ const hasOwnTransformRowPatch = (renderer: unknown): renderer is OwnTransformRow
  * under churn.
  */
 const patchRowScratch = new Float32Array(TRANSFORM_FLOATS_PER_ROW);
+
+/** Reused scratch for one patched tint row, filled and consumed inside a single patch call. */
+const patchTintScratch = new Uint8Array(TRANSFORM_TINT_BYTES_PER_ROW);
 
 /**
  * Patch one moved node's recorded transform row, or return `false` when it is
@@ -263,4 +266,70 @@ export const reconcileRetainedTransformRows = (
   fragment.markTransformsSeen();
 
   return patched;
+};
+
+/**
+ * Reconcile the content-channel marks against the fragment's baked tint rows.
+ *
+ * `true` means the product still describes the subtree: either every marked
+ * change it owns was a tint it could write into its own row store, or the
+ * fragment holds no recording and the entry replay re-reads each tint live.
+ * `false` means at least one owned change is not expressible in place - a
+ * different texture or geometry, a node the capture never recorded, a recording
+ * whose backend has no tint patch, or a cursor the index no longer covers - and
+ * the caller must rebuild.
+ *
+ * The channel split is what makes the question answerable at all. A tint write
+ * marks `Tint` and every other content change marks `Content`, so "only tints
+ * changed" is a property of the marks rather than a guess from a revision that
+ * both kinds of change bump.
+ * @internal
+ */
+export const reconcileRetainedTintRows = (fragment: RetainedGroupFragment, owns: (node: RenderNode) => boolean): boolean => {
+  const set = fragment.instructions;
+  const bundle = set?.hasRecording === true ? set.ownedBundle : null;
+  const patchable = bundle !== null && typeof bundle._patchTintRow === 'function' && bundle.transformRowBase !== undefined;
+  const base = fragment.recordedRowBase();
+
+  const applied = nodeDirtyIndex.readSince(fragment.contentCursor, DirtyChannel.Content | DirtyChannel.Tint, (node, marked) => {
+    const changed = node as unknown as RenderNode;
+
+    if (!owns(changed)) {
+      return true;
+    }
+
+    if ((marked & DirtyChannel.Content) !== 0) {
+      // Not a tint-only change: nothing in a recorded product expresses a new
+      // texture, geometry or blend mode without re-recording it.
+      return false;
+    }
+
+    if (bundle === null) {
+      // No recording: the entry replay re-emits the draw and reads the live
+      // tint, so there is no baked row to correct.
+      return true;
+    }
+
+    if (!patchable) {
+      return false;
+    }
+
+    const drawable = changed as unknown as Drawable;
+    const rowIndex = fragment.recordedRowIndex(drawable);
+
+    if (rowIndex === undefined) {
+      return false;
+    }
+
+    packTintRow(patchTintScratch, 0, drawable.tint);
+    bundle._patchTintRow!(rowIndex - base, patchTintScratch);
+
+    return true;
+  });
+
+  if (applied) {
+    fragment.markContentSeen();
+  }
+
+  return applied;
 };

--- a/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
+++ b/src/rendering/webgl2/WebGl2RetainedGroupResources.ts
@@ -385,6 +385,24 @@ export class WebGl2RetainedGroupResources implements RetainedGroupBundle {
   }
 
   /**
+   * Fast patch: overwrite one group-local tint row in place and mark ONLY that
+   * row's texel for upload. Same contract as {@link _patchTransformRow} on the
+   * parallel store - no generation bump, out-of-range rows ignored - and the
+   * reason the two stores are separate: a tint change and a move touch
+   * different bytes, so neither pays for the other's upload.
+   */
+  public _patchTintRow(localRow: number, bytes: Uint8Array): void {
+    if (this._tintTexture === null || this._tintBytes === null || this._transformLayout === null || localRow < 0 || localRow >= this._transformRowCount) {
+      return;
+    }
+
+    const rect = tintTextureRect(this._transformLayout, localRow, 1, this._rectScratch);
+
+    this._tintBytes.set(bytes, localRow * tintBytesPerRow);
+    this._tintTexture.commitRect(rect.x, rect.y, rect.width, rect.height);
+  }
+
+  /**
    * CPU-side vertex re-bake patch, for a renderer that bakes world
    * positions into its instance bytes rather than reading a shared-transform
    * row live (Text on WebGL2, the confirmed ANGLE/D3D11 vertex-texel-fetch

--- a/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
+++ b/src/rendering/webgpu/WebGpuRetainedGroupResources.ts
@@ -442,6 +442,21 @@ export class WebGpuRetainedGroupBundle implements RetainedGroupBundle {
   }
 
   /**
+   * Fast patch: overwrite one group-local tint slot in place. Same contract as
+   * {@link _patchTransformRow} on the parallel store - no generation bump,
+   * out-of-range slots and a lost device ignored - and the reason the two
+   * stores are separate: a tint change and a move touch different bytes, so
+   * neither pays for the other's upload.
+   */
+  public _patchTintRow(localRow: number, bytes: Uint8Array): void {
+    if (this._tintBuffer === null || this._patchDevice === null || localRow < 0 || localRow >= this._transformRowCount) {
+      return;
+    }
+
+    this._patchDevice.queue.writeBuffer(this._tintBuffer, localRow * retainedTintSlotBytes, bytes.buffer, bytes.byteOffset, retainedTintSlotBytes);
+  }
+
+  /**
    * The bind group(0) pairing the group UBO with the group transform storage
    * (and, for a renderer that reads per-instance tint - sprite - the tint
    * storage too), against the calling renderer's own uniform layout. Cached;

--- a/test/core/node-dirty-index.test.ts
+++ b/test/core/node-dirty-index.test.ts
@@ -1,0 +1,143 @@
+import { DirtyChannel, nodeDirtyIndex } from '#core/NodeDirtyIndex';
+import type { SceneNode } from '#core/SceneNode';
+import { Container } from '#rendering/Container';
+
+/** Every node marked on `channels` since `cursor`, in visit order. */
+const readSince = (cursor: number, channels: number = DirtyChannel.Transform): SceneNode[] => {
+  const seen: SceneNode[] = [];
+
+  nodeDirtyIndex.readSince(cursor, channels, node => {
+    seen.push(node);
+
+    return true;
+  });
+
+  return seen;
+};
+
+beforeEach(() => {
+  nodeDirtyIndex.reset();
+});
+
+afterEach(() => {
+  nodeDirtyIndex.reset();
+});
+
+describe('NodeDirtyIndex', () => {
+  test('a mark is visible to a cursor taken before it and invisible to one taken after', () => {
+    const node = new Container();
+    const before = nodeDirtyIndex.sequence;
+
+    nodeDirtyIndex.mark(node, DirtyChannel.Transform);
+
+    const after = nodeDirtyIndex.sequence;
+
+    expect(readSince(before)).toEqual([node]);
+    expect(readSince(after)).toEqual([]);
+
+    node.destroy();
+  });
+
+  test('a cursor taken between two marks of the SAME node still sees the second', () => {
+    // The trap the generation alone cannot catch: a consumer that captured in
+    // the middle of a frame must still be told about a move made after it, even
+    // though the node already had an entry in that generation.
+    const node = new Container();
+
+    nodeDirtyIndex.mark(node, DirtyChannel.Transform);
+
+    const between = nodeDirtyIndex.sequence;
+
+    nodeDirtyIndex.mark(node, DirtyChannel.Transform);
+
+    expect(readSince(between)).toEqual([node]);
+
+    node.destroy();
+  });
+
+  test('a node marked a thousand times in one generation holds one entry', () => {
+    const node = new Container();
+    const before = nodeDirtyIndex.sequence;
+
+    for (let index = 0; index < 1000; index++) {
+      nodeDirtyIndex.mark(node, DirtyChannel.Transform);
+    }
+
+    expect(readSince(before)).toEqual([node]);
+
+    node.destroy();
+  });
+
+  test('a node marked in two retained generations is visited once, not once per generation', () => {
+    // A consumer that writes on every visit - a renderer patching its own
+    // private row - would otherwise do the work twice for one moved node.
+    const node = new Container();
+    const before = nodeDirtyIndex.sequence;
+
+    nodeDirtyIndex.mark(node, DirtyChannel.Transform);
+    nodeDirtyIndex.advance();
+    nodeDirtyIndex.mark(node, DirtyChannel.Transform);
+
+    expect(readSince(before)).toEqual([node]);
+
+    node.destroy();
+  });
+
+  test('marks are filtered by channel', () => {
+    const moved = new Container();
+    const before = nodeDirtyIndex.sequence;
+
+    nodeDirtyIndex.mark(moved, DirtyChannel.Transform);
+
+    expect(readSince(before, DirtyChannel.Transform)).toEqual([moved]);
+    expect(readSince(before, 1 << 5)).toEqual([]);
+
+    moved.destroy();
+  });
+
+  test('a visit that stops the walk reports the read as incomplete', () => {
+    const first = new Container();
+    const second = new Container();
+    const before = nodeDirtyIndex.sequence;
+    const seen: SceneNode[] = [];
+
+    nodeDirtyIndex.mark(first, DirtyChannel.Transform);
+    nodeDirtyIndex.mark(second, DirtyChannel.Transform);
+
+    const complete = nodeDirtyIndex.readSince(before, DirtyChannel.Transform, node => {
+      seen.push(node);
+
+      return false;
+    });
+
+    expect(complete).toBe(false);
+    expect(seen).toEqual([first]);
+
+    first.destroy();
+    second.destroy();
+  });
+
+  test('a cursor that falls out of the window is reported rather than answered incompletely', () => {
+    // The bounded half of the design: a consumer that has not looked for longer
+    // than the window gets `false` and rebuilds, instead of a partial answer it
+    // cannot tell from a complete one.
+    const node = new Container();
+    const stale = nodeDirtyIndex.sequence;
+
+    nodeDirtyIndex.mark(node, DirtyChannel.Transform);
+
+    for (let generation = 0; generation < 16; generation++) {
+      nodeDirtyIndex.advance();
+      nodeDirtyIndex.mark(node, DirtyChannel.Transform);
+    }
+
+    expect(nodeDirtyIndex.covers(stale)).toBe(false);
+    expect(nodeDirtyIndex.readSince(stale, DirtyChannel.Transform, () => true)).toBe(false);
+
+    node.destroy();
+  });
+
+  test('a fresh cursor of -1 is never covered, so nothing starts out silently up to date', () => {
+    expect(nodeDirtyIndex.covers(-1)).toBe(false);
+  });
+});

--- a/test/core/node-dirty-index.test.ts
+++ b/test/core/node-dirty-index.test.ts
@@ -83,6 +83,31 @@ describe('NodeDirtyIndex', () => {
     node.destroy();
   });
 
+  test('a content change and a later tint stay apart, so a cursor between them sees only the tint', () => {
+    // The distinction the whole channel split exists for: a retained product
+    // has to tell "only tints changed since I looked" from "something changed
+    // that I cannot patch", and folding both into one entry's mask would make
+    // every tint after any content change unpatchable.
+    const node = new Container();
+    const seen: number[] = [];
+
+    nodeDirtyIndex.mark(node, DirtyChannel.Content);
+
+    const between = nodeDirtyIndex.sequence;
+
+    nodeDirtyIndex.mark(node, DirtyChannel.Tint);
+
+    nodeDirtyIndex.readSince(between, DirtyChannel.Content | DirtyChannel.Tint, (_node, marked) => {
+      seen.push(marked);
+
+      return true;
+    });
+
+    expect(seen).toEqual([DirtyChannel.Tint]);
+
+    node.destroy();
+  });
+
   test('marks are filtered by channel', () => {
     const moved = new Container();
     const before = nodeDirtyIndex.sequence;

--- a/test/perf/rendering/capture-kept-bounds.test.ts
+++ b/test/perf/rendering/capture-kept-bounds.test.ts
@@ -29,7 +29,7 @@ import { Sprite } from '#rendering/sprite/Sprite';
 import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
 
 import type { ServedBy } from './cullMarginProbe';
-import { beginProbeFrame, endProbeFrame, installTierProbe, refusePersistentSlots } from './cullMarginProbe';
+import { beginProbeFrame, endProbeFrame, hasCaptureCullRect, installTierProbe, refusePersistentSlots } from './cullMarginProbe';
 import { makeTextures } from './fixtures';
 import type { WebGl2Harness } from './harness';
 import { createWebGl2Harness } from './harness';
@@ -88,14 +88,7 @@ const render = (harness: WebGl2Harness, root: Container): { submitted: number; s
 };
 
 /** Whether the capture's own cull rect could still be carrying the frame. */
-const viewFitsCaptureRect = (root: Container): boolean => {
-  const representation = (root as unknown as { _retainedRootRepresentation(): unknown })._retainedRootRepresentation() as {
-    _captureCullRect: { containsRect(rect: unknown): boolean };
-    _hasCaptureCullRect: boolean;
-  };
-
-  return representation._hasCaptureCullRect;
-};
+const viewFitsCaptureRect = (root: Container): boolean => hasCaptureCullRect(root);
 
 afterEach(() => {
   for (const { harness, root } of live.splice(0)) {

--- a/test/perf/rendering/cull-margin-correctness.test.ts
+++ b/test/perf/rendering/cull-margin-correctness.test.ts
@@ -28,7 +28,16 @@
 import { afterEach, describe, expect, test } from 'vitest';
 
 import type { ServedBy } from './cullMarginProbe';
-import { beginProbeFrame, buildScrollingWorld, endProbeFrame, installTierProbe, SCROLLING_WORLD, VIEWPORT_HEIGHT, VIEWPORT_WIDTH } from './cullMarginProbe';
+import {
+  beginProbeFrame,
+  buildScrollingWorld,
+  captureCullRectOf,
+  endProbeFrame,
+  installTierProbe,
+  SCROLLING_WORLD,
+  VIEWPORT_HEIGHT,
+  VIEWPORT_WIDTH,
+} from './cullMarginProbe';
 import type { WebGl2Harness } from './harness';
 import { createWebGl2Harness } from './harness';
 
@@ -145,12 +154,9 @@ const marginRatio = (): number => {
   render(fixture);
 
   const view = fixture.harness.view.getBounds();
-  const representation = (fixture.scene.root as unknown as { _retainedRootRepresentation(): unknown })._retainedRootRepresentation() as {
-    _captureCullRect: { width: number };
-    _hasCaptureCullRect: boolean;
-  };
+  const cullRect = captureCullRectOf(fixture.scene.root);
 
-  return representation._hasCaptureCullRect ? (representation._captureCullRect.width - view.width) / (2 * view.width) : 0;
+  return cullRect === null ? 0 : (cullRect.width - view.width) / (2 * view.width);
 };
 
 const setCenter =

--- a/test/perf/rendering/cullMarginProbe.ts
+++ b/test/perf/rendering/cullMarginProbe.ts
@@ -458,10 +458,25 @@ export const endProbeFrame = (root: RenderNode): ServedBy => {
 export const sourceItemCount = (root: RenderNode): number =>
   (root as unknown as { _retainedRootRepresentation(): RetainedRootRepresentation })._retainedRootRepresentation().source?.itemCount ?? 0;
 
+/**
+ * The cull-rect fields of the capture slot the root last drew from.
+ *
+ * Two hops, because the representation holds one product per render target and
+ * the rect belongs to the product: reaching for `_captureCullRect` on the
+ * representation itself finds nothing.
+ */
+const activeCaptureSlot = (root: RenderNode): { _captureCullRect: ReadonlyRectangle; _hasCaptureCullRect: boolean } => {
+  const representation = (root as unknown as { _retainedRootRepresentation(): RetainedRootRepresentation })._retainedRootRepresentation();
+
+  return (representation as unknown as { _capture: { _captureCullRect: ReadonlyRectangle; _hasCaptureCullRect: boolean } })._capture;
+};
+
+/** Whether the root's active capture recorded a cull rect at all. */
+export const hasCaptureCullRect = (root: RenderNode): boolean => activeCaptureSlot(root)._hasCaptureCullRect;
+
 /** The rect the last capture culled against, or `null` while there is none. */
 export const captureCullRectOf = (root: RenderNode): ReadonlyRectangle | null => {
-  const representation = (root as unknown as { _retainedRootRepresentation(): RetainedRootRepresentation })._retainedRootRepresentation();
-  const internals = representation as unknown as { _captureCullRect: ReadonlyRectangle; _hasCaptureCullRect: boolean };
+  const slot = activeCaptureSlot(root);
 
-  return internals._hasCaptureCullRect ? internals._captureCullRect : null;
+  return slot._hasCaptureCullRect ? slot._captureCullRect : null;
 };

--- a/test/perf/rendering/order-stream-rewrite.test.ts
+++ b/test/perf/rendering/order-stream-rewrite.test.ts
@@ -1,0 +1,118 @@
+/**
+ * What the draw-order stream costs on a re-selection, and what an incremental
+ * one could save.
+ *
+ * The indexed tier keeps two things apart: the derived SLOT each visible item
+ * owns, which survives a camera step, and the ORDER those slots are drawn in,
+ * which is rewritten in full whenever membership is re-queried - four bytes per
+ * visible item. `DerivedSelectionState` argues that rebuilding beats diffing,
+ * because a diff has to answer where each survivor moved to; the retention
+ * review kept the question open on the grounds that the rewrite is still
+ * O(visible) while everything around it became O(delta).
+ *
+ * This decides it with counts rather than a clock. On a re-selection frame,
+ * `orderEntries` is exactly what the full rewrite writes and `allocated +
+ * released` is exactly what an incremental stream would still have to write, so
+ * the difference is the upside of building one - measured, not argued.
+ *
+ * The camera is driven hard on purpose. At the archetype's own speed the frame
+ * is answered from the cached order stream (`slotReplay`) and writes nothing at
+ * all, which is the case the margin exists to produce and the case where the
+ * question does not arise; only a frame that leaves the margin re-selects, and
+ * those are the frames counted here.
+ *
+ * @internal Test/perf-only.
+ */
+import { describe, expect, test } from 'vitest';
+
+import type { DerivedSlotStats } from '#rendering/plan/DerivedSelectionState';
+import type { RetainedRootRepresentation } from '#rendering/plan/RetainedRootRepresentation';
+import type { RenderNode } from '#rendering/RenderNode';
+
+import { beginProbeFrame, buildScrollingWorld, endProbeFrame, installTierProbe, SCROLLING_WORLD, VIEWPORT_HEIGHT, VIEWPORT_WIDTH } from './cullMarginProbe';
+import { createWebGl2Harness } from './harness';
+
+const LEAF_COUNT = 4000;
+/** Fast enough that a frame leaves the last selection's margin and re-queries. */
+const CAMERA_SPEED = 400;
+const WARMUP_FRAMES = 12;
+const MEASURED_FRAMES = 20;
+
+const slotStatsOf = (root: RenderNode): DerivedSlotStats | null => {
+  const representation = (root as unknown as { _retainedRootRepresentation(): RetainedRootRepresentation })._retainedRootRepresentation();
+
+  return representation.derivedProduct?.slots.stats ?? null;
+};
+
+interface Totals {
+  /** Order-stream entries written - the full-rewrite cost, four bytes each. */
+  orderEntries: number;
+  /** Items that became visible - entries an incremental stream would still write. */
+  entered: number;
+  /** Items that left the view - removals an incremental stream would still write. */
+  left: number;
+  /** Items that stayed visible and had their order entry rewritten anyway. */
+  retained: number;
+  /** Re-selection frames the numbers come from. */
+  reselects: number;
+}
+
+describe('indexed tier — the draw-order stream on a re-selection', () => {
+  test('a re-selection rewrites every visible entry, most of them unchanged', () => {
+    installTierProbe();
+
+    const harness = createWebGl2Harness({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT });
+    const scene = buildScrollingWorld(harness, LEAF_COUNT, CAMERA_SPEED, SCROLLING_WORLD.worldSpan);
+    const totals: Totals = { orderEntries: 0, entered: 0, left: 0, retained: 0, reselects: 0 };
+
+    for (let frame = 0; frame < WARMUP_FRAMES + MEASURED_FRAMES; frame++) {
+      harness.backend.resetStats();
+      scene.step(frame);
+      harness.backend.clear();
+      beginProbeFrame();
+      scene.root.render(harness.backend);
+      harness.backend.flush();
+
+      const servedBy = endProbeFrame(scene.root);
+      const stats = slotStatsOf(scene.root);
+
+      // Only a frame that actually re-queried membership wrote an order stream.
+      // A replayed frame leaves the previous selection's counters standing, so
+      // folding it in would count one selection once per frame it stayed valid
+      // for - the exact mistake the margin work had to correct once already.
+      if (frame < WARMUP_FRAMES || servedBy !== 'slotReselect' || stats === null) {
+        continue;
+      }
+
+      totals.orderEntries += stats.orderEntries;
+      totals.entered += stats.allocated;
+      totals.left += stats.released;
+      totals.retained += stats.retained;
+      totals.reselects++;
+    }
+
+    scene.destroy();
+    harness.destroy();
+
+    // The tier under test has to be the one answering, or everything below
+    // passes vacuously.
+    expect(totals.reselects).toBeGreaterThan(0);
+
+    // What the stream writes is exactly the visible set: the arrivals plus
+    // everyone who was already there.
+    expect(totals.orderEntries).toBe(totals.entered + totals.retained);
+
+    // The finding, and the size of the prize. Measured on this scene at this
+    // camera speed - 4000 leaves, ~1360 visible, a 400px step every frame -
+    // 61% of the entries belong to items that neither entered nor left, so an
+    // incremental stream would write ~540 entries where this writes ~1360.
+    // That is ~3.3 KB of integer writes per re-selection frame, on the frames
+    // that re-select at all (at the archetype's own speed, one in eight); the
+    // rest replay the cached stream and write nothing. The ratio is a property
+    // of step size against viewport, not of scene size, so the saving scales
+    // with the visible count and only becomes interesting where that count is
+    // in the hundreds of thousands.
+    expect(totals.retained / totals.orderEntries).toBeGreaterThan(0.5);
+    expect(totals.left).toBeGreaterThan(0);
+  });
+});

--- a/test/perf/rendering/target-slot-thrash.test.ts
+++ b/test/perf/rendering/target-slot-thrash.test.ts
@@ -1,0 +1,247 @@
+/**
+ * One render root drawn to more than one render target in the same frame.
+ *
+ * A captured product is compiled for the target it was recorded against, so a
+ * root drawn into a `RenderTexture` and onto the screen within one frame -
+ * minimap, portal, mirror, post-processing source - needs one product per
+ * target. Held in a single field, each draw found the other draw's product,
+ * discarded it and captured again: measured on the scene below, all 20 draws of
+ * a 10-frame window missed their keys, 13 of them re-captured, and every one of
+ * them walked the scene graph (28,809 nodes culled, against 0 for the same
+ * scene drawn twice to one target). Unlike a backend switch this never settles,
+ * because both draws repeat every frame.
+ *
+ * The arms are counts, not a clock. `culledNodes` is booked per COLLECT, so a
+ * frame that replays contributes nothing to it and a frame that walks the scene
+ * graph contributes the whole world - an exact, machine-independent measure of
+ * how much retention was lost. A wall clock against a fake GL context would
+ * mostly measure the recorder.
+ *
+ * `screenTwice` is the arm that isolates the cause: two draws per frame, same
+ * scene, same view, same work, differing from `bothTargets` in the render
+ * target alone.
+ *
+ * @internal Test/perf-only.
+ */
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { RetainedCaptureSlot } from '#rendering/plan/RetainedCaptureSlot';
+import type { RetainedRootRepresentation } from '#rendering/plan/RetainedRootRepresentation';
+import type { RenderNode } from '#rendering/RenderNode';
+import { Sprite } from '#rendering/sprite/Sprite';
+import { RenderTexture } from '#rendering/texture/RenderTexture';
+import { WebGl2Backend } from '#rendering/webgl2/WebGl2Backend';
+
+import { buildScrollingWorld, SCROLLING_WORLD, VIEWPORT_HEIGHT, VIEWPORT_WIDTH } from './cullMarginProbe';
+import type { WebGl2Harness } from './harness';
+import { createWebGl2Harness } from './harness';
+
+const LEAF_COUNT = 2000;
+const WARMUP_FRAMES = 4;
+const MEASURED_FRAMES = 10;
+
+/** What one arm paid over {@link MEASURED_FRAMES} steady-state frames. */
+interface ArmCounts {
+  /** Draws issued - one per `root.render()`. */
+  draws: number;
+  /** Draws whose captured product did not match the frame's keys. */
+  cleanMisses: number;
+  /** Captures committed. Lower than the miss count once thrash suppression engages. */
+  commits: number;
+  /** Nodes the view test discarded, booked per collect: 0 for a frame that replayed. */
+  culledNodes: number;
+}
+
+/** Count capture commits and key misses per call rather than per frame. */
+const installCaptureCounter = (): { commits: number; misses: number; reset(): void; restore(): void } => {
+  const prototype = RetainedCaptureSlot.prototype;
+  const commitCapture = prototype.commitCapture;
+  const isClean = prototype.isCleanIgnoringTransform;
+  const state = {
+    commits: 0,
+    misses: 0,
+    reset(): void {
+      state.commits = 0;
+      state.misses = 0;
+    },
+    restore(): void {
+      prototype.commitCapture = commitCapture;
+      prototype.isCleanIgnoringTransform = isClean;
+    },
+  };
+
+  prototype.commitCapture = function commit(this: RetainedCaptureSlot, ...args): void {
+    state.commits++;
+
+    commitCapture.apply(this, args);
+  };
+
+  prototype.isCleanIgnoringTransform = function clean(this: RetainedCaptureSlot, ...args): boolean {
+    const value = isClean.apply(this, args);
+
+    if (!value) {
+      state.misses++;
+    }
+
+    return value;
+  };
+
+  return state;
+};
+
+/**
+ * Refuse the indexed slot tier for the duration of `run`. That tier sits above
+ * the capture decision and is keyed on the backend alone, so leaving it in
+ * would answer both draws and hide the tier under test - which is itself a
+ * result, asserted in the last case.
+ */
+const withoutPersistentSlots = <T>(run: () => T): T => {
+  const prototype = WebGl2Backend.prototype as unknown as { _acquirePersistentSlots: unknown };
+  const acquire = prototype._acquirePersistentSlots;
+
+  prototype._acquirePersistentSlots = (): null => null;
+
+  try {
+    return run();
+  } finally {
+    prototype._acquirePersistentSlots = acquire;
+  }
+};
+
+/** How many products the root is holding. */
+const slotCount = (root: RenderNode): number => {
+  const representation = (root as unknown as { _retainedRootRepresentation(): RetainedRootRepresentation })._retainedRootRepresentation();
+
+  return (representation as unknown as { _captureSlots: readonly unknown[] })._captureSlots.length;
+};
+
+const live: Array<() => void> = [];
+
+interface Arm {
+  readonly harness: WebGl2Harness;
+  readonly root: RenderNode;
+  readonly first: RenderTexture;
+  readonly second: RenderTexture;
+}
+
+const openScene = (): Arm => {
+  const harness = createWebGl2Harness({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT });
+  const scene = buildScrollingWorld(harness, LEAF_COUNT, SCROLLING_WORLD.cameraSpeed, SCROLLING_WORLD.worldSpan);
+  const first = new RenderTexture(VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+  const second = new RenderTexture(VIEWPORT_WIDTH, VIEWPORT_HEIGHT);
+
+  live.push(() => {
+    scene.destroy();
+    first.destroy();
+    second.destroy();
+    harness.destroy();
+  });
+
+  return { harness, root: scene.root, first, second };
+};
+
+/** Draw the root once per entry of `targets`, in order, within one frame. */
+const drawFrame = (arm: Arm, targets: ReadonlyArray<RenderTexture | null>): void => {
+  const { backend } = arm.harness;
+
+  backend.clear();
+
+  for (const target of targets) {
+    backend.setRenderTarget(target);
+    backend.setView(arm.harness.view);
+    arm.root.render(backend);
+  }
+
+  backend.flush();
+};
+
+const measure = (arm: Arm, targets: ReadonlyArray<RenderTexture | null>, beforeMeasuredFrame?: (frame: number) => void): ArmCounts => {
+  const { backend } = arm.harness;
+  const probe = installCaptureCounter();
+
+  try {
+    for (let i = 0; i < WARMUP_FRAMES; i++) {
+      backend.resetStats();
+      drawFrame(arm, targets);
+    }
+
+    probe.reset();
+
+    let culledNodes = 0;
+
+    for (let i = 0; i < MEASURED_FRAMES; i++) {
+      backend.resetStats();
+      beforeMeasuredFrame?.(i);
+      drawFrame(arm, targets);
+      culledNodes += backend.stats.culledNodes;
+    }
+
+    return { draws: targets.length * MEASURED_FRAMES, cleanMisses: probe.misses, commits: probe.commits, culledNodes };
+  } finally {
+    probe.restore();
+  }
+};
+
+afterEach(() => {
+  for (const destroy of live.splice(0)) {
+    destroy();
+  }
+});
+
+describe('retained products — one root, several render targets per frame', () => {
+  test('drawing to one target twice per frame replays: the second draw is free', () => {
+    const arm = openScene();
+    const counts = withoutPersistentSlots(() => measure(arm, [null, null]));
+
+    expect(counts).toEqual({ draws: 20, cleanMisses: 0, commits: 0, culledNodes: 0 });
+    expect(slotCount(arm.root)).toBe(1);
+  });
+
+  test('a render texture and the screen hold one product each and both replay', () => {
+    const arm = openScene();
+    const counts = withoutPersistentSlots(() => measure(arm, [arm.first, null]));
+
+    expect(counts).toEqual({ draws: 20, cleanMisses: 0, commits: 0, culledNodes: 0 });
+    expect(slotCount(arm.root)).toBe(2);
+  });
+
+  test('a descendant move reaches the product the frame is not drawing, so both stay replayable', () => {
+    const movingLeaf = (arm: Arm): RenderNode => (arm.root as unknown as { children: RenderNode[] }).children.find(child => child instanceof Sprite)!;
+    const stepLeaf =
+      (arm: Arm) =>
+      (frame: number): void => {
+        movingLeaf(arm).setPosition(400 + frame, 300);
+      };
+    const control = openScene();
+    const twoTargets = openScene();
+
+    // A move that reached only the product being drawn would send the other one
+    // back through a collect, which `culledNodes` reports. The single-target arm
+    // is the control: the baked-row patch is what keeps either arm at zero, and
+    // it has to hold for every product a root owns, not only the active one.
+    const single = withoutPersistentSlots(() => measure(control, [null], stepLeaf(control)));
+    const both = withoutPersistentSlots(() => measure(twoTargets, [twoTargets.first, null], stepLeaf(twoTargets)));
+
+    expect(single.culledNodes).toBe(0);
+    expect(both).toEqual({ draws: 20, cleanMisses: 0, commits: 0, culledNodes: 0 });
+  });
+
+  test('a third target in one frame evicts rather than growing the set', () => {
+    const arm = openScene();
+    const counts = withoutPersistentSlots(() => measure(arm, [arm.first, arm.second, null]));
+
+    // Two products are held, so the least recently used one is evicted on every
+    // draw and the frame pays what a single field paid for two targets. The cap
+    // is the point: a product is a full instruction set plus its recorded
+    // entries, and "screen plus one offscreen" is the case worth serving.
+    expect(slotCount(arm.root)).toBe(2);
+    expect(counts.cleanMisses).toBeGreaterThan(0);
+  });
+
+  test('the indexed slot tier is keyed on the backend alone and absorbs the target switch', () => {
+    const arm = openScene();
+    const counts = measure(arm, [arm.first, null]);
+
+    expect(counts.culledNodes).toBe(0);
+  });
+});

--- a/test/rendering/retained-container.test.ts
+++ b/test/rendering/retained-container.test.ts
@@ -11,6 +11,7 @@ import { RenderPlanOptimizer } from '#rendering/plan/RenderPlanOptimizer';
 import { RenderPlanPlayer } from '#rendering/plan/RenderPlanPlayer';
 import type { GroupScope, GroupScopeEntry } from '#rendering/plan/RenderScope';
 import { type RetainedFragmentEntry, type RetainedGroupFragment } from '#rendering/plan/RetainedGroupFragment';
+import { forEachMovedNode } from '#rendering/plan/retainedTransformRowPatch';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import { RenderBackendType } from '#rendering/RenderBackendType';
 import type { RenderNode } from '#rendering/RenderNode';
@@ -28,14 +29,23 @@ class LeafDrawable extends Drawable {
 
 const fragmentOf = (group: RetainedContainer): RetainedGroupFragment => (group as unknown as { _fragment: RetainedGroupFragment })._fragment;
 
-/** The fragment's queued transform-row nodes, materialized through its logical length. */
-const queuedRows = (fragment: RetainedGroupFragment): RenderNode[] =>
-  Array.from({ length: fragment.dirtyTransformRowCount }, (_unused, index) => fragment.dirtyTransformRowAt(index));
+/**
+ * The moves this group owns and has not accounted for yet - what the dirty
+ * index answers where the fragment used to hold a queue of its own.
+ */
+const unseenOwnedMoves = (group: RetainedContainer): RenderNode[] => {
+  const owns = (group as unknown as { _ownsMove(node: RenderNode): boolean })._ownsMove.bind(group);
+  const moves: RenderNode[] = [];
 
-// F4: the enqueue seam is gated on a live committed recording (only the
-// recorded-instruction tier ever consumes a queued row), so tests that
-// exercise the enqueue MECHANICS (routing, dedup, re-arm) must arm one first
-// - otherwise every move is correctly skipped and there is nothing to observe.
+  forEachMovedNode(fragmentOf(group), owns, node => {
+    moves.push(node);
+
+    return true;
+  });
+
+  return moves;
+};
+
 const armRecording = (group: RetainedContainer, backend: RenderBackend): void => {
   const set = fragmentOf(group).instructionsForRecording();
 
@@ -44,24 +54,24 @@ const armRecording = (group: RetainedContainer, backend: RenderBackend): void =>
 };
 
 describe('RetainedContainer: transform-row patch seam', () => {
-  test('a direct child move enqueues that node on the group fragment', () => {
+  test('a direct child move is a move this group owns', () => {
     const backend = createTestBackend();
     const group = new RetainedContainer();
     const child = new LeafDrawable('a');
 
     group.addChild(child);
     armRecording(group, backend);
-    fragmentOf(group).clearDirtyTransformRows(); // drop the add-time churn
+    fragmentOf(group).markTransformsSeen(); // drop the add-time churn
 
     child.setPosition(40, 40);
 
-    expect(queuedRows(fragmentOf(group))).toEqual([child]);
+    expect(unseenOwnedMoves(group)).toEqual([child]);
 
     group.destroy();
     backend.destroy();
   });
 
-  test('a move nested below a plain sub-container still enqueues on the enclosing group', () => {
+  test('a move nested below a plain sub-container belongs to the enclosing group', () => {
     const backend = createTestBackend();
     const group = new RetainedContainer();
     const inner = new Container();
@@ -70,28 +80,28 @@ describe('RetainedContainer: transform-row patch seam', () => {
     inner.addChild(child);
     group.addChild(inner);
     armRecording(group, backend);
-    fragmentOf(group).clearDirtyTransformRows();
+    fragmentOf(group).markTransformsSeen();
 
     child.setPosition(5, 5);
 
-    expect(queuedRows(fragmentOf(group))).toContain(child);
+    expect(unseenOwnedMoves(group)).toContain(child);
 
     group.destroy();
     backend.destroy();
   });
 
-  test("the group's OWN move does not enqueue a row (it is a one-matrix group move)", () => {
+  test("the group's OWN move is not a move it owns (it is a one-matrix group move)", () => {
     const backend = createTestBackend();
     const group = new RetainedContainer();
     const child = new LeafDrawable('a');
 
     group.addChild(child);
     armRecording(group, backend);
-    fragmentOf(group).clearDirtyTransformRows();
+    fragmentOf(group).markTransformsSeen();
 
     group.setPosition(100, 100);
 
-    expect(fragmentOf(group).hasDirtyTransformRows()).toBe(false);
+    expect(unseenOwnedMoves(group)).toEqual([]);
 
     group.destroy();
     backend.destroy();
@@ -108,79 +118,76 @@ describe('RetainedContainer: transform-row patch seam', () => {
     root.destroy();
   });
 
-  test('a descendant move IS enqueued while the fragment holds a committed recording (F4: the gate never drops a consumable row)', () => {
-    // The recorded-instruction tier bakes each direct child's transform into the
-    // replayed instance bytes, so a transform-only move MUST be queued for
-    // reconcile (patched in place, or the recording dropped to entry replay).
+  test('a move below a NESTED group belongs to that group, not to the outer one', () => {
+    // Ownership is the nearest enclosing boundary. The outer group recorded the
+    // inner one as a nested boundary, not as rows of its own, so a move down
+    // there must not send the outer group's recording away.
     const backend = createTestBackend();
-    const group = new RetainedContainer();
-    const child = new LeafDrawable('a');
+    const outer = new RetainedContainer();
+    const inner = new RetainedContainer();
+    const child = new LeafDrawable('deep');
 
-    group.addChild(child);
+    inner.addChild(child);
+    outer.addChild(inner);
+    armRecording(outer, backend);
+    armRecording(inner, backend);
+    fragmentOf(outer).markTransformsSeen();
+    fragmentOf(inner).markTransformsSeen();
 
-    const fragment = fragmentOf(group);
-    const set = fragment.instructionsForRecording();
+    child.setPosition(5, 5);
 
-    set.beginRecording(backend);
-    set.commitRecording();
-    fragmentOf(group).clearDirtyTransformRows(); // drop the add-time churn
+    expect(unseenOwnedMoves(inner)).toEqual([child]);
+    expect(unseenOwnedMoves(outer)).toEqual([]);
 
-    child.setPosition(40, 40);
-
-    expect(queuedRows(fragment)).toEqual([child]);
-
-    group.destroy();
+    outer.destroy();
     backend.destroy();
   });
 
-  test('a descendant move is NOT enqueued when no recording exists (F4: entry replay re-reads transforms live, so the queue would only be cleared unused)', () => {
-    // On the entry-replay tier the splice re-reads each node's live transform, so
-    // a queued row would be discarded untouched at the next reconcile. Gating the
-    // enqueue on a live recording spares that per-move walk + push for nothing.
+  test('a move is marked whatever tier the group is on - the recorded tier is simply the one that consumes it', () => {
+    // The mark is written once per moved node, for every consumer at once, so
+    // there is no per-tier enqueue gate to get wrong any more. A group without a
+    // recording reads the same mark and finds nothing to patch.
     const group = new RetainedContainer();
     const child = new LeafDrawable('a');
 
     group.addChild(child);
-    fragmentOf(group).clearDirtyTransformRows();
+    fragmentOf(group).markTransformsSeen();
 
     child.setPosition(40, 40);
 
-    expect(fragmentOf(group).hasDirtyTransformRows()).toBe(false);
+    expect(fragmentOf(group).instructions?.hasRecording).not.toBe(true);
+    expect(unseenOwnedMoves(group)).toEqual([child]);
 
     group.destroy();
   });
 
-  test('a descendant move stops enqueuing again once the recording is dropped (F4: signal tracks the tier live)', () => {
+  test('accounting for the moves advances the cursor, so the next frame sees only what moved since', () => {
     const backend = createTestBackend();
     const group = new RetainedContainer();
     const child = new LeafDrawable('a');
 
     group.addChild(child);
-
-    const fragment = fragmentOf(group);
-    const set = fragment.instructionsForRecording();
-
-    set.beginRecording(backend);
-    set.commitRecording();
-    fragment.clearDirtyTransformRows();
+    armRecording(group, backend);
+    fragmentOf(group).markTransformsSeen();
 
     child.setPosition(10, 10);
-    expect(fragment.hasDirtyTransformRows()).toBe(true); // recorded tier: enqueued
+    expect(unseenOwnedMoves(group)).toEqual([child]);
 
-    fragment.clearDirtyTransformRows();
-    set.invalidate(); // e.g. recapture dropped the recording -> back to entry replay
+    fragmentOf(group).markTransformsSeen();
+    expect(unseenOwnedMoves(group)).toEqual([]);
 
     child.setPosition(20, 20);
-    expect(fragment.hasDirtyTransformRows()).toBe(false); // entry-replay tier: skipped
+    expect(unseenOwnedMoves(group)).toEqual([child]);
 
     group.destroy();
     backend.destroy();
   });
 
   test('the move seam re-arms across a group destroy (boundary-count balance)', () => {
-    // With no live boundary the seam short-circuits; a child under a group must
-    // still enqueue after another group elsewhere has been destroyed (the global
-    // count must balance construct/destroy exactly, never leaving it stuck at 0).
+    // With no live consumer the seam short-circuits; a child under a group must
+    // still be marked after another group elsewhere has been destroyed (the
+    // global count must balance construct/destroy exactly, never leaving it
+    // stuck at 0).
     const throwaway = new RetainedContainer();
 
     throwaway.destroy();
@@ -191,11 +198,11 @@ describe('RetainedContainer: transform-row patch seam', () => {
 
     group.addChild(child);
     armRecording(group, backend);
-    fragmentOf(group).clearDirtyTransformRows();
+    fragmentOf(group).markTransformsSeen();
 
     child.setPosition(7, 7);
 
-    expect(queuedRows(fragmentOf(group))).toContain(child);
+    expect(unseenOwnedMoves(group)).toContain(child);
 
     group.destroy();
     backend.destroy();
@@ -1145,16 +1152,14 @@ describe('RetainedContainer: capture suppression under thrash', () => {
     backend.destroy();
   });
 
-  test('a descendant move during an ACTIVE suppression window is never queued (nitpick 5: no stale node reference can accumulate un-drained)', () => {
-    // Before F4 gated the enqueue on a live recording, a move during a
-    // continuing (already-suppressed) frame was queued unconditionally and
-    // only drained on the transition-into-suppression frame - a later move
-    // could sit in the queue, holding a strong node reference, until
-    // suppression eventually lifted. `capture()` unconditionally invalidates
-    // any recording, and suppression can only be entered after at least one
-    // capture, so `hasRecording` is provably false for the whole suppressed
-    // window - the F4 gate now prevents the enqueue from ever happening here
-    // in the first place.
+  test('a descendant move during an ACTIVE suppression window accumulates nothing on the fragment', () => {
+    // A fragment holding its own queue could accumulate node references through
+    // a long suppressed window, because only a reconcile drained it and a
+    // suppressed frame never reaches one. The index removes the failure mode
+    // rather than gating it: marks live in the shared ring, one entry per node
+    // per generation, recycled after eight of them whether anyone read or not.
+    // What is asserted here is the fragment's side of that - it holds no queue
+    // to leak.
     const backend = createTestBackend();
     const root = new Container();
     const group = new RetainedContainer();
@@ -1175,7 +1180,7 @@ describe('RetainedContainer: capture suppression under thrash', () => {
 
     leaf.setPosition(9, 9); // a move while still inside the suppressed window
 
-    expect(fragment.hasDirtyTransformRows()).toBe(false);
+    expect((fragment as unknown as Record<string, unknown>)['_dirtyTransformRows']).toBeUndefined();
 
     root.destroy();
     backend.destroy();

--- a/test/rendering/retained-group-fragment.test.ts
+++ b/test/rendering/retained-group-fragment.test.ts
@@ -1,3 +1,4 @@
+import { DirtyChannel, nodeDirtyIndex } from '#core/NodeDirtyIndex';
 import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
 import { type DrawCommand, type MaterialKey, RenderEntryKind } from '#rendering/plan/RenderCommand';
@@ -133,74 +134,34 @@ describe('RetainedGroupFragment', () => {
     sprite.destroy();
   });
 
-  test('dirty-transform-row queue dedups moved nodes and clears', () => {
+  test('the transform cursor separates what a fragment has accounted for from what it has not', () => {
+    // The fragment keeps no queue of its own any more: it keeps the point in
+    // the shared index it has caught up to, and everything marked after that is
+    // still owed to it.
     const fragment = new RetainedGroupFragment();
     const a = new Drawable();
-    const b = new Drawable();
 
-    expect(fragment.hasDirtyTransformRows()).toBe(false);
+    fragment.markTransformsSeen();
 
-    fragment.enqueueDirtyTransformRow(a);
-    fragment.enqueueDirtyTransformRow(a); // same node twice — deduped
-    fragment.enqueueDirtyTransformRow(b);
+    expect(fragment.hasUnseenTransformMarks()).toBe(false);
 
-    expect(fragment.hasDirtyTransformRows()).toBe(true);
-    expect(fragment.dirtyTransformRowCount).toBe(2);
-    expect(fragment.dirtyTransformRowAt(0)).toBe(a);
-    expect(fragment.dirtyTransformRowAt(1)).toBe(b);
+    nodeDirtyIndex.mark(a, DirtyChannel.Transform);
 
-    fragment.clearDirtyTransformRows();
+    expect(fragment.hasUnseenTransformMarks()).toBe(true);
 
-    expect(fragment.hasDirtyTransformRows()).toBe(false);
+    fragment.markTransformsSeen();
+
+    expect(fragment.hasUnseenTransformMarks()).toBe(false);
 
     a.destroy();
-    b.destroy();
   });
 
-  test('a cleared queue reports only what was queued after it, never the slots it kept', () => {
-    // The reset rewinds a logical length and keeps the backing array, so the
-    // records of the previous cycle are still physically in it. Nothing may see
-    // them: the count is the contract.
+  test('a fragment that never accounted for anything is unprovable rather than quietly up to date', () => {
+    // A fresh cursor cannot claim that nothing moved: it has no evidence either
+    // way, and the caller has to re-collect instead of replaying.
     const fragment = new RetainedGroupFragment();
-    const a = new Drawable();
-    const b = new Drawable();
-    const c = new Drawable();
 
-    fragment.enqueueDirtyTransformRow(a);
-    fragment.enqueueDirtyTransformRow(b);
-    fragment.clearDirtyTransformRows();
-
-    fragment.enqueueDirtyTransformRow(c);
-
-    expect(fragment.dirtyTransformRowCount).toBe(1);
-    expect(fragment.dirtyTransformRowAt(0)).toBe(c);
-
-    a.destroy();
-    b.destroy();
-    c.destroy();
-  });
-
-  test('invalidate() releases the queue references so a dropped node can GC', async () => {
-    // The per-frame reset deliberately keeps its slots (that is what makes the
-    // refill allocation-free), so the structural paths - invalidate and capture -
-    // are what has to hand the references back.
-    const fragment = new RetainedGroupFragment();
-    // Queued, cleared and released inside a scope that ends here, so the only
-    // reference that could keep the node alive is the fragment's own slot.
-    const ref = ((): WeakRef<Drawable> => {
-      const node = new Drawable();
-
-      fragment.enqueueDirtyTransformRow(node);
-      fragment.clearDirtyTransformRows();
-      fragment.invalidate();
-      node.destroy();
-
-      return new WeakRef(node);
-    })();
-
-    await forceGc();
-
-    expect(ref.deref()).toBeUndefined();
+    expect(fragment.transformMarksProvable).toBe(false);
   });
 
   test('invalidate() clears the capture', () => {

--- a/test/rendering/retained-root-representation.test.ts
+++ b/test/rendering/retained-root-representation.test.ts
@@ -472,13 +472,13 @@ describe('automatic render-root representation: nested RetainedContainer', () =>
     expect(rootSetOf(root)).toBeNull();
 
     // The group's own row-patch seam is still live, which is the whole point of
-    // deferring: it only enqueues while it holds a committed recording.
+    // deferring: the move below it is the group's to account for, not the root's.
     const leaf = group.children[0]!;
 
-    fragmentOf(group).clearDirtyTransformRows();
+    fragmentOf(group).markTransformsSeen();
     leaf.setPosition(3, 3);
 
-    expect(fragmentOf(group).hasDirtyTransformRows()).toBe(true);
+    expect(fragmentOf(group).hasUnseenTransformMarks()).toBe(true);
 
     root.destroy();
     backend.destroy();

--- a/test/rendering/retained-transform-row-patch.test.ts
+++ b/test/rendering/retained-transform-row-patch.test.ts
@@ -1,3 +1,4 @@
+import { Color } from '#core/Color';
 import { Container } from '#rendering/Container';
 import { Drawable } from '#rendering/Drawable';
 import { RenderPlanBuilder } from '#rendering/plan/RenderPlanBuilder';
@@ -36,10 +37,16 @@ interface PatchCall {
   readonly localRow: number;
 }
 
+interface TintPatchCall {
+  readonly localRow: number;
+  readonly rgba: readonly number[];
+}
+
 interface Harness {
   readonly backend: RenderBackend;
   readonly events: string[];
   readonly patches: PatchCall[];
+  readonly tintPatches: TintPatchCall[];
 }
 
 // File-local fake backend (repo convention keeps test harnesses file-local). It
@@ -49,6 +56,7 @@ const createPatchingBackend = (): Harness => {
   const renderTarget = new RenderTarget(800, 600, true);
   const events: string[] = [];
   const patches: PatchCall[] = [];
+  const tintPatches: TintPatchCall[] = [];
   const pending: string[] = [];
   const activeCaptures: RetainedInstructionSet[] = [];
 
@@ -57,6 +65,9 @@ const createPatchingBackend = (): Harness => {
     transformRowBase: 0,
     _patchTransformRow(localRow: number): void {
       patches.push({ localRow });
+    },
+    _patchTintRow(localRow: number, bytes: Uint8Array): void {
+      tintPatches.push({ localRow, rgba: [...bytes] });
     },
   };
 
@@ -179,7 +190,7 @@ const createPatchingBackend = (): Harness => {
     },
   } as unknown as RenderBackend;
 
-  return { backend, events, patches };
+  return { backend, events, patches, tintPatches };
 };
 
 const playFrame = (root: RenderNode, backend: RenderBackend): void => {
@@ -202,6 +213,7 @@ const reachSpliceTier = (root: RenderNode, harness: Harness): void => {
   playFrame(root, harness.backend);
   harness.events.length = 0;
   harness.patches.length = 0;
+  harness.tintPatches.length = 0;
 };
 
 describe('recorded row base spans nested draws', () => {
@@ -463,6 +475,125 @@ describe('automatic render-root representation: incremental transform rows', () 
     expect(harness.patches).toHaveLength(2);
 
     world.destroy();
+    harness.backend.destroy();
+  });
+});
+
+describe('automatic render-root representation: incremental tint rows', () => {
+  test('a tint change rewrites one row and keeps the recording', () => {
+    // The change this exists for: a tint written every frame - a hit flash, a
+    // selection highlight, a fade - used to throw the whole recorded product
+    // away on every frame it happened.
+    const harness = createPatchingBackend();
+    const root = new Container();
+    const leaf = new RecordableLeaf('a');
+
+    root.addChild(leaf);
+    reachSpliceTier(root, harness);
+
+    harness.events.length = 0;
+    leaf.setTint(new Color(255, 0, 0, 0.5));
+    playFrame(root, harness.backend);
+
+    expect(harness.tintPatches).toEqual([{ localRow: 0, rgba: [255, 0, 0, 128] }]);
+    expect(harness.patches).toEqual([]); // nothing moved
+    expect(harness.events).toEqual(['replay:a']); // recorded tier held
+  });
+
+  test('k tint changes cost k row writes, not a re-record', () => {
+    const harness = createPatchingBackend();
+    const root = new Container();
+    const first = new RecordableLeaf('a');
+    const second = new RecordableLeaf('b');
+    const third = new RecordableLeaf('c');
+
+    root.addChild(first);
+    root.addChild(second);
+    root.addChild(third);
+    reachSpliceTier(root, harness);
+
+    harness.events.length = 0;
+    first.setTint(new Color(1, 2, 3));
+    third.setTint(new Color(4, 5, 6));
+    playFrame(root, harness.backend);
+
+    expect(harness.tintPatches.map(patch => patch.localRow)).toEqual([0, 2]);
+    expect(harness.events).toEqual(['replay:a,b,c']);
+  });
+
+  test('the same node tinted twice between frames is written once', () => {
+    const harness = createPatchingBackend();
+    const root = new Container();
+    const leaf = new RecordableLeaf('a');
+
+    root.addChild(leaf);
+    reachSpliceTier(root, harness);
+
+    leaf.setTint(new Color(1, 1, 1));
+    leaf.setTint(new Color(9, 9, 9));
+    playFrame(root, harness.backend);
+
+    expect(harness.tintPatches).toEqual([{ localRow: 0, rgba: [9, 9, 9, 255] }]);
+  });
+
+  test('a content change that is NOT a tint still rebuilds', () => {
+    // The other half of the channel split: a texture, geometry or blend-mode
+    // change decides which batch a node belongs to, and no row write says that.
+    const harness = createPatchingBackend();
+    const root = new Container();
+    const leaf = new RecordableLeaf('a');
+
+    root.addChild(leaf);
+    reachSpliceTier(root, harness);
+
+    harness.events.length = 0;
+    leaf.invalidateContent();
+    playFrame(root, harness.backend);
+
+    expect(harness.tintPatches).toEqual([]);
+    expect(harness.events).toContain('flush:a'); // re-collected, not replayed
+  });
+
+  test('a tint change on a node the product never recorded rebuilds instead of writing a stray row', () => {
+    const harness = createPatchingBackend();
+    const root = new Container();
+    const recorded = new RecordableLeaf('a');
+    const outsider = new RecordableLeaf('b');
+
+    root.addChild(recorded);
+    reachSpliceTier(root, harness);
+
+    // Added after the capture, so it has no row in this product. Its own
+    // structure change already forces a rebuild; the tint must not be written
+    // against whatever row index the map happens not to hold.
+    root.addChild(outsider);
+    harness.events.length = 0;
+    outsider.setTint(new Color(3, 3, 3));
+    playFrame(root, harness.backend);
+
+    expect(harness.tintPatches).toEqual([]);
+  });
+
+  test('a tint change under ANOTHER root does not touch this product', () => {
+    const harness = createPatchingBackend();
+    const world = new Container();
+    const other = new Container();
+    const mine = new RecordableLeaf('a');
+    const theirs = new RecordableLeaf('b');
+
+    world.addChild(mine);
+    other.addChild(theirs);
+    reachSpliceTier(world, harness);
+    reachSpliceTier(other, harness);
+
+    harness.tintPatches.length = 0;
+    theirs.setTint(new Color(7, 7, 7));
+    playFrame(world, harness.backend);
+
+    expect(harness.tintPatches).toEqual([]);
+
+    world.destroy();
+    other.destroy();
     harness.backend.destroy();
   });
 });


### PR DESCRIPTION
Group B of the retention track, in the order the registry fixes: P5 → P6 → P7 → P8. One commit per package.

### P5 — one retained product per render target (`NEU-O51`)

Measured first, as the decision required. A root drawn into a `RenderTexture` and onto the screen in one frame missed its keys on **all 20 draws** of a 10-frame window, re-captured 13 times and walked the scene graph 28 809 nodes' worth - against **0/0/0** for the same scene drawn twice to a single target, which differs in the render target alone. So it costs, and it never settles.

The capture half of `RetainedRootRepresentation` moved to `RetainedCaptureSlot`; a root holds at most two, MRU first, and one draw selects one. Two is a hard cap - a product is a full instruction set plus its recorded entries, and screen-plus-one-offscreen is the case that recurs. The indexed slot tier was never affected: it is keyed on the backend alone.

### P6 — a changed-record index instead of a push seam

Every own-transform mutation walked from the moved node to the scene root, offering its row to the enclosing group and every render root above, because a moved node cannot know which products recorded it. `NodeDirtyIndex` inverts that: a mutation marks the node once, each product pulls what it cares about against the row map it already keeps.

An index, not a journal. One entry per node per generation, ordering carried by the node's own mark sequence (the per-record revision the decision asked for), so a node written a thousand times in a frame holds one entry. Re-marking retires the older entry, so a read visits a node once. Marks live in a ring of eight generations; a product whose cursor falls out is told so and rebuilds.

### P7 — generic channels, and tint made incremental (`NEU-O49`)

Channels are `Transform`, `Content` and `Tint`. Tint is the one content change a recorded product can express in place - it lives in a per-row store parallel to the transform rows - so `_patchTintRow` on both backends rewrites the row and the product replays. Tinting per frame (hit flash, selection highlight, fade) used to throw the whole recording away on every frame it happened.

Material, geometry and other content still rebuild, deliberately: they decide which batch a node belongs to, and no row write says that. They are now a named channel rather than undifferentiated "content".

### P8 — the order stream, measured and left alone (`NEU-O50`)

The open half was compaction of the order stream. On a re-selection frame (4000 leaves, ~1360 visible, a 400px camera step every frame) **61%** of the entries belong to items that neither entered nor left: an incremental stream would write ~540 where this writes ~1360, about **3.3 KB of integer writes per re-selection frame** - and only on frames that re-select, which at the archetype's own speed is one in eight. The rest replay the cached stream and write nothing.

The ratio is a property of step size against viewport, not of scene size, so the saving scales with the visible count. At the sizes measured it does not carry a segmented stream with barriers and live-playback interleaving, so none was built; the threshold that would reopen it is recorded (visible items in the hundreds of thousands, where the re-selection frame misses budget).

### Validation

Every selected lane passed in the pre-push hook: `gates typecheck`/`lint`/`sync`/`site`, `pnpm test`, `test:alloc`, and all four browser lanes (WebGL2, WebGPU, build, assets). Both new mechanisms were probed for teeth - the tint channel turned back to `Content` makes three of its tests fail, and the `@ts-expect-error` style of proof is applied to the index's window rule instead.