### PR TITLE
test(rendering): drop a mock for a module that does not exist

### DIFF
--- a/test/rendering/webgl2-backend.test.ts
+++ b/test/rendering/webgl2-backend.test.ts
@@ -158,21 +158,6 @@ describe('Application.setCursor', () => {
         };
       }),
     }));
-    vi.doMock('#input/FocusManager', () => ({
-      FocusManager: vi.fn(function () {
-        return {
-          focused: null,
-          focus: vi.fn(),
-          blur: vi.fn(),
-          pushScope: vi.fn(),
-          popScope: vi.fn(),
-          focusNext: vi.fn(),
-          focusPrevious: vi.fn(),
-          _notifyNodeRemoved: vi.fn(),
-          destroy: vi.fn(),
-        };
-      }),
-    }));
     vi.doMock('#input/InteractionSystem', () => ({
       InteractionSystem: vi.fn(function () {
         return { update: vi.fn(), destroy: vi.fn() };


### PR DESCRIPTION
The backend-selection test mocked `'#input/FocusManager'`. No such module exists - the class is `FocusController` - so `vi.doMock` matched nothing and the block was a silent no-op.

Repointing it at the real path would not help either: `FocusController` is constructed only by `InteractionSystem`, which the same test already mocks. The block is removed rather than fixed.

Verified: every remaining `vi.doMock`/`vi.mock` subpath-import target in the repo resolves to a real module. `test/rendering/webgl2-backend.test.ts` passes (9 tests).