### PR TITLE
Make the dirty-index read cost what its design claimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1626,6 +1626,10 @@ FadeSceneTransition({ color: Color.white, duration: 300 })`.
   is a property of the marks rather than a guess from a revision that every
   kind of change bumps.
 
+  Tinting something the frame does not draw - a node the capture culled, or one
+  added after it - writes nothing and rebuilds nothing either: a colour that
+  reaches no recorded draw cannot change the picture.
+
   Writing through the `tint` instance in place (`sprite.tint.r = 8`) still
   bypasses the setter and is not observed at all; assign a colour, or call
   `invalidateContent()` after mutating one.

--- a/src/core/NodeDirtyIndex.ts
+++ b/src/core/NodeDirtyIndex.ts
@@ -46,12 +46,18 @@ interface DirtyBucket {
   generation: number;
   /** Mark sequence when this generation opened - the window test reads it. */
   firstSequence: number;
+  /**
+   * Highest mark sequence written into this bucket - the skip test reads it. A
+   * reader whose cursor is at or past it has already seen everything here, and
+   * scanning the entries would only re-derive that one comparison at a time.
+   */
+  lastSequence: number;
   count: number;
   readonly nodes: SceneNode[];
   readonly channels: number[];
 }
 
-const createBucket = (): DirtyBucket => ({ generation: -1, firstSequence: 0, count: 0, nodes: [], channels: [] });
+const createBucket = (): DirtyBucket => ({ generation: -1, firstSequence: 0, lastSequence: 0, count: 0, nodes: [], channels: [] });
 
 /**
  * The changed-record index: which nodes changed since a given point, in time
@@ -109,6 +115,7 @@ class NodeDirtyIndex {
 
     bucket.generation = this._generation;
     bucket.firstSequence = this._sequence;
+    bucket.lastSequence = this._sequence;
     bucket.count = 0;
 
     const oldestGeneration = this._generation - RETAINED_GENERATIONS + 1;
@@ -131,6 +138,7 @@ class NodeDirtyIndex {
     const held = live !== null && live.generation === node._dirtyMarkGeneration && live.nodes[node._dirtyMarkSlot] === node;
 
     node._dirtyMarkSequence = ++this._sequence;
+    bucket.lastSequence = this._sequence;
 
     // Repeating the SAME channels keeps the entry and only moves the sequence
     // on: a node written a thousand times in a frame stays one entry, which is
@@ -189,7 +197,12 @@ class NodeDirtyIndex {
     for (let step = Math.max(0, this._generation - RETAINED_GENERATIONS + 1); step <= this._generation; step++) {
       const bucket = this._buckets[step % RETAINED_GENERATIONS]!;
 
-      if (bucket.generation !== step) {
+      // A generation whose newest mark is already accounted for holds nothing
+      // for this reader. Skipping it whole is what keeps a read proportional to
+      // what changed since the cursor rather than to everything the window
+      // still remembers - with a consumer that looks every frame, only the
+      // current generation is ever scanned.
+      if (bucket.generation !== step || bucket.lastSequence <= sequence) {
         continue;
       }
 
@@ -231,6 +244,7 @@ class NodeDirtyIndex {
     for (const bucket of this._buckets) {
       bucket.generation = -1;
       bucket.firstSequence = 0;
+      bucket.lastSequence = 0;
       bucket.count = 0;
       bucket.nodes.length = 0;
       bucket.channels.length = 0;

--- a/src/rendering/plan/RetainedCaptureSlot.ts
+++ b/src/rendering/plan/RetainedCaptureSlot.ts
@@ -1,6 +1,5 @@
 import { Bounds } from '#core/Bounds';
 import { type ReadonlyRectangle, Rectangle } from '#math/Rectangle';
-import type { Drawable } from '#rendering/Drawable';
 import type { RenderBackend } from '#rendering/RenderBackend';
 import type { RenderNode } from '#rendering/RenderNode';
 import type { View } from '#rendering/View';
@@ -286,8 +285,8 @@ export class RetainedCaptureSlot {
     const viewRect = view.getBounds();
     const insideCaptureRect = this._viewFitsCaptureCullRect(view);
 
-    return forEachMovedNode(this.fragment, owns, node => {
-      if (this._culledDuringCapture && this.fragment.recordedDraw(node as unknown as Drawable) === undefined) {
+    return forEachMovedNode(this.fragment, owns, (node, record) => {
+      if (this._culledDuringCapture && record === undefined) {
         return false;
       }
 

--- a/src/rendering/plan/retainedTransformRowPatch.ts
+++ b/src/rendering/plan/retainedTransformRowPatch.ts
@@ -4,7 +4,7 @@ import type { RenderBackend } from '#rendering/RenderBackend';
 import type { RenderNode } from '#rendering/RenderNode';
 import { packTintRow, packTransformRow, TRANSFORM_FLOATS_PER_ROW, TRANSFORM_TINT_BYTES_PER_ROW } from '#rendering/TransformBuffer';
 
-import type { RetainedGroupFragment } from './RetainedGroupFragment';
+import type { RetainedFragmentDraw, RetainedGroupFragment } from './RetainedGroupFragment';
 import type { RetainedGroupBundle } from './RetainedInstructionSet';
 
 /**
@@ -80,7 +80,7 @@ const patchTintScratch = new Uint8Array(TRANSFORM_TINT_BYTES_PER_ROW);
  */
 export const tryPatchRetainedTransformRow = (
   node: RenderNode,
-  fragment: RetainedGroupFragment,
+  record: RetainedFragmentDraw | undefined,
   bundle: PatchableRetainedGroupBundle,
   backend: RenderBackend,
   base: number,
@@ -101,15 +101,15 @@ export const tryPatchRetainedTransformRow = (
     }
   }
 
-  const nodeIndex = fragment.recordedRowIndex(drawable);
-
   // A recorded draw may be pixel-snapped in either mode: its patched row carries
   // the raw transform plus the snap flag (packTransformRow) and the shader rounds
   // the device origin (and, in geometry mode, the quad edges), so the row stays
   // view-independent and fully recordable.
-  if (nodeIndex === undefined) {
+  if (record === undefined) {
     return false;
   }
+
+  const nodeIndex = record.nodeIndex;
 
   // Transform-only patch: tint is not part of this row (it lives in the bundle's
   // separate tint texture) and a moved node's tint does not change.
@@ -121,23 +121,40 @@ export const tryPatchRetainedTransformRow = (
 
 /**
  * Visit every node whose transform moved since `fragment` last accounted for
- * one and that `owns` claims. `false` means the index no longer covers the
- * fragment's cursor, or `visit` abandoned the walk - either way the caller
- * cannot treat the channel as settled.
+ * one and that this fragment has to answer for. `false` means the index no
+ * longer covers the fragment's cursor, or `visit` abandoned the walk - either
+ * way the caller cannot treat the channel as settled.
  *
- * The ownership test is the caller's, because the two consumers draw the
- * boundary differently: a {@link RetainedContainer} owns the moves whose
- * NEAREST enclosing boundary it is (a move below a nested group belongs to that
- * group's rows, not to its own), while a render root owns every move in its
- * subtree. Marks outside the caller's subtree belong to another consumer and
- * are skipped without being looked at twice.
+ * **A recorded draw is answered by the row map alone.** That is the whole
+ * economy of pulling instead of pushing: the common mark is a node this
+ * fragment drew, and recognising it costs one map lookup rather than the walk
+ * from the node up to this consumer. The walk only runs for a mark the map does
+ * not know, where the answer decides between "below me but not in my product"
+ * (the caller has to deal with it) and "someone else's subtree" (skip).
+ *
+ * `owns` is the caller's, because the two consumers draw that boundary
+ * differently: a {@link RetainedContainer} owns the moves whose NEAREST
+ * enclosing boundary it is - one below a nested group belongs to that group's
+ * rows - while a render root owns every move in its subtree.
  * @internal
  */
-export const forEachMovedNode = (fragment: RetainedGroupFragment, owns: (node: RenderNode) => boolean, visit: (node: RenderNode) => boolean): boolean =>
+export const forEachMovedNode = (
+  fragment: RetainedGroupFragment,
+  owns: (node: RenderNode) => boolean,
+  visit: (node: RenderNode, record: RetainedFragmentDraw | undefined) => boolean,
+): boolean =>
   nodeDirtyIndex.readSince(fragment.transformCursor, DirtyChannel.Transform, node => {
     const moved = node as unknown as RenderNode;
+    const record = fragment.recordedDraw(moved as unknown as Drawable);
 
-    return !owns(moved) || visit(moved);
+    // The record is handed to the visitor rather than looked up again: it
+    // answers ownership, the bounds refresh and the row index in one lookup,
+    // and this runs once per changed node per consumer per frame.
+    if (record === undefined && !owns(moved)) {
+      return true;
+    }
+
+    return visit(moved, record);
   });
 
 /** Whether `node` lies anywhere below `ancestor`. */
@@ -162,9 +179,7 @@ export const isUnder = (node: RenderNode, ancestor: RenderNode): boolean => {
  * decide whether a batch run may be reordered past an intervening draw, and a
  * stale extent can hide a real overlap.
  */
-const refreshRetainedDrawBounds = (fragment: RetainedGroupFragment, node: RenderNode): void => {
-  const record = fragment.recordedDraw(node as unknown as Drawable);
-
+const refreshRetainedDrawBounds = (node: RenderNode, record: RetainedFragmentDraw | undefined): void => {
   if (record === undefined) {
     return;
   }
@@ -216,8 +231,8 @@ export const reconcileRetainedTransformRows = (
     // transform, so there is no row to patch. Only the RECORD's snapshotted
     // screen AABB is stale, and the optimizer's reorder-safety test reads it -
     // refresh those and report the moves as accounted for.
-    const complete = forEachMovedNode(fragment, owns, node => {
-      refreshRetainedDrawBounds(fragment, node);
+    const complete = forEachMovedNode(fragment, owns, (node, record) => {
+      refreshRetainedDrawBounds(node, record);
 
       return true;
     });
@@ -249,10 +264,10 @@ export const reconcileRetainedTransformRows = (
   const base = fragment.recordedRowBase();
   const patchableBundle = bundle as PatchableRetainedGroupBundle;
 
-  const patched = forEachMovedNode(fragment, owns, node => {
-    refreshRetainedDrawBounds(fragment, node);
+  const patched = forEachMovedNode(fragment, owns, (node, record) => {
+    refreshRetainedDrawBounds(node, record);
 
-    return isEligible(node) && tryPatchRetainedTransformRow(node, fragment, patchableBundle, backend, base);
+    return isEligible(node) && tryPatchRetainedTransformRow(node, record, patchableBundle, backend, base);
   });
 
   if (!patched) {
@@ -293,8 +308,13 @@ export const reconcileRetainedTintRows = (fragment: RetainedGroupFragment, owns:
 
   const applied = nodeDirtyIndex.readSince(fragment.contentCursor, DirtyChannel.Content | DirtyChannel.Tint, (node, marked) => {
     const changed = node as unknown as RenderNode;
+    const drawable = changed as unknown as Drawable;
+    const rowIndex = fragment.recordedRowIndex(drawable);
 
-    if (!owns(changed)) {
+    // Same economy as the transform channel: a change to something this
+    // fragment drew is recognised by the row map, and only a mark the map does
+    // not know needs the walk to decide whether it is even ours.
+    if (rowIndex === undefined && !owns(changed)) {
       return true;
     }
 
@@ -314,11 +334,14 @@ export const reconcileRetainedTintRows = (fragment: RetainedGroupFragment, owns:
       return false;
     }
 
-    const drawable = changed as unknown as Drawable;
-    const rowIndex = fragment.recordedRowIndex(drawable);
-
     if (rowIndex === undefined) {
-      return false;
+      // Owned, but this product has no row for it: the capture culled it, or it
+      // arrived after the capture. Either way its colour cannot reach these
+      // pixels - a node that arrived also moved the structure revision, which
+      // the key check refuses on its own - so there is nothing to correct and
+      // nothing to rebuild for. Tinting something off-screen is an ordinary
+      // thing for a game to do every frame.
+      return true;
     }
 
     packTintRow(patchTintScratch, 0, drawable.tint);

--- a/test/rendering/retained-transform-row-patch.test.ts
+++ b/test/rendering/retained-transform-row-patch.test.ts
@@ -554,7 +554,7 @@ describe('automatic render-root representation: incremental tint rows', () => {
     expect(harness.events).toContain('flush:a'); // re-collected, not replayed
   });
 
-  test('a tint change on a node the product never recorded rebuilds instead of writing a stray row', () => {
+  test('a tint change on a node the product never recorded writes nothing and forces nothing', () => {
     const harness = createPatchingBackend();
     const root = new Container();
     const recorded = new RecordableLeaf('a');
@@ -563,15 +563,43 @@ describe('automatic render-root representation: incremental tint rows', () => {
     root.addChild(recorded);
     reachSpliceTier(root, harness);
 
-    // Added after the capture, so it has no row in this product. Its own
-    // structure change already forces a rebuild; the tint must not be written
-    // against whatever row index the map happens not to hold.
+    // Added after the capture, so it has no row in this product. The tint must
+    // not be written against a row index the map does not hold - and it must
+    // not force a rebuild either, because a colour that reaches no recorded
+    // draw cannot change these pixels. The structure change this particular
+    // node brought with it is what rebuilds the frame, on its own key.
     root.addChild(outsider);
     harness.events.length = 0;
     outsider.setTint(new Color(3, 3, 3));
     playFrame(root, harness.backend);
 
     expect(harness.tintPatches).toEqual([]);
+  });
+
+  test('tinting a node the capture CULLED keeps the product instead of rebuilding it', () => {
+    // Found by measuring: a scene tinting off-screen nodes alternated collect
+    // and replay forever, because an owned tint with no recorded row was read
+    // as "cannot express this" rather than "cannot matter here".
+    const harness = createPatchingBackend();
+    const root = new Container();
+    const onScreen = new RecordableLeaf('a');
+    const offScreen = new RecordableLeaf('b');
+
+    offScreen.cullable = true;
+    offScreen.setPosition(100_000, 100_000);
+    root.addChild(onScreen);
+    root.addChild(offScreen);
+    reachSpliceTier(root, harness);
+
+    harness.events.length = 0;
+    offScreen.setTint(new Color(3, 3, 3));
+    playFrame(root, harness.backend);
+
+    expect(harness.tintPatches).toEqual([]);
+    expect(harness.events).toEqual(['replay:a']); // held the recorded tier
+
+    root.destroy();
+    harness.backend.destroy();
   });
 
   test('a tint change under ANOTHER root does not touch this product', () => {


### PR DESCRIPTION
Follow-up to #629, from measuring what that PR actually bought.

### The measurement

A/B against the push seam it replaced, run in a worktree at the pre-#629 `main` so both sides are real code rather than a reconstruction. Scene: 500 leaves moving every frame, 40 frames, one retained root, two spine depths. Three runs a side, tight spread.

| | old push seam | #629 as merged |
| --- | --- | --- |
| mutation path, depth 4 | 0.9 ms | 1.1 ms |
| mutation path, depth 24 | 2.6 ms | 1.7 ms |
| whole frame, depth 4 | 14.0 ms | 16.5 ms |
| whole frame, depth 24 | 27.1 ms | 28.2 ms |

The mutation path did what it was supposed to - the ancestor walk is gone and the saving grows with depth. The frame did not, and the reason was the read path, not the mechanism.

### What was wrong

- **The ownership walk ran before the row map.** The common mark is a node this product drew, and recognising it should cost one lookup; instead every mark paid the climb from the node up to the consumer - the same walk the mark was introduced to remove, moved from the mutation to the read.
- **That lookup was then repeated twice more**, by the bounds refresh and by the row patch.
- **A read scanned every retained generation**, so eight frames of marks were walked to find one frame's worth.

### After

| | old push seam | this branch |
| --- | --- | --- |
| whole frame, depth 4 | 14.0 ms | 15.8 ms |
| whole frame, depth 24 | 27.1 ms | 26.6 ms |

Level at depth, still ~13% behind on a shallow tree where 500 nodes move every single frame - that is the honest residual, and it is the price of a per-channel answer. What the index buys is on the other side of that trade: the tint channel it carries is worth **3.6×** on a scene that tints every frame (51 ms → 14 ms over 20 frames, 20 full collects → 1).

### Also found by measuring

An owned tint on a node with no recorded row was read as "cannot express this" and forced a rebuild, when a colour that reaches no recorded draw cannot change the picture. A scene tinting off-screen nodes alternated collect and replay forever; it now holds the recorded tier. Covered by a test that pins the culled case.